### PR TITLE
detect BigQuery location #226

### DIFF
--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/BigQueryUtilTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/BigQueryUtilTest.scala
@@ -41,15 +41,4 @@ class BigQueryUtilTest extends FlatSpec with Matchers {
     BigQueryUtil.parseSchema(schema.toString) should equal (schema)
   }
 
-  "extractTables" should "work" in {
-    val t1 = BigQueryIO.parseTableSpec("my-project:dataset_a.table_a")
-    val t2 = BigQueryIO.parseTableSpec("dataset_b.table_b")
-    BigQueryUtil.extractLegacyTables(
-      """
-        |SELECT col1, col2
-        |FROM [my-project:dataset_a.table_a] JOIN [dataset_b.table_b]
-        |GROUP BY col1
-      """.stripMargin) should equal (Set(t1, t2))
-  }
-
 }


### PR DESCRIPTION
BigQuery dry-run now supports both legacy and SQL syntax and will return tables accessed by the query. We can fetch their locations when creating staging dataset.
This will deprecate `-Dbigquery.staging_dataset.location`.