### PR TITLE
Add filterNot()

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -303,6 +303,12 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     this.pApply(Filter.byPredicate(Functions.serializableFn(f.asInstanceOf[T => JBoolean])))
 
   /**
+   * Return a new SCollection containing only the elements that do not satisfy the given predicate.
+   * @group transform
+   */
+  def filterNot(f: T => Boolean): SCollection[T] = this.filter(!f(_))
+
+  /**
    * Return a new SCollection by first applying a function to all elements of
    * this SCollection, and then flattening the results.
    * @group transform

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -196,6 +196,13 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
+  it should "support filterNot()" in {
+    runWithContext { sc =>
+      val p = sc.parallelize(Seq(1, 2, 3, 4, 5)).filterNot(_ % 2 == 0)
+      p should containInAnyOrder (Seq(1, 3, 5))
+    }
+  }
+
   it should "support flatMap()" in {
     runWithContext { sc =>
       val p = sc.parallelize(Seq("a b c", "d e", "f")).flatMap(_.split(" "))


### PR DESCRIPTION
@nevillelyh @ravwojdyla I know it's basically the same as the user just negating the predicate, but is this good to have just for the sake of consistency with Scalding API?
