### PR TITLE
Reduce default eps for skewedJoin

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -262,7 +262,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)])
    */
   def skewedJoin[W: ClassTag](that: SCollection[(K, W)],
                               hotKeyThreshold: Long = 9000,
-                              eps: Double = 0.0001,
+                              eps: Double = 0.001,
                               seed: Int = 42,
                               delta: Double = 1E-10,
                               sampleFraction: Double = 1.0,


### PR DESCRIPTION
For default/large jobs it might be still too much to have 0.0001.
Production pipeline with 4B records was to large for 0.0001, reduce
to 0.001.