### PR TITLE
Update to Datastore API v1

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -24,8 +24,8 @@ import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 import java.util.jar.{Attributes, JarFile}
 
+import com.google.datastore.v1.{Query, Entity}
 import com.google.api.services.bigquery.model.TableReference
-import com.google.api.services.datastore.DatastoreV1.{Entity, Query}
 import com.google.cloud.dataflow.sdk.Pipeline
 import com.google.cloud.dataflow.sdk.PipelineResult.State
 import com.google.cloud.dataflow.sdk.coders.TableRowJsonCoder
@@ -457,17 +457,16 @@ class ScioContext private[scio] (val options: PipelineOptions,
    * Get an SCollection for a Datastore query.
    * @group input
    */
-  def datastore(datasetId: String, query: Query, namespace: String = null): SCollection[Entity] =
+  def datastore(projectId: String, query: Query, namespace: String = null): SCollection[Entity] =
     pipelineOp {
       if (this.isTest) {
-        this.getTestInput(DatastoreIO(datasetId, query, namespace))
+        this.getTestInput(DatastoreIO(projectId, query, namespace))
       } else {
         wrap(this.applyInternal(
-          gio.Read.from(
-            gio.DatastoreIO.source()
-              .withDataset(datasetId)
-              .withNamespace(namespace)
-              .withQuery(query))))
+          gio.datastore.DatastoreIO.v1().read()
+            .withProjectId(projectId)
+            .withNamespace(namespace)
+            .withQuery(query)))
       }
     }
 

--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -18,7 +18,7 @@
 package com.spotify.scio.testing
 
 import com.google.api.services.bigquery.model.TableRow
-import com.google.api.services.datastore.DatastoreV1.{Entity, Query}
+import com.google.datastore.v1.{Entity, Query}
 import com.spotify.scio.values.SCollection
 
 import scala.collection.mutable.{Map => MMap, Set => MSet}
@@ -101,8 +101,8 @@ case class AvroIO[T](path: String) extends TestIO(path)
 
 case class BigQueryIO(tableSpecOrQuery: String) extends TestIO[TableRow](tableSpecOrQuery)
 
