### PR TITLE
add Cassandra sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Scio includes the following artifacts:
 - `scio-test`: test utilities, add to your project as a "test" dependency
 - `scio-bigquery`: Add-on for BigQuery, included in `scio-core` but can also be used standalone
 - `scio-bigtable`: Add-on for Bigtable
+- `scio-cassandra2`: Add-on for Cassandra 2.x
+- `scio-cassandra3`: Add-on for Cassandra 3.x
 - `scio-elasticsearch`: Add-on for Elasticsearch
 - `scio-extra`: Extra utilities for working with collections, Breeze, etc.
 - `scio-hdfs`: Add-on for HDFS IO

--- a/build.sbt
+++ b/build.sbt
@@ -199,6 +199,8 @@ lazy val root: Project = Project(
   scioTest,
   scioBigQuery,
   scioBigtable,
+  scioCassandra2,
+  scioCassandra3,
   scioElasticsearch,
   scioExtra,
   scioJdbc,
@@ -290,6 +292,41 @@ lazy val scioBigtable: Project = Project(
     "com.google.cloud.bigtable" % "bigtable-client-core" % bigtableVersion,
     "io.netty" % "netty-tcnative-boringssl-static" % nettyTcNativeVersion,
     "org.scalatest" %% "scalatest" % scalatestVersion % "test"
+  )
+).dependsOn(
+  scioCore,
+  scioTest % "it"
+).configs(IntegrationTest)
+
+lazy val scioCassandra2: Project = Project(
+  "scio-cassandra2",
+  file("scio-cassandra2")
+).settings(
+  commonSettings ++ itSettings,
+  description := "Scio add-on for Apache Cassandra 2.x",
+  scalaSource in Compile := (baseDirectory in ThisBuild).value / "scio-cassandra3/src/main/scala",
+  libraryDependencies ++= Seq(
+    "com.datastax.cassandra" % "cassandra-driver-core" % "2.1.10.3",
+    "org.apache.cassandra" % "cassandra-all" % "2.0.17",
+    "org.apache.hadoop" % "hadoop-client" % hadoopVersion
+  )
+).dependsOn(
+  scioCore,
+  scioTest % "it"
+).configs(IntegrationTest)
+
+lazy val scioCassandra3: Project = Project(
+  "scio-cassandra3",
+  file("scio-cassandra3")
+).settings(
+  commonSettings ++ itSettings,
+  description := "Scio add-on for Apache Cassandra 3.x",
+  libraryDependencies ++= Seq(
+    "com.datastax.cassandra" % "cassandra-driver-core" % "3.2.0",
+    ("org.apache.cassandra" % "cassandra-all" % "3.11.0")
+      .exclude("ch.qos.logback", "logback-classic")
+      .exclude("org.slf4j", "log4j-over-slf4j"),
+    "org.apache.hadoop" % "hadoop-client" % hadoopVersion
   )
 ).dependsOn(
   scioCore,

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,9 @@ machine:
     SBT_OPTS: "-XX:ReservedCodeCacheSize=256m"
     JAVA_OPTS: "-Xms1g -Xmx2g -Dsun.io.serialization.extendedDebugInfo=true"
     GOOGLE_APPLICATION_CREDENTIALS: "scripts/data-integration-test.json"
+  services:
+    - cassandra
+
 
 dependencies:
   cache_directories:
@@ -22,6 +25,10 @@ dependencies:
     - scio-bigquery/target/streams
     - scio-bigtable/target/resolution-cache
     - scio-bigtable/target/streams
+    - scio-cassandra2/target/resolution-cache
+    - scio-cassandra2/target/streams
+    - scio-cassandra3/target/resolution-cache
+    - scio-cassandra3/target/streams
     - scio-elasticsearch/target/resolution-cache
     - scio-elasticsearch/target/streams
     - scio-extra/target/resolution-cache

--- a/scio-cassandra2/src/it/scala/com/spotify/scio/cassandra/CassandraIT.scala
+++ b/scio-cassandra2/src/it/scala/com/spotify/scio/cassandra/CassandraIT.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.cassandra
+
+import java.math.{BigInteger, BigDecimal => JBigDecimal}
+import java.nio.ByteBuffer
+import java.time.Instant
+import java.util.{Date, UUID}
+
+import com.datastax.driver.core.utils.UUIDs
+import com.datastax.driver.core.{Cluster, Row}
+import com.spotify.scio._
+import org.scalatest._
+
+import scala.collection.JavaConverters._
+
+class CassandraIT extends FlatSpec with Matchers with BeforeAndAfterAll {
+
+  import CassandraIT._
+
+  private val n = 1000
+  private val host = "127.0.0.1"
+
+  // TODO: figure out why inet/InetAddress doesn't work
+  private val table1Cql =
+    """
+      |CREATE TABLE scio.table1 (
+      |  key text,          // String
+      |  i1 int,            // Int
+      |  i2 bigint,         // Long
+      |  d decimal,         // java.math.BigDecimal
+      |  f1 float,          // Float
+      |  f2 double,         // Double
+      |  b1 boolean,        // Boolean
+      |  b2 blob,           // java.nio.ByteBuffer
+      |  dt timestamp,      // java.util.Date
+      |  u1 uuid,           // java.util.UUID
+      |  u2 timeuuid,       // java.util.UUID, Version 1
+      |  v1 varchar,        // String
+      |  v2 varint,         // java.math.BigInteger
+      |  c1 list<text>,     // java.util.List
+      |  c2 set<text>,      // java.util.Set
+      |  c3 map<text, int>, // java.util.Map
+      |  PRIMARY KEY (key)
+      |)
+    """.stripMargin
+
+  private val table2Cql =
+    """
+      |CREATE TABLE scio.table2 (
+      |  k1 text,
+      |  k2 text,
+      |  k3 text,
+      |  v1 text,
+      |  v2 int,
+      |  v3 float,
+      |  PRIMARY KEY (k1, k2, k3)
+      |);
+    """.stripMargin
+
+  private def connect(): Cluster = Cluster.builder().addContactPoint(host).build()
+
+  override protected def beforeAll(): Unit = {
+    val cluster = connect()
+    try {
+      val session = cluster.connect()
+      if (cluster.getMetadata.getKeyspace("scio") != null) {
+        session.execute("DROP KEYSPACE scio")
+      }
+      session.execute(
+        """
+          |CREATE KEYSPACE scio
+          |WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+        """.stripMargin)
+      session.execute(table1Cql)
+      session.execute(table2Cql)
+    } catch {
+      case e: Throwable =>
+        cluster.close()
+        throw e
+    }
+  }
+
+  ignore should "work with single key" in {
+    val cql =
+      """
+        |INSERT INTO scio.table1
+        |(key, i1, i2, d, f1, f2, b1, b2, dt, u1, u2, v1, v2, c1, c2, c3)
+        |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      """.stripMargin
+    val opts = CassandraOptions("scio", "table1", cql, host)
+
+    val cluster = connect()
+    try {
+      val sc = ScioContext()
+      sc.parallelize(1 to n)
+        .saveAsCassandra(opts)(toValues1)
+      sc.close()
+
+      val result = cluster.connect().execute("SELECT * FROM scio.table1").asScala
+      val expected = (1 to n).map(toValues1)
+      result.map(fromRow1) should contain theSameElementsAs expected
+    } finally {
+      cluster.close()
+      CassandraUtil.cleanup()
+    }
+  }
+
+  ignore should "work with composite key" in {
+    val cql =
+      """
+        |INSERT INTO scio.table2
+        |(k1, k2, k3, v1, v2, v3) VALUES (?, ?, ?, ?, ?, ?);
+      """.stripMargin
+    val opts = CassandraOptions("scio", "table2", cql, host)
+
+    val cluster = connect()
+    try {
+      val sc = ScioContext()
+      sc.parallelize(1 to n)
+        .saveAsCassandra(opts)(toValues2)
+      sc.close()
+
+      val result = cluster.connect().execute("SELECT * FROM scio.table2").asScala
+      val expected = (1 to n).map(toValues2)
+      result.map(fromRow2) should contain theSameElementsAs expected
+    } finally {
+      cluster.close()
+      CassandraUtil.cleanup()
+    }
+  }
+
+}
+
+object CassandraIT {
+
+  private val u1: UUID = UUID.randomUUID()
+  private val u2: UUID = UUIDs.timeBased()
+  private val timestamp = Date.from(Instant.now())
+
+  def toValues1(i: Int): Seq[Any] = Seq(
+    s"key$i", i, i.toLong, JBigDecimal.valueOf(i), i.toFloat, i.toDouble,
+    i % 2 == 0, ByteBuffer.wrap(s"blob$i".getBytes), timestamp,
+    u1, u2, s"varchar$i", BigInteger.valueOf(i),
+    List(s"list$i").asJava, Set(s"set$i").asJava, Map(s"key$i" -> i).asJava)
+
+  def fromRow1(r: Row): Seq[Any] = Seq(
+    r.getString("key"), r.getInt("i1"), r.getLong("i2"),
+    r.getDecimal("d"), r.getFloat("f1"), r.getDouble("f2"), r.getBool("b1"), r.getBytes("b2"),
+    r.getDate("dt"), r.getUUID("u1"), r.getUUID("u2"), r.getString("v1"), r.getVarint("v2"),
+    r.getList("c1", classOf[String]), r.getSet("c2", classOf[String]),
+    r.getMap("c3", classOf[String], classOf[java.lang.Integer]))
+
+  def toValues2(i: Int): Seq[Any] = Seq(s"k1_$i", s"k2_$i", s"k3_$i", s"v1_$i", i, i.toFloat)
+
+  def fromRow2(r: Row): Seq[Any] = Seq(
+    r.getString("k1"), r.getString("k2"), r.getString("k3"),
+    r.getString("v1"), r.getInt("v2"), r.getFloat("v3"))
+
+}

--- a/scio-cassandra2/src/main/java/com/datastax/driver/core/Connection.java
+++ b/scio-cassandra2/src/main/java/com/datastax/driver/core/Connection.java
@@ -1,0 +1,1353 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.Responses.Result.SetKeyspace;
+import com.datastax.driver.core.exceptions.AuthenticationException;
+import com.datastax.driver.core.exceptions.DriverException;
+import com.datastax.driver.core.exceptions.DriverInternalError;
+import com.datastax.driver.core.utils.MoreFutures;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.google.common.collect.MapMaker;
+import com.google.common.util.concurrent.*;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.*;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.Timeout;
+import io.netty.util.Timer;
+import io.netty.util.TimerTask;
+import io.netty.util.concurrent.GlobalEventExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLEngine;
+import java.lang.ref.WeakReference;
+import java.net.InetSocketAddress;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.datastax.driver.core.Message.Response.Type.ERROR;
+import static io.netty.handler.timeout.IdleState.ALL_IDLE;
+
+// For LoggingHandler
+//import org.jboss.netty.handler.logging.LoggingHandler;
+//import org.jboss.netty.logging.InternalLogLevel;
+
+/**
+ * A connection to a Cassandra Node.
+ */
+class Connection {
+
+    private static final Logger logger = LoggerFactory.getLogger(Connection.class);
+    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
+    private static final boolean DISABLE_COALESCING = SystemProperties.getBoolean("com.datastax.driver.DISABLE_COALESCING", false);
+
+    enum State {OPEN, TRASHED, RESURRECTING, GONE}
+
+    final AtomicReference<State> state = new AtomicReference<State>(State.OPEN);
+
+    volatile long maxIdleTime;
+
+    public final InetSocketAddress address;
+    private final String name;
+
+    @VisibleForTesting
+    volatile Channel channel;
+    private final Factory factory;
+
+    @VisibleForTesting
+    final Dispatcher dispatcher;
+
+    // Used by connection pooling to count how many requests are "in flight" on that connection.
+    public final AtomicInteger inFlight = new AtomicInteger(0);
+
+    private final AtomicInteger writer = new AtomicInteger(0);
+    private volatile String keyspace;
+
+    private volatile boolean isInitialized;
+    private final AtomicBoolean isDefunct = new AtomicBoolean();
+    private final AtomicBoolean signaled = new AtomicBoolean();
+
+    private final AtomicReference<ConnectionCloseFuture> closeFuture = new AtomicReference<ConnectionCloseFuture>();
+
+    private final AtomicReference<Owner> ownerRef = new AtomicReference<Owner>();
+
+    /**
+     * /**
+     * Create a new connection to a Cassandra node and associate it with the given pool.
+     *
+     * @param name    the connection name
+     * @param address the remote address
+     * @param factory the connection factory to use
+     * @param owner   the component owning this connection (may be null).
+     *                Note that an existing connection can also be associated to an owner later with {@link #setOwner(Owner)}.
+     */
+    protected Connection(String name, InetSocketAddress address, Factory factory, Owner owner) {
+        this.address = address;
+        this.factory = factory;
+        this.dispatcher = new Dispatcher();
+        this.name = name;
+        this.ownerRef.set(owner);
+    }
+
+    /**
+     * Create a new connection to a Cassandra node.
+     */
+    Connection(String name, InetSocketAddress address, Factory factory) {
+        this(name, address, factory, null);
+    }
+
+    public ListenableFuture<Void> initAsync() {
+        if (factory.isShutdown)
+            return Futures.immediateFailedFuture(new ConnectionException(address, "Connection factory is shut down"));
+
+        ProtocolVersion protocolVersion = factory.protocolVersion == null ? ProtocolVersion.NEWEST_SUPPORTED : factory.protocolVersion;
+        final SettableFuture<Void> channelReadyFuture = SettableFuture.create();
+
+        try {
+            Bootstrap bootstrap = factory.newBootstrap();
+            ProtocolOptions protocolOptions = factory.configuration.getProtocolOptions();
+            bootstrap.handler(
+                    new Initializer(this, protocolVersion, protocolOptions.getCompression().compressor(), protocolOptions.getSSLOptions(),
+                            factory.configuration.getPoolingOptions().getHeartbeatIntervalSeconds(),
+                            factory.configuration.getNettyOptions()));
+
+            ChannelFuture future = bootstrap.connect(address);
+
+            writer.incrementAndGet();
+            future.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture future) throws Exception {
+                    writer.decrementAndGet();
+                    channel = future.channel();
+                    if (isClosed()) {
+                        channel.close().addListener(new ChannelFutureListener() {
+                            @Override
+                            public void operationComplete(ChannelFuture future) throws Exception {
+                                channelReadyFuture.setException(new TransportException(Connection.this.address, "Connection closed during initialization."));
+                            }
+                        });
+                    } else {
+                        Connection.this.factory.allChannels.add(channel);
+                        if (!future.isSuccess()) {
+                            if (logger.isDebugEnabled())
+                                logger.debug(String.format("%s Error connecting to %s%s", Connection.this, Connection.this.address, extractMessage(future.cause())));
+                            channelReadyFuture.setException(new TransportException(Connection.this.address, "Cannot connect", future.cause()));
+                        } else {
+                            logger.debug("{} Connection established, initializing transport", Connection.this);
+                            channel.closeFuture().addListener(new ChannelCloseListener());
+                            channelReadyFuture.set(null);
+                        }
+                    }
+                }
+            });
+        } catch (RuntimeException e) {
+            closeAsync().force();
+            throw e;
+        }
+
+        Executor initExecutor = factory.manager.configuration.getPoolingOptions().getInitializationExecutor();
+
+        ListenableFuture<Void> initializeTransportFuture = Futures.transformAsync(channelReadyFuture,
+                onChannelReady(protocolVersion, initExecutor), initExecutor);
+
+
+        // Fallback on initializeTransportFuture so we can properly propagate specific exceptions.
+        ListenableFuture<Void> initFuture = Futures.catchingAsync(initializeTransportFuture, Throwable.class, new AsyncFunction<Throwable, Void>() {
+            @Override
+            public ListenableFuture<Void> apply(@Nullable Throwable t) throws Exception {
+                SettableFuture<Void> future = SettableFuture.create();
+                // Make sure the connection gets properly closed.
+                if (t instanceof ClusterNameMismatchException || t instanceof UnsupportedProtocolVersionException) {
+                    // Just propagate
+                    closeAsync().force();
+                    future.setException(t);
+                } else {
+                    // Defunct to ensure that the error will be signaled (marking the host down)
+                    Exception e = (t instanceof ConnectionException || t instanceof DriverException || t instanceof InterruptedException)
+                            ? (Exception) t
+                            : new ConnectionException(Connection.this.address,
+                            String.format("Unexpected error during transport initialization (%s)", t),
+                            t);
+                    future.setException(defunct(e));
+                }
+                return future;
+            }
+        }, initExecutor);
+
+        // Ensure the connection gets closed if the caller cancels the returned future.
+        Futures.addCallback(initFuture, new MoreFutures.FailureCallback<Void>() {
+            @Override
+            public void onFailure(Throwable t) {
+                if (!isClosed()) {
+                    closeAsync().force();
+                }
+            }
+        }, initExecutor);
+
+        return initFuture;
+    }
+
+    private static String extractMessage(Throwable t) {
+        if (t == null)
+            return "";
+        String msg = t.getMessage() == null || t.getMessage().isEmpty()
+                ? t.toString()
+                : t.getMessage();
+        return " (" + msg + ')';
+    }
+
+    private AsyncFunction<Void, Void> onChannelReady(final ProtocolVersion protocolVersion, final Executor initExecutor) {
+        return new AsyncFunction<Void, Void>() {
+            @Override
+            public ListenableFuture<Void> apply(Void input) throws Exception {
+                ProtocolOptions.Compression compression = factory.configuration.getProtocolOptions().getCompression();
+                Future startupResponseFuture = write(new Requests.Startup(compression));
+                return Futures.transformAsync(startupResponseFuture,
+                        onStartupResponse(protocolVersion, initExecutor), initExecutor);
+            }
+        };
+    }
+
+    private AsyncFunction<Message.Response, Void> onStartupResponse(final ProtocolVersion protocolVersion, final Executor initExecutor) {
+        return new AsyncFunction<Message.Response, Void>() {
+            @Override
+            public ListenableFuture<Void> apply(Message.Response response) throws Exception {
+                switch (response.type) {
+                    case READY:
+                        return checkClusterName(protocolVersion, initExecutor);
+                    case ERROR:
+                        Responses.Error error = (Responses.Error) response;
+                        // Testing for a specific string is a tad fragile but well, we don't have much choice
+                        if (error.code == ExceptionCode.PROTOCOL_ERROR && error.message.contains("Invalid or unsupported protocol version"))
+                            throw unsupportedProtocolVersionException(protocolVersion, error.serverProtocolVersion);
+                        throw new TransportException(address, String.format("Error initializing connection: %s", error.message));
+                    case AUTHENTICATE:
+                        Authenticator authenticator = factory.authProvider.newAuthenticator(address);
+                        switch (protocolVersion) {
+                            case V1:
+                                if (authenticator instanceof ProtocolV1Authenticator)
+                                    return authenticateV1(authenticator, protocolVersion, initExecutor);
+                                else
+                                    // DSE 3.x always uses SASL authentication backported from protocol v2
+                                    return authenticateV2(authenticator, protocolVersion, initExecutor);
+                            case V2:
+                            case V3:
+                                return authenticateV2(authenticator, protocolVersion, initExecutor);
+                            default:
+                                throw defunct(protocolVersion.unsupported());
+                        }
+                    default:
+                        throw new TransportException(address, String.format("Unexpected %s response message from server to a STARTUP message", response.type));
+                }
+            }
+        };
+    }
+
+    // Due to C* gossip bugs, system.peers may report nodes that are gone from the cluster.
+    // If these nodes have been recommissionned to another cluster and are up, nothing prevents the driver from connecting
+    // to them. So we check that the cluster the node thinks it belongs to is our cluster (JAVA-397).
+    private ListenableFuture<Void> checkClusterName(ProtocolVersion protocolVersion, final Executor executor) {
+        final String expected = factory.manager.metadata.clusterName;
+
+        // At initialization, the cluster is not known yet
+        if (expected == null) {
+            markInitialized();
+            return MoreFutures.VOID_SUCCESS;
+        }
+
+        DefaultResultSetFuture clusterNameFuture = new DefaultResultSetFuture(null, protocolVersion, new Requests.Query("select cluster_name from system.local"));
+        try {
+            write(clusterNameFuture);
+            return Futures.transformAsync(clusterNameFuture,
+                    new AsyncFunction<ResultSet, Void>() {
+                        @Override
+                        public ListenableFuture<Void> apply(ResultSet rs) throws Exception {
+                            Row row = rs.one();
+                            String actual = row.getString("cluster_name");
+                            if (!expected.equals(actual))
+                                throw new ClusterNameMismatchException(address, actual, expected);
+                            markInitialized();
+                            return MoreFutures.VOID_SUCCESS;
+                        }
+                    }, executor);
+        } catch (Exception e) {
+            return Futures.immediateFailedFuture(e);
+        }
+    }
+
+    private void markInitialized() {
+        isInitialized = true;
+        Host.statesLogger.debug("[{}] {} Transport initialized, connection ready", address, this);
+    }
+
+    private ListenableFuture<Void> authenticateV1(Authenticator authenticator, final ProtocolVersion protocolVersion, final Executor executor) {
+        Requests.Credentials creds = new Requests.Credentials(((ProtocolV1Authenticator) authenticator).getCredentials());
+        try {
+            Future authResponseFuture = write(creds);
+            return Futures.transformAsync(authResponseFuture,
+                    new AsyncFunction<Message.Response, Void>() {
+                        @Override
+                        public ListenableFuture<Void> apply(Message.Response authResponse) throws Exception {
+                            switch (authResponse.type) {
+                                case READY:
+                                    return checkClusterName(protocolVersion, executor);
+                                case ERROR:
+                                    throw new AuthenticationException(address, ((Responses.Error) authResponse).message);
+                                default:
+                                    throw new TransportException(address, String.format("Unexpected %s response message from server to a CREDENTIALS message", authResponse.type));
+                            }
+                        }
+                    }, executor);
+        } catch (Exception e) {
+            return Futures.immediateFailedFuture(e);
+        }
+    }
+
+    private ListenableFuture<Void> authenticateV2(final Authenticator authenticator, final ProtocolVersion protocolVersion, final Executor executor) {
+        byte[] initialResponse = authenticator.initialResponse();
+        if (null == initialResponse)
+            initialResponse = EMPTY_BYTE_ARRAY;
+
+        try {
+            Future authResponseFuture = write(new Requests.AuthResponse(initialResponse));
+            return Futures.transformAsync(authResponseFuture, onV2AuthResponse(authenticator, protocolVersion, executor), executor);
+        } catch (Exception e) {
+            return Futures.immediateFailedFuture(e);
+        }
+    }
+
+    private AsyncFunction<Message.Response, Void> onV2AuthResponse(final Authenticator authenticator, final ProtocolVersion protocolVersion, final Executor executor) {
+        return new AsyncFunction<Message.Response, Void>() {
+            @Override
+            public ListenableFuture<Void> apply(Message.Response authResponse) throws Exception {
+                switch (authResponse.type) {
+                    case AUTH_SUCCESS:
+                        logger.trace("{} Authentication complete", this);
+                        authenticator.onAuthenticationSuccess(((Responses.AuthSuccess) authResponse).token);
+                        return checkClusterName(protocolVersion, executor);
+                    case AUTH_CHALLENGE:
+                        byte[] responseToServer = authenticator.evaluateChallenge(((Responses.AuthChallenge) authResponse).token);
+                        if (responseToServer == null) {
+                            // If we generate a null response, then authentication has completed, proceed without
+                            // sending a further response back to the server.
+                            logger.trace("{} Authentication complete (No response to server)", this);
+                            return checkClusterName(protocolVersion, executor);
+                        } else {
+                            // Otherwise, send the challenge response back to the server
+                            logger.trace("{} Sending Auth response to challenge", this);
+                            Future nextResponseFuture = write(new Requests.AuthResponse(responseToServer));
+                            return Futures.transformAsync(nextResponseFuture, onV2AuthResponse(authenticator, protocolVersion, executor), executor);
+                        }
+                    case ERROR:
+                        // This is not very nice, but we're trying to identify if we
+                        // attempted v2 auth against a server which only supports v1
+                        // The AIOOBE indicates that the server didn't recognise the
+                        // initial AuthResponse message
+                        String message = ((Responses.Error) authResponse).message;
+                        if (message.startsWith("java.lang.ArrayIndexOutOfBoundsException: 15"))
+                            message = String.format("Cannot use authenticator %s with protocol version 1, "
+                                    + "only plain text authentication is supported with this protocol version", authenticator);
+                        throw new AuthenticationException(address, message);
+                    default:
+                        throw new TransportException(address, String.format("Unexpected %s response message from server to authentication message", authResponse.type));
+                }
+            }
+        };
+    }
+
+    private UnsupportedProtocolVersionException unsupportedProtocolVersionException(ProtocolVersion triedVersion, ProtocolVersion serverProtocolVersion) {
+        logger.debug("Got unsupported protocol version error from {} for version {} server supports version {}", address, triedVersion, serverProtocolVersion);
+        return new UnsupportedProtocolVersionException(address, triedVersion, serverProtocolVersion);
+    }
+
+    public boolean isDefunct() {
+        return isDefunct.get();
+    }
+
+    public int maxAvailableStreams() {
+        return dispatcher.streamIdHandler.maxAvailableStreams();
+    }
+
+    <E extends Exception> E defunct(E e) {
+        if (isDefunct.compareAndSet(false, true)) {
+
+            if (Host.statesLogger.isTraceEnabled())
+                Host.statesLogger.trace("Defuncting " + this, e);
+            else if (Host.statesLogger.isDebugEnabled())
+                Host.statesLogger.debug("Defuncting {} because: {}", this, e.getMessage());
+
+
+            Host host = factory.manager.metadata.getHost(address);
+            if (host != null) {
+                // Sometimes close() can be called before defunct(); avoid decrementing the connection count twice, but
+                // we still want to signal the error to the conviction policy.
+                boolean decrement = signaled.compareAndSet(false, true);
+
+                boolean hostDown = host.convictionPolicy.signalConnectionFailure(this, decrement);
+                if (hostDown) {
+                    factory.manager.signalHostDown(host, host.wasJustAdded());
+                } else {
+                    notifyOwnerWhenDefunct();
+                }
+            }
+
+            // Force the connection to close to make sure the future completes. Otherwise force() might never get called and
+            // threads will wait on the future forever.
+            // (this also errors out pending handlers)
+            closeAsync().force();
+        }
+        return e;
+    }
+
+    private void notifyOwnerWhenDefunct() {
+        // If an error happens during initialization, the owner will detect it and take appropriate action
+        if (!isInitialized)
+            return;
+
+        Owner owner = this.ownerRef.get();
+        if (owner != null)
+            owner.onConnectionDefunct(this);
+    }
+
+    public String keyspace() {
+        return keyspace;
+    }
+
+    public void setKeyspace(String keyspace) throws ConnectionException {
+        if (keyspace == null)
+            return;
+
+        if (this.keyspace != null && this.keyspace.equals(keyspace))
+            return;
+
+        try {
+            Uninterruptibles.getUninterruptibly(setKeyspaceAsync(keyspace));
+        } catch (ConnectionException e) {
+            throw defunct(e);
+        } catch (BusyConnectionException e) {
+            logger.warn("Tried to set the keyspace on busy {}. "
+                    + "This should not happen but is not critical (it will be retried)", this);
+            throw new ConnectionException(address, "Tried to set the keyspace on busy connection");
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof OperationTimedOutException) {
+                // Rethrow so that the caller doesn't try to use the connection, but do not defunct as we don't want to mark down
+                logger.warn("Timeout while setting keyspace on {}. "
+                        + "This should not happen but is not critical (it will be retried)", this);
+                throw new ConnectionException(address, "Timeout while setting keyspace on connection");
+            } else {
+                throw defunct(new ConnectionException(address, "Error while setting keyspace", cause));
+            }
+        }
+    }
+
+    ListenableFuture<Void> setKeyspaceAsync(final String keyspace) throws ConnectionException, BusyConnectionException {
+        logger.trace("{} Setting keyspace {}", this, keyspace);
+        // Note: we quote the keyspace below, because the name is the one coming from Cassandra, so it's in the right case already
+        Future future = write(new Requests.Query("USE \"" + keyspace + '"'));
+        return Futures.transformAsync(future, new AsyncFunction<Message.Response, Void>() {
+            @Override
+            public ListenableFuture<Void> apply(Message.Response response) throws Exception {
+                if (response instanceof SetKeyspace) {
+                    Connection.this.keyspace = ((SetKeyspace) response).keyspace;
+                    return MoreFutures.VOID_SUCCESS;
+                } else if (response.type == ERROR) {
+                    Responses.Error error = (Responses.Error) response;
+                    throw defunct(error.asException(address));
+                } else {
+                    throw defunct(new DriverInternalError("Unexpected response while setting keyspace: " + response));
+                }
+            }
+        }, factory.manager.configuration.getPoolingOptions().getInitializationExecutor());
+    }
+
+    /**
+     * Write a request on this connection.
+     *
+     * @param request the request to send
+     * @return a future on the server response
+     * @throws ConnectionException if the connection is closed
+     * @throws TransportException  if an I/O error while sending the request
+     */
+    public Future write(Message.Request request) throws ConnectionException, BusyConnectionException {
+        Future future = new Future(request);
+        write(future);
+        return future;
+    }
+
+    public ResponseHandler write(ResponseCallback callback) throws ConnectionException, BusyConnectionException {
+        return write(callback, true);
+    }
+
+    public ResponseHandler write(ResponseCallback callback, boolean startTimeout) throws ConnectionException, BusyConnectionException {
+
+        ResponseHandler handler = new ResponseHandler(this, callback);
+        dispatcher.add(handler);
+
+        Message.Request request = callback.request().setStreamId(handler.streamId);
+
+        /*
+         * We check for close/defunct *after* having set the handler because closing/defuncting
+         * will set their flag and then error out handler if need. So, by doing the check after
+         * having set the handler, we guarantee that even if we race with defunct/close, we may
+         * never leave a handler that won't get an answer or be errored out.
+         */
+        if (isDefunct.get()) {
+            dispatcher.removeHandler(handler, true);
+            throw new ConnectionException(address, "Write attempt on defunct connection");
+        }
+
+        if (isClosed()) {
+            dispatcher.removeHandler(handler, true);
+            throw new ConnectionException(address, "Connection has been closed");
+        }
+
+        logger.trace("{}, stream {}, writing request {}", this, request.getStreamId(), request);
+        writer.incrementAndGet();
+
+        if (DISABLE_COALESCING) {
+            channel.writeAndFlush(request).addListener(writeHandler(request, handler));
+        } else {
+            flush(new FlushItem(channel, request, writeHandler(request, handler)));
+        }
+        if (startTimeout)
+            handler.startTimeout();
+
+        return handler;
+    }
+
+    private ChannelFutureListener writeHandler(final Message.Request request, final ResponseHandler handler) {
+        return new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture writeFuture) {
+
+                writer.decrementAndGet();
+
+                if (!writeFuture.isSuccess()) {
+                    logger.debug("{}, stream {}, Error writing request {}", Connection.this, request.getStreamId(), request);
+                    // Remove this handler from the dispatcher so it don't get notified of the error
+                    // twice (we will fail that method already)
+                    dispatcher.removeHandler(handler, true);
+
+                    final ConnectionException ce;
+                    if (writeFuture.cause() instanceof java.nio.channels.ClosedChannelException) {
+                        ce = new TransportException(address, "Error writing: Closed channel");
+                    } else {
+                        ce = new TransportException(address, "Error writing", writeFuture.cause());
+                    }
+                    final long latency = System.nanoTime() - handler.startTime;
+                    // This handler is executed while holding the writeLock of the channel.
+                    // defunct might close the pool, which will close all of its connections; closing a connection also
+                    // requires its writeLock.
+                    // Therefore if multiple connections in the same pool get a write error, they could deadlock;
+                    // we run defunct on a separate thread to avoid that.
+                    ListeningExecutorService executor = factory.manager.executor;
+                    if (!executor.isShutdown())
+                        executor.execute(new Runnable() {
+                            @Override
+                            public void run() {
+                                handler.callback.onException(Connection.this, defunct(ce), latency, handler.retryCount);
+                            }
+                        });
+                } else {
+                    logger.trace("{}, stream {}, request sent successfully", Connection.this, request.getStreamId());
+                }
+            }
+        };
+    }
+
+    boolean hasOwner() {
+        return this.ownerRef.get() != null;
+    }
+
+    /**
+     * @return whether the connection was already associated with an owner
+     */
+    boolean setOwner(Owner owner) {
+        return ownerRef.compareAndSet(null, owner);
+    }
+
+    /**
+     * If the connection is part of a pool, return it to the pool.
+     * The connection should generally not be reused after that.
+     */
+    void release() {
+        Owner owner = ownerRef.get();
+        if (owner instanceof HostConnectionPool)
+            ((HostConnectionPool) owner).returnConnection(this);
+    }
+
+    public boolean isClosed() {
+        return closeFuture.get() != null;
+    }
+
+    /**
+     * Closes the connection: no new writes will be accepted after this method has returned.
+     * <p/>
+     * However, a closed connection might still have ongoing queries awaiting for their result.
+     * When all these ongoing queries have completed, the underlying channel will be closed; we
+     * refer to this final state as "terminated".
+     *
+     * @return a future that will complete once the connection has terminated.
+     * @see #tryTerminate(boolean)
+     */
+    public CloseFuture closeAsync() {
+
+        ConnectionCloseFuture future = new ConnectionCloseFuture();
+        if (!closeFuture.compareAndSet(null, future)) {
+            // close had already been called, return the existing future
+            return closeFuture.get();
+        }
+
+        logger.debug("{} closing connection", this);
+
+        // Only signal if defunct hasn't done it already
+        if (signaled.compareAndSet(false, true)) {
+            Host host = factory.manager.metadata.getHost(address);
+            if (host != null) {
+                host.convictionPolicy.signalConnectionClosed(this);
+            }
+        }
+
+        boolean terminated = tryTerminate(false);
+        if (!terminated) {
+            // The time by which all pending requests should have normally completed (use twice the read timeout for a generous
+            // estimate -- note that this does not cover the eventuality that read timeout is updated dynamically, but we can live
+            // with that).
+            long terminateTime = System.currentTimeMillis() + 2 * factory.getReadTimeoutMillis();
+            factory.reaper.register(this, terminateTime);
+        }
+        return future;
+    }
+
+    /**
+     * Tries to terminate a closed connection, i.e. release system resources.
+     * <p/>
+     * This is called both by "normal" code and by {@link Cluster.ConnectionReaper}.
+     *
+     * @param force whether to proceed if there are still outstanding requests.
+     * @return whether the connection has actually terminated.
+     * @see #closeAsync()
+     */
+    boolean tryTerminate(boolean force) {
+        assert isClosed();
+        ConnectionCloseFuture future = closeFuture.get();
+
+        if (future.isDone()) {
+            logger.debug("{} has already terminated", this);
+            return true;
+        } else {
+            if (force || dispatcher.pending.isEmpty()) {
+                if (force)
+                    logger.warn("Forcing termination of {}. This should not happen and is likely a bug, please report.", this);
+                future.force();
+                return true;
+            } else {
+                logger.debug("Not terminating {}: there are still pending requests", this);
+                return false;
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Connection[%s, inFlight=%d, closed=%b]", name, inFlight.get(), isClosed());
+    }
+
+    public static class Factory {
+
+        public final Timer timer;
+
+        final EventLoopGroup eventLoopGroup;
+        private final Class<? extends Channel> channelClass;
+
+        private final ChannelGroup allChannels = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+
+        private final ConcurrentMap<Host, AtomicInteger> idGenerators = new ConcurrentHashMap<Host, AtomicInteger>();
+        public final DefaultResponseHandler defaultHandler;
+        final Cluster.Manager manager;
+        final Cluster.ConnectionReaper reaper;
+        public final Configuration configuration;
+
+        public final AuthProvider authProvider;
+        private volatile boolean isShutdown;
+
+        volatile ProtocolVersion protocolVersion;
+        private final NettyOptions nettyOptions;
+
+        Factory(Cluster.Manager manager, Configuration configuration) {
+            this.defaultHandler = manager;
+            this.manager = manager;
+            this.reaper = manager.reaper;
+            this.configuration = configuration;
+            this.authProvider = configuration.getProtocolOptions().getAuthProvider();
+            this.protocolVersion = configuration.getProtocolOptions().initialProtocolVersion;
+            this.nettyOptions = configuration.getNettyOptions();
+            this.eventLoopGroup = nettyOptions.eventLoopGroup(manager.threadFactory("nio-worker"));
+            this.channelClass = nettyOptions.channelClass();
+            this.timer = nettyOptions.timer(manager.threadFactory("timeouter"));
+        }
+
+        public int getPort() {
+            return configuration.getProtocolOptions().getPort();
+        }
+
+        /**
+         * Opens a new connection to the node this factory points to.
+         *
+         * @return the newly created (and initialized) connection.
+         * @throws ConnectionException if connection attempt fails.
+         */
+        public Connection open(Host host) throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
+            InetSocketAddress address = host.getSocketAddress();
+
+            if (isShutdown)
+                throw new ConnectionException(address, "Connection factory is shut down");
+
+            host.convictionPolicy.signalConnectionsOpening(1);
+            Connection connection = new Connection(buildConnectionName(host), address, this);
+            // This method opens the connection synchronously, so wait until it's initialized
+            try {
+                connection.initAsync().get();
+                return connection;
+            } catch (ExecutionException e) {
+                throw launderAsyncInitException(e);
+            }
+        }
+
+        /**
+         * Same as open, but associate the created connection to the provided connection pool.
+         */
+        public Connection open(HostConnectionPool pool) throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
+
+            pool.host.convictionPolicy.signalConnectionsOpening(1);
+            Connection connection = new Connection(buildConnectionName(pool.host), pool.host.getSocketAddress(), this, pool);
+            try {
+                connection.initAsync().get();
+                return connection;
+            } catch (ExecutionException e) {
+                throw launderAsyncInitException(e);
+            }
+        }
+
+        /**
+         * Creates new connections and associate them to the provided connection pool, but does not start them.
+         */
+        public List<Connection> newConnections(HostConnectionPool pool, int count) {
+            pool.host.convictionPolicy.signalConnectionsOpening(count);
+            List<Connection> connections = Lists.newArrayListWithCapacity(count);
+            for (int i = 0; i < count; i++)
+                connections.add(new Connection(buildConnectionName(pool.host), pool.host.getSocketAddress(), this, pool));
+            return connections;
+        }
+
+        private String buildConnectionName(Host host) {
+            return host.getSocketAddress().toString() + '-' + getIdGenerator(host).getAndIncrement();
+        }
+
+        static RuntimeException launderAsyncInitException(ExecutionException e) throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
+            Throwable t = e.getCause();
+            if (t instanceof ConnectionException)
+                throw (ConnectionException) t;
+            if (t instanceof InterruptedException)
+                throw (InterruptedException) t;
+            if (t instanceof UnsupportedProtocolVersionException)
+                throw (UnsupportedProtocolVersionException) t;
+            if (t instanceof ClusterNameMismatchException)
+                throw (ClusterNameMismatchException) t;
+            if (t instanceof DriverException)
+                throw (DriverException) t;
+
+            return new RuntimeException("Unexpected exception during connection initialization", t);
+        }
+
+        private AtomicInteger getIdGenerator(Host host) {
+            AtomicInteger g = idGenerators.get(host);
+            if (g == null) {
+                g = new AtomicInteger(1);
+                AtomicInteger old = idGenerators.putIfAbsent(host, g);
+                if (old != null)
+                    g = old;
+            }
+            return g;
+        }
+
+        public long getReadTimeoutMillis() {
+            return configuration.getSocketOptions().getReadTimeoutMillis();
+        }
+
+        private Bootstrap newBootstrap() {
+            Bootstrap b = new Bootstrap();
+            b.group(eventLoopGroup)
+                    .channel(channelClass);
+
+            SocketOptions options = configuration.getSocketOptions();
+
+            b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, options.getConnectTimeoutMillis());
+            Boolean keepAlive = options.getKeepAlive();
+            if (keepAlive != null)
+                b.option(ChannelOption.SO_KEEPALIVE, keepAlive);
+            Boolean reuseAddress = options.getReuseAddress();
+            if (reuseAddress != null)
+                b.option(ChannelOption.SO_REUSEADDR, reuseAddress);
+            Integer soLinger = options.getSoLinger();
+            if (soLinger != null)
+                b.option(ChannelOption.SO_LINGER, soLinger);
+            Boolean tcpNoDelay = options.getTcpNoDelay();
+            if (tcpNoDelay != null)
+                b.option(ChannelOption.TCP_NODELAY, tcpNoDelay);
+            Integer receiveBufferSize = options.getReceiveBufferSize();
+            if (receiveBufferSize != null)
+                b.option(ChannelOption.SO_RCVBUF, receiveBufferSize);
+            Integer sendBufferSize = options.getSendBufferSize();
+            if (sendBufferSize != null)
+                b.option(ChannelOption.SO_SNDBUF, sendBufferSize);
+
+            nettyOptions.afterBootstrapInitialized(b);
+            return b;
+        }
+
+        public void shutdown() {
+            // Make sure we skip creating connection from now on.
+            isShutdown = true;
+
+            // All channels should be closed already, we call this just to be sure. And we know
+            // we're not on an I/O thread or anything, so just call await.
+            allChannels.close().awaitUninterruptibly();
+
+            nettyOptions.onClusterClose(eventLoopGroup);
+            nettyOptions.onClusterClose(timer);
+        }
+    }
+
+    private static final class Flusher implements Runnable {
+        final WeakReference<EventLoop> eventLoopRef;
+        final Queue<FlushItem> queued = new ConcurrentLinkedQueue<FlushItem>();
+        final AtomicBoolean running = new AtomicBoolean(false);
+        final HashSet<Channel> channels = new HashSet<Channel>();
+        int runsWithNoWork = 0;
+
+        private Flusher(EventLoop eventLoop) {
+            this.eventLoopRef = new WeakReference<EventLoop>(eventLoop);
+        }
+
+        void start() {
+            if (!running.get() && running.compareAndSet(false, true)) {
+                EventLoop eventLoop = eventLoopRef.get();
+                if (eventLoop != null)
+                    eventLoop.execute(this);
+            }
+        }
+
+        @Override
+        public void run() {
+
+            boolean doneWork = false;
+            FlushItem flush;
+            while (null != (flush = queued.poll())) {
+                Channel channel = flush.channel;
+                if (channel.isActive()) {
+                    channels.add(channel);
+                    channel.write(flush.request).addListener(flush.listener);
+                    doneWork = true;
+                }
+            }
+
+            // Always flush what we have (don't artificially delay to try to coalesce more messages)
+            for (Channel channel : channels)
+                channel.flush();
+            channels.clear();
+
+            if (doneWork) {
+                runsWithNoWork = 0;
+            } else {
+                // either reschedule or cancel
+                if (++runsWithNoWork > 5) {
+                    running.set(false);
+                    if (queued.isEmpty() || !running.compareAndSet(false, true))
+                        return;
+                }
+            }
+
+            EventLoop eventLoop = eventLoopRef.get();
+            if (eventLoop != null && !eventLoop.isShuttingDown()) {
+                eventLoop.schedule(this, 10000, TimeUnit.NANOSECONDS);
+            }
+        }
+    }
+
+    private static final ConcurrentMap<EventLoop, Flusher> flusherLookup = new MapMaker()
+            .concurrencyLevel(16)
+            .weakKeys()
+            .makeMap();
+
+    private static class FlushItem {
+        final Channel channel;
+        final Object request;
+        final ChannelFutureListener listener;
+
+        private FlushItem(Channel channel, Object request, ChannelFutureListener listener) {
+            this.channel = channel;
+            this.request = request;
+            this.listener = listener;
+        }
+    }
+
+    private void flush(FlushItem item) {
+        EventLoop loop = item.channel.eventLoop();
+        Flusher flusher = flusherLookup.get(loop);
+        if (flusher == null) {
+            Flusher alt = flusherLookup.putIfAbsent(loop, flusher = new Flusher(loop));
+            if (alt != null)
+                flusher = alt;
+        }
+
+        flusher.queued.add(item);
+        flusher.start();
+    }
+
+    class Dispatcher extends SimpleChannelInboundHandler<Message.Response> {
+
+        public final StreamIdGenerator streamIdHandler;
+        private final ConcurrentMap<Integer, ResponseHandler> pending = new ConcurrentHashMap<Integer, ResponseHandler>();
+
+        Dispatcher() {
+            ProtocolVersion protocolVersion = factory.protocolVersion;
+            if (protocolVersion == null) {
+                // This happens for the first control connection because the protocol version has not been
+                // negociated yet.
+                protocolVersion = ProtocolVersion.V2;
+            }
+            streamIdHandler = StreamIdGenerator.newInstance(protocolVersion);
+        }
+
+        public void add(ResponseHandler handler) {
+            ResponseHandler old = pending.put(handler.streamId, handler);
+            assert old == null;
+        }
+
+        public void removeHandler(ResponseHandler handler, boolean releaseStreamId) {
+
+            // If we don't release the ID, mark first so that we can rely later on the fact that if
+            // we receive a response for an ID with no handler, it's that this ID has been marked.
+            if (!releaseStreamId)
+                streamIdHandler.mark(handler.streamId);
+
+            // If a RequestHandler is cancelled right when the response arrives, this method (called with releaseStreamId=false) will race with messageReceived.
+            // messageReceived could have already released the streamId, which could have already been reused by another request. We must not remove the handler
+            // if it's not ours, because that would cause the other request to hang forever.
+            boolean removed = pending.remove(handler.streamId, handler);
+            if (!removed) {
+                // We raced, so if we marked the streamId above, that was wrong.
+                if (!releaseStreamId)
+                    streamIdHandler.unmark(handler.streamId);
+                return;
+            }
+            handler.cancelTimeout();
+
+            if (releaseStreamId)
+                streamIdHandler.release(handler.streamId);
+
+            if (isClosed())
+                tryTerminate(false);
+        }
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, Message.Response response) throws Exception {
+            int streamId = response.getStreamId();
+
+            if (logger.isTraceEnabled())
+                logger.trace("{}, stream {}, received: {}", Connection.this, streamId, asDebugString(response));
+
+            if (streamId < 0) {
+                factory.defaultHandler.handle(response);
+                return;
+            }
+
+            ResponseHandler handler = pending.remove(streamId);
+            streamIdHandler.release(streamId);
+            if (handler == null) {
+                /**
+                 * During normal operation, we should not receive responses for which we don't have a handler. There is
+                 * two cases however where this can happen:
+                 *   1) The connection has been defuncted due to some internal error and we've raced between removing the
+                 *      handler and actually closing the connection; since the original error has been logged, we're fine
+                 *      ignoring this completely.
+                 *   2) This request has timed out. In that case, we've already switched to another host (or errored out
+                 *      to the user). So log it for debugging purpose, but it's fine ignoring otherwise.
+                 */
+                streamIdHandler.unmark(streamId);
+                if (logger.isDebugEnabled())
+                    logger.debug("{} Response received on stream {} but no handler set anymore (either the request has "
+                            + "timed out or it was closed due to another error). Received message is {}", Connection.this, streamId, asDebugString(response));
+                return;
+            }
+            handler.cancelTimeout();
+            handler.callback.onSet(Connection.this, response, System.nanoTime() - handler.startTime, handler.retryCount);
+
+            // If we happen to be closed and we're the last outstanding request, we need to terminate the connection
+            // (note: this is racy as the signaling can be called more than once, but that's not a problem)
+            if (isClosed())
+                tryTerminate(false);
+        }
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (!isClosed() && evt instanceof IdleStateEvent && ((IdleStateEvent) evt).state() == ALL_IDLE) {
+                logger.debug("{} was inactive for {} seconds, sending heartbeat", Connection.this, factory.configuration.getPoolingOptions().getHeartbeatIntervalSeconds());
+                write(HEARTBEAT_CALLBACK);
+            }
+        }
+
+        // Make sure we don't print huge responses in debug/error logs.
+        private String asDebugString(Object obj) {
+            if (obj == null)
+                return "null";
+
+            String msg = obj.toString();
+            if (msg.length() < 500)
+                return msg;
+
+            return msg.substring(0, 500) + "... [message of size " + msg.length() + " truncated]";
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            if (logger.isDebugEnabled())
+                logger.debug(String.format("%s connection error", Connection.this), cause);
+
+            // Ignore exception while writing, this will be handled by write() directly
+            if (writer.get() > 0)
+                return;
+
+            defunct(new TransportException(address, String.format("Unexpected exception triggered (%s)", cause), cause));
+        }
+
+        public void errorOutAllHandler(ConnectionException ce) {
+            Iterator<ResponseHandler> iter = pending.values().iterator();
+            while (iter.hasNext()) {
+                ResponseHandler handler = iter.next();
+                handler.cancelTimeout();
+                handler.callback.onException(Connection.this, ce, System.nanoTime() - handler.startTime, handler.retryCount);
+                iter.remove();
+            }
+        }
+    }
+
+    private class ChannelCloseListener implements ChannelFutureListener {
+        @Override
+        public void operationComplete(ChannelFuture future) throws Exception {
+            // If we've closed the channel client side then we don't really want to defunct the connection, but
+            // if there is remaining thread waiting on us, we still want to wake them up
+            if (!isInitialized || isClosed()) {
+                dispatcher.errorOutAllHandler(new TransportException(address, "Channel has been closed"));
+                // we still want to force so that the future completes
+                Connection.this.closeAsync().force();
+            } else
+                defunct(new TransportException(address, "Channel has been closed"));
+        }
+    }
+
+    private static final ResponseCallback HEARTBEAT_CALLBACK = new ResponseCallback() {
+
+        @Override
+        public Message.Request request() {
+            return new Requests.Options();
+        }
+
+        @Override
+        public int retryCount() {
+            return 0; // no retries here
+        }
+
+        @Override
+        public void onSet(Connection connection, Message.Response response, long latency, int retryCount) {
+            switch (response.type) {
+                case SUPPORTED:
+                    logger.debug("{} heartbeat query succeeded", connection);
+                    break;
+                default:
+                    fail(connection, new ConnectionException(connection.address, "Unexpected heartbeat response: " + response));
+            }
+        }
+
+        @Override
+        public void onException(Connection connection, Exception exception, long latency, int retryCount) {
+            // Nothing to do: the connection is already defunct if we arrive here
+        }
+
+        @Override
+        public boolean onTimeout(Connection connection, long latency, int retryCount) {
+            fail(connection, new ConnectionException(connection.address, "Heartbeat query timed out"));
+            return true;
+        }
+
+        private void fail(Connection connection, Exception e) {
+            connection.defunct(e);
+        }
+    };
+
+    private class ConnectionCloseFuture extends CloseFuture {
+
+        @Override
+        public ConnectionCloseFuture force() {
+            // Note: we must not call releaseExternalResources on the bootstrap, because this shutdown the executors, which are shared
+
+            // This method can be thrown during initialization, at which point channel is not yet set. This is ok.
+            if (channel == null) {
+                set(null);
+                return this;
+            }
+
+            // We're going to close this channel. If anyone is waiting on that connection, we should defunct it otherwise it'll wait
+            // forever. In general this won't happen since we get there only when all ongoing query are done, but this can happen
+            // if the shutdown is forced. This is a no-op if there is no handler set anymore.
+            dispatcher.errorOutAllHandler(new TransportException(address, "Connection has been closed"));
+
+            ChannelFuture future = channel.close();
+            future.addListener(new ChannelFutureListener() {
+                public void operationComplete(ChannelFuture future) {
+                    factory.allChannels.remove(channel);
+                    if (future.cause() != null) {
+                        logger.warn("Error closing channel", future.cause());
+                        ConnectionCloseFuture.this.setException(future.cause());
+                    } else
+                        ConnectionCloseFuture.this.set(null);
+                }
+            });
+            return this;
+        }
+    }
+
+    static class Future extends AbstractFuture<Message.Response> implements RequestHandler.Callback {
+
+        private final Message.Request request;
+        private volatile InetSocketAddress address;
+
+        public Future(Message.Request request) {
+            this.request = request;
+        }
+
+        @Override
+        public void register(RequestHandler handler) {
+            // noop, we don't care about the handler here so far
+        }
+
+        @Override
+        public Message.Request request() {
+            return request;
+        }
+
+        @Override
+        public int retryCount() {
+            // This is ignored, as there is no retry logic in this class
+            return 0;
+        }
+
+        @Override
+        public void onSet(Connection connection, Message.Response response, ExecutionInfo info, Statement statement, long latency) {
+            onSet(connection, response, latency, 0);
+        }
+
+        @Override
+        public void onSet(Connection connection, Message.Response response, long latency, int retryCount) {
+            this.address = connection.address;
+            super.set(response);
+        }
+
+        @Override
+        public void onException(Connection connection, Exception exception, long latency, int retryCount) {
+            // If all nodes are down, we will get a null connection here. This is fine, if we have
+            // an exception, consumers shouldn't assume the address is not null.
+            if (connection != null)
+                this.address = connection.address;
+            super.setException(exception);
+        }
+
+        @Override
+        public boolean onTimeout(Connection connection, long latency, int retryCount) {
+            assert connection != null; // We always timeout on a specific connection, so this shouldn't be null
+            this.address = connection.address;
+            return super.setException(new OperationTimedOutException(connection.address));
+        }
+
+        public InetSocketAddress getAddress() {
+            return address;
+        }
+    }
+
+    interface ResponseCallback {
+        public Message.Request request();
+
+        public int retryCount();
+
+        public void onSet(Connection connection, Message.Response response, long latency, int retryCount);
+
+        public void onException(Connection connection, Exception exception, long latency, int retryCount);
+
+        public boolean onTimeout(Connection connection, long latency, int retryCount);
+    }
+
+    static class ResponseHandler {
+
+        public final Connection connection;
+        public final int streamId;
+        public final ResponseCallback callback;
+        public final int retryCount;
+
+        private final long startTime;
+        private volatile Timeout timeout;
+
+        private final AtomicBoolean isCancelled = new AtomicBoolean();
+
+        public ResponseHandler(Connection connection, ResponseCallback callback) throws BusyConnectionException {
+            this.connection = connection;
+            this.streamId = connection.dispatcher.streamIdHandler.next();
+            this.callback = callback;
+            this.retryCount = callback.retryCount();
+
+            this.startTime = System.nanoTime();
+        }
+
+        void startTimeout() {
+            long timeoutMs = connection.factory.getReadTimeoutMillis();
+            this.timeout = timeoutMs <= 0 ? null : connection.factory.timer.newTimeout(onTimeoutTask(), timeoutMs, TimeUnit.MILLISECONDS);
+        }
+
+        void cancelTimeout() {
+            if (timeout != null)
+                timeout.cancel();
+        }
+
+        public boolean cancelHandler() {
+            if (!isCancelled.compareAndSet(false, true))
+                return false;
+
+            // We haven't really received a response: we want to remove the handle because we gave up on that
+            // request and there is no point in holding the handler, but we don't release the streamId. If we
+            // were, a new request could reuse that ID but get the answer to the request we just gave up on instead
+            // of its own answer, and we would have no way to detect that.
+            connection.dispatcher.removeHandler(this, false);
+            return true;
+        }
+
+        private TimerTask onTimeoutTask() {
+            return new TimerTask() {
+                @Override
+                public void run(Timeout timeout) {
+                    if (callback.onTimeout(connection, System.nanoTime() - startTime, retryCount))
+                        cancelHandler();
+                }
+            };
+        }
+    }
+
+    public interface DefaultResponseHandler {
+        public void handle(Message.Response response);
+    }
+
+    private static class Initializer extends ChannelInitializer<SocketChannel> {
+        // Stateless handlers
+        private static final Message.ProtocolDecoder messageDecoder = new Message.ProtocolDecoder();
+        private static final Message.ProtocolEncoder messageEncoderV1 = new Message.ProtocolEncoder(ProtocolVersion.V1);
+        private static final Message.ProtocolEncoder messageEncoderV2 = new Message.ProtocolEncoder(ProtocolVersion.V2);
+        private static final Message.ProtocolEncoder messageEncoderV3 = new Message.ProtocolEncoder(ProtocolVersion.V3);
+        private static final Frame.Encoder frameEncoder = new Frame.Encoder();
+
+        private final ProtocolVersion protocolVersion;
+        private final Connection connection;
+        private final FrameCompressor compressor;
+        private final SSLOptions sslOptions;
+        private final NettyOptions nettyOptions;
+        private final ChannelHandler idleStateHandler;
+
+        public Initializer(Connection connection, ProtocolVersion protocolVersion, FrameCompressor compressor, SSLOptions sslOptions, int heartBeatIntervalSeconds, NettyOptions nettyOptions) {
+            this.connection = connection;
+            this.protocolVersion = protocolVersion;
+            this.compressor = compressor;
+            this.sslOptions = sslOptions;
+            this.nettyOptions = nettyOptions;
+            this.idleStateHandler = new IdleStateHandler(0, 0, heartBeatIntervalSeconds);
+        }
+
+        @Override
+        protected void initChannel(SocketChannel channel) throws Exception {
+            ChannelPipeline pipeline = channel.pipeline();
+
+            if (sslOptions != null) {
+                SSLEngine engine = sslOptions.context.createSSLEngine();
+                engine.setUseClientMode(true);
+                engine.setEnabledCipherSuites(sslOptions.cipherSuites);
+                SslHandler handler = new SslHandler(engine);
+                pipeline.addLast("ssl", handler);
+            }
+
+//            pipeline.addLast("debug", new LoggingHandler(LogLevel.INFO));
+
+            pipeline.addLast("frameDecoder", new Frame.Decoder());
+            pipeline.addLast("frameEncoder", frameEncoder);
+
+            if (compressor != null) {
+                pipeline.addLast("frameDecompressor", new Frame.Decompressor(compressor));
+                pipeline.addLast("frameCompressor", new Frame.Compressor(compressor));
+            }
+
+            pipeline.addLast("messageDecoder", messageDecoder);
+            pipeline.addLast("messageEncoder", messageEncoderFor(protocolVersion));
+
+            pipeline.addLast("idleStateHandler", idleStateHandler);
+
+            pipeline.addLast("dispatcher", connection.dispatcher);
+
+            nettyOptions.afterChannelInitialized(channel);
+        }
+
+        private Message.ProtocolEncoder messageEncoderFor(ProtocolVersion version) {
+            switch (version) {
+                case V1:
+                    return messageEncoderV1;
+                case V2:
+                    return messageEncoderV2;
+                case V3:
+                    return messageEncoderV3;
+                default:
+                    throw new DriverInternalError("Unsupported protocol version " + protocolVersion);
+            }
+        }
+    }
+
+    /**
+     * A component that "owns" a connection, and should be notified when it dies.
+     */
+    interface Owner {
+        void onConnectionDefunct(Connection connection);
+    }
+}

