### PR TITLE
[RFC] Support for user-defined functions in BQ client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 
 script:
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-      travis_wait 60 sbt -J-XX:ReservedCodeCacheSize=256m ++$TRAVIS_SCALA_VERSION -Dbigquery.project=data-integration-test -Dbigquery.secret=scripts/data-integration-test-421ab9f796e8.json clean scalastyle coverage test it:test coverageReport coverageAggregate;
+      travis_wait 60 sbt -J-XX:ReservedCodeCacheSize=256m ++$TRAVIS_SCALA_VERSION -Dbigquery.project=data-integration-test -Dbigquery.secret=scripts/data-integration-test-421ab9f796e8.json -Dbigquery.resource_uri=gs://data-integration-test-us/bigquery-js/lib.js clean scalastyle coverage test it:test coverageReport coverageAggregate;
     else
       ./scripts/travis.sh;
       travis_wait 60 sbt -J-XX:ReservedCodeCacheSize=256m ++$TRAVIS_SCALA_VERSION -Dbigquery.project=dummy-project clean scalastyle coverage test coverageReport coverageAggregate;

--- a/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/BigQueryClientIT.scala
+++ b/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/BigQueryClientIT.scala
@@ -32,6 +32,12 @@ class BigQueryClientIT extends FlatSpec with Matchers {
     "SELECT word, word_count FROM [bigquery-public-data:samples.shakespeare] LIMIT 10"
   val sqlQuery =
     "SELECT word, word_count FROM `bigquery-public-data.samples.shakespeare` LIMIT 10"
+  val legacyQueryWithUdf =
+    """
+      |SELECT bword
+      |FROM bigWords(SELECT word FROM [bigquery-public-data:samples.shakespeare]
+      | LIMIT 10)
+    """.stripMargin
 
   "extractLocation" should "work with legacy syntax" in {
     val query = "SELECT word FROM [data-integration-test:samples_%s.shakespeare]"
@@ -73,6 +79,13 @@ class BigQueryClientIT extends FlatSpec with Matchers {
       new TableFieldSchema().setName("word_count").setType("INTEGER").setMode("NULLABLE")
     ).asJava)
     bq.getQuerySchema(sqlQuery) should equal (expected)
+  }
+
+  it should "work with UDF legacy syntax" in {
+    val expected = new TableSchema().setFields(List(
+      new TableFieldSchema().setName("bword").setType("STRING").setMode("NULLABLE")
+    ).asJava)
+    bq.getQuerySchema(legacyQueryWithUdf) should equal (expected)
   }
 
   // scalastyle:off no.whitespace.before.left.bracket

--- a/scio-core/src/main/scala/com/spotify/scio/values/DistCache.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/DistCache.scala
@@ -28,7 +28,7 @@ import com.google.common.hash.Hashing
 import com.spotify.scio.util.ScioUtil
 import org.slf4j.{Logger, LoggerFactory}
 
-/** Encapsulate files on Google Cloud Storage that can be distributed to all workers. */
+/** Encapsulate arbitrary data that can be distributed to all workers. */
 sealed trait DistCache[F] extends Serializable {
   /** Extract the underlying data. */
   def apply(): F

--- a/scio-hdfs/src/main/scala/com/spotify/scio/hdfs/package.scala
+++ b/scio-hdfs/src/main/scala/com/spotify/scio/hdfs/package.scala
@@ -17,9 +17,10 @@
 
 package com.spotify.scio
 
-import java.io.{File, InputStream, SequenceInputStream}
+import java.io._
 import java.net.URI
 import java.nio.channels.Channels
+import java.nio.file.Files
 import java.security.PrivilegedAction
 import java.util.Collections
 
@@ -28,6 +29,7 @@ import com.google.cloud.dataflow.sdk.coders.AvroCoder
 import com.google.cloud.dataflow.sdk.io.hdfs._
 import com.google.cloud.dataflow.sdk.io.{Read, Write}
 import com.google.cloud.dataflow.sdk.options.DataflowPipelineOptions
+import com.google.cloud.dataflow.sdk.runners.DirectPipelineRunner
 import com.google.cloud.dataflow.sdk.util.MimeTypes
 import com.google.cloud.dataflow.sdk.util.gcsfs.GcsPath
 import com.google.common.base.Charsets
@@ -36,15 +38,11 @@ import com.spotify.scio.io.{Tap, Taps}
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.{DistCache, SCollection}
 import org.apache.avro.Schema
-import org.apache.avro.file.DataFileStream
-import org.apache.avro.generic.GenericDatumReader
 import org.apache.avro.mapred.AvroOutputFormat
 import org.apache.avro.mapreduce.AvroJob
-import org.apache.avro.specific.{SpecificDatumReader, SpecificRecordBase}
-import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path, PathFilter}
-import org.apache.hadoop.io.compress.{CompressionCodecFactory, DefaultCodec}
+import org.apache.hadoop.io.compress.DefaultCodec
 import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
 import org.apache.hadoop.security.UserGroupInformation
