### PR TITLE
add function to update the number of bigtable nodes

### DIFF
--- a/scio-bigtable/src/main/java/com/spotify/scio/bigtable/BigtableMultiTableWrite.java
+++ b/scio-bigtable/src/main/java/com/spotify/scio/bigtable/BigtableMultiTableWrite.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.scio.bigtable;
 
 import com.google.api.client.util.Lists;

--- a/scio-bigtable/src/main/java/com/spotify/scio/bigtable/BigtableUtil.java
+++ b/scio-bigtable/src/main/java/com/spotify/scio/bigtable/BigtableUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.bigtable;
+
+import com.google.bigtable.repackaged.com.google.cloud.config.BigtableOptions;
+import com.google.bigtable.repackaged.com.google.cloud.grpc.io.ChannelPool;
+import com.google.bigtable.repackaged.com.google.com.google.bigtable.admin.v2.Cluster;
+import com.google.bigtable.repackaged.com.google.com.google.bigtable.admin.v2.ListClustersRequest;
+import com.google.bigtable.repackaged.com.google.com.google.bigtable.admin.v2.BigtableInstanceAdminGrpc;
+import com.google.bigtable.repackaged.com.google.com.google.bigtable.admin.v2.BigtableInstanceAdminGrpc.BigtableInstanceAdminBlockingStub;
+import com.google.bigtable.repackaged.com.google.com.google.bigtable.admin.v2.ListClustersResponse;
+import com.google.cloud.bigtable.dataflow.CloudBigtableConfiguration;
+import org.joda.time.Duration;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utilities to deal with Bigtable.
+ */
+public final class BigtableUtil {
+
+  private BigtableUtil() { }
+
+  /**
+   * Updates all clusters within the specified Bigtable Instance to have a specified number
+   * of nodes. Useful for increasing the number of nodes at the start of the job and decreasing
+   * it at the end to lower costs yet still get high throughput during bulk ingests/dumps.
+   *
+   * @param cloudBigtableConfiguration Configuration of Bigtable Instance
+   * @param numberOfNodes Number of nodes to make cluster
+   * @param sleepDuration How long to sleep after updating the number of nodes. Google recommends
+   *                      at least 20 minutes before the new nodes are fully functional
+   * @throws IOException If setting up channel pool fails
+   * @throws InterruptedException If sleep fails
+   */
+  public static void updateNumberOfBigtableNodes(final CloudBigtableConfiguration cloudBigtableConfiguration,
+                                                 final int numberOfNodes,
+                                                 final Duration sleepDuration) throws IOException, InterruptedException {
+    final BigtableOptions bigtableOptions = cloudBigtableConfiguration.toBigtableOptions();
+    final ChannelPool channelPool = ChannelPoolCreator.createPool(bigtableOptions.getClusterAdminHost());
+    final BigtableInstanceAdminBlockingStub adminGrpc = BigtableInstanceAdminGrpc.newBlockingStub(channelPool);
+
+    final String instanceName = bigtableOptions.getInstanceName().toString();
+
+    // Fetch clusters in Bigtable instance
+    final ListClustersRequest clustersRequest = ListClustersRequest.newBuilder().setParent(instanceName).build();
+    final ListClustersResponse clustersResponse = adminGrpc.listClusters(clustersRequest);
+
+    // For each cluster update the number of nodes
+    for (Cluster cluster : clustersResponse.getClustersList()) {
+      final Cluster updatedCluster = Cluster.newBuilder()
+              .setName(cluster.getName())
+              .setServeNodes(numberOfNodes)
+              .build();
+      adminGrpc.updateCluster(updatedCluster);
+    }
+
+    // Wait for the new nodes to be provisioned
+    Thread.sleep(TimeUnit.SECONDS.toMillis(sleepDuration.getStandardSeconds()));
+    channelPool.shutdownNow();
+  }
+}

--- a/scio-bigtable/src/main/java/com/spotify/scio/bigtable/ChannelPoolCreator.java
+++ b/scio-bigtable/src/main/java/com/spotify/scio/bigtable/ChannelPoolCreator.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
 package com.spotify.scio.bigtable;
 
 import com.google.bigtable.repackaged.com.google.cloud.config.BigtableOptions;

