### PR TITLE
Revert "use buffered prefix count in JIterableWrapperSerializer"

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/JIterableWrapperSerializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/JIterableWrapperSerializer.scala
@@ -26,46 +26,22 @@ import com.twitter.chill.KSerializer
 
 import scala.collection.JavaConverters._
 
-/**
- * Based on [[org.apache.beam.sdk.coders.IterableLikeCoder]] and
- * [[org.apache.beam.sdk.util.BufferedElementCountingOutputStream]].
- */
 private class JIterableWrapperSerializer[T] extends KSerializer[Iterable[T]] {
 
-  private val bufferSize = 64 * 1024
-
   override def write(kser: Kryo, out: Output, obj: Iterable[T]): Unit = {
-    val buffer = new Output(bufferSize)
-    var count = 0
     val i = obj.iterator
     while (i.hasNext) {
-      if (buffer.position() >= bufferSize) {
-        out.writeInt(count)
-        out.write(buffer.getBuffer, 0, buffer.position())
-        buffer.clear()
-        count = 0
-      }
-      kser.writeClassAndObject(buffer, i.next())
-      count += 1
+      out.writeBoolean(true)
+      kser.writeClassAndObject(out, i.next())
     }
-    if (buffer.position() > 0) {
-      out.writeInt(count)
-      out.write(buffer.getBuffer, 0, buffer.position())
-    }
-    out.writeInt(0)
+    out.writeBoolean(false)
   }
 
   override def read(kser: Kryo, in: Input, cls: Class[Iterable[T]]): Iterable[T] = {
     val list = Lists.newArrayList[T]
-    var count = in.readInt()
-    while (count > 0) {
-      var i = 0
-      while (i < count) {
-        val item = kser.readClassAndObject(in).asInstanceOf[T]
-        list.add(item)
-        i += 1
-      }
-      count = in.readInt()
+    while (in.readBoolean()) {
+      val item = kser.readClassAndObject(in).asInstanceOf[T]
+      list.add(item)
     }
     list.asInstanceOf[JIterable[T]].asScala
   }


### PR DESCRIPTION
This reverts commit 611d375aa73e3cb3eb138c6ed33bfa40d486ab6c.