### PR TITLE
Do not override df appName if set by user

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -125,8 +125,10 @@ class ScioContext private[scio] (val options: DataflowPipelineOptions,
 
   import Implicits._
 
-  // Set default name
-  this.setName(CallSites.getAppName)
+  // Set default name if no app name specified by user
+  if (options.getAppName == null) {
+    this.setName(CallSites.getAppName)
+  }
 
   /** Dataflow pipeline. */
   def pipeline: Pipeline = {


### PR DESCRIPTION
I ran into problems with this setting when running multiple jobs from the same jvm instance. Even though I passed the `--appName` argument, it got overridden by this line.