### PR TITLE
Enforce numeric as partition for latest. Fixes #780.

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryPartitionUtil.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryPartitionUtil.scala
@@ -20,6 +20,7 @@ package com.spotify.scio.bigquery
 import java.util.regex.Pattern
 
 import com.google.api.services.bigquery.model.TableReference
+import com.google.common.primitives.Longs
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO
 
 private[bigquery] object BigQueryPartitionUtil {
@@ -59,6 +60,9 @@ private[bigquery] object BigQueryPartitionUtil {
       .filter(_.getTableId.startsWith(prefix))
       .map(_.getTableId.substring(prefix.length))
       .toSet
+      // get all table with prefix and filter only the day/date partitioned tables. Current
+      // format for date partition is YYYYMMDD, thus all numeric.
+      .filter(e => Longs.tryParse(e) != null)
   }
 
   def latestQuery(bq: BigQueryClient, sqlQuery: String): String = {


### PR DESCRIPTION
Added table_latest in IT dataset, so this is tested as part of current IT
latest tests.