### PR TITLE
BigQuery Fix for DateTime and Timestamp format

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/package.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/package.scala
@@ -84,7 +84,7 @@ package object bigquery {
 
     // FIXME: verify that these match BigQuery specification
     // YYYY-[M]M-[D]D[ [H]H:[M]M:[S]S[.DDDDDD]][time zone]
-    private val formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSS ZZZ")
+    private val formatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS ZZZ")
     private val parser = new DateTimeFormatterBuilder()
       .append(DateTimeFormat.forPattern("yyyy-MM-dd"))
       .appendOptional(new DateTimeFormatterBuilder()
@@ -140,7 +140,7 @@ package object bigquery {
   /** Utility for BigQuery DATETIME type. */
   object DateTime {
     // YYYY-[M]M-[D]D[ [H]H:[M]M:[S]S[.DDDDDD]]
-    private val formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSS")
+    private val formatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
     private val parser = new DateTimeFormatterBuilder()
       .append(DateTimeFormat.forPattern("yyyy-MM-dd"))
       .appendOptional(new DateTimeFormatterBuilder()

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/package.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/package.scala
@@ -92,6 +92,10 @@ package object bigquery {
         .appendOptional(DateTimeFormat.forPattern(".SSSSSS").getParser)
         .toParser)
       .appendOptional(new DateTimeFormatterBuilder()
+        .append(DateTimeFormat.forPattern("'T'HH:mm:ss").getParser)
+        .appendOptional(DateTimeFormat.forPattern(".SSSSSS").getParser)
+        .toParser)
+      .appendOptional(new DateTimeFormatterBuilder()
         .append(null, Array(" ZZZ", "ZZ").map(p => DateTimeFormat.forPattern(p).getParser))
         .toParser)
       .toFormatter
@@ -145,6 +149,10 @@ package object bigquery {
       .append(DateTimeFormat.forPattern("yyyy-MM-dd"))
       .appendOptional(new DateTimeFormatterBuilder()
         .append(DateTimeFormat.forPattern(" HH:mm:ss").getParser)
+        .appendOptional(DateTimeFormat.forPattern(".SSSSSS").getParser)
+        .toParser)
+      .appendOptional(new DateTimeFormatterBuilder()
+        .append(DateTimeFormat.forPattern("'T'HH:mm:ss").getParser)
         .appendOptional(DateTimeFormat.forPattern(".SSSSSS").getParser)
         .toParser)
       .toFormatter


### PR DESCRIPTION
Input BigQuery DateTime and Timestamp in the currently expected format (with a `T` character separating the Date and the Time). Update the parser to support multiple formats.

See [#376](https://github.com/spotify/scio/issues/376) for additional details and discussion.