### PR TITLE
Expose ScioResult metrics

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
@@ -29,6 +29,7 @@ import com.google.cloud.dataflow.sdk.util._
 import com.google.cloud.dataflow.sdk.{Pipeline, PipelineResult}
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.Accumulator
+import com.spotify.scio.metrics._
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -68,7 +69,6 @@ class ScioResult private[scio] (val internal: PipelineResult,
     getAggregatorValues(acc).flatMap(_.getValuesAtSteps.asScala).toMap
   }
 
-  // scalastyle:off method.length
   /** Save metrics of the finished pipeline to a file. */
   def saveMetrics(filename: String): Unit = {
     require(isCompleted, "Pipeline has to be finished to save metrics.")
@@ -81,80 +81,59 @@ class ScioResult private[scio] (val internal: PipelineResult,
         out.close()
       }
     }
+  }
 
-    def getMetrics: MetricSchema.Metrics = {
-      import MetricSchema._
-
-      val totalValues = accumulators
+  /** Get metrics of the finished pipeline. */
+  def getMetrics: Metrics = {
+    val totalValues = accumulators
         .map(acc => AccumulatorValue(acc.name, accumulatorTotalValue(acc)))
 
-      val stepsValues = accumulators.map(acc => AccumulatorStepsValue(acc.name,
-        accumulatorValuesAtSteps(acc).map(a => AccumulatorStepValue(a._1, a._2))))
+    val stepsValues = accumulators.map(acc => AccumulatorStepsValue(acc.name,
+      accumulatorValuesAtSteps(acc).map(a => AccumulatorStepValue(a._1, a._2))))
 
-      val options = this.pipeline.getOptions
+    val options = this.pipeline.getOptions
 
-      val (jobId, dfMetrics) = if (ScioUtil.isLocalRunner(options)) {
-        // to be safe let's use app name at a cost of duplicate for local runner
-        // there are no dataflow service metrics on local runner
-        (options.as(classOf[ApplicationNameOptions]).getAppName, Nil)
-      } else {
-        val jobId = internal.asInstanceOf[DataflowPipelineJob].getJobId
-        // given that this depends on internals of dataflow service - handle failure gracefully
-        // if there is an error - no dataflow service metrics will be saved
-        val dfMetrics = Try {
-          ScioUtil
-            .getDataflowServiceMetrics(options.as(classOf[DataflowPipelineOptions]), jobId)
-            .getMetrics.asScala
-            .map(e => {
-              val name = DFMetricName(e.getName.getName,
-                e.getName.getOrigin,
-                Option(e.getName.getContext)
-                  .getOrElse(Map.empty[String, String].asJava).asScala.toMap)
-              DFServiceMetrics(name, e.getScalar, e.getUpdateTime)
-            })
-        } match {
-          case Success(x) => x
-          case Failure(e) => {
-            logger.error(s"Failed to fetch dataflow metrics due to $e")
-            Nil
-          }
+    val (jobId, dfMetrics) = if (ScioUtil.isLocalRunner(options)) {
+      // to be safe let's use app name at a cost of duplicate for local runner
+      // there are no dataflow service metrics on local runner
+      (options.as(classOf[ApplicationNameOptions]).getAppName, Nil)
+    } else {
+      val jobId = internal.asInstanceOf[DataflowPipelineJob].getJobId
+      // given that this depends on internals of dataflow service - handle failure gracefully
+      // if there is an error - no dataflow service metrics will be saved
+      val dfMetrics = Try {
+        ScioUtil
+          .getDataflowServiceMetrics(options.as(classOf[DataflowPipelineOptions]), jobId)
+          .getMetrics.asScala
+          .map(e => {
+            val name = DFMetricName(e.getName.getName,
+              e.getName.getOrigin,
+              Option(e.getName.getContext)
+                    .getOrElse(Map.empty[String, String].asJava).asScala.toMap)
+            DFServiceMetrics(name, e.getScalar, e.getUpdateTime)
+          })
+      } match {
+        case Success(x) => x
+        case Failure(e) => {
+          logger.error(s"Failed to fetch dataflow metrics due to $e")
+          Nil
         }
-        (jobId, dfMetrics)
       }
-
-      Metrics(scioVersion,
-        scalaVersion,
-        options.as(classOf[ApplicationNameOptions]).getAppName,
-        jobId,
-        this.state.toString,
-        AccumulatorMetrics(totalValues, stepsValues),
-        dfMetrics
-        )
+      (jobId, dfMetrics)
     }
+
+    Metrics(scioVersion,
+      scalaVersion,
+      options.as(classOf[ApplicationNameOptions]).getAppName,
+      jobId,
+      this.state.toString,
+      AccumulatorMetrics(totalValues, stepsValues),
+      dfMetrics
+    )
   }
-  // scalastyle:on method.length
 
   private def getAggregatorValues[T](acc: Accumulator[T]): Iterable[AggregatorValues[T]] =
     aggregators.getOrElse(acc.name, Nil)
       .map(a => internal.getAggregatorValues(a.asInstanceOf[Aggregator[_, T]]))
 
-}
-
-private[scio] object MetricSchema {
-  case class Metrics(version: String,
-                     scalaVersion: String,
-                     jobName: String,
-                     jobId: String,
-                     state: String,
-                     accumulators: AccumulatorMetrics,
-                     cloudMetrics: Iterable[DFServiceMetrics])
-  case class DFServiceMetrics(name: DFMetricName,
-                              scalar: AnyRef,
-                              updateTime: String)
-  case class DFMetricName(name: String, origin: String, context: Map[String, String])
-  case class AccumulatorMetrics(total: Iterable[AccumulatorValue],
-                                steps: Iterable[AccumulatorStepsValue])
-  case class AccumulatorValue(name: String, value: Any)
-  case class AccumulatorStepValue(name: String, value: Any)
-  case class AccumulatorStepsValue(name: String, steps: Iterable[AccumulatorStepValue])
 }

--- a/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio
+
+/**
+  * This package contains the schema types for metrics collected during a pipeline run.
+  *
+  * See [[ScioResult.getMetrics]]
+  */
+package object metrics {
+  case class Metrics(version: String,
+      scalaVersion: String,
+      jobName: String,
+      jobId: String,
+      state: String,
+      accumulators: AccumulatorMetrics,
+      cloudMetrics: Iterable[DFServiceMetrics])
+  case class DFServiceMetrics(name: DFMetricName,
+      scalar: AnyRef,
+      updateTime: String)
+  case class DFMetricName(name: String, origin: String, context: Map[String, String])
+  case class AccumulatorMetrics(total: Iterable[AccumulatorValue],
+      steps: Iterable[AccumulatorStepsValue])
+  case class AccumulatorValue(name: String, value: Any)
+  case class AccumulatorStepValue(name: String, value: Any)
+  case class AccumulatorStepsValue(name: String, steps: Iterable[AccumulatorStepValue])
+}

--- a/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -25,7 +25,7 @@ import com.google.cloud.dataflow.sdk.runners.{DataflowPipelineRunner, DirectPipe
 import com.google.cloud.dataflow.sdk.testing.DataflowAssert
 import com.google.cloud.dataflow.sdk.transforms.Create
 import com.google.common.collect.Lists
-import com.spotify.scio.MetricSchema.Metrics
+import com.spotify.scio.metrics.Metrics
 import com.spotify.scio.options.ScioOptions
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.util.ScioUtil

--- a/scio-test/src/test/scala/com/spotify/scio/values/AccumulatorTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/AccumulatorTest.scala
@@ -149,7 +149,7 @@ class AccumulatorTest extends PipelineSpec {
     r.saveMetrics(metricsFile.toString)
 
     val mapper = ScioUtil.getScalaJsonMapper
-    import MetricSchema._
+    import com.spotify.scio.metrics._
 
     val metrics = mapper.readValue(metricsFile, classOf[Metrics])
 


### PR DESCRIPTION
This is useful when publishing the job metrics to other services from a Scala context, instead of having to go through the json file.

Not sure what the preferred package layout for the types are, feedback welcome.