### PR TITLE
Support for AvroType macros

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -218,7 +218,8 @@ lazy val root: Project = Project(
   scioRepl,
   scioExamples,
   scioSchemas,
-  scioTensorFlow
+  scioTensorFlow,
+  scioAvro
 )
 
 lazy val scioCore: Project = Project(
@@ -245,7 +246,8 @@ lazy val scioCore: Project = Project(
     "com.google.auto.value" % "auto-value" % autoValueVersion % "provided"
   )
 ).dependsOn(
-  scioBigQuery
+  scioBigQuery,
+  scioAvro
 )
 
 lazy val scioTest: Project = Project(
@@ -435,6 +437,24 @@ lazy val scioHdfs: Project = Project(
   scioTest % "test->test",
   scioSchemas % "test"
 )
+
+lazy val scioAvro: Project = Project(
+  "scio-avro",
+  file("scio-avro")
+).settings(
+  commonSettings ++ macroSettings ++ itSettings,
+  description := "Scio add-on for working with Avro",
+  libraryDependencies ++= beamDependencies,
+  libraryDependencies ++= Seq(
+    "org.apache.avro" % "avro" % avroVersion,
+    "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion,
+    "org.slf4j" % "slf4j-api" % slf4jVersion,
+    "org.slf4j" % "slf4j-simple" % slf4jVersion % "test,it",
+    "org.scalatest" %% "scalatest" % scalatestVersion % "test,it",
+    "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % scalacheckShapelessVersion % "test",
+    "me.lyh" %% "shapeless-datatype-core" % shapelessDatatypeVersion % "test"
+  )
+).configs(IntegrationTest)
 
 lazy val scioJdbc: Project = Project(
   "scio-jdbc",

--- a/scio-avro/src/it/scala/com/spotify/scio/avro/types/AvroTypeIT.scala
+++ b/scio-avro/src/it/scala/com/spotify/scio/avro/types/AvroTypeIT.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro.types
+
+import org.apache.avro.Schema.Parser
+import org.scalatest.{FlatSpec, Matchers}
+
+object AvroTypeIT {
+  @AvroType.fromPath(
+    "gs://data-integration-test-eu/avro-integration-test/folder-a/folder-b/")
+  class FromPath
+
+  @AvroType.fromPath(
+    "gs://data-integration-test-eu/*/*/*/")
+  class FromGlob
+
+  @AvroType.fromPath(
+    """
+      |gs://data-integration-test-eu/
+      |avro-integration-test/folder-a/folder-b/
+    """.stripMargin)
+  class FromPathMultiLine
+}
+
+class AvroTypeIT extends FlatSpec with Matchers  {
+  import AvroTypeIT._
+
+  private val expectedSchema = new Parser().parse("""{
+                                                  |  "type" : "record",
+                                                  |  "name" : "Root",
+                                                  |  "fields" : [ {
+                                                  |    "name" : "word",
+                                                  |    "type" : [ "string", "null" ]
+                                                  |  }, {
+                                                  |    "name" : "word_count",
+                                                  |    "type" : [ "long", "null" ]
+                                                  |  }, {
+                                                  |    "name" : "corpus",
+                                                  |    "type" : [ "string", "null" ]
+                                                  |  }, {
+                                                  |    "name" : "corpus_date",
+                                                  |    "type" : [ "long", "null" ]
+                                                  |  } ]
+                                                  |}""".stripMargin)
+
+  "fromPath" should "correctly read schema from GCS path" in {
+    FromPath.schema shouldBe expectedSchema
+  }
+
+  it should "correctly read schema from GCS glob" in {
+    FromGlob.schema shouldBe expectedSchema
+  }
+
+  it should "correctly read schema from multilne GCS path" in {
+    FromPathMultiLine.schema shouldBe expectedSchema
+  }
+
+  it should "support roundtrip conversion when reading schema from GCS path" in {
+    val r1 = FromPath(Some("word"), Some(2L), Some("corpus"), Some(123L))
+    val r2 = FromPath.fromGenericRecord(FromPath.toGenericRecord(r1))
+    r1 shouldBe r2
+  }
+
+  it should "support roundtrip conversion when reading schema from GCS glob" in {
+    val r1 = FromGlob(word=Some("word"), word_count=Some(2L))
+    val r2 = FromGlob.fromGenericRecord(FromGlob.toGenericRecord(r1))
+    r1 shouldBe r2
+  }
+
+  it should "support roundtrip conversion when reading schema from multilne GCS path" in {
+    val r1 = FromPathMultiLine(corpus=Some("corpus"), corpus_date=Some(123L))
+    val r2 = FromPathMultiLine.fromGenericRecord(FromPathMultiLine.toGenericRecord(r1))
+    r1 shouldBe r2
+  }
+}

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/AvroType.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/AvroType.scala
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro.types
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+
+import scala.annotation.StaticAnnotation
+import scala.language.experimental.macros
+import scala.reflect.runtime.universe._
+
+/**
+  * Macro annotations and converter generators for Avro types.
+  *
+  * The following table lists Avro types and their Scala counterparts.
+  * {{{
+  * Avro type      Scala type
+  * BOOLEAN        Boolean
+  * LONG           Long
+  * INT            Int
+  * DOUBLE         Double
+  * FLOAT          Float
+  * STRING, ENUM   String
+  * BYTES          com.google.protobuf.ByteString
+  * ARRAY          List[T]
+  * MAP            Map[String, T]
+  * UNION          Optional[T]
+  * RECORD         Nested case class
+  * }}}
+  *
+  * @groupname trait Traits for annotated types
+  * @groupname annotation Type annotations
+  * @groupname converters Converters
+  * @groupname Ungrouped Other Members
+  */
+object AvroType {
+  /**
+    * Macro annotation for an Avro schema.
+    *
+    * Generate case classes for an Avro schema. Note that `schema` must be a single string literal
+    * of the JSON schema with optional `.stripMargin` at the end. For example:
+    *
+    * {{{
+    *   @AvroType.fromSchema(
+    *       """
+    *         |{
+    *         |  "type": "record",
+    *         |  "namespace": "com.spotify.namespace",
+    *         |  "name": "RecordName",
+    *         |  "fields": [
+    *         |    { "name": "boolF", "type": "boolean"},
+    *         |    { "name": "intF", "type": "int"},
+    *         |    { "name": "longF", "type": "long"},
+    *         |    { "name": "floatF", "type": "float"},
+    *         |    { "name": "doubleF", "type": "double"},
+    *         |    { "name": "stringF", "type": "string"},
+    *         |    { "name": "byteStringF", "type": "bytes"}
+    *         |  ]
+    *         |}
+    *       """.stripMargin)
+    *   class MyRecord
+    * }}}
+    *
+    * Also generate a companion object with convenience methods.
+    * @group annotation
+    */
+  class fromSchema(schema: String) extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro TypeProvider.schemaImpl
+  }
+
+  /**
+    * Macro annotation for a path containing Avro files.
+    *
+    * Generates case classes from a path which contains Avro files.
+    * Path needs to represent a folder, hence it always needs to end with `/`.
+    * Inside of the folder needs to exist at least one file matching `*.avro` glob.
+    *
+    * Note that path must be a single string literal with optional `.stripMargin` at the end.
+    * For example:
+    *
+    * {{{
+    * @AvroType.fromPath("gs://myBucket/myFolder/")
+    * class MyRecord
+    * }}}
+    *
+    * or
+    *
+    * {{{
+    * @AvroType.fromPath(
+    *    """
+    *     | gs://myBucket/myFolder/
+    *     | myLooooooooooooooooongPath/
+    *    """.stripMargin)
+    * class MyRecord
+    * }}}
+    *
+    * Globs are supported as a part of the path. For example:
+    *
+    * {{{
+    * @AvroType.fromPath("gs://myBucket{@literal /}*{@literal /}*{@literal /}*{@literal /}")
+    * class MyRecord
+    * }}}
+    *
+    * Also generate a companion object with convenience methods.
+    * @group annotation
+    */
+  class fromPath(folderGlob: String) extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro TypeProvider.pathImpl
+  }
+
+  /**
+    * Macro annotation for case classes to be saved to Avro files.
+    *
+    * Note that this annotation does not generate case classes, only a companion object with
+    * convenience methods. You need to define a complete case class for as output record. For
+    * example:
+    *
+    * {{{
+    * @AvroType.toSchema
+    * case class Result(name: String, score: Double)
+    * }}}
+    * @group annotation
+    */
+  class toSchema extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro TypeProvider.toSchemaImpl
+  }
+
+  /**
+    * Trait for generated companion objects of case classes.
+    * @group trait
+    */
+  trait HasAvroSchema[T] {
+    def schema: Schema
+
+    def fromGenericRecord: (GenericRecord => T)
+
+    def toGenericRecord: (T => GenericRecord)
+
+    def toPrettyString(indent: Int = 0): String
+  }
+
+  /**
+    * Trait for companion objects of case classes generated with docs.
+    * @group trait
+    */
+  trait HasAvroDoc {
+    def doc: String
+  }
+
+  /**
+    * Trait for case classes with generated companion objects.
+    * @group trait
+    */
+  trait HasAvroAnnotation
+
+  /**
+    * Generate [[Schema]] for a case class.
+    */
+  def schemaOf[T: TypeTag]: Schema = SchemaProvider.schemaOf[T]
+
+  /**
+    * Generate a converter function from [[GenericRecord]] to the given case class `T`.
+    * @group converters
+    */
+  def fromGenericRecord[T]: (GenericRecord => T) = macro ConverterProvider.fromGenericRecordImpl[T]
+
+  /**
+    * Generate a converter function from the given case class `T` to [[GenericRecord]].
+    * @group converters
+    */
+  def toGenericRecord[T]: (T => GenericRecord) = macro ConverterProvider.toGenericRecordImpl[T]
+
+  /** Create a new AvroType instance. */
+  def apply[T: TypeTag]: AvroType[T] = new AvroType[T]
+}
+
+/**
+  * Type class for case class `T` annotated for Avro IO.
+  *
+  * This decouples generated fields and methods from macro expansion to keep core macro free.
+  */
+class AvroType[T: TypeTag] {
+  private val instance = runtimeMirror(getClass.getClassLoader)
+    .reflectModule(typeOf[T].typeSymbol.companion.asModule)
+    .instance
+
+  private def getField(key: String) = instance.getClass.getMethod(key).invoke(instance)
+
+  /** GenericRecord to `T` converter. */
+  def fromGenericRecord: (GenericRecord => T) =
+    getField("fromGenericRecord").asInstanceOf[(GenericRecord => T)]
+
+  /** `T` to GenericRecord converter. */
+  def toGenericRecord: (T => GenericRecord) =
+    getField("toGenericRecord").asInstanceOf[(T => GenericRecord)]
+
+  /** Schema of `T`. */
+  def schema: Schema = AvroType.schemaOf[T]
+}

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/ConverterProvider.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/ConverterProvider.scala
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro.types
+
+import com.google.protobuf.ByteString
+import com.spotify.scio.avro.types.MacroUtil._
+import org.apache.avro.generic.GenericRecord
+
+import scala.language.experimental.macros
+import scala.reflect.macros._
+
+private[types] object ConverterProvider {
+
+  def fromGenericRecordImpl[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[(GenericRecord => T)] = {
+    val tpe = implicitly[c.WeakTypeTag[T]].tpe
+    val r = fromGenericRecordInternal(c)(tpe)
+
+    c.Expr[(GenericRecord => T)](r)
+  }
+
+  def toGenericRecordImpl[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[(T => GenericRecord)] = {
+    val tpe = implicitly[c.WeakTypeTag[T]].tpe
+    val r = toGenericRecordInternal(c)(tpe)
+
+    c.Expr[(T => GenericRecord)](r)
+  }
+
+  // scalastyle:off cyclomatic.complexity
+  // scalastyle:off method.length
+  private def fromGenericRecordInternal(c: blackbox.Context)(tpe: c.Type): c.Tree = {
+    import c.universe._
+
+    // =======================================================================
+    // Converter helpers
+    // =======================================================================
+
+    def cast(tree: Tree, tpe: Type): Tree = {
+      val s = q"$tree.toString"
+      tpe match {
+        case t if t =:= typeOf[Boolean] => q"$s.toBoolean"
+        case t if t =:= typeOf[Int] => q"$s.toInt"
+        case t if t =:= typeOf[Long] => q"$s.toLong"
+        case t if t =:= typeOf[Float] => q"$s.toFloat"
+        case t if t =:= typeOf[Double] => q"$s.toDouble"
+        case t if t =:= typeOf[String] => q"$s"
+
+        case t if t =:= typeOf[ByteString] =>
+          val bb = tq"_root_.java.nio.ByteBuffer"
+          q"_root_.com.google.protobuf.ByteString.copyFrom($tree.asInstanceOf[$bb])"
+
+        case t if t.erasure <:< typeOf[scala.collection.Map[String,_]].erasure =>
+          map(tree, tpe.typeArgs.tail.head)
+
+        case t if t.erasure =:= typeOf[List[_]].erasure =>
+          list(tree, tpe.typeArgs.head)
+
+        case t if isCaseClass(c)(t) =>
+          val fn = TermName("r" + t.typeSymbol.name)
+          q"""{
+                val $fn = $tree.asInstanceOf[${p(c, ApacheAvro)}.generic.GenericRecord]
+                ${constructor(t, fn)}
+              }
+          """
+        case _ => c.abort(c.enclosingPosition, s"Unsupported type: $tpe")
+      }
+    }
+
+    def option(tree: Tree, tpe: Type): Tree =
+      q"if ($tree == null) None else Some(${cast(tree, tpe)})"
+
+    def list(tree: Tree, tpe: Type): Tree = {
+      val jl = tq"_root_.java.util.List[AnyRef]"
+      q"$tree.asInstanceOf[$jl].asScala.map(x => ${cast(q"x", tpe)}).toList"
+    }
+
+    def map(tree: Tree, tpe: Type): Tree = {
+      val jm = tq"_root_.java.util.Map[String, AnyRef]"
+      q"$tree.asInstanceOf[$jm].asScala.mapValues(x => ${cast(q"x", tpe)}).toMap"
+    }
+
+    def field(symbol: Symbol, fn: TermName): Tree = {
+      val name = symbol.name.toString
+      val tpe = symbol.asMethod.returnType
+
+      val tree = q"$fn.get($name)"
+      if (tpe.erasure =:= typeOf[Option[_]].erasure) {
+        option(tree, tpe.typeArgs.head)
+      } else {
+        cast(tree, tpe)
+      }
+    }
+
+    def constructor(tpe: Type, fn: TermName): Tree = {
+      val companion = tpe.typeSymbol.companion
+      val gets = tpe.erasure match {
+        case t if isCaseClass(c)(t) => getFields(c)(t).map(s => field(s, fn))
+        case t => c.abort(c.enclosingPosition, s"Unsupported type: $tpe")
+      }
+      q"$companion(..$gets)"
+    }
+
+    // =======================================================================
+    // Entry point
+    // =======================================================================
+
+    val tn = TermName("r")
+    q"""(r: ${p(c, ApacheAvro)}.generic.GenericRecord) => {
+          import _root_.scala.collection.JavaConverters._
+          ${constructor(tpe, tn)}
+        }
+    """
+  }
+  // scalastyle:on cyclomatic.complexity
+  // scalastyle:on method.length
+
+  // scalastyle:off cyclomatic.complexity
+  // scalastyle:off method.length
+  private def toGenericRecordInternal(c: blackbox.Context)(tpe: c.Type): c.Tree = {
+    import c.universe._
+
+    // =======================================================================
+    // Converter helpers
+    // =======================================================================
+
+    def cast(tree: Tree, tpe: Type): Tree = {
+      tpe match {
+        case t if t =:= typeOf[Boolean] => tree
+        case t if t =:= typeOf[Int] => tree
+        case t if t =:= typeOf[Long] => tree
+        case t if t =:= typeOf[Float] => tree
+        case t if t =:= typeOf[Double] => tree
+        case t if t =:= typeOf[String] => tree
+
+        case t if t =:= typeOf[ByteString] =>
+          q"$tree.asReadOnlyByteBuffer"
+
+        case t if t.erasure <:< typeOf[scala.collection.Map[String,_]].erasure =>
+          map(tree, tpe.typeArgs.tail.head)
+
+        case t if t.erasure <:< typeOf[List[_]].erasure =>
+          list(tree, tpe.typeArgs.head)
+
+        case t if isCaseClass(c)(t) =>
+          val fn = TermName("r" + t.typeSymbol.name)
+          q"""{
+                val $fn = $tree
+                ${constructor(t, fn)}
+              }
+          """
+        case _ => c.abort(c.enclosingPosition, s"Unsupported type: $tpe")
+      }
+    }
+
+    def option(tree: Tree, tpe: Type): Tree =
+      q"if ($tree.isDefined) ${cast(q"$tree.get", tpe)} else null"
+
+    def list(tree: Tree, tpe: Type): Tree = q"$tree.map(x => ${cast(q"x", tpe)}).asJava"
+
+    def map(tree: Tree, tpe: Type): Tree = q"$tree.mapValues(x => ${cast(q"x", tpe)}).asJava"
+
+    def field(symbol: Symbol, fn: TermName): (String, Tree) = {
+      val name = symbol.name.toString
+      val fieldName = symbol.name.toString
+      val tpe = symbol.asMethod.returnType
+
+      val tree = q"$fn.${TermName(name)}"
+      if (tpe.erasure =:= typeOf[Option[_]].erasure) {
+        (fieldName, option(tree, tpe.typeArgs.head))
+      } else {
+        (fieldName, cast(tree, tpe))
+      }
+    }
+
+    def constructor(tpe: Type, fn: TermName): Tree = {
+      val sets = tpe.erasure match {
+        case t if isCaseClass(c)(t) => getFields(c)(t).map(s => field(s, fn))
+        case t => c.abort(c.enclosingPosition, s"Unsupported type: $tpe")
+      }
+      val schemaOf = q"${p(c, ScioAvroType)}.schemaOf[$tpe]"
+      val header = q"val result = new ${p(c, ApacheAvro)}.generic.GenericData.Record($schemaOf)"
+      val body = sets.map { case (fieldName, value) =>
+
+        q"if ($value != null) result.put($fieldName, $value)"
+      }
+      val footer = q"result"
+      q"{$header; ..$body; $footer}"
+    }
+
+    // =======================================================================
+    // Entry point
+    // =======================================================================
+
+    val tn = TermName("r")
+    q"""(r: $tpe) => {
+          import _root_.scala.collection.JavaConverters._
+          ${constructor(tpe, tn)}
+        }
+    """
+  }
+  // scalastyle:on cyclomatic.complexity
+  // scalastyle:on method.length
+
+}

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/MacroUtil.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/MacroUtil.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro.types
+
+import org.slf4j.LoggerFactory
+
+import scala.reflect.macros._
+import scala.reflect.runtime.universe._
+
+private[types] object MacroUtil {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  // Case class helpers for runtime reflection
+
+  def isCaseClass(t: Type): Boolean =
+    !t.toString.startsWith("scala.") &&
+      List(typeOf[Product], typeOf[Serializable], typeOf[Equals])
+        .forall(b => t.baseClasses.contains(b.typeSymbol))
+
+  def isField(s: Symbol): Boolean = s.isPublic && s.isMethod && !s.isSynthetic && !s.isConstructor
+
+  // Case class helpers for macros
+
+  def isCaseClass(c: blackbox.Context)(t: c.Type): Boolean = {
+    import c.universe._
+    !t.toString.startsWith("scala.") &&
+      List(typeOf[Product], typeOf[Serializable], typeOf[Equals])
+        .forall(b => t.baseClasses.contains(b.typeSymbol))
+  }
+
+  def isField(c: blackbox.Context)(s: c.Symbol): Boolean =
+    s.isPublic && s.isMethod && !s.isSynthetic && !s.isConstructor
+  def getFields(c: blackbox.Context)(t: c.Type): Iterable[c.Symbol] =
+    t.decls.filter(isField(c))
+
+  // Namespace helpers
+
+  val ScioAvro = "_root_.com.spotify.scio.avro"
+  val ApacheAvro = "_root_.org.apache.avro"
+  val ShapelessAvro = "_root_.shapeless.datatype.avro"
+  val BeamAvroIO = "_root_.org.apache.beam.sdk.io.AvroIO"
+  val ScioAvroType = s"$ScioAvro.types.AvroType"
+
+  def p(c: blackbox.Context, code: String): c.Tree = c.parse(code)
+
+}

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/SchemaProvider.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/SchemaProvider.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro.types
+
+import java.util.Collections.{emptyList, emptyMap}
+
+import com.google.protobuf.ByteString
+import com.spotify.scio.avro.types.MacroUtil._
+import org.apache.avro.{JsonProperties, Schema}
+import org.apache.avro.Schema.Field
+
+import scala.collection.JavaConverters._
+import scala.reflect.runtime.universe._
+
+private[types] object SchemaProvider {
+
+  def schemaOf[T: TypeTag]: Schema = {
+    val tpe = typeOf[T]
+
+    if (!isCaseClass(tpe.erasure)) {
+      throw new RuntimeException(s"Unsupported type $tpe.erasure")
+    }
+
+    toSchema(tpe)._1
+  }
+
+  // scalastyle:off cyclomatic.complexity
+  private def toSchema(tpe: Type): (Schema, Any) = tpe match {
+    case t if t =:= typeOf[Boolean] => (Schema.create(Schema.Type.BOOLEAN), null)
+    case t if t =:= typeOf[Int] => (Schema.create(Schema.Type.INT), null)
+    case t if t =:= typeOf[Long] => (Schema.create(Schema.Type.LONG), null)
+    case t if t =:= typeOf[Float] => (Schema.create(Schema.Type.FLOAT), null)
+    case t if t =:= typeOf[Double] => (Schema.create(Schema.Type.DOUBLE), null)
+    case t if t =:= typeOf[String] => (Schema.create(Schema.Type.STRING), null)
+    case t if t =:= typeOf[ByteString] => (Schema.create(Schema.Type.BYTES), null)
+
+    case t if t.erasure =:= typeOf[Option[_]].erasure =>
+      val s = toSchema(t.typeArgs.head)._1
+      (Schema.createUnion(Schema.create(Schema.Type.NULL), s), JsonProperties.NULL_VALUE)
+
+    case t if t.erasure <:< typeOf[scala.collection.Map[String,_]].erasure =>
+      val s = toSchema(t.typeArgs.tail.head)._1
+      (Schema.createMap(s), emptyMap())
+
+    case t if t.erasure <:< typeOf[List[_]].erasure =>
+      val s = toSchema(t.typeArgs.head)._1
+      (Schema.createArray(s), emptyList())
+
+    case t if isCaseClass(t) =>
+      val fields = toFields(t)
+      val doc = recordDoc(t)
+      val name = t.typeSymbol.name.toString.split("\\$").head
+      val pkg = t.typeSymbol.owner.fullName
+      (Schema.createRecord(name, doc.orNull, pkg, false, fields.asJava), null)
+
+    case _ => throw new RuntimeException(s"Unsupported type: $tpe")
+  }
+  // scalastyle:on cyclomatic.complexity
+
+  private def toField(f: (Symbol, Option[String])): Field = {
+    val (symbol, doc) = f
+    val name = symbol.name.toString
+    val tpe = symbol.asMethod.returnType
+    val (schema, default) = toSchema(tpe)
+    new Field(name, schema, doc.orNull, default)
+  }
+
+  private def toFields(t: Type): List[Field] = getFields(t).map(toField)(scala.collection.breakOut)
+
+  private def getFields(t: Type): Iterable[(Symbol, Option[String])] =
+    t.decls.filter(isField) zip fieldDoc(t)
+
+  private def recordDoc(t: Type): Option[String] = {
+    val tpe = "com.spotify.scio.avro.types.doc"
+    t.typeSymbol.annotations
+      .find(_.tree.tpe.toString == tpe)
+      .map { a =>
+        val q"new $t($v)" = a.tree
+        val Literal(Constant(s)) = v
+        s.toString
+      }
+  }
+
+  private def fieldDoc(t: Type): Iterable[Option[String]] = {
+    val tpe = "com.spotify.scio.avro.types.doc"
+    t.typeSymbol.asClass.primaryConstructor.typeSignature.paramLists.head.map {
+      _.annotations
+        .find(_.tree.tpe.toString == tpe)
+        .map { a =>
+          val q"new $t($v)" = a.tree
+          val Literal(Constant(s)) = v
+          s.toString
+        }
+    }
+  }
+}

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/SchemaUtil.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/SchemaUtil.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro.types
+
+import java.util.{List => JList}
+
+import org.apache.avro.Schema
+import org.apache.avro.Schema.Field
+import org.apache.avro.Schema.Type._
+
+import scala.collection.JavaConverters._
+
+/** Utility for BigQuery schemas. */
+object SchemaUtil {
+
+  /** Convert schema to case class definitions. */
+  def toPrettyString(schema: Schema, indent: Int = 0): String =
+    getCaseClass(schema.getFields, schema.getName, indent)
+
+  // scalastyle:off cyclomatic.complexity
+  private def getFieldType(fieldName: String,
+                           fieldSchema: Schema,
+                           indent: Int): (String, Seq[String]) = {
+    fieldSchema.getType match {
+      case BOOLEAN => ("Boolean", Seq.empty)
+      case INT => ("Int", Seq.empty)
+      case LONG => ("Long", Seq.empty)
+      case FLOAT => ("Float", Seq.empty)
+      case DOUBLE => ("Double", Seq.empty)
+      case STRING | ENUM => ("String", Seq.empty)
+      case BYTES => ("ByteString", Seq.empty)
+      case ARRAY =>
+        val (fieldType, nested) = getFieldType(fieldName, fieldSchema.getElementType, indent)
+        (s"List[$fieldType]", nested)
+      case MAP =>
+        val (fieldType, nested) = getFieldType(fieldName, fieldSchema.getValueType, indent)
+        (s"Map[String, $fieldType]", nested)
+      case UNION =>
+        val unionTypes = fieldSchema.getTypes.asScala.map(_.getType).distinct
+        if (unionTypes.size != 2 || !unionTypes.contains(NULL)) {
+          throw new IllegalArgumentException(
+            s"type: ${fieldSchema.getType} is not supported. " +
+            s"Union type needs to contain exactly one 'null' type and one non null type.")
+        }
+        val (fieldType, nested) = getFieldType(fieldName, fieldSchema.getTypes.get(1), indent)
+        (s"Option[$fieldType] = None", nested)
+      case RECORD =>
+        val className = NameProvider.getUniqueName(fieldSchema.getName)
+        val nested = getCaseClass(fieldSchema.getFields, className, indent)
+        (className, Seq(nested))
+      case t => throw new IllegalArgumentException(s"Type: $t not supported")
+    }
+  }
+  // scalastyle:on cyclomatic.complexity
+
+  private def getCaseClass(fields: JList[Field], name: String, indent: Int): String = {
+    val xs = fields.asScala
+      .map { f =>
+        val (fieldType, nested) = getFieldType(f.name, f.schema, indent)
+        (escapeNameIfReserved(f.name) + ": " + fieldType, nested)
+      }
+    val lines = xs.map(_._1)
+    val nested = xs.flatMap(_._2)
+
+    val sb = StringBuilder.newBuilder
+    sb.append(s"case class $name(")
+    if (indent > 0) {
+      sb.append("\n")
+    }
+    val body = if (indent > 0) {
+      val w = " " * indent
+      lines.map(w + _).mkString(",\n")
+    } else {
+      lines.mkString(", ")
+    }
+    sb.append(body)
+    sb.append(")")
+    (sb.toString() +: nested).mkString("\n")
+  }
+
+  private[types] def escapeNameIfReserved(name: String): String = {
+    if (scalaReservedWords.contains(name)) {
+      s"`$name`"
+    } else {
+      name
+    }
+  }
+
+  private[types] def unescapeNameIfReserved(name: String): String = {
+    val Pattern = "^`(.*)`$".r
+    name match {
+      case Pattern(unescapedName) =>
+        if (scalaReservedWords.contains(unescapedName)) {
+          unescapedName
+        } else {
+          name
+        }
+      case _ => name
+    }
+  }
+
+  private[types] val scalaReservedWords = Seq(
+    "abstract", "case", "catch", "class", "def", "do", "else", "extends", "false", "final",
+    "finally", "for", "forSome", "if", "implicit", "import", "lazy", "match", "new", "null",
+    "object", "override", "package", "private", "protected", "return", "sealed", "super", "this",
+    "throw", "trait", "try", "true", "type", "val", "var", "while", "with", "yield")
+
+}

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/TypeProvider.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/TypeProvider.scala
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro.types
+
+import java.io.{File, FileInputStream}
+import java.nio.channels.Channels
+import java.util.{List => JList}
+
+import com.google.api.services.storage.StorageScopes
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.common.base.Charsets
+import com.google.common.hash.Hashing
+import com.google.common.io.Files
+import com.spotify.scio.avro.types.MacroUtil._
+import org.apache.avro.Schema
+import org.apache.avro.Schema.Type._
+import org.apache.avro.file.DataFileStream
+import org.apache.avro.generic.GenericDatumReader
+import org.apache.beam.sdk.options.{GcpOptions, PipelineOptionsFactory}
+import org.apache.beam.sdk.util.IOChannelUtils
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.{Map => MMap}
+import scala.reflect.macros._
+
+// scalastyle:off line.size.limit
+private[types] object TypeProvider {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  private lazy val ioChannelFactoryGetter = {
+    java.lang.Thread.currentThread().setContextClassLoader(getClass.getClassLoader)
+
+    val gcpOptions = PipelineOptionsFactory.create().as(classOf[GcpOptions])
+
+    if (sys.props("bigquery.project") != null) {
+      gcpOptions.setProject(sys.props("bigquery.project"))
+    }
+
+    if (sys.props("bigquery.secret") != null) {
+      val credentials = GoogleCredentials
+        .fromStream(new FileInputStream(new File(sys.props("bigquery.secret"))))
+        .createScoped(StorageScopes.all())
+      gcpOptions.setGcpCredential(credentials)
+    }
+
+    IOChannelUtils.registerIOFactories(gcpOptions)
+
+    (spec: String) => IOChannelUtils.getFactory(spec)
+  }
+
+  def schemaImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    val schemaString = extractStrings(c, "Missing schema").head
+    val schema = new Schema.Parser().parse(schemaString)
+    schemaToType(c)(schema, annottees)
+  }
+
+  def pathImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    val path = extractStrings(c, "Missing path").head
+    val schema = schemaFromGcsFolder(path)
+    schemaToType(c)(schema, annottees)
+  }
+
+  private def schemaFromGcsFolder(path: String): Schema = {
+
+
+    val trimmedPath = path.trim.replaceAll("\\s+", "")
+    assume(trimmedPath.endsWith("/"), s"Path '$trimmedPath' needs to end with a '/'")
+
+    val avroFilesGlob = s"$trimmedPath*.avro"
+
+    val factory = ioChannelFactoryGetter(avroFilesGlob)
+    val avroFiles = factory.`match`(avroFilesGlob).asScala.toList
+    assume(avroFiles.nonEmpty, s"No file was returned for glob '$trimmedPath'")
+
+    val avroFile = avroFiles.max
+    logger.info(s"Trying to read Avro schema from file '$avroFile'")
+
+    var reader : DataFileStream[Void] = null
+    try {
+      reader = new DataFileStream(
+        Channels.newInputStream(factory.open(avroFile)),
+        new GenericDatumReader[Void]())
+      reader.getSchema
+    } finally {
+      if (reader != null) {
+        reader.close()
+      }
+    }
+  }
+
+  def toSchemaImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+    checkMacroEnclosed(c)
+
+    val (r, caseClassTree, name) = annottees.map(_.tree) match {
+      case l @ List(q"$mods class $name[..$tparams] $ctorMods(..$fields) extends { ..$earlydefns } with ..$parents { $self => ..$body }") if mods.asInstanceOf[Modifiers].hasFlag(Flag.CASE) =>
+        if (parents.map(_.toString()).toSet != Set("scala.Product", "scala.Serializable")) {
+          c.abort(c.enclosingPosition, s"Invalid annotation, don't extend the case class $l")
+        }
+        val docs = getRecordDocs(c)(l)
+        val docMethod = docs.headOption.map(d => q"override def doc: _root_.java.lang.String = $d").toSeq
+        val docTrait = docMethod.map(_ => tq"${p(c, ScioAvroType)}.HasAvroDoc")
+
+        val fnTrait = if (fields.size <= 22) {
+          Seq(tq"${TypeName(s"Function${fields.size}")}[..${fields.map(_.children.head)}, $name]")
+        } else {
+          Seq()
+        }
+
+        val schemaMethod = Seq(
+          q"""override def schema: ${p(c, ApacheAvro)}.Schema =
+                 ${p(c, ScioAvroType)}.schemaOf[$name]""")
+
+        val caseClassTree = q"""${caseClass(c)(name, fields, body)}"""
+        (q"""$caseClassTree
+            ${companion(c)(name, docTrait ++ fnTrait,
+          schemaMethod ++ docMethod,
+          fields.asInstanceOf[Seq[c.Tree]])}
+        """, caseClassTree, name.toString())
+      case t => c.abort(c.enclosingPosition, s"Invalid annotation $t")
+    }
+
+    if (shouldDumpClassesForPlugin) { dumpCodeForScalaPlugin(c)(Seq.empty, caseClassTree, name) }
+
+    c.Expr[Any](r)
+  }
+
+  // scalastyle:off cyclomatic.complexity
+  // scalastyle:off method.length
+  private def schemaToType(c: blackbox.Context)
+                          (schema: Schema, annottees: Seq[c.Expr[Any]]): c.Expr[Any] = {
+    import c.universe._
+    checkMacroEnclosed(c)
+
+    // Returns: (raw type, e.g. Int, String, NestedRecord, nested case class definitions)
+    def getField(fieldName: String, fieldSchema: Schema): (Tree, Seq[Tree]) = {
+      fieldSchema.getType match {
+        case UNION =>
+          val unionTypes = fieldSchema.getTypes.asScala.map(_.getType).distinct
+          if (unionTypes.size != 2 || !unionTypes.contains(NULL)) {
+            c.abort(c.enclosingPosition,
+              s"type: ${fieldSchema.getType} is not supported. " +
+              s"Union type needs to contain exactly one 'null' type and one non null type.")
+          }
+          val (field, recordClasses) =
+            getField(fieldName, fieldSchema.getTypes.asScala.filter(_.getType != NULL).head)
+          (tq"_root_.scala.Option[$field]", recordClasses)
+        case BOOLEAN =>
+          (tq"_root_.scala.Boolean", Nil)
+        case LONG =>
+          (tq"_root_.scala.Long", Nil)
+        case DOUBLE =>
+          (tq"_root_.scala.Double", Nil)
+        case INT =>
+          (tq"_root_.scala.Int", Nil)
+        case FLOAT =>
+          (tq"_root_.scala.Float", Nil)
+        case STRING | ENUM =>
+          (tq"_root_.java.lang.String", Nil)
+        case BYTES =>
+          (tq"_root_.com.google.protobuf.ByteString", Nil)
+        case ARRAY =>
+          val (field, generatedCaseClasses) = getField(fieldName, fieldSchema.getElementType)
+          (tq"_root_.scala.List[$field]", generatedCaseClasses)
+        case MAP =>
+          val (fieldType, recordCaseClasses) = getField(fieldName, fieldSchema.getValueType)
+          (tq"_root_.scala.collection.Map[_root_.java.lang.String,$fieldType]", recordCaseClasses)
+        case RECORD =>
+          val name = NameProvider.getUniqueName(fieldSchema.getName)
+          val (fields, recordClasses) = extractFields(fieldSchema.getFields)
+          (q"${Ident(TypeName(name))}", Seq(q"case class ${TypeName(name)}(..$fields)") ++ recordClasses)
+        case t =>
+          c.abort(c.enclosingPosition, s"type: $t not supported")
+      }
+    }
+
+    // Returns: ("fieldName: fieldType", nested case class definitions)
+    def extractField(fieldName: String, fieldSchema: Schema): (Tree, Seq[Tree]) = {
+      val (fieldType, recordClasses) = getField(SchemaUtil.unescapeNameIfReserved(fieldName), fieldSchema)
+      fieldSchema.getType match {
+        case UNION =>
+          (q"val ${TermName(fieldName)}: $fieldType = None", recordClasses)
+        case _ =>
+          (q"${TermName(fieldName)}: $fieldType", recordClasses)
+      }
+    }
+
+    def extractFields(fields: JList[Schema.Field]): (Seq[Tree], Seq[Tree]) = {
+      val f = fields.asScala.map(s => extractField(s.name, s.schema))
+      (f.map(_._1), f.flatMap(_._2))
+    }
+
+    val (fields, recordClasses) = extractFields(schema.getFields)
+
+    val (r, caseClassTree, name) = annottees.map(_.tree) match {
+      case l @ List(q"$mods class $name[..$tparams] $ctorMods(..$cfields) extends { ..$earlydefns } with ..$parents { $self => ..$body }") if mods.asInstanceOf[Modifiers].flags == NoFlags =>
+        if (parents.map(_.toString()).toSet != Set("scala.AnyRef")) {
+          c.abort(c.enclosingPosition, s"Invalid annotation, don't extend the case class $l")
+        }
+        if (cfields.nonEmpty) {
+          c.abort(c.enclosingPosition, s"Invalid annotation, don't provide class fields $l")
+        }
+
+        val docs = getRecordDocs(c)(l)
+        val docMethod = docs.headOption
+          .map(d => q"override def doc: _root_.java.lang.String = $d")
+          .toSeq
+        val docTrait = docMethod
+          .map(_ => tq"${p(c, ScioAvroType)}.HasAvroDoc")
+
+        val schemaMethod = Seq(
+          q"""override def schema: ${p(c, ApacheAvro)}.Schema =
+                 new ${p(c, ApacheAvro)}.Schema.Parser().parse(${schema.toString})""")
+
+        val caseClassTree = q"${caseClass(c)(name, fields, Nil)}"
+        (q"""$caseClassTree
+           ${companion(c)(name, docTrait, schemaMethod ++ docMethod, fields)}
+           ..$recordClasses
+         """, caseClassTree, name.toString())
+      case t => c.abort(c.enclosingPosition, s"Invalid annotation $t")
+    }
+
+    if (shouldDumpClassesForPlugin) { dumpCodeForScalaPlugin(c)(recordClasses, caseClassTree, name) }
+
+    c.Expr[Any](r)
+  }
+
+  /** Generate a case class. */
+  private def caseClass(c: blackbox.Context)
+                       (name: c.TypeName, fields: Seq[c.Tree], body: Seq[c.Tree]): c.Tree = {
+    import c.universe._
+    q"case class $name(..$fields) extends ${p(c, ScioAvroType)}.HasAvroAnnotation { ..$body }"
+  }
+
+  /** Generate a companion object. */
+  private def companion(c: blackbox.Context)
+                       (name: c.TypeName,
+                        traits: Seq[c.Tree],
+                        methods: Seq[c.Tree],
+                        fields: Seq[c.Tree]) : c.Tree = {
+    import c.universe._
+
+    val tupledMethod =
+      if (fields.size > 1 && fields.size <= 22) {
+        val overrideFlag = if (traits.exists(_.toString().contains("Function"))) Flag.OVERRIDE else NoFlags
+        Seq(q"$overrideFlag def tupled = (${TermName(name.toString)}.apply _).tupled")
+      } else {
+        Seq()
+      }
+
+    q"""object ${TermName(name.toString)} extends ${p(c, ScioAvroType)}.HasAvroSchema[$name] with ..$traits {
+          override def toPrettyString(indent: Int = 0): String =
+            ${p(c, s"$ScioAvro.types.SchemaUtil")}.toPrettyString(this.schema, indent)
+          override def fromGenericRecord: (${p(c, ApacheAvro)}.generic.GenericRecord => $name) =
+            ${p(c, ScioAvroType)}.fromGenericRecord[$name]
+          override def toGenericRecord: ($name => ${p(c, ApacheAvro)}.generic.GenericRecord) =
+            ${p(c, ScioAvroType)}.toGenericRecord[$name]
+          ..$tupledMethod
+          ..$methods
+        }
+     """
+  }
+
+  /** Extract string from annotation. */
+  private def extractStrings(c: blackbox.Context, errorMessage: String): List[String] = {
+    import c.universe._
+
+    def str(tree: c.Tree) = tree match {
+      // "string literal"
+      case Literal(Constant(s: String)) => s
+      // "string literal".stripMargin
+      case Select(Literal(Constant(s: String)), TermName("stripMargin")) => s.stripMargin
+      case _ => c.abort(c.enclosingPosition, errorMessage)
+    }
+
+    c.macroApplication match {
+      case Apply(Select(Apply(_, xs: List[_]), _), _) =>
+        val args = xs.map(str)
+        if (args.isEmpty) {
+          c.abort(c.enclosingPosition, errorMessage)
+        }
+        args
+      case _ => c.abort(c.enclosingPosition, errorMessage)
+    }
+  }
+
+  /** Enforce that the macro is not enclosed by a package, but a class or object instead. */
+  private def checkMacroEnclosed(c: blackbox.Context): Unit = {
+    if (!c.internal.enclosingOwner.isClass) {
+      c.abort(c.enclosingPosition,
+      s"@AvroType declaration must be inside a class or object.")
+    }
+  }
+
+  private def getRecordDocs(c: blackbox.Context)(tree: Seq[c.universe.Tree])
+  : List[c.universe.Tree] = {
+    import c.universe._
+    tree.head.asInstanceOf[ClassDef].mods.annotations
+      .filter(_.children.head.toString().matches("^new doc"))
+      .map(_.children.tail.head)
+  }
+
+  /**
+    * Check if compiler should dump generated code for Scio IDEA plugin.
+    *
+    * This is used to mitigate lack of support for Scala macros in IntelliJ.
+    */
+  private def shouldDumpClassesForPlugin = {
+    sys.props("bigquery.plugin.disable.dump") == null ||
+      !sys.props("bigquery.plugin.disable.dump").toBoolean
+  }
+
+  private def getBQClassCacheDir = {
+    // TODO: add this as key/value settings with default etc
+    if (sys.props("bigquery.class.cache.directory") != null) {
+      sys.props("bigquery.class.cache.directory")
+    } else {
+      sys.props("java.io.tmpdir") + "/bigquery-classes"
+    }
+  }
+
+  // scalastyle:off line.size.limit
+  private def pShowCode(c: blackbox.Context)(records: Seq[c.Tree], caseClass: c.Tree): Seq[String] = {
+    // print only records and case class and do it nicely so that we can just inject those
+    // in scala plugin.
+    import c.universe._
+    (Seq(caseClass) ++ records).map {
+      case q"case class $name(..$fields) { ..$body }" =>
+        s"case class $name(${fields.map{case ValDef(mods, fname, ftpt, _) =>
+          s"${SchemaUtil.escapeNameIfReserved(fname.toString)} : $ftpt"}.mkString(", ")})"
+      case q"case class $name(..$fields) extends $annotation { ..$body }" =>
+        s"case class $name(${fields.map{case ValDef(mods, fname, ftpt, _) =>
+          s"${SchemaUtil.escapeNameIfReserved(fname.toString)} : $ftpt"}.mkString(", ")}) extends $annotation"
+      case _ => ""
+    }
+  }
+  // scalastyle:on line.size.limit
+
+  private def genHashForMacro(owner: String, srcFile: String): String = {
+    Hashing.murmur3_32().newHasher()
+      .putString(owner, Charsets.UTF_8)
+      .putString(srcFile, Charsets.UTF_8)
+      .hash().toString
+  }
+
+  private def dumpCodeForScalaPlugin(c: blackbox.Context)(records: Seq[c.universe.Tree],
+                                                          caseClassTree: c.universe.Tree,
+                                                          name: String): Unit = {
+    val owner = c.internal.enclosingOwner.fullName
+    val srcFile = c.macroApplication.pos.source.path
+    val hash = genHashForMacro(owner, srcFile)
+
+    val prettyCode = pShowCode(c)(records, caseClassTree).mkString("\n")
+    val classCacheDir = getBQClassCacheDir
+    val genSrcFile = new java.io.File(s"$classCacheDir/$name-$hash.scala")
+
+    logger.info(s"Will dump generated $name of $owner from $srcFile to $genSrcFile")
+
+    Files.createParentDirs(genSrcFile)
+    Files.write(prettyCode, genSrcFile, Charsets.UTF_8)
+  }
+
+}
+// scalastyle:on line.size.limit
+
+private[types] object NameProvider {
+
+  private val m = MMap.empty[String, Int].withDefaultValue(0)
+
+  def reset() : Unit = m.clear
+
+  /**
+   * Generate a unique name for a nested record.
+   * This is necessary since we create case classes for nested records and name them with their
+   * field names.
+   */
+  def getUniqueName(name: String): String = m.synchronized {
+    m(name) += 1
+    name + "$" + m(name)
+  }
+}

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/types.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/types.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro
+
+import scala.annotation.StaticAnnotation
+
+package object types {
+
+  /**
+    * Case class and argument annotation to get Avro field and record docs.
+    *
+    * To be used with case class fields annotated with [[AvroType.toSchema]], For example:
+    *
+    * Example:
+    *
+    * {{{
+    * AvroType.toSchema
+    * @doc("User Record")
+    * case class User(@doc("user name") name: String,
+    *                 @doc("user age") age: Int)
+    * }}}
+    */
+  // scalastyle:off class.name
+  class doc(value: String) extends StaticAnnotation
+  // scalastyle:on class.name
+}