--- a/scio-cassandra2/src/main/java/com/datastax/driver/core/DataType.java
+++ b/scio-cassandra2/src/main/java/com/datastax/driver/core/DataType.java
@@ -1,0 +1,922 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.exceptions.DriverInternalError;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeToken;
+import io.netty.buffer.ByteBuf;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.*;
+
+/**
+ * Data types supported by cassandra.
+ */
+public abstract class DataType {
+
+    /**
+     * The CQL type name.
+     */
+    public enum Name {
+
+        ASCII(1, String.class),
+        BIGINT(2, Long.class),
+        BLOB(3, ByteBuffer.class),
+        BOOLEAN(4, Boolean.class),
+        COUNTER(5, Long.class),
+        DECIMAL(6, BigDecimal.class),
+        DOUBLE(7, Double.class),
+        FLOAT(8, Float.class),
+        INET(16, InetAddress.class),
+        INT(9, Integer.class),
+        TEXT(10, String.class),
+        TIMESTAMP(11, Date.class),
+        UUID(12, UUID.class),
+        VARCHAR(13, String.class),
+        VARINT(14, BigInteger.class),
+        TIMEUUID(15, UUID.class),
+        LIST(32, List.class),
+        SET(34, Set.class),
+        MAP(33, Map.class),
+        UDT(48, UDTValue.class),
+        TUPLE(49, TupleValue.class),
+        CUSTOM(0, ByteBuffer.class);
+
+        final int protocolId;
+        final Class<?> javaType;
+
+        private static final Name[] nameToIds;
+
+        static {
+            int maxCode = -1;
+            for (Name name : Name.values())
+                maxCode = Math.max(maxCode, name.protocolId);
+            nameToIds = new Name[maxCode + 1];
+            for (Name name : Name.values()) {
+                if (nameToIds[name.protocolId] != null)
+                    throw new IllegalStateException("Duplicate Id");
+                nameToIds[name.protocolId] = name;
+            }
+        }
+
+        private Name(int protocolId, Class<?> javaType) {
+            this.protocolId = protocolId;
+            this.javaType = javaType;
+        }
+
+        static Name fromProtocolId(int id) {
+            Name name = nameToIds[id];
+            if (name == null)
+                throw new DriverInternalError("Unknown data type protocol id: " + id);
+            return name;
+        }
+
+        /**
+         * Returns whether this data type name represent the name of a collection type
+         * that is a list, set or map.
+         *
+         * @return whether this data type name represent the name of a collection type.
+         */
+        public boolean isCollection() {
+            switch (this) {
+                case LIST:
+                case SET:
+                case MAP:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /**
+         * Returns the Java Class corresponding to this CQL type name.
+         * <p/>
+         * The correspondence between CQL types and java ones is as follow:
+         * <table>
+         * <caption>DataType to Java class correspondence</caption>
+         * <tr><th>DataType (CQL)</th><th>Java Class</th></tr>
+         * <tr><td>ASCII         </td><td>String</td></tr>
+         * <tr><td>BIGINT        </td><td>Long</td></tr>
+         * <tr><td>BLOB          </td><td>ByteBuffer</td></tr>
+         * <tr><td>BOOLEAN       </td><td>Boolean</td></tr>
+         * <tr><td>COUNTER       </td><td>Long</td></tr>
+         * <tr><td>CUSTOM        </td><td>ByteBuffer</td></tr>
+         * <tr><td>DECIMAL       </td><td>BigDecimal</td></tr>
+         * <tr><td>DOUBLE        </td><td>Double</td></tr>
+         * <tr><td>FLOAT         </td><td>Float</td></tr>
+         * <tr><td>INET          </td><td>InetAddress</td></tr>
+         * <tr><td>INT           </td><td>Integer</td></tr>
+         * <tr><td>LIST          </td><td>List</td></tr>
+         * <tr><td>MAP           </td><td>Map</td></tr>
+         * <tr><td>SET           </td><td>Set</td></tr>
+         * <tr><td>TEXT          </td><td>String</td></tr>
+         * <tr><td>TIMESTAMP     </td><td>Date</td></tr>
+         * <tr><td>UUID          </td><td>UUID</td></tr>
+         * <tr><td>UDT           </td><td>UDTValue</td></tr>
+         * <tr><td>TUPLE         </td><td>TupleValue</td></tr>
+         * <tr><td>VARCHAR       </td><td>String</td></tr>
+         * <tr><td>VARINT        </td><td>BigInteger</td></tr>
+         * <tr><td>TIMEUUID      </td><td>UUID</td></tr>
+         * </table>
+         *
+         * @return the java Class corresponding to this CQL type name.
+         */
+        public Class<?> asJavaClass() {
+            return javaType;
+        }
+
+        @Override
+        public String toString() {
+            return super.toString().toLowerCase();
+        }
+    }
+
+    protected final DataType.Name name;
+
+    private static final Map<Name, DataType> primitiveTypeMap = new EnumMap<Name, DataType>(Name.class);
+
+    static {
+        for (Name name : Name.values()) {
+            if (!name.isCollection() && name != Name.CUSTOM && name != Name.UDT && name != Name.TUPLE)
+                primitiveTypeMap.put(name, new DataType.Native(name));
+        }
+    }
+
+    private static final Set<DataType> primitiveTypeSet = ImmutableSet.copyOf(primitiveTypeMap.values());
+
+    protected DataType(DataType.Name name) {
+        this.name = name;
+    }
+
+    static DataType decode(ByteBuf buffer) {
+        Name name = Name.fromProtocolId(buffer.readUnsignedShort());
+        switch (name) {
+            case CUSTOM:
+                String className = CBUtil.readString(buffer);
+                return CassandraTypeParser.isUserType(className) || CassandraTypeParser.isTupleType(className)
+                        ? CassandraTypeParser.parseOne(className)
+                        : custom(className);
+            case LIST:
+                return list(decode(buffer));
+            case SET:
+                return set(decode(buffer));
+            case MAP:
+                DataType keys = decode(buffer);
+                DataType values = decode(buffer);
+                return map(keys, values);
+            case UDT:
+                String keyspace = CBUtil.readString(buffer);
+                String type = CBUtil.readString(buffer);
+                int nFields = buffer.readShort() & 0xffff;
+                List<UserType.Field> fields = new ArrayList<UserType.Field>(nFields);
+                for (int i = 0; i < nFields; i++) {
+                    String fieldName = CBUtil.readString(buffer);
+                    DataType fieldType = decode(buffer);
+                    fields.add(new UserType.Field(fieldName, fieldType));
+                }
+                return new UserType(keyspace, type, fields);
+            case TUPLE:
+                nFields = buffer.readShort() & 0xffff;
+                List<DataType> types = new ArrayList<DataType>(nFields);
+                for (int i = 0; i < nFields; i++) {
+                    types.add(decode(buffer));
+                }
+                return new TupleType(types);
+            default:
+                return primitiveTypeMap.get(name);
+        }
+    }
+
+    abstract TypeCodec<Object> codec(ProtocolVersion protocolVersion);
+
+    /**
+     * Returns the ASCII type.
+     *
+     * @return The ASCII type.
+     */
+    public static DataType ascii() {
+        return primitiveTypeMap.get(Name.ASCII);
+    }
+
+    /**
+     * Returns the BIGINT type.
+     *
+     * @return The BIGINT type.
+     */
+    public static DataType bigint() {
+        return primitiveTypeMap.get(Name.BIGINT);
+    }
+
+    /**
+     * Returns the BLOB type.
+     *
+     * @return The BLOB type.
+     */
+    public static DataType blob() {
+        return primitiveTypeMap.get(Name.BLOB);
+    }
+
+    /**
+     * Returns the BOOLEAN type.
+     *
+     * @return The BOOLEAN type.
+     */
+    public static DataType cboolean() {
+        return primitiveTypeMap.get(Name.BOOLEAN);
+    }
+
+    /**
+     * Returns the COUNTER type.
+     *
+     * @return The COUNTER type.
+     */
+    public static DataType counter() {
+        return primitiveTypeMap.get(Name.COUNTER);
+    }
+
+    /**
+     * Returns the DECIMAL type.
+     *
+     * @return The DECIMAL type.
+     */
+    public static DataType decimal() {
+        return primitiveTypeMap.get(Name.DECIMAL);
+    }
+
+    /**
+     * Returns the DOUBLE type.
+     *
+     * @return The DOUBLE type.
+     */
+    public static DataType cdouble() {
+        return primitiveTypeMap.get(Name.DOUBLE);
+    }
+
+    /**
+     * Returns the FLOAT type.
+     *
+     * @return The FLOAT type.
+     */
+    public static DataType cfloat() {
+        return primitiveTypeMap.get(Name.FLOAT);
+    }
+
+    /**
+     * Returns the INET type.
+     *
+     * @return The INET type.
+     */
+    public static DataType inet() {
+        return primitiveTypeMap.get(Name.INET);
+    }
+
+    /**
+     * Returns the INT type.
+     *
+     * @return The INT type.
+     */
+    public static DataType cint() {
+        return primitiveTypeMap.get(Name.INT);
+    }
+
+    /**
+     * Returns the TEXT type.
+     *
+     * @return The TEXT type.
+     */
+    public static DataType text() {
+        return primitiveTypeMap.get(Name.TEXT);
+    }
+
+    /**
+     * Returns the TIMESTAMP type.
+     *
+     * @return The TIMESTAMP type.
+     */
+    public static DataType timestamp() {
+        return primitiveTypeMap.get(Name.TIMESTAMP);
+    }
+
+    /**
+     * Returns the UUID type.
+     *
+     * @return The UUID type.
+     */
+    public static DataType uuid() {
+        return primitiveTypeMap.get(Name.UUID);
+    }
+
+    /**
+     * Returns the VARCHAR type.
+     *
+     * @return The VARCHAR type.
+     */
+    public static DataType varchar() {
+        return primitiveTypeMap.get(Name.VARCHAR);
+    }
+
+    /**
+     * Returns the VARINT type.
+     *
+     * @return The VARINT type.
+     */
+    public static DataType varint() {
+        return primitiveTypeMap.get(Name.VARINT);
+    }
+
+    /**
+     * Returns the TIMEUUID type.
+     *
+     * @return The TIMEUUID type.
+     */
+    public static DataType timeuuid() {
+        return primitiveTypeMap.get(Name.TIMEUUID);
+    }
+
+    /**
+     * Returns the type of lists of {@code elementType} elements.
+     *
+     * @param elementType the type of the list elements.
+     * @param frozen      whether the list is frozen.
+     * @return the type of lists of {@code elementType} elements.
+     */
+    public static DataType list(DataType elementType, boolean frozen) {
+        return new DataType.Collection(Name.LIST, ImmutableList.of(elementType), frozen);
+    }
+
+    /**
+     * Returns the type of "not frozen" lists of {@code elementType} elements.
+     * <p/>
+     * This is a shorthand for {@code list(elementType, false);}.
+     *
+     * @param elementType the type of the list elements.
+     * @return the type of "not frozen" lists of {@code elementType} elements.
+     */
+    public static DataType list(DataType elementType) {
+        return list(elementType, false);
+    }
+
+    /**
+     * Returns the type of frozen lists of {@code elementType} elements.
+     * <p/>
+     * This is a shorthand for {@code list(elementType, true);}.
+     *
+     * @param elementType the type of the list elements.
+     * @return the type of frozen lists of {@code elementType} elements.
+     */
+    public static DataType frozenList(DataType elementType) {
+        return list(elementType, true);
+    }
+
+    /**
+     * Returns the type of sets of {@code elementType} elements.
+     *
+     * @param elementType the type of the set elements.
+     * @param frozen      whether the set is frozen.
+     * @return the type of sets of {@code elementType} elements.
+     */
+    public static DataType set(DataType elementType, boolean frozen) {
+        return new DataType.Collection(Name.SET, ImmutableList.of(elementType), frozen);
+    }
+
+    /**
+     * Returns the type of "not frozen" sets of {@code elementType} elements.
+     * <p/>
+     * This is a shorthand for {@code set(elementType, false);}.
+     *
+     * @param elementType the type of the set elements.
+     * @return the type of "not frozen" sets of {@code elementType} elements.
+     */
+    public static DataType set(DataType elementType) {
+        return set(elementType, false);
+    }
+
+    /**
+     * Returns the type of frozen sets of {@code elementType} elements.
+     * <p/>
+     * This is a shorthand for {@code set(elementType, true);}.
+     *
+     * @param elementType the type of the set elements.
+     * @return the type of frozen sets of {@code elementType} elements.
+     */
+    public static DataType frozenSet(DataType elementType) {
+        return set(elementType, true);
+    }
+
+    /**
+     * Returns the type of maps of {@code keyType} to {@code valueType} elements.
+     *
+     * @param keyType   the type of the map keys.
+     * @param valueType the type of the map values.
+     * @param frozen    whether the map is frozen.
+     * @return the type of maps of {@code keyType} to {@code valueType} elements.
+     */
+    public static DataType map(DataType keyType, DataType valueType, boolean frozen) {
+        return new DataType.Collection(Name.MAP, ImmutableList.of(keyType, valueType), frozen);
+    }
+
+    /**
+     * Returns the type of "not frozen" maps of {@code keyType} to {@code valueType} elements.
+     * <p/>
+     * This is a shorthand for {@code map(keyType, valueType, false);}.
+     *
+     * @param keyType   the type of the map keys.
+     * @param valueType the type of the map values.
+     * @return the type of "not frozen" maps of {@code keyType} to {@code valueType} elements.
+     */
+    public static DataType map(DataType keyType, DataType valueType) {
+        return map(keyType, valueType, false);
+    }
+
+    /**
+     * Returns the type of frozen maps of {@code keyType} to {@code valueType} elements.
+     * <p/>
+     * This is a shorthand for {@code map(keyType, valueType, true);}.
+     *
+     * @param keyType   the type of the map keys.
+     * @param valueType the type of the map values.
+     * @return the type of frozen maps of {@code keyType} to {@code valueType} elements.
+     */
+    public static DataType frozenMap(DataType keyType, DataType valueType) {
+        return map(keyType, valueType, true);
+    }
+
+    /**
+     * Returns a Custom type.
+     * <p/>
+     * A custom type is defined by the name of the class used on the Cassandra
+     * side to implement it. Note that the support for custom type by the
+     * driver is limited: values of a custom type won't be interpreted by the
+     * driver in any way. They will thus have to be set (by {@link BoundStatement#setBytesUnsafe}
+     * and retrieved (by {@link Row#getBytesUnsafe}) as raw ByteBuffer.
+     * <p/>
+     * The use of custom types is rarely useful and is thus not encouraged.
+     *
+     * @param typeClassName the server-side fully qualified class name for the type.
+     * @return the custom type for {@code typeClassName}.
+     */
+    public static DataType custom(String typeClassName) {
+        if (typeClassName == null)
+            throw new NullPointerException();
+        return new DataType.Custom(Name.CUSTOM, typeClassName);
+    }
+
+    /**
+     * Returns the name of that type.
+     *
+     * @return the name of that type.
+     */
+    public Name getName() {
+        return name;
+    }
+
+    /**
+     * Returns whether this data type is frozen.
+     * <p/>
+     * This applies to User Defined Types, tuples and nested collections. Frozen types are serialized as a single value in
+     * Cassandra's storage engine, whereas non-frozen types are stored in a form that allows updates to individual subfields.
+     *
+     * @return whether this data type is frozen.
+     */
+    public abstract boolean isFrozen();
+
+    /**
+     * Returns the type arguments of this type.
+     * <p/>
+     * Note that only the collection types (LIST, MAP, SET) have type
+     * arguments. For the other types, this will return an empty list.
+     * <p/>
+     * For the collection types:
+     * <ul>
+     * <li>For lists and sets, this method returns one argument, the type of
+     * the elements.</li>
+     * <li>For maps, this method returns two arguments, the first one is the
+     * type of the map keys, the second one is the type of the map
+     * values.</li>
+     * </ul>
+     *
+     * @return an immutable list containing the type arguments of this type.
+     */
+    public List<DataType> getTypeArguments() {
+        return Collections.<DataType>emptyList();
+    }
+
+    abstract boolean canBeDeserializedAs(TypeToken typeToken);
+
+    /**
+     * Returns the server-side class name for a custom type.
+     *
+     * @return the server-side fully qualified class name for a custom type or
+     * {@code null} for any other type.
+     */
+    public String getCustomTypeClassName() {
+        return null;
+    }
+
+    /**
+     * Parses a string CQL value for the type this object represent, returning its
+     * value as a Java object.
+     *
+     * @param value the value to parse.
+     * @return a java object representing {@code value}. If {@code value == null}, then
+     * {@code null} is returned.
+     * @throws InvalidTypeException if {@code value} is not a valid CQL string
+     *                              representation for this type. Please note that values for custom types
+     *                              can never be parsed and will always return this exception.
+     */
+    public Object parse(String value) {
+        // We don't care about the protocol version for parsing
+        return value == null ? null : codec(ProtocolVersion.NEWEST_SUPPORTED).parse(value);
+    }
+
+    /**
+     * Format a Java object as an equivalent CQL value.
+     *
+     * @param value the value to format.
+     * @return a string corresponding to the CQL representation of {@code value}.
+     * @throws InvalidTypeException if {@code value} does not correspond to
+     *                              a CQL value (known by the driver). Please note that for custom types this
+     *                              method will always return this exception.
+     */
+    public String format(Object value) {
+        // We don't care about the protocol version for formatting
+        return value == null ? null : codec(ProtocolVersion.NEWEST_SUPPORTED).format(value);
+    }
+
+    /**
+     * Returns whether this type is a collection one, i.e. a list, set or map type.
+     *
+     * @return whether this type is a collection one.
+     */
+    public boolean isCollection() {
+        return name.isCollection();
+    }
+
+    /**
+     * Returns the Java Class corresponding to this type.
+     * <p/>
+     * This is a shortcut for {@code getName().asJavaClass()}.
+     *
+     * @return the java Class corresponding to this type.
+     * @see Name#asJavaClass
+     */
+    public Class<?> asJavaClass() {
+        return getName().asJavaClass();
+    }
+
+    /**
+     * Returns a set of all the primitive types, where primitive types are
+     * defined as the types that don't have type arguments (that is excluding
+     * lists, sets, and maps).
+     *
+     * @return returns a set of all the primitive types.
+     */
+    public static Set<DataType> allPrimitiveTypes() {
+        return primitiveTypeSet;
+    }
+
+    /**
+     * Serialize a value of this type to bytes, with the given protocol version.
+     * <p/>
+     * The actual format of the resulting bytes will correspond to the
+     * Cassandra encoding for this type (for the requested protocol version).
+     *
+     * @param value           the value to serialize.
+     * @param protocolVersion the protocol version to use when serializing
+     *                        {@code bytes}. In most cases, the proper value to provide for this argument
+     *                        is the value returned by {@link ProtocolOptions#getProtocolVersion} (which
+     *                        is the protocol version in use by the driver).
+     * @return the value serialized, or {@code null} if {@code value} is null.
+     * @throws InvalidTypeException if {@code value} is not a valid object
+     *                              for this {@code DataType}.
+     */
+    public ByteBuffer serialize(Object value, ProtocolVersion protocolVersion) {
+        Class<?> providedClass = value.getClass();
+        Class<?> expectedClass = asJavaClass();
+        if (!expectedClass.isAssignableFrom(providedClass))
+            throw new InvalidTypeException(String.format("Invalid value for CQL type %s, expecting %s but %s provided", toString(), expectedClass, providedClass));
+
+        try {
+            return codec(protocolVersion).serialize(value);
+        } catch (ClassCastException e) {
+            // With collections, the element type has not been checked, so it can throw
+            throw new InvalidTypeException("Invalid type for collection element: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Serialize a value of this type to bytes, with the given numeric protocol version.
+     *
+     * @throws IllegalArgumentException if {@code protocolVersion} does not correspond to any known version.
+     * @deprecated This method is provided for backward compatibility. Use
+     * {@link #serialize(Object, ProtocolVersion)} instead.
+     */
+    @Deprecated
+    public ByteBuffer serialize(Object value, int protocolVersion) {
+        return serialize(value, ProtocolVersion.fromInt(protocolVersion));
+    }
+
+    /**
+     * @deprecated This method is provided for binary compatibility only. It is no longer supported, will be removed,
+     * and simply throws {@link UnsupportedOperationException}. Use {@link #serialize(Object, ProtocolVersion)} instead.
+     */
+    @Deprecated
+    public ByteBuffer serialize(Object value) {
+        throw new UnsupportedOperationException("Method no longer supported; use serialize(Object,ProtocolVersion)");
+    }
+
+    /**
+     * Deserialize a value of this type from the provided bytes using the given protocol version.
+     *
+     * @param bytes           bytes holding the value to deserialize.
+     * @param protocolVersion the protocol version to use when deserializing
+     *                        {@code bytes}. In most cases, the proper value to provide for this argument
+     *                        is the value returned by {@link ProtocolOptions#getProtocolVersion} (which
+     *                        is the protocol version in use by the driver).
+     * @return the deserialized value (of class {@code this.asJavaClass()}).
+     * Will return {@code null} if either {@code bytes} is {@code null} or if
+     * {@code bytes.remaining() == 0} and this type has no value corresponding
+     * to an empty byte buffer (the latter somewhat strange behavior is due to
+     * the fact that for historical/technical reason, Cassandra types always
+     * accept empty byte buffer as valid value of those type, and so we avoid
+     * throwing an exception in that case. It is however highly discouraged to
+     * store empty byte buffers for types for which it doesn't make sense, so
+     * this detail can generally be ignored).
+     * @throws InvalidTypeException if {@code bytes} is not a valid
+     *                              encoding of an object of this {@code DataType}.
+     */
+    public Object deserialize(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+        return codec(protocolVersion).deserialize(bytes);
+    }
+
+    /**
+     * Deserialize a value of this type from the provided bytes using the given numeric protocol version.
+     *
+     * @throws IllegalArgumentException if {@code protocolVersion} does not correspond to any known version.
+     * @deprecated This method is provided for backward compatibility. Use
+     * {@link #deserialize(ByteBuffer, ProtocolVersion)} instead.
+     */
+    public Object deserialize(ByteBuffer bytes, int protocolVersion) {
+        return deserialize(bytes, ProtocolVersion.fromInt(protocolVersion));
+    }
+
+    /**
+     * @deprecated This method is provided for binary compatibility only. It is no longer supported, will be removed,
+     * and simply throws {@link UnsupportedOperationException}. Use {@link #deserialize(ByteBuffer, ProtocolVersion)} instead.
+     */
+    @Deprecated
+    public Object deserialize(ByteBuffer bytes) {
+        throw new UnsupportedOperationException("Method no longer supported; use deserialize(ByteBuffer,ProtocolVersion)");
+    }
+
+    /**
+     * Serialize an object based on its java class.
+     * <p/>
+     * This is equivalent to {@link #serialize} but with the difference that
+     * the actual {@code DataType} of the resulting value is inferred from the
+     * java class of {@code value}. The correspondence between CQL {@code DataType}
+     * and java class used is the one induced by the method {@link Name#asJavaClass}.
+     * Note that if you know the {@code DataType} of {@code value}, you should use
+     * the {@link #serialize} method instead as it is going to be faster.
+     *
+     * @param value           the value to serialize.
+     * @param protocolVersion the protocol version to use when deserializing
+     *                        {@code bytes}. In most cases, the proper value to provide for this argument
+     *                        is the value returned by {@link ProtocolOptions#getProtocolVersion} (which
+     *                        is the protocol version in use by the driver).
+     * @return the value serialized, or {@code null} if {@code value} is null.
+     * @throws IllegalArgumentException if {@code value} is not of a type
+     *                                  corresponding to a CQL3 type, i.e. is not a Class that could be returned
+     *                                  by {@link DataType#asJavaClass}.
+     */
+    public static ByteBuffer serializeValue(Object value, ProtocolVersion protocolVersion) {
+        if (value == null)
+            return null;
+
+        try {
+            DataType dt = TypeCodec.getDataTypeFor(value);
+            return dt.serialize(value, protocolVersion);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format("Could not serialize value of type %s", value.getClass()), e);
+        } catch (InvalidTypeException e) {
+            // In theory we couldn't get that if getDataTypeFor does his job correctly,
+            // but there is no point in sending an exception that the user won't expect if we're
+            // wrong on that.
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+    /**
+     * Serialize an object based on its java class, with the given numeric protocol version.
+     *
+     * @throws IllegalArgumentException if {@code protocolVersion} does not correspond to any known version.
+     * @deprecated This method is provided for backward compatibility. Use
+     * {@link #serializeValue(Object, ProtocolVersion)} instead.
+     */
+    @Deprecated
+    public static ByteBuffer serializeValue(Object value, int protocolVersion) {
+        return serializeValue(value, ProtocolVersion.fromInt(protocolVersion));
+    }
+
+    /**
+     * @deprecated This method is provided for binary compatibility only. It is no longer supported, will be removed,
+     * and simply throws {@link UnsupportedOperationException}. Use {@link #serializeValue(Object, ProtocolVersion)} instead.
+     */
+    @Deprecated
+    public static ByteBuffer serializeValue(Object value) {
+        throw new UnsupportedOperationException("Method no longer supported; use serializeValue(Object,ProtocolVersion)");
+    }
+
+    private static class Native extends DataType {
+        private Native(DataType.Name name) {
+            super(name);
+        }
+
+        @Override
+        public boolean isFrozen() {
+            return false;
+        }
+
+        @Override
+        boolean canBeDeserializedAs(TypeToken typeToken) {
+            return typeToken.isSupertypeOf(getName().javaType);
+        }
+
+        @Override
+        TypeCodec<Object> codec(ProtocolVersion protocolVersion) {
+            return TypeCodec.createFor(name);
+        }
+
+        @Override
+        public final int hashCode() {
+            return (name == Name.TEXT)
+                    ? Name.VARCHAR.hashCode()
+                    : name.hashCode();
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (!(o instanceof DataType.Native))
+                return false;
+
+            Native that = (DataType.Native) o;
+            return name == that.name ||
+                    name == Name.VARCHAR && that.name == Name.TEXT ||
+                    name == Name.TEXT && that.name == Name.VARCHAR;
+        }
+
+        @Override
+        public String toString() {
+            return name.toString();
+        }
+    }
+
+    private static class Collection extends DataType {
+
+        private final List<DataType> typeArguments;
+        private boolean frozen;
+
+        private Collection(DataType.Name name, List<DataType> typeArguments, boolean frozen) {
+            super(name);
+            this.typeArguments = typeArguments;
+            this.frozen = frozen;
+        }
+
+        @Override
+        public boolean isFrozen() {
+            return frozen;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        boolean canBeDeserializedAs(TypeToken typeToken) {
+            switch (name) {
+                case LIST:
+                    return typeToken.getRawType().isAssignableFrom(List.class) &&
+                            typeArguments.get(0).canBeDeserializedAs(typeToken.resolveType(typeToken.getRawType().getTypeParameters()[0]));
+                case SET:
+                    return typeToken.getRawType().isAssignableFrom(Set.class) &&
+                            typeArguments.get(0).canBeDeserializedAs(typeToken.resolveType(typeToken.getRawType().getTypeParameters()[0]));
+                case MAP:
+                    return typeToken.getRawType().isAssignableFrom(Map.class) &&
+                            typeArguments.get(0).canBeDeserializedAs(typeToken.resolveType(typeToken.getRawType().getTypeParameters()[0])) &&
+                            typeArguments.get(1).canBeDeserializedAs(typeToken.resolveType(typeToken.getRawType().getTypeParameters()[1]));
+            }
+            throw new AssertionError();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        TypeCodec<Object> codec(ProtocolVersion protocolVersion) {
+            switch (name) {
+                case LIST:
+                    return (TypeCodec) TypeCodec.listOf(typeArguments.get(0), protocolVersion);
+                case SET:
+                    return (TypeCodec) TypeCodec.setOf(typeArguments.get(0), protocolVersion);
+                case MAP:
+                    return (TypeCodec) TypeCodec.mapOf(typeArguments.get(0), typeArguments.get(1), protocolVersion);
+            }
+            throw new AssertionError();
+        }
+
+        @Override
+        public List<DataType> getTypeArguments() {
+            return typeArguments;
+        }
+
+        @Override
+        public final int hashCode() {
+            return Arrays.hashCode(new Object[]{name, typeArguments});
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (!(o instanceof DataType.Collection))
+                return false;
+
+            DataType.Collection d = (DataType.Collection) o;
+            return name == d.name && typeArguments.equals(d.typeArguments);
+        }
+
+        @Override
+        public String toString() {
+            if (name == Name.MAP) {
+                String template = frozen ? "frozen<%s<%s, %s>>" : "%s<%s, %s>";
+                return String.format(template, name, typeArguments.get(0), typeArguments.get(1));
+            } else {
+                String template = frozen ? "frozen<%s<%s>>" : "%s<%s>";
+                return String.format(template, name, typeArguments.get(0));
+            }
+        }
+    }
+
+    private static class Custom extends DataType {
+
+        private final String customClassName;
+
+        private Custom(DataType.Name name, String className) {
+            super(name);
+            this.customClassName = className;
+        }
+
+        @Override
+        public boolean isFrozen() {
+            return false;
+        }
+
+        @Override
+        boolean canBeDeserializedAs(TypeToken typeToken) {
+            return typeToken.getRawType().getName().equals(customClassName);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        TypeCodec<Object> codec(ProtocolVersion protocolVersion) {
+            return (TypeCodec) TypeCodec.bytesCodec;
+        }
+
+        @Override
+        public String getCustomTypeClassName() {
+            return customClassName;
+        }
+
+        @Override
+        public final int hashCode() {
+            return Arrays.hashCode(new Object[]{name, customClassName});
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (!(o instanceof DataType.Custom))
+                return false;
+
+            DataType.Custom d = (DataType.Custom) o;
+            return name == d.name && Objects.equal(customClassName, d.customClassName);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("'%s'", customClassName);
+        }
+    }
+}

--- a/scio-cassandra2/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/scio-cassandra2/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -1,0 +1,685 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.exceptions.AuthenticationException;
+import com.datastax.driver.core.utils.MoreFutures;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.datastax.driver.core.Connection.State.*;
+
+class HostConnectionPool implements Connection.Owner {
+
+    private static final Logger logger = LoggerFactory.getLogger(HostConnectionPool.class);
+
+    private static final int MAX_SIMULTANEOUS_CREATION = 1;
+
+    final Host host;
+    volatile HostDistance hostDistance;
+    protected final SessionManager manager;
+
+    final List<Connection> connections;
+    private final AtomicInteger open;
+    /**
+     * The total number of in-flight requests on all connections of this pool.
+     */
+    final AtomicInteger totalInFlight = new AtomicInteger();
+    /**
+     * The maximum value of {@link #totalInFlight} since the last call to {@link #cleanupIdleConnections(long)}
+     */
+    private final AtomicInteger maxTotalInFlight = new AtomicInteger();
+    @VisibleForTesting
+    final Set<Connection> trash = new CopyOnWriteArraySet<Connection>();
+
+    private volatile int waiter = 0;
+    private final Lock waitLock = new ReentrantLock(true);
+    private final Condition hasAvailableConnection = waitLock.newCondition();
+
+    private final Runnable newConnectionTask;
+
+    private final AtomicInteger scheduledForCreation = new AtomicInteger();
+
+    protected final AtomicReference<CloseFuture> closeFuture = new AtomicReference<CloseFuture>();
+
+    private enum Phase {INITIALIZING, READY, INIT_FAILED, CLOSING}
+
+    protected final AtomicReference<Phase> phase = new AtomicReference<Phase>(Phase.INITIALIZING);
+
+    // When a request times out, we may never release its stream ID. So over time, a given connection
+    // may get less an less available streams. When the number of available ones go below the
+    // following threshold, we just replace the connection by a new one.
+    private final int minAllowedStreams;
+
+    public HostConnectionPool(Host host, HostDistance hostDistance, SessionManager manager) {
+        assert hostDistance != HostDistance.IGNORED;
+        this.host = host;
+        this.hostDistance = hostDistance;
+        this.manager = manager;
+
+        this.newConnectionTask = new Runnable() {
+            @Override
+            public void run() {
+                addConnectionIfUnderMaximum();
+                scheduledForCreation.decrementAndGet();
+            }
+        };
+
+        this.connections = new CopyOnWriteArrayList<Connection>();
+        this.open = new AtomicInteger();
+
+        this.minAllowedStreams = options().getMaxRequestsPerConnection(hostDistance) * 3 / 4;
+    }
+
+    /**
+     * @param reusedConnection an existing connection (from a reconnection attempt) that we want to
+     *                         reuse as part of this pool. Might be null or already used by another
+     *                         pool.
+     */
+    ListenableFuture<Void> initAsync(Connection reusedConnection) {
+        Executor initExecutor = manager.cluster.manager.configuration.getPoolingOptions().getInitializationExecutor();
+
+        // Create initial core connections
+        final int coreSize = options().getCoreConnectionsPerHost(hostDistance);
+        final List<Connection> connections = Lists.newArrayListWithCapacity(coreSize);
+        final List<ListenableFuture<Void>> connectionFutures = Lists.newArrayListWithCapacity(coreSize);
+
+        int toCreate = coreSize;
+
+        if (reusedConnection != null && reusedConnection.setOwner(this)) {
+            toCreate -= 1;
+            connections.add(reusedConnection);
+            connectionFutures.add(MoreFutures.VOID_SUCCESS);
+        }
+
+        List<Connection> newConnections = manager.connectionFactory().newConnections(this, toCreate);
+        connections.addAll(newConnections);
+        for (Connection connection : newConnections) {
+            ListenableFuture<Void> connectionFuture = connection.initAsync();
+            connectionFutures.add(handleErrors(connectionFuture, initExecutor));
+        }
+
+        ListenableFuture<List<Void>> allConnectionsFuture = Futures.allAsList(connectionFutures);
+
+        final SettableFuture<Void> initFuture = SettableFuture.create();
+        Futures.addCallback(allConnectionsFuture, new FutureCallback<List<Void>>() {
+            @Override
+            public void onSuccess(List<Void> l) {
+                // Some of the connections might have failed, keep only the successful ones
+                ListIterator<Connection> it = connections.listIterator();
+                while (it.hasNext()) {
+                    if (it.next().isClosed())
+                        it.remove();
+                }
+
+                HostConnectionPool.this.connections.addAll(connections);
+                open.set(connections.size());
+
+                if (isClosed()) {
+                    initFuture.setException(new ConnectionException(host.getSocketAddress(), "Pool was closed during initialization"));
+                    // we're not sure if closeAsync() saw the connections, so ensure they get closed
+                    forceClose(connections);
+                } else {
+                    logger.debug("Created connection pool to host {} ({} connections needed, {} successfully opened)",
+                            host, coreSize, connections.size());
+                    phase.compareAndSet(Phase.INITIALIZING, Phase.READY);
+                    initFuture.set(null);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                phase.compareAndSet(Phase.INITIALIZING, Phase.INIT_FAILED);
+                forceClose(connections);
+                initFuture.setException(t);
+            }
+        }, initExecutor);
+        return initFuture;
+    }
+
+    private ListenableFuture<Void> handleErrors(ListenableFuture<Void> connectionInitFuture, Executor executor) {
+        return Futures.catchingAsync(connectionInitFuture, Throwable.class, new AsyncFunction<Throwable, Void>() {
+            @Override
+            public ListenableFuture<Void> apply(@Nullable Throwable t) throws Exception {
+                // Propagate these exceptions because they mean no connection will ever succeed. They will be handled
+                // accordingly in SessionManager#maybeAddPool.
+                Throwables.propagateIfInstanceOf(t, ClusterNameMismatchException.class);
+                Throwables.propagateIfInstanceOf(t, UnsupportedProtocolVersionException.class);
+
+                // We don't want to swallow Errors either as they probably indicate a more serious issue (OOME...)
+                Throwables.propagateIfInstanceOf(t, Error.class);
+
+                // Otherwise, return success. The pool will simply ignore this connection when it sees that it's been closed.
+                return MoreFutures.VOID_SUCCESS;
+            }
+        }, executor);
+    }
+
+    // Clean up if we got a fatal error at construction time but still created part of the core connections
+    private void forceClose(List<Connection> connections) {
+        for (Connection connection : connections) {
+            connection.closeAsync().force();
+        }
+    }
+
+    private PoolingOptions options() {
+        return manager.configuration().getPoolingOptions();
+    }
+
+    public Connection borrowConnection(long timeout, TimeUnit unit) throws ConnectionException, TimeoutException {
+        Phase phase = this.phase.get();
+        if (phase != Phase.READY)
+            // Note: throwing a ConnectionException is probably fine in practice as it will trigger the creation of a new host.
+            // That being said, maybe having a specific exception could be cleaner.
+            throw new ConnectionException(host.getSocketAddress(), "Pool is " + phase);
+
+        if (connections.isEmpty()) {
+            if (!host.convictionPolicy.canReconnectNow())
+                throw new TimeoutException("Connection pool is empty, currently trying to reestablish connections");
+            else {
+                int coreSize = options().getCoreConnectionsPerHost(hostDistance);
+                if (coreSize == 0) {
+                    maybeSpawnNewConnection();
+                } else {
+                    for (int i = 0; i < coreSize; i++) {
+                        // We don't respect MAX_SIMULTANEOUS_CREATION here because it's  only to
+                        // protect against creating connection in excess of core too quickly
+                        scheduledForCreation.incrementAndGet();
+                        manager.blockingExecutor().submit(newConnectionTask);
+                    }
+                }
+                Connection c = waitForConnection(timeout, unit);
+                totalInFlight.incrementAndGet();
+                c.setKeyspace(manager.poolsState.keyspace);
+                return c;
+            }
+        }
+
+        int minInFlight = Integer.MAX_VALUE;
+        Connection leastBusy = null;
+        for (Connection connection : connections) {
+            int inFlight = connection.inFlight.get();
+            if (inFlight < minInFlight) {
+                minInFlight = inFlight;
+                leastBusy = connection;
+            }
+        }
+
+        if (leastBusy == null) {
+            // We could have raced with a shutdown since the last check
+            if (isClosed())
+                throw new ConnectionException(host.getSocketAddress(), "Pool is shutdown");
+            // This might maybe happen if the number of core connections per host is 0 and a connection was trashed between
+            // the previous check to connections and now. But in that case, the line above will have trigger the creation of
+            // a new connection, so just wait that connection and move on
+            leastBusy = waitForConnection(timeout, unit);
+        } else {
+            while (true) {
+                int inFlight = leastBusy.inFlight.get();
+
+                if (inFlight >= Math.min(leastBusy.maxAvailableStreams(), options().getMaxRequestsPerConnection(hostDistance))) {
+                    leastBusy = waitForConnection(timeout, unit);
+                    break;
+                }
+
+                if (leastBusy.inFlight.compareAndSet(inFlight, inFlight + 1))
+                    break;
+            }
+        }
+
+        int totalInFlightCount = totalInFlight.incrementAndGet();
+        // update max atomically:
+        while (true) {
+            int oldMax = maxTotalInFlight.get();
+            if (totalInFlightCount <= oldMax || maxTotalInFlight.compareAndSet(oldMax, totalInFlightCount))
+                break;
+        }
+
+        int connectionCount = open.get() + scheduledForCreation.get();
+        if (connectionCount < options().getCoreConnectionsPerHost(hostDistance)) {
+            maybeSpawnNewConnection();
+        } else if (connectionCount < options().getMaxConnectionsPerHost(hostDistance)) {
+            // Add a connection if we fill the first n-1 connections and almost fill the last one
+            int currentCapacity = (connectionCount - 1) * options().getMaxRequestsPerConnection(hostDistance)
+                    + options().getNewConnectionThreshold(hostDistance);
+            if (totalInFlightCount > currentCapacity)
+                maybeSpawnNewConnection();
+        }
+
+        leastBusy.setKeyspace(manager.poolsState.keyspace);
+        return leastBusy;
+    }
+
+    private void awaitAvailableConnection(long timeout, TimeUnit unit) throws InterruptedException {
+        waitLock.lock();
+        waiter++;
+        try {
+            hasAvailableConnection.await(timeout, unit);
+        } finally {
+            waiter--;
+            waitLock.unlock();
+        }
+    }
+
+    private void signalAvailableConnection() {
+        // Quick check if it's worth signaling to avoid locking
+        if (waiter == 0)
+            return;
+
+        waitLock.lock();
+        try {
+            hasAvailableConnection.signal();
+        } finally {
+            waitLock.unlock();
+        }
+    }
+
+    private void signalAllAvailableConnection() {
+        // Quick check if it's worth signaling to avoid locking
+        if (waiter == 0)
+            return;
+
+        waitLock.lock();
+        try {
+            hasAvailableConnection.signalAll();
+        } finally {
+            waitLock.unlock();
+        }
+    }
+
+    private Connection waitForConnection(long timeout, TimeUnit unit) throws ConnectionException, TimeoutException {
+        if (timeout == 0)
+            throw new TimeoutException("All connections are busy and pool timeout is 0");
+
+        long start = System.nanoTime();
+        long remaining = timeout;
+        do {
+            try {
+                awaitAvailableConnection(remaining, unit);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                // If we're interrupted fine, check if there is a connection available but stop waiting otherwise
+                timeout = 0; // this will make us stop the loop if we don't get a connection right away
+            }
+
+            if (isClosed())
+                throw new ConnectionException(host.getSocketAddress(), "Pool is shutdown");
+
+            int minInFlight = Integer.MAX_VALUE;
+            Connection leastBusy = null;
+            for (Connection connection : connections) {
+                int inFlight = connection.inFlight.get();
+                if (inFlight < minInFlight) {
+                    minInFlight = inFlight;
+                    leastBusy = connection;
+                }
+            }
+
+            // If we race with shutdown, leastBusy could be null. In that case we just loop and we'll throw on the next
+            // iteration anyway
+            if (leastBusy != null) {
+                while (true) {
+                    int inFlight = leastBusy.inFlight.get();
+
+                    if (inFlight >= Math.min(leastBusy.maxAvailableStreams(), options().getMaxRequestsPerConnection(hostDistance)))
+                        break;
+
+                    if (leastBusy.inFlight.compareAndSet(inFlight, inFlight + 1))
+                        return leastBusy;
+                }
+            }
+
+            remaining = timeout - Cluster.timeSince(start, unit);
+        } while (remaining > 0);
+
+        throw new TimeoutException("All connections are busy");
+    }
+
+    public void returnConnection(Connection connection) {
+        connection.inFlight.decrementAndGet();
+        totalInFlight.decrementAndGet();
+
+        if (isClosed()) {
+            close(connection);
+            return;
+        }
+
+        if (connection.isDefunct()) {
+            // As part of making it defunct, we have already replaced it or
+            // closed the pool.
+            return;
+        }
+
+        if (connection.state.get() != TRASHED) {
+            if (connection.maxAvailableStreams() < minAllowedStreams) {
+                replaceConnection(connection);
+            } else {
+                signalAvailableConnection();
+            }
+        }
+    }
+
+    // Trash the connection and create a new one, but we don't call trashConnection
+    // directly because we want to make sure the connection is always trashed.
+    private void replaceConnection(Connection connection) {
+        if (!connection.state.compareAndSet(OPEN, TRASHED))
+            return;
+        open.decrementAndGet();
+        maybeSpawnNewConnection();
+        connection.maxIdleTime = Long.MIN_VALUE;
+        doTrashConnection(connection);
+    }
+
+    private boolean trashConnection(Connection connection) {
+        if (!connection.state.compareAndSet(OPEN, TRASHED))
+            return true;
+
+        // First, make sure we don't go below core connections
+        for (; ; ) {
+            int opened = open.get();
+            if (opened <= options().getCoreConnectionsPerHost(hostDistance)) {
+                connection.state.set(OPEN);
+                return false;
+            }
+
+            if (open.compareAndSet(opened, opened - 1))
+                break;
+        }
+        logger.trace("Trashing {}", connection);
+        connection.maxIdleTime = System.currentTimeMillis() + options().getIdleTimeoutSeconds() * 1000;
+        doTrashConnection(connection);
+        return true;
+    }
+
+    private void doTrashConnection(Connection connection) {
+        connections.remove(connection);
+        trash.add(connection);
+    }
+
+    private boolean addConnectionIfUnderMaximum() {
+
+        // First, make sure we don't cross the allowed limit of open connections
+        for (; ; ) {
+            int opened = open.get();
+            if (opened >= options().getMaxConnectionsPerHost(hostDistance))
+                return false;
+
+            if (open.compareAndSet(opened, opened + 1))
+                break;
+        }
+
+        if (phase.get() != Phase.READY) {
+            open.decrementAndGet();
+            return false;
+        }
+
+        // Now really open the connection
+        try {
+            Connection newConnection = tryResurrectFromTrash();
+            if (newConnection == null) {
+                if (!host.convictionPolicy.canReconnectNow()) {
+                    open.decrementAndGet();
+                    return false;
+                }
+                logger.debug("Creating new connection on busy pool to {}", host);
+                newConnection = manager.connectionFactory().open(this);
+            }
+            connections.add(newConnection);
+
+            newConnection.state.compareAndSet(RESURRECTING, OPEN); // no-op if it was already OPEN
+
+            // We might have raced with pool shutdown since the last check; ensure the connection gets closed in case the pool did not do it.
+            if (isClosed() && !newConnection.isClosed()) {
+                close(newConnection);
+                open.decrementAndGet();
+                return false;
+            }
+
+            signalAvailableConnection();
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            // Skip the open but ignore otherwise
+            open.decrementAndGet();
+            return false;
+        } catch (ConnectionException e) {
+            open.decrementAndGet();
+            logger.debug("Connection error to {} while creating additional connection", host);
+            return false;
+        } catch (AuthenticationException e) {
+            // This shouldn't really happen in theory
+            open.decrementAndGet();
+            logger.error("Authentication error while creating additional connection (error is: {})", e.getMessage());
+            return false;
+        } catch (UnsupportedProtocolVersionException e) {
+            // This shouldn't happen since we shouldn't have been able to connect in the first place
+            open.decrementAndGet();
+            logger.error("UnsupportedProtocolVersionException error while creating additional connection (error is: {})", e.getMessage());
+            return false;
+        } catch (ClusterNameMismatchException e) {
+            open.decrementAndGet();
+            logger.error("ClusterNameMismatchException error while creating additional connection (error is: {})", e.getMessage());
+            return false;
+        }
+    }
+
+    private Connection tryResurrectFromTrash() {
+        long highestMaxIdleTime = System.currentTimeMillis();
+        Connection chosen = null;
+
+        while (true) {
+            for (Connection connection : trash)
+                if (connection.maxIdleTime > highestMaxIdleTime && connection.maxAvailableStreams() > minAllowedStreams) {
+                    chosen = connection;
+                    highestMaxIdleTime = connection.maxIdleTime;
+                }
+
+            if (chosen == null)
+                return null;
+            else if (chosen.state.compareAndSet(TRASHED, RESURRECTING))
+                break;
+        }
+        logger.trace("Resurrecting {}", chosen);
+        trash.remove(chosen);
+        return chosen;
+    }
+
+    private void maybeSpawnNewConnection() {
+        if (isClosed() || !host.convictionPolicy.canReconnectNow())
+            return;
+
+        while (true) {
+            int inCreation = scheduledForCreation.get();
+            if (inCreation >= MAX_SIMULTANEOUS_CREATION)
+                return;
+            if (scheduledForCreation.compareAndSet(inCreation, inCreation + 1))
+                break;
+        }
+
+        manager.blockingExecutor().submit(newConnectionTask);
+    }
+
+    @Override
+    public void onConnectionDefunct(final Connection connection) {
+        if (connection.state.compareAndSet(OPEN, GONE))
+            open.decrementAndGet();
+        connections.remove(connection);
+
+        // Don't try to replace the connection now. Connection.defunct already signaled the failure,
+        // and either the host will be marked DOWN (which destroys all pools), or we want to prevent
+        // new connections for some time
+    }
+
+    void cleanupIdleConnections(long now) {
+        if (isClosed())
+            return;
+
+        shrinkIfBelowCapacity();
+        cleanupTrash(now);
+    }
+
+    /**
+     * If we have more active connections than needed, trash some of them
+     */
+    private void shrinkIfBelowCapacity() {
+        int currentLoad = maxTotalInFlight.getAndSet(totalInFlight.get());
+
+        int maxRequestsPerConnection = options().getMaxRequestsPerConnection(hostDistance);
+        int needed = currentLoad / maxRequestsPerConnection + 1;
+        if (currentLoad % maxRequestsPerConnection > options().getNewConnectionThreshold(hostDistance))
+            needed += 1;
+        needed = Math.max(needed, options().getCoreConnectionsPerHost(hostDistance));
+        int actual = open.get();
+        int toTrash = Math.max(0, actual - needed);
+
+        logger.trace("Current inFlight = {}, {} connections needed, {} connections available, trashing {}",
+                currentLoad, needed, actual, toTrash);
+
+        if (toTrash <= 0)
+            return;
+
+        for (Connection connection : connections)
+            if (trashConnection(connection)) {
+                toTrash -= 1;
+                if (toTrash == 0)
+                    return;
+            }
+    }
+
+    /**
+     * Close connections that have been sitting in the trash for too long
+     */
+    private void cleanupTrash(long now) {
+        for (Connection connection : trash) {
+            if (connection.maxIdleTime < now && connection.state.compareAndSet(TRASHED, GONE)) {
+                if (connection.inFlight.get() == 0) {
+                    logger.trace("Cleaning up {}", connection);
+                    trash.remove(connection);
+                    close(connection);
+                } else {
+                    // Given that idleTimeout >> request timeout, all outstanding requests should
+                    // have finished by now, so we should not get here.
+                    // Restore the status so that it's retried on the next cleanup.
+                    connection.state.set(TRASHED);
+                }
+            }
+        }
+    }
+
+    private void close(final Connection connection) {
+        connection.closeAsync();
+    }
+
+    public final boolean isClosed() {
+        return closeFuture.get() != null;
+    }
+
+    public final CloseFuture closeAsync() {
+
+        CloseFuture future = closeFuture.get();
+        if (future != null)
+            return future;
+
+        phase.set(Phase.CLOSING);
+
+        // Wake up all threads that wait
+        signalAllAvailableConnection();
+
+        future = new CloseFuture.Forwarding(discardAvailableConnections());
+
+        return closeFuture.compareAndSet(null, future)
+                ? future
+                : closeFuture.get(); // We raced, it's ok, return the future that was actually set
+    }
+
+    public int opened() {
+        return open.get();
+    }
+
+    int trashed() {
+        return trash.size();
+    }
+
+    private List<CloseFuture> discardAvailableConnections() {
+        // Note: if this gets called before initialization has completed, both connections and trash will be empty,
+        // so this will return an empty list
+
+        List<CloseFuture> futures = new ArrayList<CloseFuture>(connections.size() + trash.size());
+
+        for (final Connection connection : connections) {
+            CloseFuture future = connection.closeAsync();
+            future.addListener(new Runnable() {
+                @Override
+                public void run() {
+                    if (connection.state.compareAndSet(OPEN, GONE))
+                        open.decrementAndGet();
+                }
+            }, MoreExecutors.sameThreadExecutor());
+            futures.add(future);
+        }
+
+        // Some connections in the trash might still be open if they hadn't reached their idle timeout
+        for (Connection connection : trash)
+            futures.add(connection.closeAsync());
+
+        return futures;
+    }
+
+    // This creates connections if we have less than core connections (if we
+    // have more than core, connection will just get trash when we can).
+    public void ensureCoreConnections() {
+        if (isClosed())
+            return;
+
+        if (!host.convictionPolicy.canReconnectNow())
+            return;
+
+        // Note: this process is a bit racy, but it doesn't matter since we're still guaranteed to not create
+        // more connection than maximum (and if we create more than core connection due to a race but this isn't
+        // justified by the load, the connection in excess will be quickly trashed anyway)
+        int opened = open.get();
+        for (int i = opened; i < options().getCoreConnectionsPerHost(hostDistance); i++) {
+            // We don't respect MAX_SIMULTANEOUS_CREATION here because it's only to
+            // protect against creating connection in excess of core too quickly
+            scheduledForCreation.incrementAndGet();
+            manager.blockingExecutor().submit(newConnectionTask);
+        }
+    }
+
+    static class PoolState {
+        volatile String keyspace;
+
+        void setKeyspace(String keyspace) {
+            this.keyspace = keyspace;
+        }
+    }
+}

--- a/scio-cassandra2/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/scio-cassandra2/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -1,0 +1,739 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.Message.Response;
+import com.datastax.driver.core.exceptions.DriverInternalError;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
+import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.ReconnectionPolicy;
+import com.datastax.driver.core.policies.SpeculativeExecutionPolicy;
+import com.datastax.driver.core.utils.MoreFutures;
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.*;
+import io.netty.util.concurrent.EventExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Driver implementation of the Session interface.
+ */
+class SessionManager extends AbstractSession {
+
+    private static final Logger logger = LoggerFactory.getLogger(Session.class);
+
+    private static final boolean CHECK_IO_DEADLOCKS = SystemProperties.getBoolean(
+            "com.datastax.driver.CHECK_IO_DEADLOCKS", true);
+
+    final Cluster cluster;
+    final ConcurrentMap<Host, HostConnectionPool> pools;
+    final HostConnectionPool.PoolState poolsState;
+    private final AtomicReference<ListenableFuture<Session>> initFuture = new AtomicReference<ListenableFuture<Session>>();
+    final AtomicReference<CloseFuture> closeFuture = new AtomicReference<CloseFuture>();
+
+    private volatile boolean isInit;
+    private volatile boolean isClosing;
+
+    // Package protected, only Cluster should construct that.
+    SessionManager(Cluster cluster) {
+        this.cluster = cluster;
+        this.pools = new ConcurrentHashMap<Host, HostConnectionPool>();
+        this.poolsState = new HostConnectionPool.PoolState();
+    }
+
+    @Override
+    public Session init() {
+        try {
+            return Uninterruptibles.getUninterruptibly(initAsync());
+        } catch (ExecutionException e) {
+            throw DriverThrowables.propagateCause(e);
+        }
+    }
+
+    @Override
+    public ListenableFuture<Session> initAsync() {
+        // If we haven't initialized the cluster, do it now
+        cluster.init();
+
+        ListenableFuture<Session> existing = initFuture.get();
+        if (existing != null)
+            return existing;
+
+        final SettableFuture<Session> myInitFuture = SettableFuture.create();
+        if (!initFuture.compareAndSet(null, myInitFuture))
+            return initFuture.get();
+
+        Collection<Host> hosts = cluster.getMetadata().allHosts();
+        ListenableFuture<?> allPoolsCreatedFuture = createPools(hosts);
+        ListenableFuture<?> allPoolsUpdatedFuture = Futures.transformAsync(allPoolsCreatedFuture,
+                new AsyncFunction<Object, Object>() {
+                    @Override
+                    public ListenableFuture<Object> apply(Object input) throws Exception {
+                        isInit = true;
+                        return (ListenableFuture<Object>) updateCreatedPools();
+                    }
+                });
+
+        Futures.addCallback(allPoolsUpdatedFuture, new FutureCallback<Object>() {
+            @Override
+            public void onSuccess(Object result) {
+                myInitFuture.set(SessionManager.this);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                SessionManager.this.closeAsync(); // don't leak the session
+                myInitFuture.setException(t);
+            }
+        });
+        return myInitFuture;
+    }
+
+    private ListenableFuture<?> createPools(Collection<Host> hosts) {
+        List<ListenableFuture<Boolean>> futures = Lists.newArrayListWithCapacity(hosts.size());
+        for (Host host : hosts)
+            if (host.state != Host.State.DOWN)
+                futures.add(maybeAddPool(host, null));
+        return Futures.allAsList(futures);
+    }
+
+    @Override
+    public String getLoggedKeyspace() {
+        return poolsState.keyspace;
+    }
+
+    @Override
+    public ResultSetFuture executeAsync(final Statement statement) {
+        if (isInit) {
+            DefaultResultSetFuture future = new DefaultResultSetFuture(this, cluster.manager.protocolVersion(), makeRequestMessage(statement, null));
+            new RequestHandler(this, future, statement).sendRequest();
+            return future;
+        } else {
+            // If the session is not initialized, we can't call makeRequestMessage() synchronously, because it
+            // requires internal Cluster state that might not be initialized yet (like the protocol version).
+            // Because of the way the future is built, we need another 'proxy' future that we can return now.
+            final ChainedResultSetFuture chainedFuture = new ChainedResultSetFuture();
+            this.initAsync().addListener(new Runnable() {
+                @Override
+                public void run() {
+                    DefaultResultSetFuture actualFuture = new DefaultResultSetFuture(SessionManager.this, cluster.manager.protocolVersion(), makeRequestMessage(statement, null));
+                    execute(actualFuture, statement);
+                    chainedFuture.setSource(actualFuture);
+                }
+            }, executor());
+            return chainedFuture;
+        }
+    }
+
+    @Override
+    public ListenableFuture<PreparedStatement> prepareAsync(String query) {
+        Connection.Future future = new Connection.Future(new Requests.Prepare(query));
+        execute(future, Statement.DEFAULT);
+        return toPreparedStatement(query, future);
+    }
+
+    @Override
+    public CloseFuture closeAsync() {
+        CloseFuture future = closeFuture.get();
+        if (future != null)
+            return future;
+
+        isClosing = true;
+        cluster.manager.removeSession(this);
+
+        List<CloseFuture> futures = new ArrayList<CloseFuture>(pools.size());
+        for (HostConnectionPool pool : pools.values())
+            futures.add(pool.closeAsync());
+
+        future = new CloseFuture.Forwarding(futures);
+
+        return closeFuture.compareAndSet(null, future)
+                ? future
+                : closeFuture.get(); // We raced, it's ok, return the future that was actually set
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closeFuture.get() != null;
+    }
+
+    @Override
+    public Cluster getCluster() {
+        return cluster;
+    }
+
+    @Override
+    public Session.State getState() {
+        return new State(this);
+    }
+
+    private ListenableFuture<PreparedStatement> toPreparedStatement(final String query, final Connection.Future future) {
+        return Futures.transformAsync(future, new AsyncFunction<Response, PreparedStatement>() {
+            @Override
+            public ListenableFuture<PreparedStatement> apply(Response response) {
+                switch (response.type) {
+                    case RESULT:
+                        Responses.Result rm = (Responses.Result) response;
+                        switch (rm.kind) {
+                            case PREPARED:
+                                Responses.Result.Prepared pmsg = (Responses.Result.Prepared) rm;
+                                PreparedStatement stmt = DefaultPreparedStatement.fromMessage(pmsg, cluster.getMetadata(), cluster.getConfiguration().getProtocolOptions().getProtocolVersionEnum(), query, poolsState.keyspace);
+                                stmt = cluster.manager.addPrepared(stmt);
+                                if (cluster.getConfiguration().getQueryOptions().isPrepareOnAllHosts()) {
+                                    // All Sessions are connected to the same nodes so it's enough to prepare only the nodes of this session.
+                                    // If that changes, we'll have to make sure this propagate to other sessions too.
+                                    return prepare(stmt, future.getAddress());
+                                } else {
+                                    return Futures.immediateFuture(stmt);
+                                }
+                            default:
+                                return Futures.immediateFailedFuture(
+                                        new DriverInternalError(String.format("%s response received when prepared statement was expected", rm.kind)));
+                        }
+                    case ERROR:
+                        return Futures.immediateFailedFuture(
+                                ((Responses.Error) response).asException(future.getAddress()));
+                    default:
+                        return Futures.immediateFailedFuture(
+                                new DriverInternalError(String.format("%s response received when prepared statement was expected", response.type)));
+                }
+            }
+        }, executor());
+    }
+
+    Connection.Factory connectionFactory() {
+        return cluster.manager.connectionFactory;
+    }
+
+    Configuration configuration() {
+        return cluster.manager.configuration;
+    }
+
+    LoadBalancingPolicy loadBalancingPolicy() {
+        return cluster.manager.loadBalancingPolicy();
+    }
+
+    SpeculativeExecutionPolicy speculativeRetryPolicy() {
+        return cluster.manager.speculativeRetryPolicy();
+    }
+
+    ReconnectionPolicy reconnectionPolicy() {
+        return cluster.manager.reconnectionPolicy();
+    }
+
+    ListeningExecutorService executor() {
+        return cluster.manager.executor;
+    }
+
+    ListeningExecutorService blockingExecutor() {
+        return cluster.manager.blockingExecutor;
+    }
+
+    // Returns whether there was problem creating the pool
+    ListenableFuture<Boolean> forceRenewPool(final Host host, Connection reusedConnection) {
+        final HostDistance distance = cluster.manager.loadBalancingPolicy().distance(host);
+        if (distance == HostDistance.IGNORED)
+            return Futures.immediateFuture(true);
+
+        if (isClosing)
+            return Futures.immediateFuture(false);
+
+        final HostConnectionPool newPool = new HostConnectionPool(host, distance, this);
+        ListenableFuture<Void> poolInitFuture = newPool.initAsync(reusedConnection);
+
+        final SettableFuture<Boolean> future = SettableFuture.create();
+
+        Futures.addCallback(poolInitFuture, new FutureCallback<Void>() {
+            @Override
+            public void onSuccess(Void result) {
+                HostConnectionPool previous = pools.put(host, newPool);
+                if (previous == null) {
+                    logger.debug("Added connection pool for {}", host);
+                } else {
+                    logger.debug("Renewed connection pool for {}", host);
+                    previous.closeAsync();
+                }
+
+                // If we raced with a session shutdown, ensure that the pool will be closed.
+                if (isClosing) {
+                    newPool.closeAsync();
+                    pools.remove(host);
+                    future.set(false);
+                } else {
+                    future.set(true);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                logger.warn("Error creating pool to " + host, t);
+                future.set(false);
+            }
+        });
+
+        return future;
+    }
+
+    // Replace pool for a given host only if it's the given previous value (which can be null)
+    // This returns a future if the replacement was successful, or null if we raced.
+    private ListenableFuture<Void> replacePool(final Host host, HostDistance distance, HostConnectionPool previous, Connection reusedConnection) {
+        if (isClosing)
+            return MoreFutures.VOID_SUCCESS;
+
+        final HostConnectionPool newPool = new HostConnectionPool(host, distance, this);
+        if (previous == null) {
+            if (pools.putIfAbsent(host, newPool) != null) {
+                return null;
+            }
+        } else {
+            if (!pools.replace(host, previous, newPool)) {
+                return null;
+            }
+            if (!previous.isClosed()) {
+                logger.warn("Replacing a pool that wasn't closed. Closing it now, but this was not expected.");
+                previous.closeAsync();
+            }
+        }
+
+        ListenableFuture<Void> poolInitFuture = newPool.initAsync(reusedConnection);
+
+        Futures.addCallback(poolInitFuture, new FutureCallback<Void>() {
+            @Override
+            public void onSuccess(Void result) {
+                // If we raced with a session shutdown, ensure that the pool will be closed.
+                if (isClosing) {
+                    newPool.closeAsync();
+                    pools.remove(host);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                pools.remove(host);
+            }
+        });
+        return poolInitFuture;
+    }
+
+    // Returns whether there was problem creating the pool
+    ListenableFuture<Boolean> maybeAddPool(final Host host, Connection reusedConnection) {
+        final HostDistance distance = cluster.manager.loadBalancingPolicy().distance(host);
+        if (distance == HostDistance.IGNORED)
+            return Futures.immediateFuture(true);
+
+        HostConnectionPool previous = pools.get(host);
+        if (previous != null && !previous.isClosed())
+            return Futures.immediateFuture(true);
+
+        while (true) {
+            previous = pools.get(host);
+            if (previous != null && !previous.isClosed())
+                return Futures.immediateFuture(true);
+
+            final SettableFuture<Boolean> future = SettableFuture.create();
+            ListenableFuture<Void> newPoolInit = replacePool(host, distance, previous, reusedConnection);
+            if (newPoolInit != null) {
+                Futures.addCallback(newPoolInit, new FutureCallback<Void>() {
+                    @Override
+                    public void onSuccess(Void result) {
+                        logger.debug("Added connection pool for {}", host);
+                        future.set(true);
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        if (t instanceof UnsupportedProtocolVersionException) {
+                            cluster.manager.logUnsupportedVersionProtocol(host, ((UnsupportedProtocolVersionException) t).unsupportedVersion);
+                            cluster.manager.triggerOnDown(host, false);
+                        } else if (t instanceof ClusterNameMismatchException) {
+                            ClusterNameMismatchException e = (ClusterNameMismatchException) t;
+                            cluster.manager.logClusterNameMismatch(host, e.expectedClusterName, e.actualClusterName);
+                            cluster.manager.triggerOnDown(host, false);
+                        } else {
+                            logger.warn("Error creating pool to " + host, t);
+                        }
+                        future.set(false);
+                    }
+                });
+                return future;
+            }
+        }
+    }
+
+    CloseFuture removePool(Host host) {
+        final HostConnectionPool pool = pools.remove(host);
+        return pool == null
+                ? CloseFuture.immediateFuture()
+                : pool.closeAsync();
+    }
+
+    /*
+     * When the set of live nodes change, the loadbalancer will change his
+     * mind on host distances. It might change it on the node that came/left
+     * but also on other nodes (for instance, if a node dies, another
+     * previously ignored node may be now considered).
+     *
+     * This method ensures that all hosts for which a pool should exist
+     * have one, and hosts that shouldn't don't.
+     */
+    ListenableFuture<?> updateCreatedPools() {
+        // This method does nothing during initialization. Some hosts may be non-responsive but not yet marked DOWN; if
+        // we execute the code below we would try to create their pool over and over again.
+        // It's called explicitly at the end of init(), once isInit has been set to true.
+        if (!isInit)
+            return MoreFutures.VOID_SUCCESS;
+
+        // We do 2 iterations, so that we add missing pools first, and them remove all unecessary pool second.
+        // That way, we'll avoid situation where we'll temporarily lose connectivity
+        final List<Host> toRemove = new ArrayList<Host>();
+        List<ListenableFuture<Boolean>> poolCreatedFutures = Lists.newArrayList();
+
+        for (Host h : cluster.getMetadata().allHosts()) {
+            HostDistance dist = loadBalancingPolicy().distance(h);
+            HostConnectionPool pool = pools.get(h);
+
+            if (pool == null) {
+                if (dist != HostDistance.IGNORED && h.state == Host.State.UP)
+                    poolCreatedFutures.add(maybeAddPool(h, null));
+            } else if (dist != pool.hostDistance) {
+                if (dist == HostDistance.IGNORED) {
+                    toRemove.add(h);
+                } else {
+                    pool.hostDistance = dist;
+                    pool.ensureCoreConnections();
+                }
+            }
+        }
+
+        // Wait pool creation before removing, so we don't lose connectivity
+        ListenableFuture<?> allPoolsCreatedFuture = Futures.successfulAsList(poolCreatedFutures);
+
+        return Futures.transformAsync(allPoolsCreatedFuture, new AsyncFunction<Object, List<Void>>() {
+            @Override
+            public ListenableFuture<List<Void>> apply(Object input) throws Exception {
+                List<ListenableFuture<Void>> poolRemovedFuture = Lists.newArrayListWithCapacity(toRemove.size());
+                for (Host h : toRemove)
+                    poolRemovedFuture.add(removePool(h));
+
+                return Futures.successfulAsList(poolRemovedFuture);
+            }
+        });
+    }
+
+    void updateCreatedPools(Host h) {
+        HostDistance dist = loadBalancingPolicy().distance(h);
+        HostConnectionPool pool = pools.get(h);
+
+        try {
+            if (pool == null) {
+                if (dist != HostDistance.IGNORED && h.state == Host.State.UP)
+                    try {
+                        maybeAddPool(h, null).get();
+                    } catch (ExecutionException e) {
+                        // Ignore, maybeAddPool has already handled the error
+                    }
+            } else if (dist != pool.hostDistance) {
+                if (dist == HostDistance.IGNORED) {
+                    removePool(h).get();
+                } else {
+                    pool.hostDistance = dist;
+                    pool.ensureCoreConnections();
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.error("Unexpected error while refreshing connection pools", e.getCause());
+        }
+    }
+
+    void onDown(Host host) throws InterruptedException, ExecutionException {
+        // Note that with well behaved balancing policy (that ignore dead nodes), the removePool call is not necessary
+        // since updateCreatedPools should take care of it. But better protect against non well behaving policies.
+        removePool(host).force().get();
+        updateCreatedPools().get();
+    }
+
+    void onRemove(Host host) throws InterruptedException, ExecutionException {
+        onDown(host);
+    }
+
+    Message.Request makeRequestMessage(Statement statement, ByteBuffer pagingState) {
+        // We need the protocol version, which is only available once the cluster has initialized. Initialize the session to ensure this is the case.
+        // init() locks, so avoid if we know we don't need it.
+        if (!isInit)
+            init();
+        ProtocolVersion version = cluster.manager.protocolVersion();
+
+        ConsistencyLevel consistency = statement.getConsistencyLevel();
+        if (consistency == null)
+            consistency = configuration().getQueryOptions().getConsistencyLevel();
+
+        ConsistencyLevel serialConsistency = statement.getSerialConsistencyLevel();
+        if (version.compareTo(ProtocolVersion.V3) < 0 && statement instanceof BatchStatement) {
+            if (serialConsistency != null)
+                throw new UnsupportedFeatureException(version, "Serial consistency on batch statements is not supported");
+        } else if (serialConsistency == null)
+            serialConsistency = configuration().getQueryOptions().getSerialConsistencyLevel();
+
+        long defaultTimestamp = Long.MIN_VALUE;
+        if (cluster.manager.protocolVersion().compareTo(ProtocolVersion.V3) >= 0) {
+            defaultTimestamp = statement.getDefaultTimestamp();
+            if (defaultTimestamp == Long.MIN_VALUE)
+                defaultTimestamp = cluster.getConfiguration().getPolicies().getTimestampGenerator().next();
+        }
+
+        int fetchSize = statement.getFetchSize();
+        ByteBuffer usedPagingState = pagingState;
+
+        if (version == ProtocolVersion.V1) {
+            assert pagingState == null;
+            // We don't let the user change the fetchSize globally if the proto v1 is used, so we just need to
+            // check for the case of a per-statement override
+            if (fetchSize <= 0)
+                fetchSize = -1;
+            else if (fetchSize != Integer.MAX_VALUE)
+                throw new UnsupportedFeatureException(version, "Paging is not supported");
+        } else if (fetchSize <= 0) {
+            fetchSize = configuration().getQueryOptions().getFetchSize();
+        }
+
+        if (fetchSize == Integer.MAX_VALUE)
+            fetchSize = -1;
+
+        if (pagingState == null) {
+            usedPagingState = statement.getPagingState();
+        }
+
+        if (statement instanceof StatementWrapper)
+            statement = ((StatementWrapper) statement).getWrappedStatement();
+
+        if (statement instanceof RegularStatement) {
+            RegularStatement rs = (RegularStatement) statement;
+
+            // It saddens me that we special case for the query builder here, but for now this is simpler.
+            // We could provide a general API in RegularStatement instead at some point but it's unclear what's
+            // the cleanest way to do that is right now (and it's probably not really that useful anyway).
+            if (version == ProtocolVersion.V1 && rs instanceof com.datastax.driver.core.querybuilder.BuiltStatement)
+                ((com.datastax.driver.core.querybuilder.BuiltStatement) rs).setForceNoValues(true);
+
+            ByteBuffer[] rawValues = rs.getValues(version);
+
+            if (version == ProtocolVersion.V1 && rawValues != null)
+                throw new UnsupportedFeatureException(version, "Binary values are not supported");
+
+            List<ByteBuffer> values = rawValues == null ? Collections.<ByteBuffer>emptyList() : Arrays.asList(rawValues);
+            String qString = rs.getQueryString();
+            Requests.QueryProtocolOptions options = new Requests.QueryProtocolOptions(Message.Request.Type.QUERY, consistency, values, false,
+                    fetchSize, usedPagingState, serialConsistency, defaultTimestamp);
+            return new Requests.Query(qString, options, statement.isTracing());
+        } else if (statement instanceof BoundStatement) {
+            BoundStatement bs = (BoundStatement) statement;
+            if (!cluster.manager.preparedQueries.containsKey(bs.statement.getPreparedId().id)) {
+                throw new InvalidQueryException(String.format("Tried to execute unknown prepared query : %s. "
+                        + "You may have used a PreparedStatement that was created with another Cluster instance.", bs.statement.getPreparedId().id));
+            }
+            bs.ensureAllSet();
+            boolean skipMetadata = version != ProtocolVersion.V1 && bs.statement.getPreparedId().resultSetMetadata != null;
+            Requests.QueryProtocolOptions options = new Requests.QueryProtocolOptions(Message.Request.Type.EXECUTE, consistency, Arrays.asList(bs.wrapper.values), skipMetadata,
+                    fetchSize, usedPagingState, serialConsistency, defaultTimestamp);
+            return new Requests.Execute(bs.statement.getPreparedId().id, options, statement.isTracing());
+        } else {
+            assert statement instanceof BatchStatement : statement;
+            assert pagingState == null;
+
+            if (version == ProtocolVersion.V1)
+                throw new UnsupportedFeatureException(version, "Protocol level batching is not supported");
+
+            BatchStatement bs = (BatchStatement) statement;
+            bs.ensureAllSet();
+            BatchStatement.IdAndValues idAndVals = bs.getIdAndValues(version);
+            Requests.BatchProtocolOptions options = new Requests.BatchProtocolOptions(consistency, serialConsistency, defaultTimestamp);
+            return new Requests.Batch(bs.batchType, idAndVals.ids, idAndVals.values, options, statement.isTracing());
+        }
+    }
+
+    /**
+     * Execute the provided request.
+     * <p/>
+     * This method will find a suitable node to connect to using the
+     * {@link LoadBalancingPolicy} and handle host failover.
+     */
+    void execute(final RequestHandler.Callback callback, final Statement statement) {
+        if (isInit)
+            new RequestHandler(this, callback, statement).sendRequest();
+        else
+            this.initAsync().addListener(new Runnable() {
+                @Override
+                public void run() {
+                    new RequestHandler(SessionManager.this, callback, statement).sendRequest();
+                }
+            }, executor());
+    }
+
+    private ListenableFuture<PreparedStatement> prepare(final PreparedStatement statement, InetSocketAddress toExclude) {
+        final String query = statement.getQueryString();
+        List<ListenableFuture<Response>> futures = Lists.newArrayListWithExpectedSize(pools.size());
+        for (final Map.Entry<Host, HostConnectionPool> entry : pools.entrySet()) {
+            if (entry.getKey().getSocketAddress().equals(toExclude))
+                continue;
+
+            try {
+                // Preparing is not critical: if it fails, it will fix itself later when the user tries to execute
+                // the prepared query. So don't block if no connection is available, simply abort.
+                final Connection c = entry.getValue().borrowConnection(0, TimeUnit.MILLISECONDS);
+                ListenableFuture<Response> future = c.write(new Requests.Prepare(query));
+                Futures.addCallback(future, new FutureCallback<Response>() {
+                    @Override
+                    public void onSuccess(Response result) {
+                        c.release();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        logger.debug(String.format("Unexpected error while preparing query (%s) on %s", query, entry.getKey()), t);
+                        c.release();
+                    }
+                });
+                futures.add(future);
+            } catch (Exception e) {
+                // Again, not being able to prepare the query right now is no big deal, so just ignore
+            }
+        }
+        // Return the statement when all futures are done
+        return Futures.transform(
+                Futures.successfulAsList(futures),
+                Functions.constant(statement));
+    }
+
+    ResultSetFuture executeQuery(Message.Request msg, Statement statement) {
+        DefaultResultSetFuture future = new DefaultResultSetFuture(this, configuration().getProtocolOptions().getProtocolVersionEnum(), msg);
+        execute(future, statement);
+        return future;
+    }
+
+    void cleanupIdleConnections(long now) {
+        for (HostConnectionPool pool : pools.values()) {
+            pool.cleanupIdleConnections(now);
+        }
+    }
+
+    @Override
+    protected void checkNotInEventLoop() {
+        Connection.Factory connectionFactory = cluster.manager.connectionFactory;
+        if (!CHECK_IO_DEADLOCKS || connectionFactory == null)
+            return;
+        for (EventExecutor executor : connectionFactory.eventLoopGroup) {
+            if (executor.inEventLoop()) {
+                throw new IllegalStateException(
+                        "Detected a synchronous Session call (execute() or prepare()) on an I/O thread, " +
+                                "this can cause deadlocks or unpredictable behavior. " +
+                                "Make sure your Future callbacks only use async calls, or schedule them on a " +
+                                "different executor.");
+            }
+        }
+    }
+
+    private static class State implements Session.State {
+
+        private final SessionManager session;
+        private final List<Host> connectedHosts;
+        private final int[] openConnections;
+        private final int[] trashedConnections;
+        private final int[] inFlightQueries;
+
+        private State(SessionManager session) {
+            this.session = session;
+            this.connectedHosts = ImmutableList.copyOf(session.pools.keySet());
+
+            this.openConnections = new int[connectedHosts.size()];
+            this.trashedConnections = new int[connectedHosts.size()];
+            this.inFlightQueries = new int[connectedHosts.size()];
+
+            int i = 0;
+            for (Host h : connectedHosts) {
+                HostConnectionPool p = session.pools.get(h);
+                // It's possible we race and the host has been removed since the beginning of this
+                // functions. In that case, the fact it's part of getConnectedHosts() but has no opened
+                // connections will be slightly weird, but it's unlikely enough that we don't bother avoiding.
+                if (p == null) {
+                    openConnections[i] = 0;
+                    trashedConnections[i] = 0;
+                    inFlightQueries[i] = 0;
+                    continue;
+                }
+
+                openConnections[i] = p.opened();
+                inFlightQueries[i] = p.totalInFlight.get();
+                trashedConnections[i] = p.trashed();
+                i++;
+            }
+        }
+
+        private int getIdx(Host h) {
+            // We guarantee that we only ever create one Host object per-address, which means that '=='
+            // comparison is a proper way to test Host equality. Given that, the number of hosts
+            // per-session will always be small enough (even 1000 is kind of small and even with a 1000+
+            // node cluster, you probably don't want a Session to connect to all of them) that iterating
+            // over connectedHosts will never be much more inefficient than keeping a
+            // Map<Host, SomeStructureForHostInfo>. And it's less garbage/memory consumption so...
+            for (int i = 0; i < connectedHosts.size(); i++)
+                if (h == connectedHosts.get(i))
+                    return i;
+            return -1;
+        }
+
+        @Override
+        public Session getSession() {
+            return session;
+        }
+
+        @Override
+        public Collection<Host> getConnectedHosts() {
+            return connectedHosts;
+        }
+
+        @Override
+        public int getOpenConnections(Host host) {
+            int i = getIdx(host);
+            return i < 0 ? 0 : openConnections[i];
+        }
+
+        @Override
+        public int getTrashedConnections(Host host) {
+            int i = getIdx(host);
+            return i < 0 ? 0 : trashedConnections[i];
+        }
+
+        @Override
+        public int getInFlightQueries(Host host) {
+            int i = getIdx(host);
+            return i < 0 ? 0 : inFlightQueries[i];
+        }
+    }
+}

--- a/scio-cassandra2/src/main/java/com/google/common/util/concurrent/FutureFallback.java
+++ b/scio-cassandra2/src/main/java/com/google/common/util/concurrent/FutureFallback.java
@@ -1,0 +1,5 @@
+package com.google.common.util.concurrent;
+
+public interface FutureFallback<V> {
+
+}

--- a/scio-cassandra2/src/main/java/com/spotify/scio/cassandra/CompatUtil.java
+++ b/scio-cassandra2/src/main/java/com/spotify/scio/cassandra/CompatUtil.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.ProtocolVersion;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.RandomPartitioner;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
+/**
+ * Utilities to handle Datastax Java Driver compatibility issues.
+ */
+class CompatUtil {
+
+  private static RandomPartitioner randomPartitioner = new RandomPartitioner();
+  private static Murmur3Partitioner murmur3Partitioner = new Murmur3Partitioner();
+
+  public static ProtocolVersion getProtocolVersion(Cluster cluster) {
+    return cluster.getConfiguration().getProtocolOptions().getProtocolVersionEnum();
+  }
+
+  public static <T> ByteBuffer serialize(DataType dataType, T value,
+                                         ProtocolVersion protocolVersion) {
+    return dataType.serialize(value, protocolVersion);
+  }
+
+  public static BigInteger maxToken(String partitioner) {
+    switch (partitioner) {
+      case "org.apache.cassandra.dht.RandomPartitioner":
+        return RandomPartitioner.MAXIMUM.subtract(BigInteger.ONE);
+      case "org.apache.cassandra.dht.Murmur3Partitioner":
+        return BigInteger.valueOf(Murmur3Partitioner.MAXIMUM);
+      default:
+        throw new IllegalArgumentException("Unsupported partitioner " + partitioner);
+    }
+  }
+
+  public static BigInteger minToken(String partitioner) {
+    switch (partitioner) {
+      case "org.apache.cassandra.dht.RandomPartitioner":
+        return RandomPartitioner.ZERO;
+      case "org.apache.cassandra.dht.Murmur3Partitioner":
+        return BigInteger.valueOf(Murmur3Partitioner.MINIMUM.token);
+      default:
+        throw new IllegalArgumentException("Unsupported partitioner " + partitioner);
+    }
+  }
+
+  public static BigInteger getToken(String partitioner, ByteBuffer key) {
+    switch (partitioner) {
+      case "org.apache.cassandra.dht.RandomPartitioner":
+        return randomPartitioner.getToken(key).getToken().token;
+      case "org.apache.cassandra.dht.Murmur3Partitioner":
+        return BigInteger.valueOf(murmur3Partitioner.getToken(key).token)
+            .add(BigInteger.valueOf(Murmur3Partitioner.MINIMUM.token));
+      default:
+        throw new IllegalArgumentException("Unsupported partitioner " + partitioner);
+    }
+  }
+
+}

--- a/scio-cassandra2/src/main/java/org/apache/cassandra/db/DeletionInfo.java
+++ b/scio-cassandra2/src/main/java/org/apache/cassandra/db/DeletionInfo.java
@@ -1,0 +1,441 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.*;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Iterators;
+
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.io.IVersionedSerializer;
+
+/**
+ * A combination of a top-level (or row) tombstone and range tombstones describing the deletions
+ * within a {@link ColumnFamily} (or row).
+ */
+public class DeletionInfo
+{
+    private static final Serializer serializer = new Serializer();
+
+    /**
+     * This represents a deletion of the entire row.  We can't represent this within the RangeTombstoneList, so it's
+     * kept separately.  This also slightly optimizes the common case of a full row deletion.
+     */
+    private DeletionTime topLevel;
+
+    /**
+     * A list of range tombstones within the row.  This is left as null if there are no range tombstones
+     * (to save an allocation (since it's a common case).
+     */
+    private RangeTombstoneList ranges;
+
+    /**
+     * Creates a DeletionInfo with only a top-level (row) tombstone.
+     * @param markedForDeleteAt the time after which the entire row should be considered deleted
+     * @param localDeletionTime what time the deletion write was applied locally (for purposes of
+     *                          purging the tombstone after gc_grace_seconds).
+     */
+    public DeletionInfo(long markedForDeleteAt, int localDeletionTime)
+    {
+        // Pre-1.1 node may return MIN_VALUE for non-deleted container, but the new default is MAX_VALUE
+        // (see CASSANDRA-3872)
+        this(new DeletionTime(markedForDeleteAt, localDeletionTime == Integer.MIN_VALUE ? Integer.MAX_VALUE : localDeletionTime));
+    }
+
+    public DeletionInfo(DeletionTime topLevel)
+    {
+        this(topLevel, null);
+    }
+
+    public DeletionInfo(ByteBuffer start, ByteBuffer end, Comparator<ByteBuffer> comparator, long markedForDeleteAt, int localDeletionTime)
+    {
+        this(DeletionTime.LIVE, new RangeTombstoneList(comparator, 1));
+        ranges.add(start, end, markedForDeleteAt, localDeletionTime);
+    }
+
+    public DeletionInfo(RangeTombstone rangeTombstone, Comparator<ByteBuffer> comparator)
+    {
+        this(rangeTombstone.min, rangeTombstone.max, comparator, rangeTombstone.data.markedForDeleteAt, rangeTombstone.data.localDeletionTime);
+    }
+
+    private DeletionInfo(DeletionTime topLevel, RangeTombstoneList ranges)
+    {
+        this.topLevel = topLevel;
+        this.ranges = ranges;
+    }
+
+    /**
+     * Returns a new DeletionInfo that has no top-level tombstone or any range tombstones.
+     */
+    public static DeletionInfo live()
+    {
+        return new DeletionInfo(DeletionTime.LIVE);
+    }
+
+    public static Serializer serializer()
+    {
+        return serializer;
+    }
+
+    public DeletionInfo copy()
+    {
+        return new DeletionInfo(topLevel, ranges == null ? null : ranges.copy());
+    }
+
+    /**
+     * Returns whether this DeletionInfo is live, that is deletes no columns.
+     */
+    public boolean isLive()
+    {
+        return topLevel.markedForDeleteAt == Long.MIN_VALUE
+            && topLevel.localDeletionTime == Integer.MAX_VALUE
+            && (ranges == null || ranges.isEmpty());
+    }
+
+    /**
+     * Return whether a given column is deleted by the container having this deletion info.
+     *
+     * @param column the column to check.
+     * @return true if the column is deleted, false otherwise
+     */
+    public boolean isDeleted(Column column)
+    {
+        return isDeleted(column.name(), column.timestamp());
+    }
+
+    public boolean isDeleted(ByteBuffer name, long timestamp)
+    {
+        // We do rely on this test: if topLevel.markedForDeleteAt is MIN_VALUE, we should not
+        // consider the column deleted even if timestamp=MIN_VALUE, otherwise this break QueryFilter.isRelevant
+        if (isLive())
+            return false;
+
+        if (timestamp <= topLevel.markedForDeleteAt)
+            return true;
+
+        return ranges != null && ranges.isDeleted(name, timestamp);
+    }
+
+    /**
+     * Returns a new {@link InOrderTester} in forward order.
+     */
+    InOrderTester inOrderTester()
+    {
+        return inOrderTester(false);
+    }
+
+    /**
+     * Returns a new {@link InOrderTester} given the order in which
+     * columns will be passed to it.
+     */
+    public InOrderTester inOrderTester(boolean reversed)
+    {
+        return new InOrderTester(reversed);
+    }
+
+    /**
+     * Purge every tombstones that are older than {@code gcbefore}.
+     *
+     * @param gcBefore timestamp (in seconds) before which tombstones should be purged
+     */
+    public void purge(int gcBefore)
+    {
+        topLevel = topLevel.localDeletionTime < gcBefore ? DeletionTime.LIVE : topLevel;
+
+        if (ranges != null)
+        {
+            ranges.purge(gcBefore);
+            if (ranges.isEmpty())
+                ranges = null;
+        }
+    }
+
+    /**
+     * Evaluates difference between this deletion info and superset for read repair
+     *
+     * @return the difference between the two, or LIVE if no difference
+     */
+    public DeletionInfo diff(DeletionInfo superset)
+    {
+        RangeTombstoneList rangeDiff = superset.ranges == null || superset.ranges.isEmpty()
+                                     ? null
+                                     : ranges == null ? superset.ranges : ranges.diff(superset.ranges);
+
+        return topLevel.markedForDeleteAt != superset.topLevel.markedForDeleteAt || rangeDiff != null
+             ? new DeletionInfo(superset.topLevel, rangeDiff)
+             : DeletionInfo.live();
+    }
+
+    /**
+     * Returns true if {@code purge} would remove the top-level tombstone or any of the range
+     * tombstones, false otherwise.
+     * @param gcBefore timestamp (in seconds) before which tombstones should be purged
+     */
+    public boolean hasPurgeableTombstones(int gcBefore)
+    {
+        if (topLevel.localDeletionTime < gcBefore)
+            return true;
+
+        return ranges != null && ranges.hasPurgeableTombstones(gcBefore);
+    }
+
+    /**
+     * Potentially replaces the top-level tombstone with another, keeping whichever has the higher markedForDeleteAt
+     * timestamp.
+     * @param newInfo
+     */
+    public void add(DeletionTime newInfo)
+    {
+        if (topLevel.markedForDeleteAt < newInfo.markedForDeleteAt)
+            topLevel = newInfo;
+    }
+
+    public void add(RangeTombstone tombstone, Comparator<ByteBuffer> comparator)
+    {
+        if (ranges == null)
+            ranges = new RangeTombstoneList(comparator, 1);
+
+        ranges.add(tombstone);
+    }
+
+    /**
+     * Combines another DeletionInfo with this one and returns the result.  Whichever top-level tombstone
+     * has the higher markedForDeleteAt timestamp will be kept, along with its localDeletionTime.  The
+     * range tombstones will be combined.
+     *
+     * @return this object.
+     */
+    public DeletionInfo add(DeletionInfo newInfo)
+    {
+        add(newInfo.topLevel);
+
+        if (ranges == null)
+            ranges = newInfo.ranges == null ? null : newInfo.ranges.copy();
+        else if (newInfo.ranges != null)
+            ranges.addAll(newInfo.ranges);
+
+        return this;
+    }
+
+    /**
+     * Returns the minimum timestamp in any of the range tombstones or the top-level tombstone.
+     */
+    public long minTimestamp()
+    {
+        return ranges == null
+             ? topLevel.markedForDeleteAt
+             : Math.min(topLevel.markedForDeleteAt, ranges.minMarkedAt());
+    }
+
+    /**
+     * Returns the maximum timestamp in any of the range tombstones or the top-level tombstone.
+     */
+    public long maxTimestamp()
+    {
+        return ranges == null
+             ? topLevel.markedForDeleteAt
+             : Math.max(topLevel.markedForDeleteAt, ranges.maxMarkedAt());
+    }
+
+    /**
+     * Returns the top-level (or "row") tombstone.
+     */
+    public DeletionTime getTopLevelDeletion()
+    {
+        return topLevel;
+    }
+
+    // Use sparingly, not the most efficient thing
+    public Iterator<RangeTombstone> rangeIterator()
+    {
+        return ranges == null ? Collections.emptyIterator() : ranges.iterator();
+    }
+
+    public DeletionTime rangeCovering(ByteBuffer name)
+    {
+        return ranges == null ? null : ranges.search(name);
+    }
+
+    public int dataSize()
+    {
+        int size = TypeSizes.NATIVE.sizeof(topLevel.markedForDeleteAt);
+        return size + (ranges == null ? 0 : ranges.dataSize());
+    }
+
+    public boolean hasRanges()
+    {
+        return ranges != null && !ranges.isEmpty();
+    }
+
+    public int rangeCount()
+    {
+        return hasRanges() ? ranges.size() : 0;
+    }
+
+    /**
+     * Whether this deletion info may modify the provided one if added to it.
+     */
+    public boolean mayModify(DeletionInfo delInfo)
+    {
+        return topLevel.markedForDeleteAt > delInfo.topLevel.markedForDeleteAt
+            || hasRanges();
+    }
+
+    @Override
+    public String toString()
+    {
+        if (ranges == null || ranges.isEmpty())
+            return String.format("{%s}", topLevel);
+        else
+            return String.format("{%s, ranges=%s}", topLevel, rangesAsString());
+    }
+
+    private String rangesAsString()
+    {
+        assert !ranges.isEmpty();
+        StringBuilder sb = new StringBuilder();
+        AbstractType at = (AbstractType)ranges.comparator();
+        assert at != null;
+        Iterator<RangeTombstone> iter = rangeIterator();
+        while (iter.hasNext())
+        {
+            RangeTombstone i = iter.next();
+            sb.append("[");
+            sb.append(at.getString(i.min)).append("-");
+            sb.append(at.getString(i.max)).append(", ");
+            sb.append(i.data);
+            sb.append("]");
+        }
+        return sb.toString();
+    }
+
+    // Updates all the timestamp of the deletion contained in this DeletionInfo to be {@code timestamp}.
+    public void updateAllTimestamp(long timestamp)
+    {
+        if (topLevel.markedForDeleteAt != Long.MIN_VALUE)
+            topLevel = new DeletionTime(timestamp, topLevel.localDeletionTime);
+
+        if (ranges != null)
+            ranges.updateAllTimestamp(timestamp);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if(!(o instanceof DeletionInfo))
+            return false;
+        DeletionInfo that = (DeletionInfo)o;
+        return topLevel.equals(that.topLevel) && Objects.equal(ranges, that.ranges);
+    }
+
+    @Override
+    public final int hashCode()
+    {
+        return Objects.hashCode(topLevel, ranges);
+    }
+
+    public static class Serializer implements IVersionedSerializer<DeletionInfo>
+    {
+        public void serialize(DeletionInfo info, DataOutput out, int version) throws IOException
+        {
+            DeletionTime.serializer.serialize(info.topLevel, out);
+            RangeTombstoneList.serializer.serialize(info.ranges, out, version);
+        }
+
+        /*
+         * Range tombstones internally depend on the column family serializer, but it is not serialized.
+         * Thus deserialize(DataInput, int, Comparator<ByteBuffer>) should be used instead of this method.
+         */
+        public DeletionInfo deserialize(DataInput in, int version) throws IOException
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        public DeletionInfo deserialize(DataInput in, int version, Comparator<ByteBuffer> comparator) throws IOException
+        {
+            DeletionTime topLevel = DeletionTime.serializer.deserialize(in);
+            RangeTombstoneList ranges = RangeTombstoneList.serializer.deserialize(in, version, comparator);
+            return new DeletionInfo(topLevel, ranges);
+        }
+
+        public long serializedSize(DeletionInfo info, TypeSizes typeSizes, int version)
+        {
+            long size = DeletionTime.serializer.serializedSize(info.topLevel, typeSizes);
+            return size + RangeTombstoneList.serializer.serializedSize(info.ranges, typeSizes, version);
+        }
+
+        public long serializedSize(DeletionInfo info, int version)
+        {
+            return serializedSize(info, TypeSizes.NATIVE, version);
+        }
+    }
+
+    /**
+     * This object allow testing whether a given column (name/timestamp) is deleted
+     * or not by this DeletionInfo, assuming that the columns given to this
+     * object are passed in forward or reversed comparator sorted order.
+     *
+     * This is more efficient that calling DeletionInfo.isDeleted() repeatedly
+     * in that case.
+     */
+    public class InOrderTester
+    {
+        /*
+         * Note that because because range tombstone are added to this DeletionInfo while we iterate,
+         * `ranges` may be null initially and we need to wait for the first range to create the tester (once
+         * created the test will pick up new tombstones however). We are guaranteed that a range tombstone
+         * will be added *before* we test any column that it may delete, so this is ok.
+         */
+        private RangeTombstoneList.InOrderTester tester;
+        private final boolean reversed;
+
+        private InOrderTester(boolean reversed)
+        {
+            this.reversed = reversed;
+        }
+
+        public boolean isDeleted(Column column)
+        {
+            return isDeleted(column.name(), column.timestamp());
+        }
+
+        public boolean isDeleted(ByteBuffer name, long timestamp)
+        {
+            if (timestamp <= topLevel.markedForDeleteAt)
+                return true;
+
+            /*
+             * We don't optimize the reversed case for now because RangeTombstoneList
+             * is always in forward sorted order.
+             */
+            if (reversed)
+                 return DeletionInfo.this.isDeleted(name, timestamp);
+
+            // Maybe create the tester if we hadn't yet and we now have some ranges (see above).
+            if (tester == null && ranges != null)
+                tester = ranges.inOrderTester();
+
+            return tester != null && tester.isDeleted(name, timestamp);
+        }
+    }
+}

--- a/scio-cassandra2/src/main/java/org/apache/cassandra/hadoop/cql3/CqlBulkRecordWriterUtil.java
+++ b/scio-cassandra2/src/main/java/org/apache/cassandra/hadoop/cql3/CqlBulkRecordWriterUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.hadoop.cql3;
+
+import org.apache.cassandra.hadoop.ConfigHelper;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+
+public class CqlBulkRecordWriterUtil {
+  /** Workaround to expose package private constructor. */
+  public static CqlBulkRecordWriter newWriter(Configuration conf,
+                                              String host,
+                                              int port,
+                                              String username,
+                                              String password,
+                                              String keyspace,
+                                              String table,
+                                              String partitioner,
+                                              String tableSchema,
+                                              String insertStatement)
+      throws IOException {
+    ConfigHelper.setOutputInitialAddress(conf, host);
+    if (port >= 0) {
+      ConfigHelper.setOutputRpcPort(conf, String.valueOf(port));
+    }
+    if (username != null && password != null) {
+      ConfigHelper.setOutputKeyspaceUserNameAndPassword(conf, username, password);
+    }
+    ConfigHelper.setOutputKeyspace(conf, keyspace);
+    ConfigHelper.setOutputColumnFamily(conf, table);
+    ConfigHelper.setOutputPartitioner(conf, partitioner);
+    CqlBulkOutputFormat.setColumnFamilySchema(conf, table, tableSchema);
+    CqlBulkOutputFormat.setColumnFamilyInsertStatement(conf, table, insertStatement);
+
+    // workaround for Hadoop static initialization
+    if (!System.getProperties().containsKey("hadoop.home.dir") &&
+        !System.getenv().containsKey("HADOOP_HOME")) {
+      System.setProperty("hadoop.home.dir", "/");
+    }
+
+    return new CqlBulkRecordWriter(conf);
+  }
+}

--- a/scio-cassandra2/src/main/java/org/apache/cassandra/streaming/StreamManager.java
+++ b/scio-cassandra2/src/main/java/org/apache/cassandra/streaming/StreamManager.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.streaming;
+
+import java.net.InetAddress;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.management.ListenerNotFoundException;
+import javax.management.MBeanNotificationInfo;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.RateLimiter;
+
+import org.cliffc.high_scale_lib.NonBlockingHashMap;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.streaming.management.StreamEventJMXNotifier;
+import org.apache.cassandra.streaming.management.StreamStateCompositeData;
+
+/**
+ * StreamManager manages currently running {@link StreamResultFuture}s and provides status of all operation invoked.
+ *
+ * All stream operation should be created through this class to track streaming status and progress.
+ */
+public class StreamManager implements StreamManagerMBean
+{
+    public static final StreamManager instance = new StreamManager();
+
+    /**
+     * Gets streaming rate limiter.
+     * When stream_throughput_outbound_megabits_per_sec is 0, this returns rate limiter
+     * with the rate of Double.MAX_VALUE bytes per second.
+     * Rate unit is bytes per sec.
+     *
+     * @return StreamRateLimiter with rate limit set based on peer location.
+     */
+    public static StreamRateLimiter getRateLimiter(InetAddress peer)
+    {
+        return new StreamRateLimiter(peer);
+    }
+
+    public static class StreamRateLimiter
+    {
+        private static final double BYTES_PER_MEGABIT = 1024 * 1024 / 8;
+        private static final RateLimiter limiter = RateLimiter.create(Double.MAX_VALUE);
+        private static final RateLimiter interDCLimiter = RateLimiter.create(Double.MAX_VALUE);
+        private final boolean isLocalDC;
+
+        public StreamRateLimiter(InetAddress peer)
+        {
+            double throughput = ((double) DatabaseDescriptor.getStreamThroughputOutboundMegabitsPerSec()) * BYTES_PER_MEGABIT;
+            mayUpdateThroughput(throughput, limiter);
+
+            double interDCThroughput = ((double) DatabaseDescriptor.getInterDCStreamThroughputOutboundMegabitsPerSec()) * BYTES_PER_MEGABIT;
+            mayUpdateThroughput(interDCThroughput, interDCLimiter);
+
+            if (DatabaseDescriptor.getLocalDataCenter() != null && DatabaseDescriptor.getEndpointSnitch() != null)
+                isLocalDC = DatabaseDescriptor.getLocalDataCenter().equals(
+                            DatabaseDescriptor.getEndpointSnitch().getDatacenter(peer));
+            else
+                isLocalDC = true;
+        }
+
+        private void mayUpdateThroughput(double limit, RateLimiter rateLimiter)
+        {
+            // if throughput is set to 0, throttling is disabled
+            if (limit == 0)
+                limit = Double.MAX_VALUE;
+            if (rateLimiter.getRate() != limit)
+                rateLimiter.setRate(limit);
+        }
+
+        public void acquire(int toTransfer)
+        {
+            limiter.acquire(toTransfer);
+            if (!isLocalDC)
+                interDCLimiter.acquire(toTransfer);
+        }
+    }
+
+    private final StreamEventJMXNotifier notifier = new StreamEventJMXNotifier();
+
+    /*
+     * Currently running streams. Removed after completion/failure.
+     * We manage them in two different maps to distinguish plan from initiated ones to
+     * receiving ones withing the same JVM.
+     */
+    private final Map<UUID, StreamResultFuture> initiatedStreams = new NonBlockingHashMap<>();
+    private final Map<UUID, StreamResultFuture> receivingStreams = new NonBlockingHashMap<>();
+
+    public Set<CompositeData> getCurrentStreams()
+    {
+        return Sets.newHashSet(Iterables.transform(Iterables.concat(initiatedStreams.values(), receivingStreams.values()), new Function<StreamResultFuture, CompositeData>()
+        {
+            public CompositeData apply(StreamResultFuture input)
+            {
+                return StreamStateCompositeData.toCompositeData(input.getCurrentState());
+            }
+        }));
+    }
+
+    public void register(final StreamResultFuture result)
+    {
+        result.addEventListener(notifier);
+        // Make sure we remove the stream on completion (whether successful or not)
+        result.addListener(new Runnable()
+        {
+            public void run()
+            {
+                initiatedStreams.remove(result.planId);
+            }
+        }, MoreExecutors.sameThreadExecutor());
+
+        initiatedStreams.put(result.planId, result);
+    }
+
+    public void registerReceiving(final StreamResultFuture result)
+    {
+        result.addEventListener(notifier);
+        // Make sure we remove the stream on completion (whether successful or not)
+        result.addListener(new Runnable()
+        {
+            public void run()
+            {
+                receivingStreams.remove(result.planId);
+            }
+        }, MoreExecutors.sameThreadExecutor());
+
+        receivingStreams.put(result.planId, result);
+    }
+
+    public StreamResultFuture getReceivingStream(UUID planId)
+    {
+        return receivingStreams.get(planId);
+    }
+
+    public void addNotificationListener(NotificationListener listener, NotificationFilter filter, Object handback)
+    {
+        notifier.addNotificationListener(listener, filter, handback);
+    }
+
+    public void removeNotificationListener(NotificationListener listener) throws ListenerNotFoundException
+    {
+        notifier.removeNotificationListener(listener);
+    }
+
+    public void removeNotificationListener(NotificationListener listener, NotificationFilter filter, Object handback) throws ListenerNotFoundException
+    {
+        notifier.removeNotificationListener(listener, filter, handback);
+    }
+
+    public MBeanNotificationInfo[] getNotificationInfo()
+    {
+        return notifier.getNotificationInfo();
+    }
+}

--- a/scio-cassandra3/src/it/scala/com/spotify/scio/cassandra/CassandraIT.scala
+++ b/scio-cassandra3/src/it/scala/com/spotify/scio/cassandra/CassandraIT.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.cassandra
+
+import java.math.{BigInteger, BigDecimal => JBigDecimal}
+import java.nio.ByteBuffer
+import java.time.{Instant, LocalTime}
+import java.util.{Date, UUID}
+
+import com.datastax.driver.core.utils.UUIDs
+import com.datastax.driver.core.{Cluster, LocalDate, Row}
+import com.spotify.scio._
+import org.scalatest._
+
+import scala.collection.JavaConverters._
+
+class CassandraIT extends FlatSpec with Matchers with BeforeAndAfterAll {
+
+  import CassandraIT._
+
+  private val n = 1000
+  private val host = "127.0.0.1"
+
+  // TODO: figure out why inet/InetAddress doesn't work
+  private val table1Cql =
+    """
+      |CREATE TABLE scio.table1 (
+      |  key text,          // String
+      |  i1 tinyint,        // Byte
+      |  i2 smallint,       // Short
+      |  i3 int,            // Int
+      |  i4 bigint,         // Long
+      |  d decimal,         // java.math.BigDecimal
+      |  f1 float,          // Float
+      |  f2 double,         // Double
+      |  b1 boolean,        // Boolean
+      |  b2 blob,           // java.nio.ByteBuffer
+      |  dt1 date,          // com.datastax.driver.core.LocalDate
+      |  dt2 time,          // Long, the number of nanoseconds since midnight
+      |  dt3 timestamp,     // java.util.Date
+      |  u1 uuid,           // java.util.UUID
+      |  u2 timeuuid,       // java.util.UUID, Version 1
+      |  v1 varchar,        // String
+      |  v2 varint,         // java.math.BigInteger
+      |  c1 list<text>,     // java.util.List
+      |  c2 set<text>,      // java.util.Set
+      |  c3 map<text, int>, // java.util.Map
+      |  PRIMARY KEY (key)
+      |)
+    """.stripMargin
+
+  private val table2Cql =
+    """
+      |CREATE TABLE scio.table2 (
+      |  k1 text,
+      |  k2 text,
+      |  k3 text,
+      |  v1 text,
+      |  v2 int,
+      |  v3 float,
+      |  PRIMARY KEY (k1, k2, k3)
+      |);
+    """.stripMargin
+
+  private def connect(): Cluster = Cluster.builder().addContactPoint(host).build()
+
+  override protected def beforeAll(): Unit = {
+    val cluster = connect()
+    try {
+      val session = cluster.connect()
+      if (cluster.getMetadata.getKeyspace("scio") != null) {
+        session.execute("DROP KEYSPACE scio")
+      }
+      session.execute(
+        """
+          |CREATE KEYSPACE scio
+          |WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+        """.stripMargin)
+      session.execute(table1Cql)
+      session.execute(table2Cql)
+    } catch {
+      case e: Throwable =>
+        cluster.close()
+        throw e
+    }
+  }
+
+  "Bulk write" should "work with single key" in {
+    val cql =
+      """
+        |INSERT INTO scio.table1
+        |(key, i1, i2, i3, i4, d, f1, f2, b1, b2, dt1, dt2, dt3, u1, u2, v1, v2, c1, c2, c3)
+        |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      """.stripMargin
+    val opts = CassandraOptions("scio", "table1", cql, host)
+
+    val cluster = connect()
+    try {
+      val sc = ScioContext()
+      sc.parallelize(1 to n)
+        .saveAsCassandra(opts)(toValues1)
+      sc.close()
+
+      val result = cluster.connect().execute("SELECT * FROM scio.table1").asScala
+      val expected = (1 to n).map(toValues1)
+      result.map(fromRow1) should contain theSameElementsAs expected
+    } finally {
+      cluster.close()
+      CassandraUtil.cleanup()
+    }
+  }
+
+  it should "work with composite key" in {
+    val cql =
+      """
+        |INSERT INTO scio.table2
+        |(k1, k2, k3, v1, v2, v3) VALUES (?, ?, ?, ?, ?, ?);
+      """.stripMargin
+    val opts = CassandraOptions("scio", "table2", cql, host)
+
+    val cluster = connect()
+    try {
+      val sc = ScioContext()
+      sc.parallelize(1 to n)
+        .saveAsCassandra(opts)(toValues2)
+      sc.close()
+
+      val result = cluster.connect().execute("SELECT * FROM scio.table2").asScala
+      val expected = (1 to n).map(toValues2)
+      result.map(fromRow2) should contain theSameElementsAs expected
+    } finally {
+      cluster.close()
+      CassandraUtil.cleanup()
+    }
+  }
+
+}
+
+object CassandraIT {
+
+  private val u1: UUID = UUID.randomUUID()
+  private val u2: UUID = UUIDs.timeBased()
+  private val date = LocalDate.fromMillisSinceEpoch(System.currentTimeMillis())
+  private val time = LocalTime.now().toNanoOfDay
+  private val timestamp = Date.from(Instant.now())
+
+  def toValues1(i: Int): Seq[Any] = Seq(
+    s"key$i", i.toByte, i.toShort, i, i.toLong, JBigDecimal.valueOf(i), i.toFloat, i.toDouble,
+    i % 2 == 0, ByteBuffer.wrap(s"blob$i".getBytes), date, time, timestamp,
+    u1, u2, s"varchar$i", BigInteger.valueOf(i),
+    List(s"list$i").asJava, Set(s"set$i").asJava, Map(s"key$i" -> i).asJava)
+
+  def fromRow1(r: Row): Seq[Any] = Seq(
+    r.getString("key"), r.getByte("i1"), r.getShort("i2"), r.getInt("i3"), r.getLong("i4"),
+    r.getDecimal("d"), r.getFloat("f1"), r.getDouble("f2"), r.getBool("b1"), r.getBytes("b2"),
+    r.getDate("dt1"), r.getTime("dt2"), r.getTimestamp("dt3"),
+    r.getUUID("u1"), r.getUUID("u2"), r.getString("v1"), r.getVarint("v2"),
+    r.getList("c1", classOf[String]), r.getSet("c2", classOf[String]),
+    r.getMap("c3", classOf[String], classOf[java.lang.Integer]))
+
+  def toValues2(i: Int): Seq[Any] = Seq(s"k1_$i", s"k2_$i", s"k3_$i", s"v1_$i", i, i.toFloat)
+
+  def fromRow2(r: Row): Seq[Any] = Seq(
+    r.getString("k1"), r.getString("k2"), r.getString("k3"),
+    r.getString("v1"), r.getInt("v2"), r.getFloat("v3"))
+
+}

--- a/scio-cassandra3/src/main/java/com/spotify/scio/cassandra/CompatUtil.java
+++ b/scio-cassandra3/src/main/java/com/spotify/scio/cassandra/CompatUtil.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.CodecRegistry;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.ProtocolVersion;
+import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.RandomPartitioner;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
+/**
+ * Utilities to handle Datastax Java Driver compatibility issues.
+ */
+class CompatUtil {
+
+  private static RandomPartitioner randomPartitioner = new RandomPartitioner();
+  private static Murmur3Partitioner murmur3Partitioner = new Murmur3Partitioner();
+
+  public static ProtocolVersion getProtocolVersion(Cluster cluster) {
+    return cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
+  }
+
+  public static <T> ByteBuffer serialize(DataType dataType, T value,
+                                         ProtocolVersion protocolVersion) {
+    return CodecRegistry.DEFAULT_INSTANCE
+        .codecFor(dataType, value)
+        .serialize(value, protocolVersion);
+  }
+
+  public static BigInteger maxToken(String partitioner) {
+    switch (partitioner) {
+      case "org.apache.cassandra.dht.RandomPartitioner":
+        return RandomPartitioner.MAXIMUM.subtract(BigInteger.ONE);
+      case "org.apache.cassandra.dht.Murmur3Partitioner":
+        return BigInteger.valueOf(Murmur3Partitioner.MAXIMUM);
+      default:
+        throw new IllegalArgumentException("Unsupported partitioner " + partitioner);
+    }
+  }
+
+  public static BigInteger minToken(String partitioner) {
+    switch (partitioner) {
+      case "org.apache.cassandra.dht.RandomPartitioner":
+        return RandomPartitioner.ZERO;
+      case "org.apache.cassandra.dht.Murmur3Partitioner":
+        return BigInteger.valueOf((long) Murmur3Partitioner.MINIMUM.getTokenValue());
+      default:
+        throw new IllegalArgumentException("Unsupported partitioner " + partitioner);
+    }
+  }
+
+  public static BigInteger getToken(String partitioner, ByteBuffer key) {
+    switch (partitioner) {
+      case "org.apache.cassandra.dht.RandomPartitioner":
+        return randomPartitioner.getToken(key).getTokenValue();
+      case "org.apache.cassandra.dht.Murmur3Partitioner":
+        return BigInteger.valueOf((long) murmur3Partitioner.getToken(key).getTokenValue())
+            .add(BigInteger.valueOf((long) Murmur3Partitioner.MINIMUM.getTokenValue()));
+      default:
+        throw new IllegalArgumentException("Unsupported partitioner " + partitioner);
+    }
+  }
+
+}

--- a/scio-cassandra3/src/main/java/org/apache/cassandra/hadoop/cql3/CqlBulkRecordWriterUtil.java
+++ b/scio-cassandra3/src/main/java/org/apache/cassandra/hadoop/cql3/CqlBulkRecordWriterUtil.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.hadoop.cql3;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.hadoop.ConfigHelper;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+
+public class CqlBulkRecordWriterUtil {
+  /** Workaround to expose package private constructor. */
+  public static CqlBulkRecordWriter newWriter(Configuration conf,
+                                              String host,
+                                              int port,
+                                              String username,
+                                              String password,
+                                              String keyspace,
+                                              String table,
+                                              String partitioner,
+                                              String tableSchema,
+                                              String insertStatement)
+      throws IOException {
+    ConfigHelper.setOutputInitialAddress(conf, host);
+    if (port >= 0) {
+      ConfigHelper.setOutputRpcPort(conf, String.valueOf(port));
+    }
+    if (username != null && password != null) {
+      ConfigHelper.setOutputKeyspaceUserNameAndPassword(conf, username, password);
+    }
+    ConfigHelper.setOutputKeyspace(conf, keyspace);
+    ConfigHelper.setOutputColumnFamily(conf, table);
+    ConfigHelper.setOutputPartitioner(conf, partitioner);
+    CqlBulkOutputFormat.setTableSchema(conf, table, tableSchema);
+    CqlBulkOutputFormat.setTableInsertStatement(conf, table, insertStatement);
+
+    // workaround for Hadoop static initialization
+    if (!System.getProperties().containsKey("hadoop.home.dir") &&
+        !System.getenv().containsKey("HADOOP_HOME")) {
+      System.setProperty("hadoop.home.dir", "/");
+    }
+
+    DatabaseDescriptor.clientInitialization();
+    return new CqlBulkRecordWriter(conf);
+  }
+}

--- a/scio-cassandra3/src/main/scala/com/spotify/scio/cassandra/BulkOperations.scala
+++ b/scio-cassandra3/src/main/scala/com/spotify/scio/cassandra/BulkOperations.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.cassandra
+
+import java.lang.management.ManagementFactory
+import java.nio.ByteBuffer
+
+import com.datastax.driver.core.{Cluster, ProtocolVersion}
+import org.apache.cassandra.db.marshal.CompositeType
+import org.apache.cassandra.hadoop.cql3._
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapred.TaskAttemptContext
+
+import scala.collection.JavaConverters._
+
+private[cassandra] class BulkOperations(val opts: CassandraOptions) extends Serializable {
+
+  case class BulkConfig(protocol: ProtocolVersion, partitioner: String, numOfNodes: Int,
+                        tableSchema: String, partitionKeyIndices: Seq[Int],
+                        dataTypes: Seq[DataTypeExternalizer])
+
+  private val config = {
+    var b = Cluster.builder().addContactPoint(opts.seedNodeHost)
+    if (opts.seedNodePort >= 0) {
+      b = b.withPort(opts.seedNodePort)
+    }
+    if (opts.username != null && opts.password != null) {
+      b = b.withCredentials(opts.username, opts.password)
+    }
+    val cluster = b.build()
+
+    val table = for {
+      k <- cluster.getMetadata.getKeyspaces.asScala.find(_.getName == opts.keyspace)
+      t <- k.getTables.asScala.find(_.getName == opts.table)
+    } yield t
+    require(table.isDefined, s"Invalid keyspace.table: ${opts.keyspace}.${opts.table}")
+
+    val protocol = CompatUtil.getProtocolVersion(cluster)
+    val partitioner = cluster.getMetadata.getPartitioner
+    val numOfNodes = cluster.getMetadata.getAllHosts.size()
+    val tableSchema = table.get.asCQLQuery()
+
+    val variables = cluster.connect().prepare(opts.cql).getVariables.asList().asScala
+    val partitionKeys = table.get.getPartitionKey.asScala.map(_.getName).toSet
+    val partitionKeyIndices = variables
+      .map(_.getName)
+      .zipWithIndex
+      .filter(t => partitionKeys.contains(t._1))
+      .map(_._2)
+      .toArray
+    val dataTypes = variables.map(v => DataTypeExternalizer(v.getType))
+    cluster.close()
+
+    BulkConfig(protocol, partitioner, numOfNodes, tableSchema, partitionKeyIndices, dataTypes)
+  }
+
+  private def parallelism: Int = config.numOfNodes
+
+  val serializeFn: Seq[Any] => Array[ByteBuffer] = (values: Seq[Any]) => {
+    val b = Array.newBuilder[ByteBuffer]
+    val i = values.iterator
+    val j = config.dataTypes.iterator
+    while (i.hasNext && j.hasNext) {
+      b += CompatUtil.serialize(j.next().get, i.next(), config.protocol)
+    }
+    b.result()
+  }
+
+  val partitionFn: Array[ByteBuffer] => Int = {
+    // Partition tokens equally across workers regardless of cluster token distribution
+    // This may not create 1-to-1 mapping between partitions and C* nodes but handles multi-DC
+    // clusters better
+    val maxToken = BigInt(CompatUtil.maxToken(config.partitioner))
+    val minToken = BigInt(CompatUtil.minToken(config.partitioner))
+    val (q, mod) = (maxToken - minToken + 1) /% parallelism
+    val rangePerGroup = (if (mod != 0) q + 1 else q).bigInteger
+
+    (values: Array[ByteBuffer]) => {
+      val key = if (config.partitionKeyIndices.length == 1) {
+        values(config.partitionKeyIndices.head)
+      } else {
+        val keys = config.partitionKeyIndices.map(values)
+        CompositeType.build(keys: _*)
+      }
+      val token = CompatUtil.getToken(config.partitioner, key)
+      token.divide(rangePerGroup).intValue()
+    }
+  }
+
+  val writeFn: ((Int, Iterable[Array[ByteBuffer]])) => Unit =
+    (kv: (Int, Iterable[Array[ByteBuffer]])) => {
+      val w = newWriter
+      kv._2.foreach(row => w.write(null, row.toList.asJava))
+      w.close(null: TaskAttemptContext)
+    }
+
+  private def newWriter: CqlBulkRecordWriter = {
+    val conf = new Configuration()
+    CqlBulkRecordWriterUtil.newWriter(
+      conf, opts.seedNodeHost, opts.seedNodePort, opts.username, opts.password,
+      opts.keyspace, opts.table, config.partitioner, config.tableSchema, opts.cql)
+  }
+
+}
+
+private[cassandra] object CassandraUtil {
+  def cleanup(): Unit = {
+    val mbs = ManagementFactory.getPlatformMBeanServer
+    mbs.queryNames(null, null).asScala
+      .filter(_.getCanonicalName.startsWith("org.apache.cassandra."))
+      .foreach(mbs.unregisterMBean)
+  }
+}

--- a/scio-cassandra3/src/main/scala/com/spotify/scio/cassandra/DataTypeExternalizer.scala
+++ b/scio-cassandra3/src/main/scala/com/spotify/scio/cassandra/DataTypeExternalizer.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.cassandra
+
+import java.lang.{Iterable => JIterable}
+import java.util.{Collection => JCollection}
+
+import com.datastax.driver.core.DataType
+import com.google.common.collect.{ImmutableList, ImmutableSet, Lists}
+import com.twitter.chill._
+
+import scala.collection.JavaConverters._
+import scala.language.higherKinds
+
+private[cassandra] object DataTypeExternalizer {
+  def apply(dt: DataType): DataTypeExternalizer = {
+    val x = new DataTypeExternalizer
+    x.set(dt)
+    x
+  }
+}
+
+private[cassandra] class DataTypeExternalizer extends Externalizer[DataType] {
+  override protected def kryo: KryoInstantiator =
+    new (DataTypeKryoInstantiator).setReferences(true)
+}
+
+private class DataTypeKryoInstantiator extends EmptyScalaKryoInstantiator {
+  override def newKryo: KryoBase = {
+    val k = super.newKryo
+    k.forSubclass[ImmutableList[Any]](new ImmutableListSerializer[Any])
+    k.forSubclass[ImmutableSet[Any]](new ImmutableSetSerializer[Any])
+    k
+  }
+}
+
+private trait ImmutableCollectionSerializer[M] extends KSerializer[M] {
+  def readList[T](kser: Kryo, in: Input): JCollection[T] = {
+    val size = in.readInt(true)
+    val list = Lists.newArrayList[T]()
+    (1 to size).foreach(_ => list.add(kser.readClassAndObject(in).asInstanceOf[T]))
+    list
+  }
+  def writeList[T](kser: Kryo, out: Output, obj: JCollection[T]): Unit = {
+    out.writeInt(obj.size(), true)
+    obj.asScala.foreach(kser.writeClassAndObject(out, _))
+  }
+}
+
+private class ImmutableListSerializer[T] extends ImmutableCollectionSerializer[ImmutableList[T]] {
+  override def read(kser: Kryo, in: Input, cls: Class[ImmutableList[T]]): ImmutableList[T] =
+    ImmutableList.copyOf(readList(kser, in): JIterable[T])
+  override def write(kser: Kryo, out: Output, obj: ImmutableList[T]): Unit =
+    writeList(kser, out, obj)
+}
+
+private class ImmutableSetSerializer[T] extends ImmutableCollectionSerializer[ImmutableSet[T]] {
+  override def read(kser: Kryo, in: Input, cls: Class[ImmutableSet[T]]): ImmutableSet[T] =
+    ImmutableSet.copyOf(readList(kser, in): JIterable[T])
+  override def write(kser: Kryo, out: Output, obj: ImmutableSet[T]): Unit =
+    writeList(kser, out, obj)
+}

--- a/scio-cassandra3/src/main/scala/com/spotify/scio/cassandra/package.scala
+++ b/scio-cassandra3/src/main/scala/com/spotify/scio/cassandra/package.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio
+
+import com.spotify.scio.io.Tap
+import com.spotify.scio.testing.TestIO
+import com.spotify.scio.values.SCollection
+
+import scala.concurrent.Future
+
+/**
+ * Main package for Cassandra APIs. Import all.
+ *
+ * {{{
+ * import com.spotify.scio.cassandra._
+ * }}}
+ */
+package object cassandra {
+
+  case class CassandraOptions(keyspace: String, table: String, cql: String,
+                              seedNodeHost: String, seedNodePort: Int = -1,
+                              username: String = null, password: String = null)
+
+  case class CassandraIO[T](uniqueId: String) extends TestIO[T](uniqueId)
+
+  object CassandraIO {
+    def apply[T](opts: CassandraOptions): CassandraIO[T] = {
+      val sb = new StringBuilder
+      if (opts.username != null && opts.password != null) {
+        sb.append(s"${opts.username}:${opts.password}@")
+      }
+      sb.append(opts.seedNodeHost)
+      if (opts.seedNodePort >= 0) {
+        sb.append(opts.seedNodePort)
+      }
+      sb.append(s"/${opts.keyspace}/${opts.table}/${opts.cql}")
+      CassandraIO[T](sb.toString())
+    }
+  }
+
+  /** Enhanced version of [[SCollection]] with Cassandra methods. */
+  implicit class CassandraSCollection[T](@transient val self: SCollection[T])
+    extends Serializable {
+    /**
+     * Save this SCollection as a Cassandra table.
+     *
+     * Cassandra [[org.apache.cassandra.hadoop.cql3.CqlBulkRecordWriter CqlBulkRecordWriter]] is
+     * used to perform bulk writes for better throughput. The [[SCollection]] is grouped by the
+     * table partition key before written to the cluster. Therefore writes only occur at the end of
+     * each window in streaming mode. The bulk writer writes to all nodes in a cluster so remote
+     * nodes in a multi-datacenter cluster may become a bottleneck.
+     */
+    def saveAsCassandra(opts: CassandraOptions)
+                       (f: T => Seq[Any]): Future[Tap[T]] = {
+      if (self.context.isTest) {
+        self.context.testOut(CassandraIO(opts))(self)
+      } else {
+        val bulkOps = new BulkOperations(opts)
+        self
+          .map(f.andThen(bulkOps.serializeFn))
+          .groupBy(bulkOps.partitionFn)
+          .map(bulkOps.writeFn)
+      }
+      Future.failed(new NotImplementedError("Cassandra future is not implemented"))
+    }
+  }
+
+}


### PR DESCRIPTION
Had to monkey patch a lot in `scio-cassandra2` due to an old Guava dependency. Otherwise 2 & 3 are sharing Scala code and handling API changes via 2 util classes.

Couldn't get `cassandra-unit` to work since `BulkCqlWriter` uses C* internal API and conflicts with embedded C* when running in the same JVM. Will probably need to fork it as integration test. Thoughts?