### PR TITLE
Try to avoid ReflectData in SpecificAvroSerializer

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/AvroSerializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/AvroSerializer.scala
@@ -58,11 +58,10 @@ private class SpecificAvroSerializer[T <: SpecificRecordBase] extends KSerialize
   private lazy val cache: MMap[Class[T], AvroCoder[T]] = MMap()
 
   private def getCoder(cls: Class[T]): AvroCoder[T] =
-    cache.getOrElseUpdate(cls, {
+    cache.getOrElseUpdate(cls,
       Try(cls.getMethod("getClassSchema").invoke(null).asInstanceOf[Schema])
         .map(AvroCoder.of(cls, _))
-        .getOrElse(AvroCoder.of(cls))
-    })
+        .getOrElse(AvroCoder.of(cls)))
 
   override def write(kser: Kryo, out: Output, obj: T): Unit =
     this.getCoder(obj.getClass.asInstanceOf[Class[T]]).encode(obj, out, Context.NESTED)

--- a/scio-core/src/main/scala/com/spotify/scio/coders/AvroSerializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/AvroSerializer.scala
@@ -27,6 +27,7 @@ import org.apache.beam.sdk.coders.AvroCoder
 import org.apache.beam.sdk.coders.Coder.Context
 
 import scala.collection.mutable.{Map => MMap}
+import scala.util.Try
 
 private class GenericAvroSerializer extends KSerializer[GenericRecord] {
 
@@ -56,7 +57,12 @@ private class SpecificAvroSerializer[T <: SpecificRecordBase] extends KSerialize
 
   private lazy val cache: MMap[Class[T], AvroCoder[T]] = MMap()
 
-  private def getCoder(cls: Class[T]): AvroCoder[T] = cache.getOrElseUpdate(cls, AvroCoder.of(cls))
+  private def getCoder(cls: Class[T]): AvroCoder[T] =
+    cache.getOrElseUpdate(cls, {
+      Try(cls.getMethod("getClassSchema").invoke(null).asInstanceOf[Schema])
+        .map(AvroCoder.of(cls, _))
+        .getOrElse(AvroCoder.of(cls))
+    })
 
   override def write(kser: Kryo, out: Output, obj: T): Unit =
     this.getCoder(obj.getClass.asInstanceOf[Class[T]]).encode(obj, out, Context.NESTED)


### PR DESCRIPTION
If you don't pass the schema in `AvroCoder.of`, it falls back to using reflection to rebuild the schema. Since we have `T <: SpecificRecordBase`, it makes sense to try and avoid this if possible. This won't work in the case where `T` hasn't defined `getClassSchema`, but given that the avro compiler includes that all the time afaict, this shouldn't be an issue in practice.