### PR TITLE
Hide com.spotify.scio.io in REPL wildcard import

### DIFF
--- a/scio-repl/src/main/scala/com/spotify/scio/repl/ScioILoop.scala
+++ b/scio-repl/src/main/scala/com/spotify/scio/repl/ScioILoop.scala
@@ -199,7 +199,7 @@ class ScioILoop(scioClassLoader: ScioReplClassLoader,
   private def addImports(): IR.Result =
     intp.interpret(
       """
-        |import com.spotify.scio._
+        |import com.spotify.scio.{io => _, _}
         |import com.spotify.scio.avro._
         |import com.spotify.scio.bigquery._
         |import com.spotify.scio.repl._


### PR DESCRIPTION
This fixes importing packages that have a group name starting with `io`:

```
scio> import io.circe._
<console>:26: error: object circe is not a member of package com.spotify.scio.io
```