--- a/scio-avro/src/test/scala/com/spotify/scio/avro/types/ConverterProviderSpec.scala
+++ b/scio-avro/src/test/scala/com/spotify/scio/avro/types/ConverterProviderSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro.types
+
+import com.google.protobuf.ByteString
+import shapeless.datatype.record._
+import org.scalacheck._
+import org.scalacheck.Shapeless._
+import org.scalatest._
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+class ConverterProviderSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+
+  // TODO: remove this once https://github.com/scalatest/scalatest/issues/1090 is addressed
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
+
+  import Schemas._
+
+  implicit val arbByteString = Arbitrary(Gen.alphaStr.map(ByteString.copyFromUtf8))
+
+  property("round trip basic primitive types") {
+    forAll { r1: BasicFields =>
+      val r2 = AvroType.fromGenericRecord[BasicFields](AvroType.toGenericRecord[BasicFields](r1))
+      RecordMatcher[BasicFields](r1, r2) shouldBe true
+    }
+  }
+
+
+  property("round trip optional primitive types") {
+    forAll { r1: OptionalFields =>
+      val r2 = AvroType.fromGenericRecord[OptionalFields](
+        AvroType.toGenericRecord[OptionalFields](r1))
+      RecordMatcher[OptionalFields](r1, r2) shouldBe true
+    }
+  }
+
+  property("skip null optional primitive types") {
+    forAll { o: OptionalFields =>
+      val r = AvroType.toGenericRecord[OptionalFields](o)
+      // GenericRecord object should only contain a key if the corresponding Option[T] is defined
+      o.boolF.isDefined shouldBe (r.get("boolF") != null)
+      o.intF.isDefined shouldBe (r.get("intF") != null)
+      o.longF.isDefined shouldBe (r.get("longF") != null)
+      o.floatF.isDefined shouldBe (r.get("floatF") != null)
+      o.doubleF.isDefined shouldBe (r.get("doubleF") != null)
+      o.stringF.isDefined shouldBe (r.get("stringF") != null)
+      o.byteStringF.isDefined shouldBe (r.get("byteStringF") != null)
+    }
+  }
+
+  property("round trip primitive type arrays") {
+    forAll { r1: ArrayFields =>
+      val r2 = AvroType.fromGenericRecord[ArrayFields](AvroType.toGenericRecord[ArrayFields](r1))
+      RecordMatcher[ArrayFields](r1, r2) shouldBe true
+    }
+  }
+
+  property("round trip primitive type maps") {
+    forAll { r1: MapFields =>
+      val r2 = AvroType.fromGenericRecord[MapFields](AvroType.toGenericRecord[MapFields](r1))
+
+      RecordMatcher[MapFields](r1, r2) shouldBe true
+    }
+  }
+
+  property("round trip required nested types") {
+    forAll { r1: NestedFields =>
+      val r2 = AvroType.fromGenericRecord[NestedFields](
+        AvroType.toGenericRecord[NestedFields](r1))
+      RecordMatcher[NestedFields](r1, r2) shouldBe true
+    }
+  }
+
+  property("round trip optional nested types") {
+    forAll { r1: OptionalNestedFields =>
+      val r2 = AvroType.fromGenericRecord[OptionalNestedFields](
+        AvroType.toGenericRecord[OptionalNestedFields](r1))
+      RecordMatcher[OptionalNestedFields](r1, r2) shouldBe true
+    }
+  }
+
+  property("skip null optional nested types") {
+    forAll { o: OptionalNestedFields =>
+      val r = AvroType.toGenericRecord[OptionalNestedFields](o)
+      // TableRow object should only contain a key if the corresponding Option[T] is defined
+      o.basic.isDefined shouldBe (r.get("basic") != null)
+      o.optional.isDefined shouldBe (r.get("optional") != null)
+      o.array.isDefined shouldBe (r.get("array") != null)
+      o.map.isDefined shouldBe (r.get("map") != null)
+    }
+  }
+
+  property("round trip nested type arrays") {
+    forAll { r1: ArrayNestedFields =>
+      val r2 = AvroType.fromGenericRecord[ArrayNestedFields](
+        AvroType.toGenericRecord[ArrayNestedFields](r1))
+      RecordMatcher[ArrayNestedFields](r1, r2) shouldBe true
+    }
+  }
+
+  property("round trip nested type maps") {
+    forAll { r1: MapNestedFields =>
+      val r2 = AvroType.fromGenericRecord[MapNestedFields](
+        AvroType.toGenericRecord[MapNestedFields](r1))
+      RecordMatcher[MapNestedFields](r1, r2) shouldBe true
+    }
+  }
+
+}

