### PR TITLE
Fix parsing of timestamp strings with missing fractional seconds; add unit test

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/package.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/package.scala
@@ -93,7 +93,10 @@ package object bigquery {
 
     private val hasMillisRx = """\.[0-9]+$""".r
 
-    private def tryParse(timestamp: String, priorException: Option[Throwable] = None): Try[Instant] = {
+    private def tryParse(
+      timestamp: String,
+      priorException: Option[Throwable] = None
+    ): Try[Instant] = {
       // try to parse with DateTime formatter; if failure, check timestamp
       // for missing fractional seconds and potentially try again
       Try(formatter.parseDateTime(timestamp).toInstant).recoverWith {

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/TimestampTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/TimestampTest.scala
@@ -17,7 +17,8 @@
 
 package com.spotify.scio.bigquery
 
-import org.joda.time.Instant
+import org.joda.time.{Instant, DateTime, DateTimeZone}
+import org.joda.time.format.DateTimeFormat
 import org.scalatest.{Matchers, FlatSpec}
 
 class TimestampTest extends FlatSpec with Matchers {
@@ -30,6 +31,13 @@ class TimestampTest extends FlatSpec with Matchers {
   it should "round trip Long" in {
     val now = Instant.now()
     Timestamp.parse(Timestamp(now.getMillis)) shouldBe now
+  }
+
+  it should "correctly parse timestamps with no fractional seconds" in {
+    val formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss")
+
+    val now = new DateTime(DateTimeZone.UTC)
+    Timestamp.parse(formatter.print(now)) shouldBe now.withMillisOfSecond(0)
   }
 
 }


### PR DESCRIPTION
I have encountered a failure due to BigQuery returning timestamps with missing fractional seconds.  In these instances, the timestamp parser throws an IllegalArgumentException because the expected pattern is "too short", e.g.: 
```
[info]   java.lang.IllegalArgumentException: Invalid format: "2016-06-28 22:13:29" is too short
[info]   at org.joda.time.format.DateTimeFormatter.parseDateTime(DateTimeFormatter.java:945)
[info]   at com.spotify.scio.bigquery.package$Timestamp$.parse(package.scala:95)
[info]   at com.spotify.scio.bigquery.TimestampTest$$anonfun$3.apply$mcV$sp(TimestampTest.scala:40)
[info]   at com.spotify.scio.bigquery.TimestampTest$$anonfun$3.apply(TimestampTest.scala:36)
[info]   at com.spotify.scio.bigquery.TimestampTest$$anonfun$3.apply(TimestampTest.scala:36)
```

Note that I received this error when querying tables that I generated using `scio-bigquery`, with input data that originally did not contain any fractional seconds.  I'm not quite sure why BigQuery does not return zeros in the fractional second columns when they are queried, but this revision ensures that the parser does not break when this happens.

I added a unit test for this condition, which will illustrate the failure when run without the changes to package.scala in place.