### PR TITLE
Fix Pub/Sub subscription in the Scala WindowedWordCount example

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/WindowedWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/WindowedWordCount.scala
@@ -64,7 +64,7 @@ object WindowedWordCount {
 
     // initialize input
     val input = if (opts.isStreaming) {
-      sc.pubsubTopic(opts.getPubsubTopic)
+      sc.pubsubSubscription(opts.getPubsubSubscription)
     } else {
       sc
       .textFile(inputFile.getOrElse(ExampleData.KING_LEAR))

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/common/ExampleOptions.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/common/ExampleOptions.scala
@@ -26,7 +26,7 @@ trait ExampleOptions
   extends DataflowPipelineOptions
   with DataflowExampleOptions
   with ExampleBigQueryTableOptions
-  with ExamplePubsubTopicOptions
+  with ExamplePubsubTopicAndSubscriptionOptions
 
 object ExampleOptions {
   def bigQueryTable(options: ExampleOptions): String =


### PR DESCRIPTION
Use sc.pubsubSubscription instead of sc.pubsubTopic.
This will configure PubsubIO with the created subscription, instead of create another one.

ExampleOptions extends ExamplePubsubTopicAndSubscriptionOptions instead of ExamplePubsubTopicOptions.
This allow to use --pubsubSubscription parameter.

More info here: https://gitter.im/spotify/scio?at=5888ec77e836bf70108f0258

Keep Up the good work Spotify Team <3