### PR TITLE
Add default implicit conversion to PairSCollectionFunctions

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -80,6 +80,10 @@ object SCollection {
   : PairSCollectionFunctions[K, V] =
     new PairSCollectionFunctions(s)
 
+  /** Implicit conversion from SCollection[K] to PairSCollectionFunctions[K, Unit] */
+  implicit def makeDefaultPairSCollectionFunctions[K: ClassTag](s: SCollection[K])
+  : PairSCollectionFunctions[K, Unit] = new PairSCollectionFunctions[K, Unit](s.map((_, ())))
+
 }
 
 // scalastyle:off number.of.methods

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -209,6 +209,14 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
+  it should "support implicit conversion to default (K, V)" in {
+    runWithContext { sc =>
+      val p = sc.parallelize(Seq("a", "a", "b", "c"))
+        .countByKey
+      p should containInAnyOrder (Seq(("a", 2L), ("b", 1L), ("c", 1L)))
+    }
+  }
+
   it should "support keyBy()" in {
     runWithContext { sc =>
       val p = sc.parallelize(Seq("hello", "world")).keyBy(_.substring(0, 1))


### PR DESCRIPTION
@nevillelyh @ravwojdyla RFC. To address #360. This allows performing per-key operations on an `SCollection[T]` treating all the elements as keys.