--- a/scio-avro/src/test/scala/com/spotify/scio/avro/types/SchemaProviderTest.scala
+++ b/scio-avro/src/test/scala/com/spotify/scio/avro/types/SchemaProviderTest.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro.types
+
+import com.spotify.scio.avro.types.Schemas._
+import com.spotify.scio.avro.types.Schemas.FieldMode._
+import org.scalatest.{FlatSpec, Matchers}
+
+class SchemaProviderTest extends FlatSpec with Matchers {
+  "SchemaProvider.toSchema" should "support primitive types" in {
+    SchemaProvider.schemaOf[BasicFields] shouldBe
+      parseSchema(s"${basicFields()}")
+  }
+
+  it should "support nullable primitive types" in {
+    SchemaProvider.schemaOf[OptionalFields] shouldBe
+      parseSchema(s"${basicFields(OPTIONAL)}")
+  }
+
+  it should "support arrays of primitive types" in {
+    SchemaProvider.schemaOf[ArrayFields] shouldBe
+      parseSchema(s"${basicFields(ARRAY)}")
+  }
+
+  it should "support maps of primitive types" in {
+    SchemaProvider.schemaOf[MapFields] shouldBe
+      parseSchema(s"${basicFields(MAP)}")
+  }
+
+  it should "support basic records" in {
+    SchemaProvider.schemaOf[NestedFields] shouldBe
+      parseSchema(recordFields())
+  }
+
+  it should "support optional records" in {
+    SchemaProvider.schemaOf[OptionalNestedFields] shouldBe
+      parseSchema(recordFields(OPTIONAL))
+  }
+
+  it should "support array of records" in {
+    SchemaProvider.schemaOf[ArrayNestedFields] shouldBe
+      parseSchema(recordFields(ARRAY))
+  }
+
+  it should "support map of records" in {
+    SchemaProvider.schemaOf[MapNestedFields] shouldBe
+      parseSchema(recordFields(MAP))
+  }
+
+  @doc("User record schema")
+  case class User(@doc("user name") name: String, @doc("user age") age: Int)
+  @doc("Account record schema")
+  case class Account(@doc("account user") user: User,
+                     @doc("in USD") balance: Double)
+
+  val userSchema =
+    s"""
+       |{
+       |  "type": "record",
+       |  "namespace": "com.spotify.scio.avro.types.SchemaProviderTest",
+       |  "doc": "User record schema",
+       |  "name": "User",
+       |  "fields": [
+       |    { "name": "name", "type": "string", "doc": "user name"},
+       |    { "name": "age", "type": "int", "doc": "user age"}
+       |  ]
+       |}
+       |""".stripMargin
+
+  val accountSchema =
+    s"""
+       |{
+       |  "type": "record",
+       |  "namespace": "com.spotify.scio.avro.types.SchemaProviderTest",
+       |  "doc": "Account record schema",
+       |  "name": "Account",
+       |  "fields": [
+       |    { "name": "user", "type": $userSchema, "doc": "account user"},
+       |    { "name": "balance", "type": "double", "doc": "in USD"}
+       |  ]
+       |}
+     """.stripMargin
+
+  it should "support doc annotation" in {
+    // Schema.equals() ignores doc property.
+    // Hence we need to turn Schemas to string in order to compare them.
+    SchemaProvider.schemaOf[User].toString shouldBe parseSchema(userSchema).toString
+    SchemaProvider.schemaOf[Account].toString shouldBe parseSchema(accountSchema).toString
+  }
+}

