### PR TITLE
Add helpers for Metrics API [Beam 2.0]

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
@@ -30,7 +30,7 @@ import org.apache.beam.sdk.PipelineResult.State
 import org.apache.beam.sdk.options.ApplicationNameOptions
 import org.apache.beam.sdk.PipelineResult
 import org.apache.beam.sdk.io.FileSystems
-import org.apache.beam.sdk.metrics.{Metrics => _, _}
+import org.apache.beam.sdk.metrics._
 import org.apache.beam.sdk.util.MimeTypes
 import org.slf4j.LoggerFactory
 
@@ -108,7 +108,7 @@ class ScioResult private[scio] (val internal: PipelineResult,
   }
 
   /** Get metrics of the finished pipeline. */
-  def getMetrics: Metrics = {
+  def getMetrics: ServiceMetrics = {
     require(isCompleted, "Pipeline has to be finished to get metrics.")
 
     val (jobId, dfMetrics) = if (ScioUtil.isLocalRunner(this.context.options)) {
@@ -140,7 +140,7 @@ class ScioResult private[scio] (val internal: PipelineResult,
       (jobId, dfMetrics)
     }
 
-    Metrics(scioVersion,
+    ServiceMetrics(scioVersion,
       scalaVersion,
       context.optionsAs[ApplicationNameOptions].getAppName,
       jobId,
@@ -176,7 +176,7 @@ class ScioResult private[scio] (val internal: PipelineResult,
     }
 
   private lazy val internalMetrics = internal.metrics.queryMetrics(
-    MetricsFilter.builder().addNameFilter(MetricNameFilter.inNamespace(Metrics.namespace))
+    MetricsFilter.builder().addNameFilter(MetricNameFilter.inNamespace(ScioMetric.namespace))
     .build()
   )
 

--- a/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
@@ -21,11 +21,7 @@ import org.apache.beam.sdk.metrics.{Counter, Distribution, Gauge, MetricResult, 
 
 import scala.util.Try
 
-/**
- * This package contains the schema types for metrics collected during a pipeline run.
- *
- * See [[ScioResult.getMetrics]].
- */
+/** This package contains the schema types for metrics collected during a pipeline run. */
 package object metrics {
 
   /** Utility object for creating Metrics. The main types available are
@@ -39,7 +35,7 @@ package object metrics {
     def gauge(name: String): Gauge = BMetrics.gauge(namespace, name)
   }
 
-  /** Contains the aggregated value of a metric.
+  /** Contains the aggregated value of a metric. See (for example) [[ScioResult.getCounters]]
    *
    * @param attempted The value aggregated across all attempted steps, including failed steps.
    * @param committed The value aggregated across all completed steps.
@@ -51,7 +47,9 @@ package object metrics {
       new MetricValue(result.attempted, Try(result.committed).toOption)
   }
 
-  /** Case class holding metadata and service-level metrics of the job. */
+  /** Case class holding metadata and service-level metrics of the job.
+   * See [[ScioResult.getMetrics]].
+   */
   case class Metrics(version: String,
                      scalaVersion: String,
                      jobName: String,

--- a/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
@@ -28,7 +28,7 @@ package object metrics {
    * [[org.apache.beam.sdk.metrics.Counter]], [[org.apache.beam.sdk.metrics.Distribution]] and
    * [[org.apache.beam.sdk.metrics.Gauge]].
    */
-  object Metrics {
+  object ScioMetric {
     private[scio] val namespace = "scio"
     def counter(name: String): Counter = BMetrics.counter(namespace, name)
     def distribution(name: String): Distribution = BMetrics.distribution(namespace, name)
@@ -50,12 +50,12 @@ package object metrics {
   /** Case class holding metadata and service-level metrics of the job.
    * See [[ScioResult.getMetrics]].
    */
-  case class Metrics(version: String,
-                     scalaVersion: String,
-                     jobName: String,
-                     jobId: String,
-                     state: String,
-                     cloudMetrics: Iterable[DFServiceMetrics])
+  case class ServiceMetrics(version: String,
+                            scalaVersion: String,
+                            jobName: String,
+                            jobId: String,
+                            state: String,
+                            cloudMetrics: Iterable[DFServiceMetrics])
   case class DFServiceMetrics(name: DFMetricName, scalar: AnyRef, updateTime: String)
   case class DFMetricName(name: String, origin: String, context: Map[String, String])
 }

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/DebuggingWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/DebuggingWordCount.scala
@@ -21,7 +21,7 @@ import java.util.regex.Pattern
 
 import com.spotify.scio._
 import com.spotify.scio.examples.common.ExampleData
-import com.spotify.scio.metrics.Metrics
+import com.spotify.scio.metrics.ScioMetric
 import org.apache.beam.sdk.testing.PAssert
 import org.slf4j.LoggerFactory
 
@@ -44,8 +44,8 @@ object DebuggingWordCount {
 
     val filter = Pattern.compile(args.getOrElse("filterPattern", "Flourish|stomach"))
 
-    val matchedWords = Metrics.counter("matchedWords")
-    val unmatchedWords = Metrics.counter("unmatchedWords")
+    val matchedWords = ScioMetric.counter("matchedWords")
+    val unmatchedWords = ScioMetric.counter("unmatchedWords")
 
     val filteredWords = sc.textFile(args.getOrElse("input", ExampleData.KING_LEAR))
       .flatMap(_.split("[^a-zA-Z']+").filter(_.nonEmpty))

--- a/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -20,7 +20,7 @@ package com.spotify.scio
 import java.nio.file.Files
 
 import com.google.common.collect.Lists
-import com.spotify.scio.metrics.Metrics
+import com.spotify.scio.metrics.ServiceMetrics
 import com.spotify.scio.options.ScioOptions
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.util.ScioUtil
@@ -121,7 +121,7 @@ class ScioContextTest extends PipelineSpec {
 
     val mapper = ScioUtil.getScalaJsonMapper
 
-    val metrics = mapper.readValue(metricsFile, classOf[Metrics])
+    val metrics = mapper.readValue(metricsFile, classOf[ServiceMetrics])
     metrics.version shouldBe scioVersion
   }
 


### PR DESCRIPTION
This is a very simple helper to make querying the metrics less painful. I'm hiding the namespace for now to keep things simple, we can always add it back if needed. 

Later on I'd like to add some hooks so that the created metrics can be queried by reference instead of the name string but I think this is enough for an alpha release.