### PR TITLE
Force bigquery tests to be run in series.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -251,6 +251,7 @@ lazy val scioBigQuery: Project = Project(
     else
       Nil
   ),
+  parallelExecution in Test := (scalaBinaryVersion.value != "2.10"),
   addCompilerPlugin(paradiseDependency)
 ).configs(IntegrationTest)
 


### PR DESCRIPTION
@nevillelyh @ravwojdyla I've noticed the builds for scala 2.10 have been very flaky (recently it seems?) and I found out it's a problem with thread safety and runtime reflection in scala 2.10 (see here: http://docs.scala-lang.org/overviews/reflection/thread-safety.html). I haven't figured out yet why the problem is worse now, but forcing the tests to run sequentially seems to fix the problem. We won't have to worry about this once we drop scala 2.10.