### PR TITLE
Open sciocontext in scioresult, no harm

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
@@ -43,7 +43,7 @@ import scala.util.{Failure, Success, Try}
 /** Represent a Scio pipeline result. */
 class ScioResult private[scio] (val internal: PipelineResult,
                                 val accumulators: Seq[Accumulator[_]],
-                                private val context: ScioContext) {
+                                val context: ScioContext) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 


### PR DESCRIPTION
One use case is to pimp ScioResult, and check the state of sciocontext
like `isTest` otherwise would have to pimp both sciocontext and
scioresult.

Also use classOf.