### PR TITLE
Add custom ClosureCleaner

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ import sbtassembly.AssemblyPlugin.autoImport._
 import com.typesafe.sbt.SbtSite.SiteKeys._
 import com.typesafe.sbt.SbtGit.GitKeys.gitRemoteRepo
 
+val asmVersion = "5.2"
 val beamVersion = "2.0.0"
 val algebirdVersion = "0.13.0"
 val annoyVersion = "0.2.5"
@@ -226,7 +227,8 @@ lazy val scioCore: Project = Project(
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonScalaModuleVersion,
     "com.google.auto.service" % "auto-service" % autoServiceVersion,
     "com.google.auto.value" % "auto-value" % autoValueVersion % "provided",
-    "me.lyh" %% "protobuf-generic" % protobufGenericVersion
+    "me.lyh" %% "protobuf-generic" % protobufGenericVersion,
+    "org.ow2.asm" % "asm" % asmVersion
   )
 ).dependsOn(
   scioBigQuery

--- a/scio-core/src/main/scala/com/spotify/scio/util/ClosureCleaner.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/ClosureCleaner.scala
@@ -18,19 +18,231 @@
 package com.spotify.scio.util
 
 import java.io.NotSerializableException
+import java.lang.reflect.{Constructor, Field}
 
 import org.apache.beam.sdk.util.SerializableUtils
+import org.objectweb.asm.{ClassReader, ClassVisitor, MethodVisitor, Type}
+import org.objectweb.asm.Opcodes._
+
+import scala.annotation.tailrec
+import scala.collection.mutable.{Map => MMap, Set => MSet, Stack => MStack}
+import scala.util.Try
 
 private[scio] object ClosureCleaner {
-  def apply[T <: AnyRef](obj: T): T = {
+
+  /** Clean the closure in place. */
+  def apply[T <: AnyRef](func: T): T = {
     try {
-      SerializableUtils.serializeToByteArray(obj.asInstanceOf[Serializable])
+      SerializableUtils.serializeToByteArray(func.asInstanceOf[Serializable])
     } catch {
       case e: IllegalArgumentException if e.getCause.isInstanceOf[NotSerializableException] =>
-        com.twitter.chill.ClosureCleaner(obj)
+        clean(func)
       case e: ClassCastException =>
-        com.twitter.chill.ClosureCleaner(obj)
+        clean(func)
     }
-    obj
+    func
   }
+
+  def clean(func: AnyRef): AnyRef = new TransitiveClosureCleaner(func).clean
+}
+
+private trait ClosureCleaner {
+  /** The closure to clean. */
+  val func: AnyRef
+  val funcClass: Class[_] = func.getClass
+  val objectCtor: Constructor[_] = classOf[_root_.java.lang.Object].getDeclaredConstructor()
+  final val OUTER = "$outer"
+
+  /** Clean [[func]] by replacing its 'outer' with a cleaned clone. See [[cleanOuter()]]. */
+  def clean: AnyRef = {
+    val newOuter = cleanOuter()
+    setOuter(func, newOuter)
+    func
+  }
+
+  /**
+   * Create a new 'cleaned' copy of [[func]]'s outer, without modifying the original. The cleaned
+   * outer may have null values for fields that are determined to be unneeded in the context
+   * of [[func]].
+   *
+   * @return The cleaned outer.
+   */
+  def cleanOuter(): AnyRef
+
+  def outerFieldOf(c: Class[_]): Option[Field] = Try(c.getDeclaredField(OUTER)).toOption
+
+  def setOuter(obj: AnyRef, outer: AnyRef): Unit = {
+    if (outer != null) {
+      val field = outerFieldOf(obj.getClass).get
+      field.setAccessible(true)
+      field.set(obj, outer)
+    }
+  }
+
+  def copyField(f: Field, old: AnyRef, newv: AnyRef): Unit = {
+    f.setAccessible(true)
+    val accessedValue = f.get(old)
+    f.set(newv, accessedValue)
+  }
+
+  def instantiateClass(cls: Class[_]): AnyRef =
+    sun.reflect.ReflectionFactory
+      .getReflectionFactory
+      .newConstructorForSerialization(cls, objectCtor)
+      .newInstance()
+      .asInstanceOf[AnyRef]
+}
+
+/**
+ * An implementation of [[ClosureCleaner]] that cleans [[func]] by transitively tracing its method
+ * calls and field references up through its enclosing scopes. A new hierarchy of outers is
+ * constructed by cloning the outer scopes and populating only the fields that are to be accessed
+ * by [[func]] (including any of its inner closures). Additionally, outers are removed from the
+ * new hierarchy if none of their fields are accessed by [[func]].
+ */
+private class TransitiveClosureCleaner(val func: AnyRef) extends ClosureCleaner {
+  private val accessedFieldsMap = MMap[Class[_], Set[Field]]()
+  private lazy val outers: List[(Class[_], AnyRef)] = getOutersOf(func)
+  private lazy val outerClasses: List[Class[_]] = outers.map(_._1)
+
+  override def cleanOuter(): AnyRef = {
+    storeAccessedFields()
+    outers.foldLeft(null: AnyRef) { (prevOuter, clsData) =>
+      val (thisOuterCls, realOuter) = clsData
+      val nextOuter = instantiateClass(thisOuterCls)
+      accessedFieldsMap(thisOuterCls).foreach(copyField(_, realOuter, nextOuter))
+      /* If this object's outer is not transitively referenced from the starting closure
+         (or any of its inner closures), we can null it out. */
+      val parent =
+        if (!accessedFieldsMap(thisOuterCls).exists(_.getName == OUTER)) null else prevOuter
+      setOuter(nextOuter, parent)
+      nextOuter
+    }
+  }
+
+  /**
+   * Returns the (Class, AnyRef) pairs from highest level to lowest level. The last element is the
+   * outer of the closure.
+   */
+  @tailrec
+  private def getOutersOf(obj: AnyRef, hierarchy: List[(Class[_], AnyRef)] = Nil)
+  : List[(Class[_], AnyRef)] =
+  outerFieldOf(obj.getClass) match {
+    case None => hierarchy // We have finished
+    case Some(f) =>
+      // f is the $outer of obj
+      f.setAccessible(true)
+      // myOuter = obj.$outer
+      val myOuter = f.get(obj)
+      val outerType = myOuter.getClass
+      getOutersOf(myOuter, (outerType, myOuter) :: hierarchy)
+  }
+
+  private def classReader(cls: Class[_]): ClassReader = {
+    val className = cls.getName.replaceFirst("^.*\\.", "") + ".class"
+    new ClassReader(cls.getResourceAsStream(className))
+  }
+
+  private def innerClasses: Set[Class[_]] = {
+    val seen = MSet[Class[_]](funcClass)
+    val stack = MStack[Class[_]](funcClass)
+    while (stack.nonEmpty) {
+      val cr = classReader(stack.pop())
+      val set = MSet[Class[_]]()
+      cr.accept(new InnerClosureFinder(set), 0)
+      (set -- seen).foreach { cls =>
+        seen += cls
+        stack.push(cls)
+      }
+    }
+    (seen - funcClass).toSet
+  }
+
+  private def getAccessedFields: MMap[Class[_], MSet[String]] = {
+    val af = outerClasses
+      .foldLeft(MMap[Class[_], MSet[String]]()) { (m, cls) =>
+        m += ((cls, MSet[String]()))
+      }
+    (innerClasses + funcClass).foreach(classReader(_).accept(
+      new AccessedFieldsVisitor(af)(classReader), 0))
+    af
+  }
+
+  private def storeAccessedFields(): Unit = {
+    if (accessedFieldsMap.isEmpty) {
+      getAccessedFields.foreach {
+        case (cls, mset) =>
+          def toF(ss: Set[String]): Set[Field] = ss.map(cls.getDeclaredField)
+          val set = mset.toSet
+          accessedFieldsMap += ((cls, toF(set)))
+      }
+    }
+  }
+}
+
+private case class MethodIdentifier[T](cls: Class[T], name: String, desc: String)
+
+private class AccessedFieldsVisitor(output: MMap[Class[_], MSet[String]],
+                                    specificMethod: Option[MethodIdentifier[_]] = None,
+                                    visitedMethods: MSet[MethodIdentifier[_]] = MSet.empty)
+                                   (clsReader: Class[_] => ClassReader) extends ClassVisitor(ASM5) {
+  override def visitMethod(access: Int, name: String, desc: String,
+                           sig: String, exceptions: Array[String]): MethodVisitor = {
+    if (specificMethod.isDefined &&
+      (specificMethod.get.name != name || specificMethod.get.desc != desc)) {
+      null
+    } else {
+      new MethodVisitor(ASM5) {
+        override def visitFieldInsn(op: Int, owner: String, name: String, desc: String): Unit = {
+          if (op == GETFIELD) {
+            for (cl <- output.keys if cl.getName == owner.replace('/', '.')) {
+              output(cl) += name
+            }
+          }
+        }
+
+        override def visitMethodInsn(op: Int, owner: String, name: String,
+                                     desc: String, itf: Boolean): Unit = {
+          for (cl <- output.keys if cl.getName == owner.replace('/', '.')) {
+            // Check for calls a getter method for a variable in an interpreter wrapper object.
+            // This means that the corresponding field will be accessed, so we should save it.
+            if (op == INVOKEVIRTUAL && owner.endsWith("$iwC") && !name.endsWith("$outer")) {
+              output(cl) += name
+            }
+            val m = MethodIdentifier(cl, name, desc)
+            if (!visitedMethods.contains(m)) {
+              // Keep track of visited methods to avoid potential infinite cycles
+              visitedMethods += m
+              clsReader(cl).accept(
+                new AccessedFieldsVisitor(output, Some(m), visitedMethods)(clsReader), 0)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+class InnerClosureFinder(output: MSet[Class[_]]) extends ClassVisitor(ASM5) {
+  var myName: String = _
+
+  override def visit(version: Int, access: Int, name: String, sig: String,
+                     superName: String, interfaces: Array[String]): Unit = {
+    myName = name
+  }
+
+  override def visitMethod(access: Int, name: String, desc: String,
+                           sig: String, exceptions: Array[String]): MethodVisitor =
+    new MethodVisitor(ASM5) {
+      override def visitMethodInsn(op: Int, owner: String, name: String,
+                                   desc: String, itf: Boolean) {
+        val argTypes = Type.getArgumentTypes(desc)
+        if (op == INVOKESPECIAL && name == "<init>" && argTypes.nonEmpty
+          && argTypes(0).toString.startsWith("L")
+          && argTypes(0).getInternalName == myName) {
+          output += Class.forName(owner.replace('/', '.'), false,
+            Thread.currentThread.getContextClassLoader)
+        }
+      }
+    }
 }

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/checkpoint/CheckpointTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/checkpoint/CheckpointTest.scala
@@ -26,15 +26,18 @@ import scala.reflect.io.File
 import scala.util.Try
 
 object CheckpointMetrics {
-  val elemsBefore = ScioMetrics.counter("elemsBefore")
-  val elemsAfter = ScioMetrics.counter("elemsAfter")
 
   def runJob(checkpointArg: String, tempLocation: String = null): (Long, Long) = {
+    val elemsBefore = ScioMetrics.counter("elemsBefore")
+    val elemsAfter = ScioMetrics.counter("elemsAfter")
+
     val (sc, args) = ContextAndArgs(Array(s"--checkpoint=$checkpointArg") ++
       Option(tempLocation).map(e => s"--tempLocation=$e"))
-    sc.checkpoint(args("checkpoint"))(sc.parallelize(1 to 10)
-      .map { x => elemsBefore.inc(); x })
-      .map { x => elemsAfter.inc(); x }
+    sc.checkpoint(args("checkpoint")) {
+      sc.parallelize(1 to 10)
+        .map { x => elemsBefore.inc(); x }
+    }
+    .map { x => elemsAfter.inc(); x }
     val r = sc.close().waitUntilDone()
     (Try(r.counter(elemsBefore).committed.get).getOrElse(0),
       r.counter(elemsAfter).committed.get)


### PR DESCRIPTION
The `ClosureCleaner` we've been using seems to be broken in a few cases, especially when it comes to multiple layers of nesting. For example it's possible to have a closure whose enclosing scope references an outer that is not serializable, but such that (by tracing the transitive method calls / field references starting from the inner closure), we don't actually need the reference. So we can null it out. The test case I added to `ClosureTest` is an example of this.

I thought about instead just submitting this upstream but it's a fairly big change and it seems they haven't really touched their version in a couple years. Thoughts? Spark uses this approach too.

