### PR TITLE
Fix NamedTransformTest beam 2.0

### DIFF
--- a/scio-test/src/main/scala/com/spotify/scio/testing/util/ItUtils.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/util/ItUtils.scala
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableList
 import com.spotify.scio.bigquery.BigQueryClient
 import org.apache.beam.sdk.extensions.gcp.auth.NullCredentialInitializer
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions.DefaultProjectFactory
-import org.apache.beam.sdk.extensions.gcp.options.{CloudResourceManagerOptions, GcpOptions, GcsOptions}
+import org.apache.beam.sdk.extensions.gcp.options._
 import org.apache.beam.sdk.options.PipelineOptionsFactory
 import org.apache.beam.sdk.util.{GcsUtil, RetryHttpRequestInitializer, Transport}
 

--- a/scio-test/src/test/scala/com/spotify/scio/values/NamedTransformTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/NamedTransformTest.scala
@@ -89,8 +89,9 @@ class NamedTransformTest extends PipelineSpec {
       val p2 = SideOutput[String]()
       val (main, side) = p1.withSideOutputs(p2)
         .withName("MakeSideOutput").map { (x, s) => s.output(p2, x + "2"); x + "1" }
+      val sideOutput = side(p2)
       assertTransformNameStartsWith(main, "MakeSideOutput")
-      assertTransformNameStartsWith(side(p2), "MakeSideOutput")
+      assertTransformNameStartsWith(sideOutput, "MakeSideOutput")
     }
   }
 


### PR DESCRIPTION
The coder for the `SideOutput` is not set until explicitly fetched from the `SideOutputContext`, so I just fetched it before doing the transform name assertions.