### PR TITLE
Added functions for join-filtering.

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -493,6 +493,16 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)])
   def keys: SCollection[K] = self.map(_._1)
 
   /**
+   * Return an SCollection with the pairs from `this` whose keys are in `that`.
+   * @group per_key
+   */
+  def intersectByKey(that: SCollection[K]): SCollection[(K, V)] = self.transform {
+    _.cogroup(that.map((_, ()))).flatMap { t =>
+      if (t._2._1.nonEmpty && t._2._2.nonEmpty) t._2._1.map((t._1, _)) else Seq.empty
+    }
+  }
+
+  /**
    * Pass each value in the key-value pair SCollection through a map function without changing the
    * keys.
    * @group transform

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -474,7 +474,7 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support skewJoin() with empty key count (no hash join)" in {
+  it should "support skewedJoin() with empty key count (no hash join)" in {
     import com.twitter.algebird.CMSHasherImplicits._
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("a", 2)))
@@ -494,6 +494,42 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
       val rhs = sc.parallelize(Seq[(String, Unit)]())
       val result = lhs.join(rhs)
       result should beEmpty
+    }
+  }
+
+  it should "support intersectByKey()" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
+      val p2 = sc.parallelize(Seq("a", "b", "d"))
+      val p = p1.intersectByKey(p2)
+      p should containInAnyOrder (Seq(("a", 1), ("b", 2)))
+    }
+  }
+
+  it should "support intersectByKey() with duplicate keys" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3), ("b", 4)))
+      val p2 = sc.parallelize(Seq("a", "b", "b", "d"))
+      val p = p1.intersectByKey(p2)
+      p should containInAnyOrder (Seq(("a", 1), ("b", 2), ("b", 4)))
+    }
+  }
+
+  it should "support intersectByKey() with empty LHS" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq[(String, Any)]())
+      val p2 = sc.parallelize(Seq("a", "b", "d"))
+      val p = p1.intersectByKey(p2)
+      p should beEmpty
+    }
+  }
+
+  it should "support intersectByKey() with empty RHS" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3), ("b", 4)))
+      val p2 = sc.parallelize(Seq[String]())
+      val p = p1.intersectByKey(p2)
+      p should beEmpty
     }
   }
 }


### PR DESCRIPTION
@nevillelyh @rav RFC please. I often see code to filter an SCollection[(K, V)] by another one of type SCollection[K], where (k, v) pairs are filtered out if k is not present on the right hand side. It usually looks like this:

```
val s1: SCollection[(K, V)] = getIt()
val s2: SCollection[K] = getThat()

val filtered: SCollection[(K, V)] = 
    s1.join(s2.distinct.map(_, ())).map{ case(k, (v, _)) => (k, v)}
```

I find this pattern doesn't really speak to the high level intent of the operation, and personally it always takes me a bit of staring to understand what's happening when I see it. So I thought it might be useful to include in the core API. The equivalent of the above would look like this:

```
val s1: SCollection[(K, V)] = getIt()
val s2: SCollection[K] = getThat()

val filtered: SCollection[(K, V)] = s1.filterJoin(s2)
```

Do you consider this useful at all? Is there a more obvious way of doing this that I'm not thinking about? If you do think it's useful, any suggestions on naming? `filterJoin` is the first thing that came to mind since I'm implementing this on top of join but there's probably a better name. Similar functionality is achieved in a plain `SCollection[K]` via `intersect`, which internally converts both collections to a dummy `SCollection[(K, V)]`, and inner join is the equivalent for `SCollection[(K, V)], SCollection[(K, W)]`. Maybe `keyIntersect` is a better name.