--- a/scio-avro/src/test/scala/com/spotify/scio/avro/types/SchemaUtilTest.scala
+++ b/scio-avro/src/test/scala/com/spotify/scio/avro/types/SchemaUtilTest.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// scalastyle:off line.size.limit
+package com.spotify.scio.avro.types
+
+import com.spotify.scio.avro.types.Schemas._
+import com.spotify.scio.avro.types.Schemas.FieldMode._
+import org.apache.avro.Schema
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+class SchemaUtilTest extends FlatSpec with Matchers {
+
+  "toPrettyString()" should "support primitive types" in {
+    SchemaUtil.toPrettyString(parseSchema(s"${basicFields()}")) should equal (
+      """
+        |case class BasicFields(boolF: Boolean, intF: Int, longF: Long, floatF: Float, doubleF: Double, stringF: String, byteStringF: ByteString)
+      """.stripMargin.trim)
+  }
+
+  it should "support optional primitive types" in {
+    SchemaUtil.toPrettyString(parseSchema(s"${basicFields(OPTIONAL)}")) should equal (
+      """
+        |case class OptionalFields(boolF: Option[Boolean] = None, intF: Option[Int] = None, longF: Option[Long] = None, floatF: Option[Float] = None, doubleF: Option[Double] = None, stringF: Option[String] = None, byteStringF: Option[ByteString] = None)
+      """.stripMargin.trim)
+  }
+
+  it should "support primitive type arrays" in {
+    SchemaUtil.toPrettyString(parseSchema(s"${basicFields(ARRAY)}")) should equal (
+      """
+        |case class ArrayFields(boolF: List[Boolean], intF: List[Int], longF: List[Long], floatF: List[Float], doubleF: List[Double], stringF: List[String], byteStringF: List[ByteString])
+      """.stripMargin.trim)
+  }
+
+  it should "support primitive type maps" in {
+    SchemaUtil.toPrettyString(parseSchema(s"${basicFields(MAP)}")) should equal (
+      """
+        |case class MapFields(boolF: Map[String, Boolean], intF: Map[String, Int], longF: Map[String, Long], floatF: Map[String, Float], doubleF: Map[String, Double], stringF: Map[String, String], byteStringF: Map[String, ByteString])
+      """.stripMargin.trim)
+  }
+
+  it should "support nested records" in {
+    NameProvider.reset()
+    SchemaUtil.toPrettyString(parseSchema(recordFields())) should equal (
+      """
+        |case class NestedFields(basic: BasicFields$1, optional: OptionalFields$1, array: ArrayFields$1, map: MapFields$1)
+        |case class BasicFields$1(boolF: Boolean, intF: Int, longF: Long, floatF: Float, doubleF: Double, stringF: String, byteStringF: ByteString)
+        |case class OptionalFields$1(boolF: Option[Boolean] = None, intF: Option[Int] = None, longF: Option[Long] = None, floatF: Option[Float] = None, doubleF: Option[Double] = None, stringF: Option[String] = None, byteStringF: Option[ByteString] = None)
+        |case class ArrayFields$1(boolF: List[Boolean], intF: List[Int], longF: List[Long], floatF: List[Float], doubleF: List[Double], stringF: List[String], byteStringF: List[ByteString])
+        |case class MapFields$1(boolF: Map[String, Boolean], intF: Map[String, Int], longF: Map[String, Long], floatF: Map[String, Float], doubleF: Map[String, Double], stringF: Map[String, String], byteStringF: Map[String, ByteString])
+      """.stripMargin.trim)
+  }
+
+  it should "support nested optional records" in {
+    NameProvider.reset()
+    SchemaUtil.toPrettyString(parseSchema(recordFields(OPTIONAL))) should equal (
+      """
+        |case class OptionalNestedFields(basic: Option[BasicFields$1] = None, optional: Option[OptionalFields$1] = None, array: Option[ArrayFields$1] = None, map: Option[MapFields$1] = None)
+        |case class BasicFields$1(boolF: Boolean, intF: Int, longF: Long, floatF: Float, doubleF: Double, stringF: String, byteStringF: ByteString)
+        |case class OptionalFields$1(boolF: Option[Boolean] = None, intF: Option[Int] = None, longF: Option[Long] = None, floatF: Option[Float] = None, doubleF: Option[Double] = None, stringF: Option[String] = None, byteStringF: Option[ByteString] = None)
+        |case class ArrayFields$1(boolF: List[Boolean], intF: List[Int], longF: List[Long], floatF: List[Float], doubleF: List[Double], stringF: List[String], byteStringF: List[ByteString])
+        |case class MapFields$1(boolF: Map[String, Boolean], intF: Map[String, Int], longF: Map[String, Long], floatF: Map[String, Float], doubleF: Map[String, Double], stringF: Map[String, String], byteStringF: Map[String, ByteString])
+      """.stripMargin.trim)
+  }
+
+  it should "support nested record arrays" in {
+    NameProvider.reset()
+    SchemaUtil.toPrettyString(parseSchema(recordFields(ARRAY))) should equal (
+      """
+        |case class ArrayNestedFields(basic: List[BasicFields$1], optional: List[OptionalFields$1], array: List[ArrayFields$1], map: List[MapFields$1])
+        |case class BasicFields$1(boolF: Boolean, intF: Int, longF: Long, floatF: Float, doubleF: Double, stringF: String, byteStringF: ByteString)
+        |case class OptionalFields$1(boolF: Option[Boolean] = None, intF: Option[Int] = None, longF: Option[Long] = None, floatF: Option[Float] = None, doubleF: Option[Double] = None, stringF: Option[String] = None, byteStringF: Option[ByteString] = None)
+        |case class ArrayFields$1(boolF: List[Boolean], intF: List[Int], longF: List[Long], floatF: List[Float], doubleF: List[Double], stringF: List[String], byteStringF: List[ByteString])
+        |case class MapFields$1(boolF: Map[String, Boolean], intF: Map[String, Int], longF: Map[String, Long], floatF: Map[String, Float], doubleF: Map[String, Double], stringF: Map[String, String], byteStringF: Map[String, ByteString])
+      """.stripMargin.trim)
+  }
+
+  it should "support nested record maps" in {
+    NameProvider.reset()
+    SchemaUtil.toPrettyString(parseSchema(recordFields(MAP))) should equal (
+      """
+        |case class MapNestedFields(basic: Map[String, BasicFields$1], optional: Map[String, OptionalFields$1], array: Map[String, ArrayFields$1], map: Map[String, MapFields$1])
+        |case class BasicFields$1(boolF: Boolean, intF: Int, longF: Long, floatF: Float, doubleF: Double, stringF: String, byteStringF: ByteString)
+        |case class OptionalFields$1(boolF: Option[Boolean] = None, intF: Option[Int] = None, longF: Option[Long] = None, floatF: Option[Float] = None, doubleF: Option[Double] = None, stringF: Option[String] = None, byteStringF: Option[ByteString] = None)
+        |case class ArrayFields$1(boolF: List[Boolean], intF: List[Int], longF: List[Long], floatF: List[Float], doubleF: List[Double], stringF: List[String], byteStringF: List[ByteString])
+        |case class MapFields$1(boolF: Map[String, Boolean], intF: Map[String, Int], longF: Map[String, Long], floatF: Map[String, Float], doubleF: Map[String, Double], stringF: Map[String, String], byteStringF: Map[String, ByteString])
+      """.stripMargin.trim)
+  }
+
+  it should "support indent" in {
+    SchemaUtil.toPrettyString(parseSchema(s"${basicFields()}"), 2) should equal (
+      """
+        |case class BasicFields(
+        |  boolF: Boolean,
+        |  intF: Int,
+        |  longF: Long,
+        |  floatF: Float,
+        |  doubleF: Double,
+        |  stringF: String,
+        |  byteStringF: ByteString)
+      """.stripMargin.trim)
+  }
+
+  it should "support reserved words" in {
+    val expectedFields = SchemaUtil.scalaReservedWords
+      .map(e => s"`$e`").mkString(start = "", sep = ": Long, ", end = ": Long")
+    val schema =
+      Schema.createRecord("Row",
+        null,
+        null,
+        false,
+        SchemaUtil.scalaReservedWords.map {
+          name =>
+            new Schema.Field(name, Schema.create(Schema.Type.LONG), null, null.asInstanceOf[Any])
+        }.asJava)
+    SchemaUtil.toPrettyString(schema) should equal (
+      s"""|case class Row($expectedFields)""".stripMargin
+    )
+  }
+
+}
+// scalastyle:on line.size.limit

