### PR TITLE
Disable scio-hdfs and scio-examples, fix checkpoint test.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -200,10 +200,10 @@ lazy val root: Project = Project(
   scioBigtable,
   scioElasticsearch,
   scioExtra,
-  scioHdfs,
+//  scioHdfs,
   scioJdbc,
   scioRepl,
-  scioExamples,
+//  scioExamples,
   scioSchemas
 )
 


### PR DESCRIPTION
I'd like to disable the `scio-hdfs` and `scio-examples` projects for now to make it easier to focus on migrating everything else. We might be able to remove `scio-hdfs` completely but we need to address https://github.com/spotify/scio/issues/600 first.