### PR TITLE
Fixes for TFRecord

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -31,7 +31,7 @@ import com.google.protobuf.Message
 import com.spotify.scio.bigquery._
 import com.spotify.scio.bigquery.types.BigQueryType.HasAnnotation
 import com.spotify.scio.coders.AvroBytesUtil
-import com.spotify.scio.io.{TFRecordOptions, TFRecordSource, Tap}
+import com.spotify.scio.io.Tap
 import com.spotify.scio.options.ScioOptions
 import com.spotify.scio.testing._
 import com.spotify.scio.util._
@@ -43,6 +43,7 @@ import org.apache.beam.runners.dataflow.DataflowRunner
 import org.apache.beam.runners.dataflow.options._
 import org.apache.beam.sdk.PipelineResult.State
 import org.apache.beam.sdk.extensions.gcp.options.{GcpOptions, GcsOptions}
+import org.apache.beam.sdk.io.TFRecordIO.CompressionType
 import org.apache.beam.sdk.io.gcp.{bigquery => bqio, datastore => dsio, pubsub => psio}
 import org.apache.beam.sdk.options._
 import org.apache.beam.sdk.transforms.Combine.CombineFn
@@ -724,12 +725,13 @@ class ScioContext private[scio] (val options: PipelineOptions,
    * buffers (which contain [[org.tensorflow.example.Features]] as a field) serialized as bytes.
    * @group input
    */
-  def tfRecordFile(path: String, tfRecordOptions: TFRecordOptions = TFRecordOptions.readDefault)
+  def tfRecordFile(path: String, compressionType: CompressionType = CompressionType.AUTO)
   : SCollection[Array[Byte]] = requireNotClosed {
     if (this.isTest) {
       this.getTestInput(TFRecordIO(path))
     } else {
-      wrap(this.applyInternal(gio.Read.from(TFRecordSource(path, tfRecordOptions))))
+      wrap(this.applyInternal(gio.TFRecordIO.read().from(path)
+        .withCompressionType(compressionType)))
     }
   }
 

--- a/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
@@ -32,6 +32,7 @@ import org.apache.avro.Schema
 import org.apache.avro.file.{DataFileReader, SeekableFileInput, SeekableInput}
 import org.apache.avro.generic.GenericDatumReader
 import org.apache.avro.specific.{SpecificDatumReader, SpecificRecordBase}
+import org.apache.beam.sdk.io.TFRecordIO.CompressionType
 import org.apache.beam.sdk.options.PipelineOptionsFactory
 import org.apache.beam.sdk.util.GcsUtil.GcsUtilFactory
 import org.apache.beam.sdk.util.gcsfs.GcsPath
@@ -86,7 +87,7 @@ private[scio] trait FileStorage {
   def tfRecordFile: Iterator[Array[Byte]] = {
     new Iterator[Array[Byte]] {
       private def wrapInputStream(in: InputStream) =
-        TFRecordCodec.wrapInputStream(in, TFRecordOptions.readDefault)
+        TFRecordCodec.wrapInputStream(in, CompressionType.AUTO)
       private val input = getDirectoryInputStream(path, wrapInputStream)
       private var current: Array[Byte] = TFRecordCodec.read(input)
       override def hasNext: Boolean = current != null

--- a/scio-core/src/main/scala/com/spotify/scio/io/TFRecordCodec.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/TFRecordCodec.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.io
 
-import java.io.{InputStream, OutputStream, PushbackInputStream}
+import java.io.{InputStream, PushbackInputStream}
 import java.nio.{ByteBuffer, ByteOrder}
 import java.util.zip.GZIPInputStream
 
@@ -68,23 +68,6 @@ private object TFRecordCodec {
       }
     } while (n > 0 && off < data.length)
     if (n <= 0) null else data
-  }
-
-  def write(output: OutputStream, data: Array[Byte]): Unit = {
-    val length = data.length.toLong
-    val maskedCrc32OfLength = hashLong(length)
-    val maskedCrc32OfData = hashBytes(data)
-
-    val headerBuf = ByteBuffer.allocate(headerLength).order(ByteOrder.LITTLE_ENDIAN)
-    headerBuf.putLong(length)
-    headerBuf.putInt(maskedCrc32OfLength)
-    output.write(headerBuf.array(), 0, headerLength)
-
-    output.write(data)
-
-    val footerBuf = ByteBuffer.allocate(footerLength).order(ByteOrder.LITTLE_ENDIAN)
-    footerBuf.putInt(maskedCrc32OfData)
-    output.write(footerBuf.array())
   }
 
   def wrapInputStream(stream: InputStream, compressionType: CompressionType): InputStream = {

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -43,6 +43,7 @@ import org.apache.avro.specific.SpecificRecordBase
 import org.apache.beam.runners.direct.DirectRunner
 import org.apache.beam.sdk.coders.Coder
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions
+import org.apache.beam.sdk.io.TFRecordIO.CompressionType
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.{CreateDisposition, WriteDisposition}
 import org.apache.beam.sdk.io.gcp.{bigquery => bqio, datastore => dsio, pubsub => psio}
@@ -1164,7 +1165,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    */
   def saveAsTfRecordFile(path: String,
                          suffix: String = ".tfrecords",
-                         tfRecordOptions: TFRecordOptions = TFRecordOptions.writeDefault)
+                         compressionType: CompressionType = CompressionType.NONE)
                         (implicit ev: T <:< Array[Byte]): Future[Tap[Array[Byte]]] = {
     if (context.isTest) {
       context.testOut(TFRecordIO(path))(this.asInstanceOf[SCollection[Array[Byte]]])
@@ -1173,7 +1174,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
       this.asInstanceOf[SCollection[Array[Byte]]].applyInternal(
         gio.TFRecordIO.write().to(pathWithShards(path))
           .withSuffix(suffix)
-          .withCompressionType(tfRecordOptions.compressionType))
+          .withCompressionType(compressionType))
       context.makeFuture(TFRecordFileTap(path + "/part-*"))
     }
   }

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1171,7 +1171,9 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
       saveAsInMemoryTap.asInstanceOf[Future[Tap[Array[Byte]]]]
     } else {
       this.asInstanceOf[SCollection[Array[Byte]]].applyInternal(
-        gio.Write.to(new TFRecordSink(pathWithShards(path), suffix, tfRecordOptions)))
+        gio.TFRecordIO.write().to(pathWithShards(path))
+          .withSuffix(suffix)
+          .withCompressionType(tfRecordOptions.compressionType))
       context.makeFuture(TFRecordFileTap(path + "/part-*"))
     }
   }


### PR DESCRIPTION
@nevillelyh Thoughts? Not sure if this is what you had in mind, but it should be a good starting point. I removed the sink entirely (since compression behavior is the same between the internal sink and the one in Beam), and kept the source for now, but fixed it to work with the new API. 

As far as I can tell there isn't an easy way to reuse more of the beam code if we want to keep the auto-detection because Beam's `TFRecordSource` is not exposed (unless we want to resort to package hackery).