### PR TITLE
remove kantan.csv for scala 2.10 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,6 @@ val breezeVersion ="0.12"
 val chillVersion = "0.8.0"
 val commonsIoVersion = "2.4"
 val commonsMath3Version = "3.6"
-val csvVersion = "0.1.8"
 val guavaVersion = "19.0"
 val hadoopVersion = "2.7.2"
 val hamcrestVersion = "1.3"
@@ -308,7 +307,6 @@ lazy val scioRepl: Project = Project(
       "jline" % "jline" % scalaBinaryVersion.value,
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "com.nrinaudo" %% "kantan.csv" % csvVersion,
       paradiseDependency
     ),
     libraryDependencies ++= (

--- a/scio-repl/src/main/scala/com/spotify/scio/repl/IoCommands.scala
+++ b/scio-repl/src/main/scala/com/spotify/scio/repl/IoCommands.scala
@@ -26,7 +26,6 @@ import com.google.cloud.dataflow.sdk.util.GcsUtil
 import com.google.cloud.dataflow.sdk.util.GcsUtil.GcsUtilFactory
 import com.google.cloud.dataflow.sdk.util.gcsfs.GcsPath
 import com.spotify.scio.util.ScioUtil
-import kantan.csv.{RowDecoder, RowEncoder}
 import org.apache.avro.file.{DataFileStream, DataFileWriter}
 import org.apache.avro.generic.{GenericDatumReader, GenericDatumWriter, GenericRecord}
 import org.apache.avro.specific.{SpecificDatumReader, SpecificDatumWriter, SpecificRecordBase}
@@ -66,24 +65,6 @@ class IoCommands(options: PipelineOptions) {
   def readText(path: String): Iterator[String] =
     IOUtils.lineIterator(inputStream(path), Charsets.UTF_8).asScala
 
-  /** Read from a CSV file on local filesystem or GCS. */
-  def readCsv[T: RowDecoder](path: String,
-                             sep: Char = ',',
-                             header: Boolean = false): Iterator[T] = {
-    import kantan.csv.ops._
-    implicit val codec = scala.io.Codec.UTF8
-    inputStream(path).asUnsafeCsvReader[T](sep, header).toIterator
-  }
-
-  /** Read from a TSV file on local filesystem or GCS. */
-  def readTsv[T: RowDecoder](path: String,
-                             sep: Char = '\t',
-                             header: Boolean = false): Iterator[T] = {
-    import kantan.csv.ops._
-    implicit val codec = scala.io.Codec.UTF8
-    inputStream(path).asUnsafeCsvReader[T](sep, header).toIterator
-  }
-
   // =======================================================================
   // Write operations
   // =======================================================================
@@ -107,24 +88,6 @@ class IoCommands(options: PipelineOptions) {
   /** Write to a text file on local filesystem or GCS. */
   def writeText(path: String, data: Seq[String]): Unit = {
     IOUtils.writeLines(data.asJava, IOUtils.LINE_SEPARATOR, outputStream(path, TEXT))
-    logger.info("{} line{} written to {}", Array(data.size, plural(data), path))
-  }
-
-  /** Write to a CSV file on local filesystem or GCS. */
-  def writeCsv[T: RowEncoder](path: String, data: Seq[T],
-                              sep: Char = ',',
-                              header: Seq[String] = Seq.empty): Unit = {
-    import kantan.csv.ops._
-    IOUtils.write(data.asCsv(sep, header), outputStream(path, TEXT))
-    logger.info("{} line{} written to {}", Array(data.size, plural(data), path))
-  }
-
-  /** Write to a TSV file on local filesystem or GCS. */
-  def writeTsv[T: RowEncoder](path: String, data: Seq[T],
-                              sep: Char = '\t',
-                              header: Seq[String] = Seq.empty): Unit = {
-    import kantan.csv.ops._
-    IOUtils.write(data.asCsv(sep, header), outputStream(path, TEXT))
     logger.info("{} line{} written to {}", Array(data.size, plural(data), path))
   }
 


### PR DESCRIPTION
Error when compiling for 2.10:

```
[info] Compiling 7 Scala sources to /Users/neville/src/gcp/scio/scio-repl/target/scala-2.10/classes...
[error] error while loading RowDecoder, Missing dependency 'bad symbolic reference. A signature in RowDecoder.class refers to term simulacrum
[error] in package <root> which is not available.
[error] It may be completely missing from the current classpath, or the version on
[error] the classpath might be incompatible with the version used when compiling RowDecoder.class.', required by /Users/neville/.ivy2/cache/com.nrinaudo/kantan.csv_2.10/jars/kantan.csv_2.10-0.1.8.jar(kantan/csv/RowDecoder.class)
[error] error while loading CsvInput, Missing dependency 'bad symbolic reference. A signature in CsvInput.class refers to term simulacrum
[error] in package <root> which is not available.
[error] It may be completely missing from the current classpath, or the version on
[error] the classpath might be incompatible with the version used when compiling CsvInput.class.', required by /Users/neville/.ivy2/cache/com.nrinaudo/kantan.csv_2.10/jars/kantan.csv_2.10-0.1.8.jar(kantan/csv/CsvInput.class)
[error] error while loading CsvOutput, Missing dependency 'bad symbolic reference. A signature in CsvOutput.class refers to term simulacrum
[error] in package <root> which is not available.
[error] It may be completely missing from the current classpath, or the version on
[error] the classpath might be incompatible with the version used when compiling CsvOutput.class.', required by /Users/neville/.ivy2/cache/com.nrinaudo/kantan.csv_2.10/jars/kantan.csv_2.10-0.1.8.jar(kantan/csv/CsvOutput.class)
[error] error while loading RowEncoder, Missing dependency 'bad symbolic reference. A signature in RowEncoder.class refers to term simulacrum
[error] in package <root> which is not available.
[error] It may be completely missing from the current classpath, or the version on
[error] the classpath might be incompatible with the version used when compiling RowEncoder.class.', required by /Users/neville/.ivy2/cache/com.nrinaudo/kantan.csv_2.10/jars/kantan.csv_2.10-0.1.8.jar(kantan/csv/RowEncoder.class)
[error] error while loading CellEncoder, Missing dependency 'bad symbolic reference. A signature in CellEncoder.class refers to term simulacrum
[error] in package <root> which is not available.
[error] It may be completely missing from the current classpath, or the version on
[error] the classpath might be incompatible with the version used when compiling CellEncoder.class.', required by /Users/neville/.ivy2/cache/com.nrinaudo/kantan.csv_2.10/jars/kantan.csv_2.10-0.1.8.jar(kantan/csv/CellEncoder.class)
[error] 5 errors found
[error] (scio-repl/compile:compileIncremental) Compilation failed
```