### PR TITLE
expose Beam metrics, fix #720

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
@@ -17,6 +17,8 @@
 
 package com.spotify.scio
 
+import org.joda.time.Instant
+
 /** This package contains the schema types for metrics collected during a pipeline run. */
 package object metrics {
 
@@ -32,12 +34,21 @@ package object metrics {
    * Case class holding metadata and service-level metrics of the job. See
    * [[ScioResult.getMetrics]].
    */
-  case class ServiceMetrics(version: String,
-                            scalaVersion: String,
-                            jobName: String,
-                            jobId: String,
-                            state: String,
-                            cloudMetrics: Iterable[DFServiceMetrics])
+  case class Metrics(version: String,
+                     scalaVersion: String,
+                     jobName: String,
+                     jobId: String,
+                     state: String,
+                     beamMetrics: BeamMetrics,
+                     cloudMetrics: Iterable[DFServiceMetrics])
+
+  case class BeamMetrics(counters: Iterable[BeamMetric[Long]],
+                         distributions: Iterable[BeamMetric[BeamDistribution]],
+                         gauges: Iterable[BeamMetric[BeamGauge]])
+  case class BeamMetric[T](namespace: String, name: String, value: MetricValue[T])
+  case class BeamDistribution(sum: Long, count: Long, min: Long, max: Long, mean: Double)
+  case class BeamGauge(value: Long, timestamp: Instant)
+
   case class DFServiceMetrics(name: DFMetricName, scalar: AnyRef, updateTime: String)
   case class DFMetricName(name: String, origin: String, context: Map[String, String])
 

--- a/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -21,7 +21,7 @@ import java.io.PrintWriter
 import java.nio.file.Files
 
 import com.google.common.collect.Lists
-import com.spotify.scio.metrics.ServiceMetrics
+import com.spotify.scio.metrics.Metrics
 import com.spotify.scio.options.ScioOptions
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.util.ScioUtil
@@ -122,7 +122,7 @@ class ScioContextTest extends PipelineSpec {
 
     val mapper = ScioUtil.getScalaJsonMapper
 
-    val metrics = mapper.readValue(metricsFile, classOf[ServiceMetrics])
+    val metrics = mapper.readValue(metricsFile, classOf[Metrics])
     metrics.version shouldBe scioVersion
   }
 


### PR DESCRIPTION
The generated JSON looks like this:
```json
{
  "version": "0.4.0-SNAPSHOT",
  "scalaVersion": "2.11.11",
  "jobName": "JobTest-TestClass-7254660a6c8d40209d2f3f5d9dd832c5",
  "jobId": "JobTest-TestClass-7254660a6c8d40209d2f3f5d9dd832c5",
  "state": "DONE",
  "beamMetrics": {
    "counters": [
      {
        "namespace": "com.spotify.scio.ScioMetrics",
        "name": "c",
        "value": {
          "attempted": 3,
          "committed": 3
        }
      }
    ],
    "distributions": [
      {
        "namespace": "com.spotify.scio.ScioMetrics",
        "name": "d",
        "value": {
          "attempted": {
            "sum": 6,
            "count": 3,
            "min": 1,
            "max": 3,
            "mean": 2
          },
          "committed": {
            "sum": 6,
            "count": 3,
            "min": 1,
            "max": 3,
            "mean": 2
          }
        }
      }
    ],
    "gauges": [
      {
        "namespace": "com.spotify.scio.ScioMetrics",
        "name": "g",
        "value": {
          "attempted": {
            "value": 3,
            "timestamp": {
              "chronology": {
                "zone": {
                  "fixed": true,
                  "id": "UTC"
                }
              },
              "millis": 1499978787847,
              "zone": {
                "fixed": true,
                "id": "UTC"
              },
              "afterNow": false,
              "beforeNow": true,
              "equalNow": false
            }
          },
          "committed": {
            "value": 1,
            "timestamp": {
              "chronology": {
                "zone": {
                  "fixed": true,
                  "id": "UTC"
                }
              },
              "millis": 1499978787847,
              "zone": {
                "fixed": true,
                "id": "UTC"
              },
              "afterNow": false,
              "beforeNow": true,
              "equalNow": false
            }
          }
        }
      }
    ]
  },
  "cloudMetrics": [
    
  ]
}
```