--- a/scio-avro/src/test/scala/com/spotify/scio/avro/types/Schemas.scala
+++ b/scio-avro/src/test/scala/com/spotify/scio/avro/types/Schemas.scala
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro.types
+
+import com.google.protobuf.ByteString
+import org.apache.avro.Schema
+
+object Schemas {
+  case class BasicFields(boolF: Boolean,
+                         intF: Int,
+                         longF: Long,
+                         floatF: Float,
+                         doubleF: Double,
+                         stringF: String,
+                         byteStringF: ByteString)
+
+  case class OptionalFields(boolF: Option[Boolean],
+                            intF: Option[Int],
+                            longF: Option[Long],
+                            floatF: Option[Float],
+                            doubleF: Option[Double],
+                            stringF: Option[String],
+                            byteStringF: Option[ByteString])
+
+  case class ArrayFields(boolF: List[Boolean],
+                         intF: List[Int],
+                         longF: List[Long],
+                         floatF: List[Float],
+                         doubleF: List[Double],
+                         stringF: List[String],
+                         byteStringF: List[ByteString])
+
+  case class MapFields(boolF: Map[String, Boolean],
+                       intF: Map[String, Int],
+                       longF: Map[String, Long],
+                       floatF: Map[String, Float],
+                       doubleF: Map[String, Double],
+                       stringF: Map[String, String],
+                       byteStringF: Map[String, ByteString])
+
+  case class NestedFields(basic: BasicFields,
+                          optional: OptionalFields,
+                          array: ArrayFields,
+                          map: MapFields)
+
+  case class OptionalNestedFields(basic: Option[BasicFields],
+                                  optional: Option[OptionalFields],
+                                  array: Option[ArrayFields],
+                                  map: Option[MapFields])
+
+  case class ArrayNestedFields(basic: List[BasicFields],
+                               optional: List[OptionalFields],
+                               array: List[ArrayFields],
+                               map: List[MapFields])
+
+  case class MapNestedFields(basic: Map[String, BasicFields],
+                             optional: Map[String, OptionalFields],
+                             array: Map[String, ArrayFields],
+                             map: Map[String, MapFields])
+
+  object FieldMode extends Enumeration {
+    type FieldMode = Value
+    val ARRAY, MAP, OPTIONAL, NONE = Value
+  }
+  import FieldMode._
+
+  def parseSchema(str: String): Schema = new Schema.Parser().parse(str)
+
+  def basicFields(mode: FieldMode = NONE): String =
+    s"""
+       |{
+       |  "type": "record",
+       |  "namespace": "com.spotify.scio.avro.types.Schemas",
+       |  "name": "${basicRecordName(mode)}",
+       |  "fields": [
+       |    { "name": "boolF",
+       |      "type": ${fieldType("\"boolean\"", mode)}
+       |      ${setDefaultValue(mode)}},
+       |    { "name": "intF",
+       |      "type": ${fieldType("\"int\"", mode)}
+       |      ${setDefaultValue(mode)}},
+       |    { "name": "longF",
+       |      "type": ${fieldType("\"long\"", mode)}
+       |      ${setDefaultValue(mode)}},
+       |    { "name": "floatF",
+       |      "type": ${fieldType("\"float\"", mode)}
+       |      ${setDefaultValue(mode)}},
+       |    { "name": "doubleF",
+       |      "type": ${fieldType("\"double\"", mode)}
+       |      ${setDefaultValue(mode)}},
+       |    { "name": "stringF",
+       |      "type": ${fieldType("\"string\"", mode)}
+       |      ${setDefaultValue(mode)}},
+       |    { "name": "byteStringF",
+       |      "type": ${fieldType("\"bytes\"", mode)}
+       |      ${setDefaultValue(mode)}}
+       |  ]
+       |}
+       |""".stripMargin
+
+  def recordFields(mode: FieldMode = NONE): String =
+    s"""
+       |{
+       |  "type" : "record",
+       |  "namespace": "com.spotify.scio.avro.types.Schemas",
+       |  "name" : "${nestedRecordName(mode)}",
+       |  "fields" : [
+       |    { "name" : "basic",
+       |      "type" : ${fieldType(basicFields(NONE), mode)}
+       |      ${setDefaultValue(mode)}
+       |    },
+       |    { "name" : "optional",
+       |      "type" : ${fieldType(basicFields(OPTIONAL), mode)}
+       |      ${setDefaultValue(mode)}
+       |    },
+       |    { "name" : "array",
+       |      "type" : ${fieldType(basicFields(ARRAY), mode)}
+       |      ${setDefaultValue(mode)}
+       |    },
+       |    { "name" : "map",
+       |      "type" : ${fieldType(basicFields(MAP), mode)}
+       |      ${setDefaultValue(mode)}
+       |    }
+       |  ]
+       |}
+       |""".stripMargin
+
+  private def fieldType(basicType: String, mode: FieldMode): String =
+    mode match {
+      case NONE => basicType
+      case OPTIONAL => s"""["null", $basicType]"""
+      case ARRAY => s"""{ "type" : "array", "items" : $basicType }"""
+      case MAP => s"""{ "type" : "map", "values" : $basicType }"""
+    }
+
+  private def setDefaultValue(mode: FieldMode): String =
+    mode match {
+      case NONE => ""
+      case OPTIONAL => s""", "default": null"""
+      case ARRAY => s""", "default": []"""
+      case MAP => s""", "default": {}"""
+    }
+
+  private def basicRecordName(mode: FieldMode): String =
+    mode match {
+      case NONE => "BasicFields"
+      case OPTIONAL => "OptionalFields"
+      case ARRAY => "ArrayFields"
+      case MAP => "MapFields"
+    }
+
+  private def nestedRecordName(mode: FieldMode): String =
+    mode match {
+      case NONE => "NestedFields"
+      case OPTIONAL => "OptionalNestedFields"
+      case ARRAY => "ArrayNestedFields"
+      case MAP => "MapNestedFields"
+    }
+}

