### PR TITLE
Use matchNewResource to create new file otherwise throws

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
@@ -94,7 +94,7 @@ class ScioResult private[scio] (val internal: PipelineResult, val context: ScioC
   def saveMetrics(filename: String): Unit = {
     require(isCompleted, "Pipeline has to be finished to save metrics.")
     val mapper = ScioUtil.getScalaJsonMapper
-    val resourceId = FileSystems.matchSingleFileSpec(filename).resourceId
+    val resourceId = FileSystems.matchNewResource(filename, false)
     val out = FileSystems.create(resourceId, MimeTypes.TEXT)
     try {
       out.write(ByteBuffer.wrap(mapper.writeValueAsBytes(getMetrics)))


### PR DESCRIPTION
Otherwise throws:

```
java.io.FileNotFoundException: File spec /tmp/foobar not found
  at
org.apache.beam.sdk.io.FileSystems.matchSingleFileSpec(FileSystems.java:144)
  at com.spotify.scio.ScioResult.saveMetrics(ScioResult.scala:98)
```