### PR TITLE
Fix serialization of LocalDateTime and LocalDate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -237,6 +237,7 @@ lazy val scioTest: Project = Project(
   libraryDependencies ++= Seq(
     "org.apache.beam" % "beam-sdks-java-core" % beamVersion % "test" classifier "tests",
     "org.scalatest" %% "scalatest" % scalatestVersion,
+    "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
     // DataFlow testing requires junit and hamcrest
     "org.hamcrest" % "hamcrest-all" % hamcrestVersion,
     "com.spotify" % "annoy" % annoyVersion % "test",

--- a/scio-core/src/main/scala/com/spotify/scio/coders/JodaSerializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/JodaSerializer.scala
@@ -1,0 +1,59 @@
+package com.spotify.scio.coders
+
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import org.joda.time.{LocalDate, LocalDateTime}
+import org.joda.time.chrono.ISOChronology
+
+class JodaLocalDateTimeSerializer extends Serializer[LocalDateTime] {
+  setImmutable(true)
+
+  def write(kryo: Kryo, output: Output, ldt: LocalDateTime): Unit = {
+    output.writeInt(ldt.getYear, /*optimizePositive=*/ false)
+    output.writeByte(ldt.getMonthOfYear)
+    output.writeByte(ldt.getDayOfMonth)
+    output.writeLong(ldt.getMillisOfDay)
+
+    val chronology = ldt.getChronology
+    if (chronology != null && chronology != ISOChronology.getInstanceUTC) {
+      sys.error(s"Unsupported chronology: $chronology")
+    }
+  }
+
+  def read(kryo: Kryo, input: Input, tpe: Class[LocalDateTime]): LocalDateTime = {
+    val year = input.readInt(/*optimizePositive=*/ false)
+    val month = input.readByte().toInt
+    val day = input.readByte().toInt
+
+    val millis = input.readLong()
+    val hour = (millis / 3600000L).toInt
+    val minute = ((millis % 3600000L) / 60000).toInt
+    val second = ((millis % 60000L) / 1000).toInt
+    val ms = (millis % 1000L).toInt
+
+    new LocalDateTime(year, month, day, hour, minute, second, ms)
+  }
+}
+
+class JodaLocalDateSerializer extends Serializer[LocalDate] {
+  setImmutable(true)
+
+  def write(kryo: Kryo, output: Output, ld: LocalDate): Unit = {
+    output.writeInt(ld.getYear, /*optimizePositive=*/ false)
+    output.writeByte(ld.getMonthOfYear)
+    output.writeByte(ld.getDayOfMonth)
+
+    val chronology = ld.getChronology
+    if (chronology != null && chronology != ISOChronology.getInstanceUTC) {
+      sys.error(s"Unsupported chronology: $chronology")
+    }
+  }
+
+  def read(kryo: Kryo, input: Input, tpe: Class[LocalDate]): LocalDate = {
+    val year = input.readInt(/*optimizePositive=*/ false)
+    val month = input.readByte().toInt
+    val day = input.readByte().toInt
+
+    new LocalDate(year, month, day)
+  }
+}

--- a/scio-core/src/main/scala/com/spotify/scio/coders/KryoAtomicCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/KryoAtomicCoder.scala
@@ -32,6 +32,7 @@ import org.apache.beam.sdk.coders.Coder.Context
 import org.apache.beam.sdk.coders._
 import org.apache.beam.sdk.util.VarInt
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver
+import org.joda.time.{LocalDate, LocalDateTime}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -85,6 +86,9 @@ private[scio] class KryoAtomicCoder[T] extends AtomicCoder[T] {
       k.forSubclass[SpecificRecordBase](new SpecificAvroSerializer)
       k.forSubclass[GenericRecord](new GenericAvroSerializer)
       k.forSubclass[Message](new ProtobufSerializer)
+
+      k.forSubclass[LocalDateTime](new JodaLocalDateTimeSerializer)
+      k.forSubclass[LocalDate](new JodaLocalDateSerializer)
 
       k.forClass(new KVSerializer)
       // TODO:

--- a/scio-test/src/test/scala/com/spotify/scio/coders/JodaSerializerTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/JodaSerializerTest.scala
@@ -1,0 +1,49 @@
+package com.spotify.scio.coders
+
+import org.joda.time.{LocalDate, LocalDateTime}
+import org.scalacheck.{Arbitrary, Gen, Prop}
+import org.scalatest._
+import org.scalatest.prop.Checkers
+
+import scala.util.Try
+
+class JodaSerializerTest extends FlatSpec with Checkers {
+  implicit val localDateTimeArb = Arbitrary {
+    for {
+      year <- Gen.choose(-292275054, 292278993)
+      month <- Gen.choose(1, 12)
+      maxDayOfMonth <- Try {
+        Gen.const(new LocalDateTime(year, month, 1, 0, 0).dayOfMonth().getMaximumValue)
+      } getOrElse Gen.fail
+      day <- Gen.choose(1, maxDayOfMonth)
+      hour <- Gen.choose(0, 23)
+      minute <- Gen.choose(0, 59)
+      second <- Gen.choose(0, 59)
+      ms <- Gen.choose(0, 999)
+      attempt <- Try {
+        val ldt = new LocalDateTime(year, month, day, hour, minute, second, ms)
+        Gen.const(ldt)
+      } getOrElse Gen.fail
+    } yield attempt
+  }
+
+  implicit val localDateArb = Arbitrary {
+    Arbitrary.arbitrary[LocalDateTime].map(_.toLocalDate)
+  }
+
+  behavior of "KryoAtomicCoder"
+
+  val coder = KryoAtomicCoder[Any]
+
+  def roundTripProp[T](value: T): Prop = Prop.secure {
+    CoderTestUtils.testRoundTrip(coder, value)
+  }
+
+  it should "roundtrip LocalDate" in {
+    check(roundTripProp[LocalDate] _)
+  }
+
+  it should "roundtrip LocalDateTime" in {
+    check(roundTripProp[LocalDateTime] _)
+  }
+}


### PR DESCRIPTION
See https://github.com/twitter/chill/issues/226. 

I was lazy to extend it for other types from joda, but they likely have the same problem. AFAIK newest Kryo is able to serialize java8 time, but it seems Beam still uses Joda, not sure for how long it would be relevant.