### PR TITLE
Proposing additional SCollection Functions(flatten, asKey, asKeyBy)

### DIFF
--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -194,6 +194,13 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
+  it should "support flatten()" in {
+    runWithContext { sc =>
+      val p = sc.parallelize(Seq(Seq("a", "b", "c"), Seq("d", "e"), Seq("f"))).flatten
+      p should containInAnyOrder (Seq("a", "b", "c", "d", "e", "f"))
+    }
+  }
+
   it should "support fold()" in {
     runWithContext { sc =>
       val p = sc.parallelize(1 to 100)
@@ -208,6 +215,20 @@ class SCollectionTest extends PipelineSpec {
     runWithContext { sc =>
       val p = sc.parallelize(Seq(1, 2, 3, 4)).groupBy(_ % 2).mapValues(_.toSet)
       p should containInAnyOrder (Seq((0, Set(2, 4)), (1, Set(1, 3))))
+    }
+  }
+
+  it should "support asKey()" in {
+    runWithContext { sc =>
+      val p = sc.parallelize(Seq("hello", "world")).asKey
+      p should containInAnyOrder (Seq(("hello", ()), ("world", ())))
+    }
+  }
+
+  it should "support asKeyBy()" in {
+    runWithContext { sc =>
+      val p = sc.parallelize(Seq("hello", "world")).asKeyBy(_.substring(0, 1))
+      p should containInAnyOrder (Seq(("h", ()), ("w", ())))
     }
   }
 


### PR DESCRIPTION
These are somewhat lifted from the Scalding API.  There are three proposed new api functions in this PR.

1. flatten 
  a. Given a SCollection of Transversable Elements this will flatten it out to a SCollection of those elements.
2. asKey
  a. Given a SCollection of some element this lifts the elements to the Keys and adds a Unit as the values.
3. asKeyBy
  a. Similar to above but you can provide a function that extracts the key.

My only worry for the last two is that they can be confused with the current function keyBy.   

