### PR TITLE
Allow access to unformatted query/table

### DIFF
--- a/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/types/BigQueryTypeIT.scala
+++ b/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/types/BigQueryTypeIT.scala
@@ -94,11 +94,10 @@ class BigQueryTypeIT extends FlatSpec with Matchers {
 
   "fromTable" should "work" in {
     val bqt = BigQueryType[FromTableT]
-    val tableRef = BigQueryIO.parseTableSpec("bigquery-public-data:samples.shakespeare")
     bqt.isQuery should be (false)
     bqt.isTable should be (true)
     bqt.query should be (None)
-    bqt.table should be (Some(tableRef))
+    bqt.table should be (Some("bigquery-public-data:samples.shakespeare"))
     val fields = bqt.schema.getFields.asScala
     fields.size should be (4)
     fields.map(_.getName) should equal (Seq("word", "word_count", "corpus", "corpus_date"))

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
@@ -56,7 +56,7 @@ object BigQueryType {
    */
   trait HasTable {
     /** Table for case class schema. */
-    def table: TableReference
+    def table: String
   }
 
   /**
@@ -227,7 +227,7 @@ class BigQueryType[T: TypeTag] {
   def isQuery: Boolean = classOf[BigQueryType.HasQuery] isAssignableFrom instance.getClass
 
   /** Table reference from the annotation. */
-  def table: Option[TableReference] = Try(getField("table").asInstanceOf[TableReference]).toOption
+  def table: Option[String] = Try(getField("table").asInstanceOf[String]).toOption
 
   /** Query from the annotation. */
   def query: Option[String] = Try(getField("query").asInstanceOf[String]).toOption

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -45,7 +45,7 @@ private[types] object TypeProvider {
     val tableSpec = formatString(args)
     val schema = bigquery.getTableSchema(tableSpec)
     val traits = List(tq"${p(c, SType)}.HasTable")
-    val overrides = List(q"override def table: ${p(c, GModel)}.TableReference = ${p(c, GBQIO)}.parseTableSpec($tableSpec)")
+    val overrides = List(q"override def table: _root_.java.lang.String = ${args.head}")
 
     schemaToType(c)(schema, annottees, traits, overrides)
   }


### PR DESCRIPTION
This is RFC. Let me know what you think and if there is better way to implement it - i went for the simplest possible way here.

This allows to for example:

```
@BigQueryType.fromTable("project:dataset.table_%s", "20160530") class TT

sc.typedBigQuery[TT](TT.unformattedTable.format(args("tbldate")))
```

thus reduce the smell of duplicating the table/query string or getting formatted table/query (`BQT.{query, table}`) and reversing formatting by hand.

- [x] get feedback
- [x] decide on implementation
- [x] add tests