### PR TITLE
Add rate limiting DoFn

### DIFF
--- a/scio-extra/src/main/java/com/spotify/scio/extra/transforms/RateLimiterDoFn.java
+++ b/scio-extra/src/main/java/com/spotify/scio/extra/transforms/RateLimiterDoFn.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.extra.transforms;
+
+import com.google.common.util.concurrent.RateLimiter;
+
+/**
+ * DoFn which will rate limit the number of elements processed per second.
+ *
+ * Used to rate limit throughput for a job writing to a database or making
+ * calls to external services.
+ */
+public class RateLimiterDoFn<InputT> extends DoFnWithResource<InputT, InputT, RateLimiter> {
+
+  private final double recordsPerSecond;
+
+  public RateLimiterDoFn(final double recordsPerSecond) {
+    this.recordsPerSecond = recordsPerSecond;
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) {
+    getResource().acquire();
+    c.output(c.element());
+  }
+
+  @Override
+  public ResourceType getResourceType() {
+    return ResourceType.PER_CLASS;
+  }
+
+  @Override
+  public RateLimiter createResource() {
+    return RateLimiter.create(recordsPerSecond);
+  }
+}

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/transforms/RateLimiterDoFnTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/transforms/RateLimiterDoFnTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.extra.transforms
+
+import java.util.concurrent.TimeUnit
+
+import com.spotify.scio.testing._
+
+class RateLimiterDoFnTest extends PipelineSpec {
+
+  private val input = 0 until 10
+
+  it should "work" in {
+    val timeStart = System.nanoTime()
+    runWithContext { sc =>
+      val p1 = sc.parallelize(input).withRateLimit(1)
+      p1 should containInAnyOrder (input)
+    }
+    val timeElapsed = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - timeStart)
+    timeElapsed should be >= input.size.toLong
+  }
+
+  it should "work with larger rate" in {
+    val timeStart = System.nanoTime()
+    runWithContext { sc =>
+      val p1 = sc.parallelize(input).withRateLimit(2)
+      p1 should containInAnyOrder (input)
+    }
+    val timeElapsed = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - timeStart)
+    timeElapsed should be >= (input.size / 2).toLong
+  }
+
+}


### PR DESCRIPTION
@nevillelyh @ravwojdyla @andrewsmartin 

So this was necessary for calling external services from dataflow to guarantee that I will not overload them. This also is a way to solve controlling the number of write requests to bigtable (placing this before `saveAsBigtable`)

I don't love this since it kind of relies on knowing where the serialization boundaries are so its possible to use this and have a map that you expect to be rate limited not actually be rate limited. Perhaps something better would be to have an optional rate limit on maps and transforms something like: `applyTransform(myParDo, rateLimit=1000)` though that also isnt super clean since it would need to be added to many methods. For now this does work, having it in scio-extra might not be the worst since if you know what youre doing this works fine.