### PR TITLE
bump dataflowSdkVersion to 1.6.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ import com.typesafe.sbt.SbtGit.GitKeys.gitRemoteRepo
 import sbtunidoc.Plugin.UnidocKeys._
 import com.trueaccord.scalapb.{ScalaPbPlugin => PB}
 
-val dataflowSdkVersion = "1.6.0"
+val dataflowSdkVersion = "1.6.1"
 val algebirdVersion = "0.12.1"
 val avroVersion = "1.7.7"
 val bigtableVersion = "0.9.1"


### PR DESCRIPTION
There is a big bug on GZIP compression in the 1.6.0. The 1.6.1 was released to fix this: https://github.com/GoogleCloudPlatform/DataflowJavaSDK/issues/356