### PR TITLE
Adding DistCache companion object

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/DistCache.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/DistCache.scala
@@ -116,6 +116,10 @@ private[scio] class MockDistCache[F](val value: F) extends DistCache[F] {
   override def apply(): F = value
 }
 
+object MockDistCache {
+  def apply[F](value: F): MockDistCache[F] = new MockDistCache(value)
+}
+
 private[scio] class DistCacheSingle[F](val uri: URI, val initFn: File => F, options: GcsOptions)
   extends FileDistCache[F](options) {
   verifyUri(uri)


### PR DESCRIPTION
- Adding MockDistCache companion object so that it can be exposed for local testing