### PR TITLE
Allow for formatting in fromTable

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
@@ -89,7 +89,7 @@ object BigQueryType {
    * Also generate a companion object with convenience methods.
    * @group annotation
    */
-  class fromTable(tableSpec: String) extends StaticAnnotation {
+  class fromTable(tableSpec: String, args: String*) extends StaticAnnotation {
     def macroTransform(annottees: Any*): Any = macro TypeProvider.tableImpl
   }
 


### PR DESCRIPTION
If a user has multiple tables to read from, which all share the same
schema, she might define table spec with formatting inside, but
current API `fromTable` does not allow for extra arguments.