### PR TITLE
Fix InMemorySink

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/io/InMemorySink.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/InMemorySink.scala
@@ -19,8 +19,6 @@ package com.spotify.scio.io
 
 import com.spotify.scio.values.SCollection
 import org.apache.beam.runners.direct.DirectRunner
-import org.apache.beam.sdk.transforms.PTransform
-import org.apache.beam.sdk.values.{PCollection, PDone}
 
 import scala.collection.concurrent.TrieMap
 
@@ -39,9 +37,6 @@ private[scio] object InMemorySink {
         cache += (id -> values)
         ()
       }
-      .applyInternal(new PTransform[PCollection[Unit], PDone]() {
-        override def expand(input: PCollection[Unit]): PDone = PDone.in(input.getPipeline)
-      })
   }
 
   def get[T](id: String): Iterable[T] = cache(id).asInstanceOf[Iterable[T]]


### PR DESCRIPTION
This was causing a big chunk of the outstanding test failures. The problem here is that the transform I removed does not have a corresponding `TransformEvaluator` registered in the direct runner, and there doesn't seem to be a way to add one (which makes sense). Removing it altogether is the easiest way out IMO since it seems like a `PTransform[InputT, PDone]` is only convention and not actually necessary anyway.