### PR TITLE
Add ProtoIO to TestDataManager.

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -446,7 +446,13 @@ class ScioContext private[scio] (val options: PipelineOptions,
    * @group input
    */
   def protobufFile[T: ClassTag](path: String)(implicit ev: T <:< Message): SCollection[T] =
-    objectFile(path)
+    requireNotClosed {
+      if (this.isTest) {
+        this.getTestInput(ProtobufIO[T](path))
+      } else {
+        objectFile(path)
+      }
+    }
 
   /**
    * Get an SCollection for a BigQuery SELECT query.

--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -112,6 +112,8 @@ case class BigQueryIO(tableSpecOrQuery: String) extends TestIO[TableRow](tableSp
 case class DatastoreIO(projectId: String, query: Query = null, namespace: String = null)
   extends TestIO[Entity](s"$projectId\t$query\t$namespace")
 
+case class ProtobufIO[T](path: String) extends TestIO(path)
+
 case class PubsubIO(topic: String) extends TestIO[String](topic)
 
 case class TableRowJsonIO(path: String) extends TestIO[TableRow](path)

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -903,10 +903,15 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    */
   def saveAsProtobufFile(path: String, numShards: Int = 0)
                         (implicit ev: T <:< Message): Future[Tap[T]] = {
-    import me.lyh.protobuf.generic
-    val schema = generic.Schema.of[Message](ct.asInstanceOf[ClassTag[Message]]).toJson
-    val metadata = Map("protobuf.generic.schema" -> schema)
-    this.saveAsObjectFile(path, numShards, ".protobuf", metadata)
+    if (context.isTest) {
+      context.testOut(ProtobufIO(path))(this)
+      saveAsInMemoryTap
+    } else {
+      import me.lyh.protobuf.generic
+      val schema = generic.Schema.of[Message](ct.asInstanceOf[ClassTag[Message]]).toJson
+      val metadata = Map("protobuf.generic.schema" -> schema)
+      this.saveAsObjectFile(path, numShards, ".protobuf", metadata)
+    }
   }
 
   /**

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ProtobufExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ProtobufExampleTest.scala
@@ -19,7 +19,7 @@ package com.spotify.scio.examples.extra
 
 import com.spotify.scio.proto.SimpleV2.SimplePB
 import com.spotify.scio.proto.Track.TrackPB
-import com.spotify.scio.testing.{JobTest, ObjectFileIO, PipelineSpec}
+import com.spotify.scio.testing.{JobTest, PipelineSpec, ProtobufIO}
 
 class ProtobufExampleTest extends PipelineSpec {
 
@@ -36,8 +36,8 @@ class ProtobufExampleTest extends PipelineSpec {
   "ProtobufExample" should "work" in {
     JobTest[com.spotify.scio.examples.extra.ProtobufExample.type]
       .args("--input=in.proto", "--output=out.proto")
-      .input(ObjectFileIO[SimplePB]("in.proto"), input)
-      .output[TrackPB](ObjectFileIO[TrackPB]("out.proto"))(_ should
+      .input(ProtobufIO[SimplePB]("in.proto"), input)
+      .output[TrackPB](ProtobufIO[TrackPB]("out.proto"))(_ should
         containInAnyOrder[TrackPB](expected))
       .run()
   }


### PR DESCRIPTION
Besides having a named way to deal with test IO for proto (instead of just using `ObjectFileIO`), this is so we get type checking on `T <:< Message`. It's slightly ugly in that, since the non-test implementation delegates to object file IO it will go through the `if (this.isTest)` check twice, but I don't think it's a big deal.