### PR TITLE
Add skewing to timestampBy

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithWindowedValue.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithWindowedValue.scala
@@ -51,12 +51,4 @@ private[scio] object FunctionsWithWindowedValue {
     }
   }
 
-  def timestampFn[T](f: T => Instant): DoFn[T, T] = new WindowDoFn[T, T] {
-    val g = ClosureCleaner(f)  // defeat closure
-    override def processElement(c: DoFn[T, T]#ProcessContext): Unit = {
-      val t = c.element()
-      c.outputWithTimestamp(t, g(t))
-    }
-  }
-
 }

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -774,10 +774,12 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
 
   /**
    * Assign timestamps to values.
+   * With a optional skew
    * @group window
    */
-  def timestampBy(f: T => Instant): SCollection[T] =
-    this.parDo(FunctionsWithWindowedValue.timestampFn(f))
+  def timestampBy(f: T => Instant, allowedTimestampSkew: Duration = Duration.ZERO): SCollection[T] =
+    this.applyTransform(WithTimestamps.of(Functions.serializableFn(f))
+      .withAllowedTimestampSkew(allowedTimestampSkew))
 
   // =======================================================================
   // Write operations

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -443,4 +443,13 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
+  it should "support timestampBy() with skew"  in {
+    runWithContext { sc =>
+      val p = sc.parallelize(Seq(1, 2, 3))
+      val r = p.timestampBy(new Instant(_), Duration.millis(1))
+        .withTimestamp.map(kv => (kv._1, kv._2.getMillis))
+      r should containInAnyOrder (Seq((1, 1L), (2, 2L), (3, 3L)))
+    }
+  }
+
 }


### PR DESCRIPTION
This skewing thing is only useful when using streaming jobs, and a custom timestamp.

As I'm not 100% about the difference between `DoFn.ProcessContext.outputWithTimestamp` and `WithTimestamps` I preferred to use the latest.

Further more, the skew is [disabled by default](https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/DoFn.java#L292-L311) as the one in `WithTimestamps` [is not](https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/sdk/src/main/java/com/google/cloud/dataflow/sdk/transforms/WithTimestamps.java#L124-L127).