@@ -120,13 +118,11 @@ package object hdfs {
                                (initFn: Seq[File] => F): DistCache[F] = self.requireNotClosed {
       if (self.isTest) {
         self.distCache(paths)(initFn)
-      } else {
-        //TODO: should upload be asynchronous, blocking on context close
-        val dfOptions = self.optionsAs[DataflowPipelineOptions]
-        require(dfOptions.getStagingLocation != null,
-          "Staging directory not set - use `--stagingLocation`!")
+      }
+      else {
         require(!paths.contains(null), "Artifact path can't be null")
 
+        val (targetDir, writeFn) = getTargetFromOptions()
         val _conf = Option(conf).getOrElse(new Configuration())
 
         val targetPaths = paths.map { path =>
@@ -139,16 +135,17 @@ package object hdfs {
 
           val targetDistCache = new Path("distcache", s"$targetHash-${path.split("/").last}")
 
-          val target = new Path(dfOptions.getStagingLocation, targetDistCache)
+          val target = new Path(targetDir, targetDistCache)
 
+          // TODO: should upload be asynchronous, blocking on context close
           if (username != null) {
             UserGroupInformation.createRemoteUser(username).doAs(new PrivilegedAction[Unit] {
               override def run(): Unit = {
-                hadoopDistCacheCopy(new Path(path), target.toUri, _conf)
+                hadoopDistCacheCopy(new Path(path), target.toUri, _conf)(writeFn)
               }
             })
           } else {
-            hadoopDistCacheCopy(new Path(path), target.toUri, _conf)
+            hadoopDistCacheCopy(new Path(path), target.toUri, _conf)(writeFn)
           }
 
           target
@@ -158,16 +155,35 @@ package object hdfs {
       }
     }
 
-    private[scio] def hadoopDistCacheCopy(src: Path, target: URI, conf: Configuration): Unit = {
+    private def getTargetFromOptions() = {
+      if (ScioUtil.isLocalRunner(self.options)) {
+        val dfOptions = self.optionsAs[DataflowPipelineOptions]
+        require(self.optionsAs[DataflowPipelineOptions].getStagingLocation != null,
+          "Staging directory not set - use `--stagingLocation`!")
+        (dfOptions.getStagingLocation, gcsOutputStream _)
+      } else {
+        // should targetDir be specified in options?
+        (Files.createTempDirectory("distcache").toString, localOutputStream _)
+      }
+    }
+
+    private def localOutputStream(target: URI): OutputStream =
+      new FileOutputStream(new File(target))
+
+    private def gcsOutputStream(target: URI): OutputStream = {
+      //TODO: Should we attempt to detect the Mime type rather than always using MimeTypes.BINARY?
+      val dfOptions = self.optionsAs[DataflowPipelineOptions]
+      Channels.newOutputStream(
+        dfOptions.getGcsUtil.create(GcsPath.fromUri(target), MimeTypes.BINARY))
+    }
+
+    private[scio] def hadoopDistCacheCopy(src: Path, target: URI, conf: Configuration)
+                                         (createOutputStream: URI => OutputStream): Unit = {
       logger.debug(s"Will copy ${src.toUri}, to $target")
 
       val fs = src.getFileSystem(conf)
       val inStream = fs.open(src)
-
-      //TODO: Should we attempt to detect the Mime type rather than always using MimeTypes.BINARY?
-      val dfOptions = self.optionsAs[DataflowPipelineOptions]
-      val outChannel = Channels.newOutputStream(
-        dfOptions.getGcsUtil.create(GcsPath.fromUri(target), MimeTypes.BINARY))
+      val outChannel = createOutputStream(target)
 
       try {
         ByteStreams.copy(inStream, outChannel)


### PR DESCRIPTION
@nevillelyh @ravwojdyla This is a WIP, let's not merge yet. Just want to collect some thoughts here. This commit adds (partial) support for UDFs by specifying `bigquery.resource_uri`, which should be a file on GCS containing javascript UDFs as described here: https://cloud.google.com/bigquery/user-defined-functions.

A few things:

1) This only works for legacy SQL. UDFs are supported in standard SQL but it's quite a bit different. I'll look into supporting standard SQL next.

2) This isn't the most flexible approach, because a user can only link to one resource URI per job, which means having to stick all functions together in the same file and is not a good solution for externally shared UDFs. Maybe we should allow linking of multiple resource URIs?

3) I think it would also be really nice to allow users to have UDFs defined in project repos (say in `src/main/js`) and have the `BigQueryClient` upload those to GCS during initialization. Thoughts?