### PR TITLE
Fail on duplicate of outputs and inputs in the job itself

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -31,6 +31,9 @@ private[scio] class TestInput(val m: Map[TestIO[_], Iterable[_]]) {
     require(
       m.contains(key),
       s"Missing test input: $key, available: ${m.keys.mkString("[", ", ", "]")}")
+    require(!s.contains(key),
+      s"There already exists test input for $key, currently " +
+        s"registered inputs: ${s.mkString("[", ", ", "]")}")
     s.add(key)
     m(key).asInstanceOf[Iterable[T]]
   }

--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -51,6 +51,9 @@ private[scio] class TestOutput(val m: Map[TestIO[_], SCollection[_] => Unit]) {
       require(
         m.contains(key),
         s"Missing test output: $key, available: ${m.keys.mkString("[", ", ", "]")}")
+      require(!s.contains(key),
+        s"There already exists test output for $key, currently " +
+          s"registered outputs: ${s.mkString("[", ", ", "]")}")
       s.add(key)
       m(key)
     }


### PR DESCRIPTION
We currently check for duplicates in JobTest, but allow for duplicates
in job itself, this might be confusing, thus let's fail if there are
duplicates in outputs of job itself.