--- a/scio-avro/src/test/scala/com/spotify/scio/avro/types/TypeProviderTest.scala
+++ b/scio-avro/src/test/scala/com/spotify/scio/avro/types/TypeProviderTest.scala
@@ -1,0 +1,707 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.avro.types
+
+import com.google.protobuf.ByteString
+import com.spotify.scio.avro.types.AvroType.HasAvroDoc
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
+import org.scalatest.{FlatSpec, Matchers}
+
+class TypeProviderTest extends FlatSpec with Matchers {
+  @AvroType.fromSchema(
+    """{"type":"record","name": "Record","fields":[{"name":"f1","type":"int"}]}""")
+  class StringLiteralRecord
+
+  @AvroType.fromSchema(
+    """
+      {"type":"record","name": "Record","fields":[{"name":"f1","type":"int"}]}
+    """)
+  class MultiLineStringLiteral
+
+  @AvroType.fromSchema(
+    """
+      |{"type":"record","name": "Record","fields":[{"name":"f1","type":"int"}]}
+    """.stripMargin)
+  class MultiLineStripMarginStringLiteral
+
+  @AvroType.fromSchema(
+    """
+      |{"type":"record","name":"Record","fields":[{"name":"f1","type":"int"}]}
+    """.stripMargin)
+  @doc("Table Description")
+  class TableWithDescription
+
+  "AvroType.fromSchema" should "support string literal" in {
+    val r = StringLiteralRecord(1)
+    r.f1 shouldBe 1
+  }
+
+  it should "support multi-line string literal" in {
+    val r = MultiLineStringLiteral(1)
+    r.f1 shouldBe 1
+  }
+
+  it should "support multi-line string literal with stripMargin" in {
+    val r = MultiLineStripMarginStringLiteral(1)
+    r.f1 shouldBe 1
+  }
+
+  it should "support doc annotation" in {
+    TableWithDescription.doc shouldBe "Table Description"
+    TableWithDescription.isInstanceOf[HasAvroDoc] shouldBe true
+  }
+
+  @AvroType.fromSchema(
+    """
+       |{
+       |  "type": "record",
+       |  "name": "Record",
+       |  "fields": [
+       |    { "name": "boolF", "type": "boolean"},
+       |    { "name": "intF", "type": "int"},
+       |    { "name": "longF", "type": "long"},
+       |    { "name": "floatF", "type": "float"},
+       |    { "name": "doubleF", "type": "double"},
+       |    { "name": "stringF", "type": "string"},
+       |    { "name": "byteStringF", "type": "bytes"}
+       |  ]
+       |}
+    """.stripMargin)
+  class RecordWithBasicTypes
+
+  it should "support required primitive types" in {
+    val r = RecordWithBasicTypes(true, 1, 2L, 1.5f, 2.5, "string",
+      ByteString.copyFromUtf8("bytes"))
+    r.boolF shouldBe true
+    r.intF shouldBe 1
+    r.longF shouldBe 2L
+    r.floatF shouldBe 1.5f
+    r.doubleF shouldBe 2.5
+    r.stringF shouldBe "string"
+    r.byteStringF shouldBe ByteString.copyFromUtf8("bytes")
+  }
+
+  it should "support .tupled in companion object" in {
+    val r1 = RecordWithBasicTypes(true, 1, 2L, 1.5f, 2.5, "string",
+      ByteString.copyFromUtf8("bytes"))
+    val r2 = RecordWithBasicTypes.tupled((true, 1, 2L, 1.5f, 2.5, "string",
+      ByteString.copyFromUtf8("bytes")))
+    r1 shouldBe r2
+  }
+
+  it should "return correct schema for plain records" in {
+    RecordWithBasicTypes.schema shouldBe
+      new Schema.Parser().parse("""
+                                 |{
+                                 |  "type": "record",
+                                 |  "name": "Record",
+                                 |  "fields": [
+                                 |    { "name": "boolF", "type": "boolean"},
+                                 |    { "name": "intF", "type": "int"},
+                                 |    { "name": "longF", "type": "long"},
+                                 |    { "name": "floatF", "type": "float"},
+                                 |    { "name": "doubleF", "type": "double"},
+                                 |    { "name": "stringF", "type": "string"},
+                                 |    { "name": "byteStringF", "type": "bytes"}
+                                 |  ]
+                                 |}
+                               """.stripMargin)
+  }
+
+  it should "support .fromGenericRecord in companion object" in {
+    (classOf[(GenericRecord => RecordWithBasicTypes)]
+      isAssignableFrom RecordWithBasicTypes.fromGenericRecord.getClass) shouldBe true
+  }
+
+  it should "support .toGenericRecord in companion object" in {
+    (classOf[(RecordWithBasicTypes => GenericRecord)]
+      isAssignableFrom RecordWithBasicTypes.toGenericRecord.getClass) shouldBe true
+  }
+
+  it should "support round trip conversion from GenericRecord" in {
+    val r1 = RecordWithBasicTypes(true, 1, 2L, 1.5f, 2.5, "string",
+      ByteString.copyFromUtf8("bytes"))
+    val r2 = RecordWithBasicTypes.fromGenericRecord(RecordWithBasicTypes.toGenericRecord(r1))
+    r1 shouldBe r2
+  }
+
+  @AvroType.fromSchema(
+    """
+      |{
+      |  "type": "record",
+      |  "name": "Record",
+      |  "fields": [
+      |    { "name": "boolF", "type": ["null", "boolean"], "default": null},
+      |    { "name": "intF", "type": ["null", "int"], "default": null},
+      |    { "name": "longF", "type": ["null", "long"], "default": null},
+      |    { "name": "floatF", "type": ["null", "float"], "default": null},
+      |    { "name": "doubleF", "type": ["null", "double"], "default": null},
+      |    { "name": "stringF", "type": ["null", "string"], "default": null},
+      |    { "name": "byteStringF", "type": ["null", "bytes"], "default": null}
+      |  ]
+      |}
+    """.stripMargin)
+  class RecordWithOptionalBasicTypes
+
+  it should "support nullable primitive types" in {
+    val r = RecordWithOptionalBasicTypes(
+      Some(true), Some(1), Some(2L), Some(1.5f),
+      Some(2.5), Some("string"), Some(ByteString.copyFromUtf8("bytes")))
+    r.boolF shouldBe Some(true)
+    r.intF shouldBe Some(1)
+    r.longF shouldBe Some(2L)
+    r.floatF shouldBe Some(1.5f)
+    r.doubleF shouldBe Some(2.5)
+    r.stringF shouldBe Some("string")
+    r.byteStringF shouldBe Some(ByteString.copyFromUtf8("bytes"))
+  }
+
+  it should "set nullable values to None by default" in {
+    val r = RecordWithOptionalBasicTypes()
+    r.boolF shouldBe None
+    r.intF shouldBe None
+    r.longF shouldBe None
+    r.floatF shouldBe None
+    r.doubleF shouldBe None
+    r.stringF shouldBe None
+    r.byteStringF shouldBe None
+  }
+
+  @AvroType.fromSchema(
+    """
+      |{
+      |  "type": "record",
+      |  "name": "Record",
+      |  "fields": [
+      |    { "name": "boolF", "type": { "type" : "array", "items" : "boolean"}},
+      |    { "name": "intF", "type": { "type" : "array", "items" : "int"}},
+      |    { "name": "longF", "type": { "type" : "array", "items" : "long"}},
+      |    { "name": "floatF", "type": { "type" : "array", "items" : "float"}},
+      |    { "name": "doubleF", "type": { "type" : "array", "items" : "double"}},
+      |    { "name": "stringF", "type": { "type" : "array", "items" : "string"}},
+      |    { "name": "byteStringF", "type": { "type" : "array", "items" : "bytes"}}
+      |  ]
+      |}
+    """.stripMargin)
+  class RecordWithBasicTypeArrays
+
+  it should "support primitive type arrays" in {
+    val r = RecordWithBasicTypeArrays(
+      List(true), List(1), List(2L), List(1.5f),
+      List(2.5), List("string"), List(ByteString.copyFromUtf8("bytes")))
+    r.boolF shouldBe List(true)
+    r.intF shouldBe List(1)
+    r.longF shouldBe List(2L)
+    r.floatF shouldBe List(1.5f)
+    r.doubleF shouldBe List(2.5)
+    r.stringF shouldBe List("string")
+    r.byteStringF shouldBe List(ByteString.copyFromUtf8("bytes"))
+  }
+
+  @AvroType.fromSchema(
+    """
+      |{
+      |  "type": "record",
+      |  "name": "Record",
+      |  "fields": [
+      |    { "name": "boolF", "type": { "type" : "map", "values" : "boolean"}},
+      |    { "name": "intF", "type": { "type" : "map", "values" : "int"}},
+      |    { "name": "longF", "type": { "type" : "map", "values" : "long"}},
+      |    { "name": "floatF", "type": { "type" : "map", "values" : "float"}},
+      |    { "name": "doubleF", "type": { "type" : "map", "values" : "double"}},
+      |    { "name": "stringF", "type": { "type" : "map", "values" : "string"}},
+      |    { "name": "byteStringF", "type": { "type" : "map", "values" : "bytes"}}
+      |  ]
+      |}
+    """.stripMargin)
+  class RecordWithBasicTypeMaps
+
+  it should "support primitive type maps" in {
+    val r = RecordWithBasicTypeMaps(
+      Map("bool" -> true), Map("int" -> 1),
+      Map("long" -> 2L), Map("float" -> 1.5f),
+      Map("double" -> 2.5), Map("string" -> "string"),
+      Map("bytes" -> ByteString.copyFromUtf8("bytes")))
+    r.boolF shouldBe Map("bool" -> true)
+    r.intF shouldBe Map("int" -> 1)
+    r.longF shouldBe Map("long" -> 2L)
+    r.floatF shouldBe Map("float" -> 1.5f)
+    r.doubleF shouldBe Map("double" -> 2.5)
+    r.stringF shouldBe Map("string" -> "string")
+    r.byteStringF shouldBe Map("bytes" -> ByteString.copyFromUtf8("bytes"))
+  }
+
+  @AvroType.fromSchema(
+    """
+      |{
+      |  "type" : "record",
+      |  "name" : "Record",
+      |  "fields" : [
+      |    { "name" : "basic",
+      |      "type" : {
+      |        "type": "record",
+      |        "name": "Basic",
+      |        "fields": [
+      |          { "name": "intF", "type": "int"}
+      |        ]}
+      |    },
+      |    { "name" : "optional",
+      |      "type" : {
+      |        "type": "record",
+      |        "name": "Optional",
+      |        "fields": [
+      |          { "name": "intF", "type": ["null","int"], "default": null}
+      |        ]}
+      |    },
+      |    { "name" : "array",
+      |      "type" : {
+      |        "type": "record",
+      |        "name": "Array",
+      |        "fields": [
+      |          { "name": "intF", "type": { "type" : "array", "items" : "int"}}
+      |        ]}
+      |    },
+      |    { "name" : "map",
+      |      "type" : {
+      |        "type": "record",
+      |        "name": "Map",
+      |        "fields": [
+      |          { "name": "intF", "type": { "type" : "map", "values" : "int"}}
+      |        ]}
+      |    }
+      |  ]
+      |}
+      |""".stripMargin)
+  class RecordWithRecords
+
+  it should "support nested records" in {
+    val r = RecordWithRecords(Basic$1(1), Optional$1(Some(1)),
+      Array$1(List(1)), Map$1(Map("int" -> 1)))
+    r.basic.intF shouldBe 1
+    r.optional.intF shouldBe Some(1)
+    r.array.intF shouldBe List(1)
+    r.map.intF shouldBe Map("int" -> 1)
+  }
+
+  it should "return correct schema for nested objects" in {
+    RecordWithRecords.schema shouldBe
+      new Schema.Parser().parse("""
+                                  |{
+                                  |  "type" : "record",
+                                  |  "name" : "Record",
+                                  |  "fields" : [
+                                  |    { "name" : "basic",
+                                  |      "type" : {
+                                  |        "type": "record",
+                                  |        "name": "Basic",
+                                  |        "fields": [
+                                  |          { "name": "intF", "type": "int"}
+                                  |        ]}
+                                  |    },
+                                  |    { "name" : "optional",
+                                  |      "type" : {
+                                  |        "type": "record",
+                                  |        "name": "Optional",
+                                  |        "fields": [
+                                  |          { "name": "intF",
+                                  |            "type": ["null","int"],
+                                  |            "default": null}
+                                  |        ]}
+                                  |    },
+                                  |    { "name" : "array",
+                                  |      "type" : {
+                                  |        "type": "record",
+                                  |        "name": "Array",
+                                  |        "fields": [
+                                  |          { "name": "intF",
+                                  |            "type": { "type" : "array", "items" : "int"}}
+                                  |        ]}
+                                  |    },
+                                  |    { "name" : "map",
+                                  |      "type" : {
+                                  |        "type": "record",
+                                  |        "name": "Map",
+                                  |        "fields": [
+                                  |          { "name": "intF",
+                                  |            "type": { "type" : "map", "values" : "int"}}
+                                  |        ]}
+                                  |    }
+                                  |  ]
+                                  |}
+                                  |""".stripMargin)
+  }
+
+  @AvroType.fromSchema(
+    """
+      |{
+      |  "type" : "record",
+      |  "name" : "Record",
+      |  "fields" : [
+      |    { "name" : "basic",
+      |      "type" : ["null", {
+      |        "type": "record",
+      |        "name": "Basic",
+      |        "fields": [
+      |          { "name": "intF", "type": "int"}
+      |        ]}]
+      |    },
+      |    { "name" : "optional",
+      |      "type" : ["null", {
+      |        "type": "record",
+      |        "name": "Optional",
+      |        "fields": [
+      |          { "name": "intF", "type": ["null","int"], "default": null}
+      |        ]}]
+      |    },
+      |    { "name" : "array",
+      |      "type" : ["null", {
+      |        "type": "record",
+      |        "name": "Array",
+      |        "fields": [
+      |          { "name": "intF", "type": { "type" : "array", "items" : "int"}}
+      |        ]}]
+      |    },
+      |    { "name" : "map",
+      |      "type" : ["null", {
+      |        "type": "record",
+      |        "name": "Map",
+      |        "fields": [
+      |          { "name": "intF", "type": { "type" : "map", "values" : "int"}}
+      |        ]}]
+      |    }
+      |  ]
+      |}
+      |""".stripMargin)
+  class RecordWithOptionalRecords
+
+  it should "support optional nested records" in {
+    val r = RecordWithOptionalRecords(
+      Some(Basic$2(1)), Some(Optional$2(Some(1))),
+      Some(Array$2(List(1))), Some(Map$2(Map("int" -> 1))))
+    r.basic shouldBe Some(Basic$2(1))
+    r.optional shouldBe Some(Optional$2(Some(1)))
+    r.array shouldBe Some(Array$2(List(1)))
+    r.map shouldBe Some(Map$2(Map("int" -> 1)))
+  }
+
+  @AvroType.fromSchema(
+    """
+      |{
+      |  "type" : "record",
+      |  "name" : "Record",
+      |  "fields" : [
+      |    { "name" : "basic",
+      |      "type" : { "type" : "array", "items" : {
+      |        "type": "record",
+      |        "name": "Basic",
+      |        "fields": [
+      |          { "name": "intF", "type": "int"}
+      |        ]}}
+      |    },
+      |    { "name" : "optional",
+      |      "type" : { "type" : "array", "items" : {
+      |        "type": "record",
+      |        "name": "Optional",
+      |        "fields": [
+      |          { "name": "intF", "type": ["null","int"], "default": null}
+      |        ]}}
+      |    },
+      |    { "name" : "array",
+      |      "type" : { "type" : "array", "items" : {
+      |        "type": "record",
+      |        "name": "Array",
+      |        "fields": [
+      |          { "name": "intF", "type": { "type" : "array", "items" : "int"}}
+      |        ]}}
+      |    },
+      |    { "name" : "map",
+      |      "type" : { "type" : "array", "items" : {
+      |        "type": "record",
+      |        "name": "Map",
+      |        "fields": [
+      |          { "name": "intF", "type": { "type" : "map", "values" : "int"}}
+      |        ]}}
+      |    }
+      |  ]
+      |}
+      |""".stripMargin)
+  class RecordWithRecordArrays
+
+  it should "support nested record arrays" in {
+    val r = RecordWithRecordArrays(
+      List(Basic$3(1)), List(Optional$3(Some(1))),
+      List(Array$3(List(1))), List(Map$3(Map("int" -> 1))))
+    r.basic shouldBe List(Basic$3(1))
+    r.optional shouldBe List(Optional$3(Some(1)))
+    r.array shouldBe List(Array$3(List(1)))
+    r.map shouldBe List(Map$3(Map("int" -> 1)))
+  }
+
+  @AvroType.fromSchema(
+    """
+      |{
+      |  "type" : "record",
+      |  "name" : "Record",
+      |  "fields" : [
+      |    { "name" : "basic",
+      |      "type" : { "type" : "map", "values" : {
+      |        "type": "record",
+      |        "name": "Basic",
+      |        "fields": [
+      |          { "name": "intF", "type": "int"}
+      |        ]}}
+      |    },
+      |    { "name" : "optional",
+      |      "type" : { "type" : "map", "values" : {
+      |        "type": "record",
+      |        "name": "Optional",
+      |        "fields": [
+      |          { "name": "intF", "type": ["null","int"], "default": null}
+      |        ]}}
+      |    },
+      |    { "name" : "array",
+      |      "type" : { "type" : "map", "values" : {
+      |        "type": "record",
+      |        "name": "Array",
+      |        "fields": [
+      |          { "name": "intF", "type": { "type" : "array", "items" : "int"}}
+      |        ]}}
+      |    },
+      |    { "name" : "map",
+      |      "type" : { "type" : "map", "values" : {
+      |        "type": "record",
+      |        "name": "Map",
+      |        "fields": [
+      |          { "name": "intF", "type": { "type" : "map", "values" : "int"}}
+      |        ]}}
+      |    }
+      |  ]
+      |}
+      |""".stripMargin)
+  class RecordWithRecordMaps
+
+  it should "support nested record maps" in {
+    val r = RecordWithRecordMaps(
+      Map("basic" -> Basic$4(1)), Map("optional" -> Optional$4(Some(1))),
+      Map("array" -> Array$4(List(1))), Map("map" -> Map$4(Map("int" -> 1))))
+    r.basic shouldBe Map("basic" -> Basic$4(1))
+    r.optional shouldBe Map("optional" -> Optional$4(Some(1)))
+    r.array shouldBe  Map("array" -> Array$4(List(1)))
+    r.map shouldBe Map("map" -> Map$4(Map("int" -> 1)))
+  }
+
+  @AvroType.fromSchema(
+    """
+      |{"type":"record","name": "Record","fields":[{"name":"f1","type":"int"}]}
+    """.stripMargin)
+  class Artisanal1Field
+
+  it should "not provide .tupled in companion object with single field" in {
+    Artisanal1Field.getClass.getMethods.map(_.getName) should not contain "tupled"
+  }
+
+
+  @AvroType.toSchema
+  case class ToSchema(boolF: Boolean,
+                     intF: Int,
+                     longF: Long,
+                     floatF: Float,
+                     doubleF: Double,
+                     stringF: String,
+                     bytesF: ByteString)
+
+  "AvroType.toSchema" should "support .tupled in companion object" in {
+    val r1 = ToSchema(true, 1, 2L, 1.5f, 2.5, "string", ByteString.copyFromUtf8("bytes"))
+    val r2 = ToSchema.tupled((true, 1, 2L, 1.5f, 2.5, "string", ByteString.copyFromUtf8("bytes")))
+    r1 shouldBe r2
+  }
+
+  it should "returns correct schema for plain objects" in {
+    ToSchema.schema should be
+      new Schema.Parser().parse("""
+                                  |{
+                                  |  "type": "record",
+                                  |  "namespace": "com.spotify.scio.avro.types.TypeProviderTest",
+                                  |  "name": "ToSchema",
+                                  |  "fields": [
+                                  |    { "name": "boolF", "type": "boolean"},
+                                  |    { "name": "intF", "type": "int"},
+                                  |    { "name": "longF", "type": "long"},
+                                  |    { "name": "floatF", "type": "float"},
+                                  |    { "name": "doubleF", "type": "double"},
+                                  |    { "name": "stringF", "type": "string"},
+                                  |    { "name": "byteStringF", "type": "bytes"}
+                                  |  ]
+                                  |}
+                                """.stripMargin)
+  }
+
+  it should "support .fromGenericRecord in companion object" in {
+    (classOf[(GenericRecord => ToSchema)] isAssignableFrom
+      ToSchema.fromGenericRecord.getClass) shouldBe true
+  }
+
+  it should "support .toGenericRecord in companion object" in {
+    (classOf[(ToSchema => GenericRecord)] isAssignableFrom
+      ToSchema.toGenericRecord.getClass) shouldBe true
+  }
+
+  it should "support round trip conversion from GenericRecord" in {
+    val r1 = ToSchema(true, 1, 2L, 1.5f, 2.5, "string", ByteString.copyFromUtf8("bytes"))
+    val r2 = ToSchema.fromGenericRecord(ToSchema.toGenericRecord(r1))
+    r1 shouldBe r2
+  }
+
+  it should "create companion object that is a Function subtype" in {
+    val cls = classOf[Function7[Boolean, Int, Long, Float, Double, String, ByteString, ToSchema]]
+    (cls isAssignableFrom ToSchema.getClass) shouldBe true
+  }
+
+  it should "create companion object that is functionally equal to its apply method" in {
+    def doApply(f: (Boolean, Int, Long, Float, Double, String, ByteString) => ToSchema)
+               (x: (Boolean, Int, Long, Float, Double, String, ByteString)): ToSchema =
+      f(x._1, x._2, x._3, x._4, x._5, x._6, x._7)
+
+    doApply(ToSchema.apply _)(
+      (true, 1, 2L, 1.5f, 2.5, "string", ByteString.copyFromUtf8("bytes"))) shouldBe
+      doApply(ToSchema)((true, 1, 2L, 1.5f, 2.5, "string", ByteString.copyFromUtf8("bytes")))
+
+    doApply(ToSchema)(
+      (true, 1, 2L, 1.5f, 2.5, "string", ByteString.copyFromUtf8("bytes"))) shouldBe
+      ToSchema(true, 1, 2L, 1.5f, 2.5, "string", ByteString.copyFromUtf8("bytes"))
+  }
+
+  @AvroType.toSchema
+  case class ReservedName(`type`: Boolean,
+                          `int`: Int)
+
+  it should "returns correct schema for objects containing fields named as scala reserved word" in {
+    ReservedName.schema should be
+    new Schema.Parser().parse("""
+                                |{
+                                |  "type": "record",
+                                |  "namespace": "com.spotify.scio.avro.types.TypeProviderTest",
+                                |  "name": "ReservedName",
+                                |  "fields": [
+                                |    { "name": "type", "type": "boolean"},
+                                |    { "name": "int", "type": "int"}
+                                |  ]
+                                |}
+                              """.stripMargin)
+  }
+
+  @AvroType.toSchema
+  case class Artisanal1FieldToSchema(f1: Long)
+
+  it should "not provide .tupled in companion object with single field" in {
+    Artisanal1FieldToSchema.getClass.getMethods.map(_.getName) should not contain "tupled"
+  }
+
+  it should "create companion object that is a Function subtype for single field record" in {
+    val cls = classOf[Function1[Long, Artisanal1FieldToSchema]]
+    (cls isAssignableFrom Artisanal1FieldToSchema.getClass) shouldBe true
+  }
+
+  @AvroType.toSchema
+  case class RecordWithDefault(x: Int, y: Int = 2)
+
+  it should "work for case class with default params" in {
+    classOf[Function2[Int, Int, RecordWithDefault]] isAssignableFrom RecordWithDefault.getClass
+  }
+
+  it should "support default argument correctly" in {
+    RecordWithDefault(10).y shouldBe 2
+  }
+
+  @AvroType.fromSchema(
+    """
+      |{
+      |  "type": "record",
+      |  "name": "Record",
+      |  "fields": [
+      |    { "name": "f1", "type": "int"},
+      |    { "name": "f2", "type": "int"},
+      |    { "name": "f3", "type": "int"},
+      |    { "name": "f4", "type": "int"},
+      |    { "name": "f5", "type": "int"},
+      |    { "name": "f6", "type": "int"},
+      |    { "name": "f7", "type": "int"},
+      |    { "name": "f8", "type": "int"},
+      |    { "name": "f9", "type": "int"},
+      |    { "name": "f10", "type": "int"},
+      |    { "name": "f11", "type": "int"},
+      |    { "name": "f12", "type": "int"},
+      |    { "name": "f13", "type": "int"},
+      |    { "name": "f14", "type": "int"},
+      |    { "name": "f15", "type": "int"},
+      |    { "name": "f16", "type": "int"},
+      |    { "name": "f17", "type": "int"},
+      |    { "name": "f18", "type": "int"},
+      |    { "name": "f19", "type": "int"},
+      |    { "name": "f20", "type": "int"},
+      |    { "name": "f21", "type": "int"},
+      |    { "name": "f22", "type": "int"},
+      |    { "name": "f23", "type": "int"}
+      |  ]
+      |}
+    """.stripMargin)
+  class ArtisanalMoreThan22Fields
+
+  "AvroType.fromSchema" should "support .schema in companion object with >22 fields" in {
+    ArtisanalMoreThan22Fields(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23)
+    ArtisanalMoreThan22Fields.schema should not be null
+  }
+
+  it should "not provide .tupled in companion object with >22 fields" in {
+    ArtisanalMoreThan22Fields.getClass.getMethods.map(_.getName) should not contain "tupled"
+  }
+
+  @AvroType.toSchema
+  case class TwentyThree(a1:Int,a2:Int,a3:Int,a4:Int,a5:Int,a6:Int,a7:Int,a8:Int,a9:Int,a10:Int,
+                         a11:Int,a12:Int,a13:Int,a14:Int,a15:Int,a16:Int,a17:Int,a18:Int,a19:Int,
+                         a20:Int,a21:Int,a22:Int,a23:Int)
+
+  "AvroType.toSchema" should "not provide .tupled in companion object with >22 fields" in {
+    TwentyThree.getClass.getMethods.map(_.getName) should not contain "tupled"
+  }
+
+  it should "support .schema in companion object with >22 fields" in {
+    TwentyThree.schema should not be null
+  }
+
+  it should "support .fromGenericRecord in companion object with >22 fields" in {
+    val cls = classOf[(GenericRecord => TwentyThree)]
+    (cls isAssignableFrom TwentyThree.fromGenericRecord.getClass) shouldBe true
+  }
+
+  it should "support .toGenericRecord in companion object with >22 fields" in {
+    val cls = classOf[(TwentyThree => GenericRecord)]
+    (cls isAssignableFrom TwentyThree.toGenericRecord.getClass) shouldBe true
+  }
+
+  @AvroType.toSchema
+  @doc("Avro doc")
+  case class DocumentedRecord(a1:Int)
+
+  it should "support table description" in {
+    DocumentedRecord.doc shouldBe "Avro doc"
+    DocumentedRecord.isInstanceOf[HasAvroDoc] shouldBe true
+  }
+
+}


### PR DESCRIPTION
Added support for:

@AvroType.fromSchema -
  generates case classes and their companion objects from Avro schema json
@AvroType.fromPath -
  generates case classes and their companion objects from GCS path. Globs are supported.
@AvroType.toSchema -
  generates Avro schema and compantion object from a case class.

A convenience function is provided in ScioContext to read Avro files to generated case classes:

ScioContext.typedAvroFile

A convenince function is provided to SCollection to write Avro files from generated case classes:

SCollection.saveAsTypedAvroFile