### PR TITLE
performance tweak for Avro serializers

### DIFF
--- a/scio-schemas/src/main/scala/com/spotify/scio/avro/AvroUtils.scala
+++ b/scio-schemas/src/main/scala/com/spotify/scio/avro/AvroUtils.scala
@@ -41,7 +41,6 @@ object AvroUtils {
   ).asJava)
 
   def newGenericRecord(i: Int): GenericRecord = {
-
     val r = new GenericData.Record(schema)
     r.put("int_field", 1 * i)
     r.put("long_field", 1L * i)


### PR DESCRIPTION
- reduce `Schema` <-> `String` conversion
- avoid internal buffer and use `Input` and `Output` streams directly

Both are ~40% faster now.