### PR TITLE
fix repl from sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,7 @@ lazy val root: Project = Project(
 ).settings(
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject
     -- inProjects(scioRepl) -- inProjects(scioSchemas) -- inProjects(scioExamples),
+  run <<= run in Compile in scioRepl,
   aggregate in assembly := false
 ).aggregate(
   scioCore,

--- a/build.sbt
+++ b/build.sbt
@@ -346,6 +346,16 @@ lazy val scioRepl: Project = Project(
     )
   )
 ).settings(
+    mainClass in (Compile,run) := {
+      if (scalaVersion.value.startsWith("2.10")) {
+        throw new UnsupportedOperationException(
+          "\n\n\tERROR: Can't start Scio REPL in SBT for scala 2.10.x. " +
+            "Upgrade to 2.11.x. or build REPL assembly jar.\n" +
+            "\tMore info https://github.com/spotify/scio/wiki/Scio-REPL\n\n")
+      }
+      Some("com.spotify.scio.repl.ScioShell")
+    }
+).settings(
   assemblyJarName in assembly := s"scio-repl-${version.value}.jar"
 ).dependsOn(
   scioCore,


### PR DESCRIPTION
After these fixes - scio shell can be started from both:
 * assembly jar via `java -jar <assembly-jar>`
 * sbt via `sbt run` or `sbt scio-repl/run`