### PR TITLE
Return schema by invoking schema function

### DIFF
--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/AvroType.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/AvroType.scala
@@ -220,6 +220,7 @@ class AvroType[T: TypeTag] {
     getField("toGenericRecord").asInstanceOf[(T => GenericRecord)]
 
   /** Schema of `T`. */
-  def schema: Schema = AvroType.schemaOf[T]
+  def schema: Schema =
+    getField("schema").asInstanceOf[Schema]
 
 }


### PR DESCRIPTION
This will ensure that we're always returning the schema which was set when it was resolved, 
which should ensure that record namespaces are preserved.