### PR TITLE
Make transform public to allow chaining user-defined transforms.

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -124,7 +124,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     this.pApply(transform)
 
   /** Apply a transform. */
-  private[values] def transform[U: ClassTag](f: SCollection[T] => SCollection[U])
+  def transform[U: ClassTag](f: SCollection[T] => SCollection[U])
   : SCollection[U] = {
     val o = internal.apply(CallSites.getCurrent, new PTransform[PCollection[T], PCollection[U]]() {
       override def apply(input: PCollection[T]): PCollection[U] = {


### PR DESCRIPTION
This allows for better flow / readability when users define higher level transforms. For example:

```
def myTransformFn(in: SCollection[T]): SCollection[U] = ...

sc.textFile(...)
  .stuff
  .transform(myTransformFn)
  .etc
```

Instead of 

```
def myTransformFn(in: SCollection[T]): SCollection[U] = ...

val p = sc.textFile(...)
  .stuff

myTransformFn(p)
  .etc
```