-case class DatastoreIO(datasetId: String, query: Query = null, namespace: String = null)
-  extends TestIO[Entity](s"$datasetId\t$query\t$namespace")
+case class DatastoreIO(projectId: String, query: Query = null, namespace: String = null)
+  extends TestIO[Entity](s"$projectId\t$query\t$namespace")
 
 case class PubsubIO(topic: String) extends TestIO[String](topic)
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/WordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/WordCount.scala
@@ -24,13 +24,11 @@ import com.spotify.scio.accumulators._
 import com.spotify.scio.examples.common.ExampleData
 
 /*
-SBT
-runMain
-  com.spotify.scio.examples.WordCount
+sbt "scio-examples/runMain com.spotify.scio.examples.WordCount
   --project=[PROJECT] --runner=DataflowPipelineRunner --zone=[ZONE]
   --stagingLocation=gs://[BUCKET]/dataflow/staging
   --input=gs://dataflow-samples/shakespeare/kinglear.txt
-  --output=gs://[BUCKET]/[PATH]/wordcount
+  --output=gs://[BUCKET]/[PATH]/wordcount"
 */
 
 object WordCount {

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/AutoComplete.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/AutoComplete.scala
@@ -17,16 +17,17 @@
 
 package com.spotify.scio.examples.complete
 
+import com.google.datastore.v1.client.DatastoreHelper.{makeKey, makeValue}
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
-import com.google.api.services.datastore.DatastoreV1.Entity
-import com.google.api.services.datastore.client.DatastoreHelper
 import com.google.cloud.dataflow.examples.common.DataflowExampleUtils
 import com.google.cloud.dataflow.sdk.runners.DataflowPipelineRunner
+import com.google.datastore.v1.Entity
 import com.spotify.scio._
 import com.spotify.scio.bigquery._
 import com.spotify.scio.examples.common.{ExampleData, ExampleOptions}
 import com.spotify.scio.values.SCollection
 import org.joda.time.Duration
+import com.google.common.collect.ImmutableMap
 
 import scala.collection.JavaConverters._
 
@@ -78,17 +79,17 @@ object AutoComplete {
     }
 
   def makeEntity(kind: String, kv: (String, Iterable[(String, Long)])): Entity = {
-    val key = DatastoreHelper.makeKey(kind, kv._1).build();
+    val key = makeKey(kind, kv._1).build()
     val candidates = kv._2.map { p =>
-      DatastoreHelper.makeValue(Entity.newBuilder()
-        .addProperty(DatastoreHelper.makeProperty("tag", DatastoreHelper.makeValue(p._1)))
-        .addProperty(DatastoreHelper.makeProperty("count", DatastoreHelper.makeValue(p._2)))
-      ).setIndexed(false).build()
+      makeValue(Entity.newBuilder()
+        .putAllProperties(ImmutableMap.of(
+          "tag", makeValue(p._1).build(),
+          "count", makeValue(p._2).build()))
+      ).build()
     }
     Entity.newBuilder()
       .setKey(key)
-      .addProperty(
-        DatastoreHelper.makeProperty("candidates", DatastoreHelper.makeValue(candidates.asJava)))
+      .putAllProperties(ImmutableMap.of("candidates", makeValue(candidates.asJava).build()))
       .build()
   }
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/DatastoreWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/DatastoreWordCount.scala
@@ -30,15 +30,13 @@ import com.spotify.scio.examples.common.ExampleData
 import scala.collection.JavaConverters._
 
 /*
-SBT
-runMain
-  com.spotify.scio.examples.cookbook.DatastoreWordCount
+sbt "scio-examples/runMain com.spotify.scio.examples.cookbook.DatastoreWordCount
   --project=[PROJECT] --runner=BlockingDataflowPipelineRunner --zone=[ZONE]
   --stagingLocation=gs://[BUCKET]/dataflow/staging
   --input=gs://dataflow-samples/shakespeare/kinglear.txt
   --output=gs://[BUCKET]/[PATH]/datastore_wordcount
   --dataset=[PROJECT]
-  --readOnly=false
+  --readOnly=false"
 */
 
 object DatastoreWordCount {

--- a/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
@@ -17,8 +17,9 @@
 
 package com.spotify.scio.testing
 
-import com.google.api.services.datastore.DatastoreV1.Entity
-import com.google.api.services.datastore.client.DatastoreHelper
+import com.google.common.collect.ImmutableMap
+import com.google.datastore.v1.Entity
+import com.google.datastore.v1.client.DatastoreHelper.{makeKey, makeValue}
 import com.spotify.scio._
 import com.spotify.scio.avro.AvroUtils.{newGenericRecord, newSpecificRecord}
 import com.spotify.scio.avro.{AvroUtils, TestRecord}
@@ -195,8 +196,8 @@ class JobTestTest extends PipelineSpec {
   }
 
   def newEntity(i: Int): Entity = Entity.newBuilder()
-    .setKey(DatastoreHelper.makeKey())
-    .addProperty(DatastoreHelper.makeProperty("int_field", DatastoreHelper.makeValue(i)))
+    .setKey(makeKey())
+    .putAllProperties(ImmutableMap.of("int_field", makeValue(i).build()))
     .build()
 
   def testDatastore(xs: Seq[Entity]): Unit = {


### PR DESCRIPTION
Dataflow SDK 1.7.0 supports both Datastore API v1beta2 and v1, the latter being the newest and the former scheduled for decommissioning at end of month.

We're currently using v1beta2. This PR moves us to v1. (#256)

Note: There is a known bug in `google-cloud-java` which may manifest itself in scio users getting `java.lang.VerifyError` when trying to build Datastore `Value` objects. The bug, a workaround, and progress on fixing it are tracked in https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1239