### PR TITLE
Improvements around elasticsearch

### DIFF
--- a/scio-elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/scio-elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -19,6 +19,10 @@ package org.apache.beam.sdk.io.elasticsearch;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.Iterables;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -35,13 +39,13 @@ import com.twitter.jsr166e.ThreadLocalRandom;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.bulk.BulkRequest;
 import org.joda.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
@@ -85,7 +89,7 @@ public class ElasticsearchIO {
      *
      * @param function creates IndexRequest required by Elasticsearch client
      */
-    public static<T> Bound withFunction(SerializableFunction<T, IndexRequest> function) {
+    public static<T> Bound withFunction(SerializableFunction<T, Iterable<ActionRequest<?>>> function) {
       return new Bound<T>().withFunction(function);
     }
 
@@ -113,20 +117,20 @@ public class ElasticsearchIO {
       private final String clusterName;
       private final InetSocketAddress[] servers;
       private final Duration flushInterval;
-      private final SerializableFunction<T, IndexRequest> toIndexRequest;
+      private final SerializableFunction<T, Iterable<ActionRequest<?>>> toActionRequests;
       private final Long numOfShard;
       private final SerializableConsumer<String> error;
 
       private Bound(final String clusterName,
                     final InetSocketAddress[] servers,
                     final Duration flushInterval,
-                    final SerializableFunction<T, IndexRequest> toIndexRequest,
+                    final SerializableFunction<T, Iterable<ActionRequest<?>>> toActionRequests,
                     final Long numOfShard,
                     final SerializableConsumer<String> error) {
         this.clusterName = clusterName;
         this.servers = servers;
         this.flushInterval = flushInterval;
-        this.toIndexRequest = toIndexRequest;
+        this.toActionRequests = toActionRequests;
         this.numOfShard = numOfShard;
         this.error = error;
       }
@@ -136,34 +140,34 @@ public class ElasticsearchIO {
       }
 
       public Bound<T> withClusterName(String clusterName) {
-        return new Bound<>(clusterName, servers, flushInterval, toIndexRequest, numOfShard, error);
+        return new Bound<>(clusterName, servers, flushInterval, toActionRequests, numOfShard, error);
       }
 
       public Bound<T> withServers(InetSocketAddress[] servers) {
-        return new Bound<>(clusterName, servers, flushInterval, toIndexRequest, numOfShard, error);
+        return new Bound<>(clusterName, servers, flushInterval, toActionRequests, numOfShard, error);
       }
 
       public Bound<T> withFlushInterval(Duration flushInterval) {
-        return new Bound<>(clusterName, servers, flushInterval, toIndexRequest, numOfShard, error);
+        return new Bound<>(clusterName, servers, flushInterval, toActionRequests, numOfShard, error);
       }
 
-      public Bound<T> withFunction(SerializableFunction<T, IndexRequest> toIndexRequest) {
+      public Bound<T> withFunction(SerializableFunction<T, Iterable<ActionRequest<?>>> toIndexRequest) {
         return new Bound<>(clusterName, servers, flushInterval, toIndexRequest, numOfShard, error);
       }
 
       public Bound<T> withNumOfShard(Long numOfShard) {
-        return new Bound<>(clusterName, servers, flushInterval, toIndexRequest, numOfShard, error);
+        return new Bound<>(clusterName, servers, flushInterval, toActionRequests, numOfShard, error);
       }
 
       public Bound<T> withError(SerializableConsumer<String> error) {
-        return new Bound<>(clusterName, servers, flushInterval, toIndexRequest, numOfShard, error);
+        return new Bound<>(clusterName, servers, flushInterval, toActionRequests, numOfShard, error);
       }
 
       @Override
       public PDone expand(final PCollection<T> input) {
         checkNotNull(clusterName);
         checkNotNull(servers);
-        checkNotNull(toIndexRequest);
+        checkNotNull(toActionRequests);
         checkNotNull(numOfShard);
         checkNotNull(flushInterval);
         input
@@ -177,7 +181,7 @@ public class ElasticsearchIO {
             .apply(GroupByKey.create())
             .apply("Write to Elasticesarch",
                    ParDo.of(new ElasticsearchWriter<>
-                                (clusterName, servers, toIndexRequest, error)));
+                                (clusterName, servers, toActionRequests, error)));
         return PDone.in(input.getPipeline());
       }
     }
@@ -200,30 +204,33 @@ public class ElasticsearchIO {
     private static class ElasticsearchWriter<T> extends DoFn<KV<Long, Iterable<T>>, Void> {
       private final Logger LOG = LoggerFactory.getLogger(ElasticsearchWriter.class);
       private final ClientSupplier clientSupplier;
-      private final SerializableFunction<T, IndexRequest> toIndexRequest;
+      private final SerializableFunction<T, Iterable<ActionRequest<?>>> toActionRequests;
       private final SerializableConsumer<String> error;
 
       public ElasticsearchWriter(String clusterName,
                                  InetSocketAddress[] servers,
-                                 SerializableFunction<T, IndexRequest> toIndexRequest,
+                                 SerializableFunction<T, Iterable<ActionRequest<?>>> toActionRequests,
                                  SerializableConsumer<String> error) {
         this.clientSupplier = new ClientSupplier(clusterName, servers);
-        this.toIndexRequest = toIndexRequest;
+        this.toActionRequests = toActionRequests;
         this.error = error;
       }
       @ProcessElement
       public void processElement(ProcessContext c) throws Exception {
-        final BulkRequestBuilder bulkRequestBuilder = clientSupplier.get().prepareBulk();
+        final List<Iterable<ActionRequest<?>>> actionRequests =
+            StreamSupport.stream(c.element().getValue().spliterator(), false)
+                .map(toActionRequests::apply)
+                .collect(Collectors.toList());
 
-        c.element().getValue().forEach(x -> bulkRequestBuilder.add(toIndexRequest.apply(x)));
         // Elasticsearch throws ActionRequestValidationException if bulk request is empty,
         // so do nothing if number of actions is zero.
-        if (bulkRequestBuilder.numberOfActions() == 0) {
+        if (actionRequests.isEmpty()) {
           LOG.info("ElasticsearchWriter: no requests to send");
           return;
         }
 
-        final BulkResponse bulkItemResponse = bulkRequestBuilder.get();
+        final BulkRequest bulkRequest = new BulkRequest().add(Iterables.concat(actionRequests));
+        final BulkResponse bulkItemResponse = clientSupplier.get().bulk(bulkRequest).get();
         if (bulkItemResponse.hasFailures()) {
           if (error == null)
             throw new IOException(bulkItemResponse.buildFailureMessage());

--- a/scio-elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ThrowingConsumer.java
+++ b/scio-elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ThrowingConsumer.java
@@ -18,8 +18,9 @@
 package org.apache.beam.sdk.io.elasticsearch;
 
 import java.io.Serializable;
-import java.util.function.Consumer;
 
-public interface SerializableConsumer<T> extends Consumer<T>, Serializable {
+@FunctionalInterface
+public interface ThrowingConsumer<T> extends Serializable {
 
+  <X extends Throwable> void accept(T t) throws X;
 }

--- a/scio-elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ThrowingConsumer.java
+++ b/scio-elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ThrowingConsumer.java
@@ -22,5 +22,5 @@ import java.io.Serializable;
 @FunctionalInterface
 public interface ThrowingConsumer<T> extends Serializable {
 
-  <X extends Throwable> void accept(T t) throws X;
+  void accept(T t) throws Exception;
 }

--- a/scio-elasticsearch/src/test/scala/com/spotify/scio/elasticsearch/ElasticsearchTest.scala
+++ b/scio-elasticsearch/src/test/scala/com/spotify/scio/elasticsearch/ElasticsearchTest.scala
@@ -36,7 +36,7 @@ object ElasticsearchJob {
   def main(cmdlineArgs: Array[String]): Unit = {
     val (sc, _) = ContextAndArgs(cmdlineArgs)
     sc.parallelize(data)
-      .saveAsElasticsearch(options, _ => new IndexRequest, flushInterval, shard, _=> ())
+      .saveAsElasticsearch(options, _ => new IndexRequest :: Nil, flushInterval, shard, _=> ())
     sc.close()
   }
 }
@@ -46,7 +46,7 @@ object ElasticsearchDirectRunnerJob {
   def main(cmdlineArgs: Array[String]): Unit = {
     val (sc, _) = ContextAndArgs(cmdlineArgs)
     sc.parallelize(data)
-      .saveAsElasticsearch(options, _ => new IndexRequest)
+      .saveAsElasticsearch(options, _ => new IndexRequest :: Nil)
     sc.close()
   }
 }


### PR DESCRIPTION
* improved error. Added bulk execution exception with the respective failures.
* usage of `Iterable[ActionRequest]`.
  * Allows `IndexRequest` `DeleteRequest` and `UpdateRequest`
  * Actions happen in the same bulk request
  * Allows indexing `T` in different indices

@nevillelyh @ravwojdyla @andrewsmartin @lmayumi