### PR TITLE
Finish migrating properties to scalatest

### DIFF
--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
@@ -39,6 +39,9 @@ class ConverterProviderSpec extends PropSpec with GeneratorDrivenPropertyChecks 
   implicit def compareByteArrays(x: Array[Byte], y: Array[Byte]): Boolean =
     ByteString.copyFrom(x) == ByteString.copyFrom(y)
 
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
+
   property("round trip required primitive types") {
     forAll { r1: Required =>
       val r2 = BigQueryType.fromTableRow[Required](BigQueryType.toTableRow[Required](r1))

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/BreezeSpec.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/BreezeSpec.scala
@@ -21,12 +21,13 @@ import breeze.linalg.{DenseMatrix, DenseVector}
 import breeze.stats.distributions.Rand
 import com.spotify.scio.extra.Breeze._
 import com.twitter.algebird.Semigroup
-import org.scalacheck.Prop.forAll
 import org.scalacheck._
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 import scala.language.higherKinds
 
-trait BreezeSpec[M[_], T] {
+trait BreezeSpec[M[_], T] extends PropertySpec {
   val dimension = 10
   val rows = 20
   val cols = 10
@@ -37,42 +38,59 @@ trait BreezeSpec[M[_], T] {
   def sumOption(xs: Iterable[M[T]])(implicit sg: Semigroup[M[T]]): Option[M[T]] = sg.sumOption(xs)
 }
 
-object FVSpec extends Properties("FloatVectorSemigroup") with BreezeSpec[DenseVector, Float] {
+class FVSpec extends BreezeSpec[DenseVector, Float] {
   val m = Gen.const(dimension).map(DenseVector.rand[Float](_, fRand))
-  property("plus") = forAll(m, m) { (x, y) =>
-    plus(x, y) == x + y
+
+  property("plus") {
+    forAll(m, m) { (x, y) =>
+      plus(x, y) == x + y
+    }
   }
-  property("sumOption") = forAll(ms) { xs =>
-    sumOption(xs) == xs.reduceLeftOption(_ + _)
+  property("sumOption") {
+    forAll(ms) { xs =>
+      sumOption(xs) == xs.reduceLeftOption(_ + _)
+    }
   }
 }
 
-object DVSpec extends Properties("DoubleVectorSemigroup") with BreezeSpec[DenseVector, Double] {
+class DVSpec extends BreezeSpec[DenseVector, Double] {
   val m = Gen.const(dimension).map(DenseVector.rand[Double](_))
-  property("plus") = forAll(m, m) { (x, y) =>
-    plus(x, y) == x + y
+  property("plus") {
+    forAll(m, m) { (x, y) =>
+      plus(x, y) == x + y
+    }
   }
-  property("sumOption") = Prop.forAll(ms) { xs =>
-    sumOption(xs) == xs.reduceLeftOption(_ + _)
+  property("sumOption") {
+    forAll(ms) { xs =>
+      sumOption(xs) == xs.reduceLeftOption(_ + _)
+    }
   }
 }
 
-object FMSpec extends Properties("FloatMatrixSemigroup") with BreezeSpec[DenseMatrix, Float] {
+class FMSpec extends BreezeSpec[DenseMatrix, Float] {
   val m = Gen.const((rows, cols)).map { case (r, c) => DenseMatrix.rand[Float](r, c, fRand) }
-  property("plus") = forAll(m, m) { (x, y) =>
-    plus(x, y) == x + y
+  property("plus") {
+    forAll(m, m) { (x, y) =>
+      plus(x, y) == x + y
+    }
   }
-  property("sumOption") = Prop.forAll(ms) { xs =>
-    sumOption(xs) == xs.reduceLeftOption(_ + _)
+  property("sumOption") {
+    forAll(ms) { xs =>
+      sumOption(xs) == xs.reduceLeftOption(_ + _)
+    }
   }
 }
 
-object DMSpec extends Properties("DoubleMatrixSemigroup") with BreezeSpec[DenseMatrix, Double] {
+class DMSpec extends BreezeSpec[DenseMatrix, Double] {
   val m = Gen.const((rows, cols)).map { case (r, c) => DenseMatrix.rand[Double](r, c) }
-  property("plus") = forAll(m, m) { (x, y) =>
-    plus(x, y) == x + y
+  property("plus") {
+    forAll(m, m) { (x, y) =>
+      plus(x, y) == x + y
+    }
   }
-  property("sumOption") = Prop.forAll(ms) { xs =>
-    sumOption(xs) == xs.reduceLeftOption(_ + _)
+  property("sumOption") {
+    forAll(ms) { xs =>
+      sumOption(xs) == xs.reduceLeftOption(_ + _)
+    }
   }
 }

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/CollectionsSpec.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/CollectionsSpec.scala
@@ -22,7 +22,7 @@ import org.scalacheck._
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class CollectionsSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+class CollectionsSpec extends PropertySpec {
 
   val posInts = Gen.posNum[Int]
   val intLists = Arbitrary.arbitrary[List[Int]]

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/PropertySpec.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/PropertySpec.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.extra
+
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+trait PropertySpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
+
+}

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/nn/NearestNeighborSpec.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/nn/NearestNeighborSpec.scala
@@ -19,12 +19,10 @@ package com.spotify.scio.extra.nn
 
 import breeze.linalg._
 import com.spotify.scio.extra.Collections._
+import com.spotify.scio.extra.PropertySpec
 import org.scalacheck._
-import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class NearestNeighborSpec extends PropSpec with GeneratorDrivenPropertyChecks
-  with Matchers {
+class NearestNeighborSpec extends PropertySpec {
 
   val dimension = 40
   private def randVec = DenseVector.rand[Double](dimension)


### PR DESCRIPTION
Manual `minSuccessful` configuration may be removed if fixed upstream: https://github.com/scalatest/scalatest/issues/1090