--- a/scio-bigtable/src/main/java/com/spotify/scio/bigtable/ChannelPoolCreator.java
+++ b/scio-bigtable/src/main/java/com/spotify/scio/bigtable/ChannelPoolCreator.java
@@ -1,0 +1,35 @@
+package com.spotify.scio.bigtable;
+
+import com.google.bigtable.repackaged.com.google.cloud.config.BigtableOptions;
+import com.google.bigtable.repackaged.com.google.cloud.grpc.BigtableSession;
+import com.google.bigtable.repackaged.com.google.cloud.grpc.io.ChannelPool;
+import com.google.bigtable.repackaged.com.google.cloud.grpc.io.CredentialInterceptorCache;
+import com.google.bigtable.repackaged.com.google.cloud.grpc.io.HeaderInterceptor;
+import com.google.bigtable.repackaged.io.grpc.ManagedChannel;
+import com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ChannelPoolCreator {
+  public static final BigtableOptions options = new BigtableOptions.Builder().build();
+  public static List<HeaderInterceptor> interceptors;
+
+  static {
+    try {
+      interceptors = ImmutableList.of(CredentialInterceptorCache.getInstance()
+              .getCredentialsInterceptor(options.getCredentialOptions(), options.getRetryOptions()));
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static ChannelPool createPool(final String host) throws IOException {
+    return new ChannelPool(interceptors, new ChannelPool.ChannelFactory() {
+      @Override
+      public ManagedChannel create() throws IOException {
+        return BigtableSession.createNettyChannel(host, options);
+      }
+    });
+  }
+}

--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/Bigtable.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/Bigtable.scala
@@ -17,14 +17,8 @@
 
 package com.spotify.scio.bigtable
 
-import java.util.concurrent.TimeUnit
-
-import com.google.bigtable.repackaged.com.google.com.google.bigtable.admin.v2.{BigtableInstanceAdminGrpc, Cluster, ListClustersRequest}
-import com.google.cloud.bigtable.dataflow.{CloudBigtableConfiguration, CloudBigtableOptions}
+import com.google.cloud.bigtable.dataflow.CloudBigtableOptions
 import com.spotify.scio.ScioContext
-import org.joda.time.Duration
-
-import scala.collection.JavaConverters._
 
 /** Utilities for Bigtable. */
 object Bigtable {
@@ -32,43 +26,5 @@ object Bigtable {
   /** Parse CloudBigtableOptions from command line arguments. */
   def parseOptions(args: Array[String]): CloudBigtableOptions =
     ScioContext.parseArguments[CloudBigtableOptions](args)._1
-
-  /**
-    * Updates all clusters within the specified Bigtable Instance to have a specified number
-    * of nodes. Useful for increasing the number of nodes at the start of the job and decreasing
-    * it at the end to lower costs yet still get high throughput during bulk ingests/dumps.
-    *
-    * @param cloudBigtableConfiguration Configuration of Bigtable Instance
-    * @param numberOfNodes Number of nodes to make cluster
-    * @param sleepDuration How long to sleep after updating the number of nodes. Google recommends
-    *                      at least 20 minutes before the new nodes are fully functional
-    */
-  def updateNumberOfBigtableNodes(cloudBigtableConfiguration: CloudBigtableConfiguration,
-                                  numberOfNodes: Int,
-                                  sleepDuration: Duration = Duration.standardMinutes(20)): Unit = {
-    val bigtableOptions = cloudBigtableConfiguration.toBigtableOptions
-    val channel = ChannelPoolCreator.createPool(bigtableOptions.getClusterAdminHost)
-    val adminGrpc = BigtableInstanceAdminGrpc.newBlockingStub(channel)
-
-    val instanceName = bigtableOptions.getInstanceName.toString
-
-    // Fetch clusters in Bigtable instance
-    val clustersRequest = ListClustersRequest.newBuilder().setParent(instanceName).build()
-    val clustersResponse = adminGrpc.listClusters(clustersRequest)
-
-    // For each cluster update the number of nodes
-    clustersResponse.getClustersList.asScala.foreach(cluster => {
-      val updatedCluster = Cluster.newBuilder()
-        .setName(cluster.getName)
-        .setServeNodes(numberOfNodes)
-        .build
-      adminGrpc.updateCluster(updatedCluster)
-    })
-
-    // Wait for the new nodes to be provisioned
-    Thread.sleep(TimeUnit.SECONDS.toMillis(sleepDuration.getStandardSeconds))
-
-    channel.shutdownNow()
-  }
 
 }

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BigtableExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BigtableExample.scala
@@ -23,6 +23,7 @@ import com.spotify.scio.bigtable._
 import com.spotify.scio.examples.common.ExampleData
 import com.spotify.scio.values.SCollection
 import org.apache.hadoop.hbase.client.{Put, Result}
+import org.joda.time.Duration
 
 /*
  * Bigtable examples.
@@ -59,6 +60,9 @@ object BigtableWriteExample {
     val btOptions = Bigtable.parseOptions(cmdlineArgs)
     val config = bt.CloudBigtableTableConfiguration.fromCBTOptions(btOptions )
 
+    // bump up the number of bigtable nodes before writing
+    sc.updateNumberOfBigtableNodes(config, 15)
+
     sc.textFile(args.getOrElse("input", ExampleData.KING_LEAR))
       .flatMap(_.split("[^a-zA-Z']+").filter(_.nonEmpty))
       .countByValue
@@ -66,6 +70,10 @@ object BigtableWriteExample {
       .saveAsBigtable(config)
 
     sc.close()
+
+    // Bring down the number of nodes after the job ends.
+    // There is no need to wait after bumping the nodes down.
+    sc.updateNumberOfBigtableNodes(config, 3, Duration.ZERO)
   }
 }
 
@@ -88,11 +96,18 @@ object BigtableReadExample {
     val btOptions = Bigtable.parseOptions(cmdlineArgs)
     val config = bt.CloudBigtableScanConfiguration.fromCBTOptions(btOptions)
 
+    // bump up the number of bigtable nodes before writing
+    sc.updateNumberOfBigtableNodes(config, 15)
+
     sc.bigTable(config)
       .map(BigtableExample.result)
       .saveAsTextFile(args("output"))
 
     sc.close()
+
+    // Bring down the number of nodes after the job ends.
+    // There is no need to wait after bumping the nodes down.
+    sc.updateNumberOfBigtableNodes(config, 3, Duration.ZERO)
   }
 }
 


### PR DESCRIPTION
@nevillelyh @ravwojdyla Should save a lot of money to be able to update the number of nodes before and after a job. 

Tested and this does work. Perhaps I should add it to the examples?