### PR TITLE
fix(FileStorage): Catch and handle IOException gracefully

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
@@ -62,7 +62,9 @@ private trait FileStorage {
     } else {
       new GenericDatumReader[T](schema)
     }
-    new DataFileStream[T](getDirectoryInputStream(path), reader).iterator().asScala
+    Try(
+      new DataFileStream[T](getDirectoryInputStream(path), reader).iterator().asScala
+    ).getOrElse(Iterator[T]())
   }
 
   def textFile: Iterator[String] =

--- a/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
@@ -175,6 +175,20 @@ class JobTestTest extends PipelineSpec {
     }
   }
 
+  def testEmptyAvroFileJob(): Unit = {
+    JobTest[GenericAvroFileJob.type]
+      .args("--input=in.avro", "--output=out.avro")
+      .input(AvroIO(""), (1 to 3).map(newGenericRecord))
+      .output[GenericRecord](AvroIO("out.avro"))(_ should haveSize(0))
+      .run()
+  }
+
+  it should "handle empty Avro file" in {
+    an [AssertionError] should not be thrownBy {
+      testEmptyAvroFileJob()
+    }
+  }
+
   def newTableRow(i: Int): TableRow = TableRow("int_field" -> i)
 
   def testBigQuery(xs: Seq[TableRow]): Unit = {


### PR DESCRIPTION
When an Avro file is read, a `java.io.IOException` is thrown if the file
doesn't exist.

This commit makes `scio.io.FileStorage` return an `Iterator[T]()` instead of
letting the Java exception propagates.