### PR TITLE
Fix kryo performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 .DS_Store
 .bigquery
 .scio_repl
+*.jfr

--- a/build.sbt
+++ b/build.sbt
@@ -191,7 +191,8 @@ lazy val root: Project = Project(
   commonSettings ++ siteSettings ++ noPublishSettings,
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject
     -- inProjects(scioCassandra2) -- inProjects(scioElasticsearch2)
-    -- inProjects(scioRepl) -- inProjects(scioSchemas) -- inProjects(scioExamples),
+    -- inProjects(scioRepl) -- inProjects(scioSchemas) -- inProjects(scioExamples)
+    -- inProjects(scioBenchJmh),
   // unidoc handles class paths differently than compile and may give older
   // versions high precedence.
   unidocAllClasspaths in (ScalaUnidoc, unidoc) := {
@@ -218,7 +219,8 @@ lazy val root: Project = Project(
   scioTensorFlow,
   scioSchemas,
   scioExamples,
-  scioRepl
+  scioRepl,
+  scioBenchJmh
 )
 
 lazy val scioCore: Project = Project(
@@ -549,6 +551,23 @@ lazy val scioRepl: Project = Project(
   scioCore,
   scioExtra
 )
+
+lazy val scioBenchJmh: Project = Project(
+  "scio-bench-jmh",
+  file("scio-bench-jmh")
+).settings(
+  commonSettings ++ noPublishSettings,
+  description := "Scio JMH Microbenchmarks",
+  addCompilerPlugin(paradiseDependency),
+  sourceDirectory in Jmh := (sourceDirectory in Test).value,
+  classDirectory in Jmh := (classDirectory in Test).value,
+  dependencyClasspath in Jmh := (dependencyClasspath in Test).value,
+  libraryDependencies ++= Seq(
+    "org.slf4j" % "slf4j-nop" % slf4jVersion
+  )
+).dependsOn(
+  scioCore
+).enablePlugins(JmhPlugin)
 
 // =======================================================================
 // Site settings

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
 
 libraryDependencies ++= Seq(
   "com.github.os72" % "protoc-jar" % "3.3.0.1"

--- a/scio-core/src/main/scala/com/spotify/scio/coders/KryoAtomicCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/KryoAtomicCoder.scala
@@ -17,9 +17,9 @@
 
 package com.spotify.scio.coders
 
-import java.io.{ByteArrayInputStream, InputStream, OutputStream}
-import java.nio.ByteBuffer
+import java.io.{InputStream, OutputStream}
 
+import com.esotericsoftware.kryo.io.{InputChunked, OutputChunked}
 import com.google.common.io.{ByteStreams, CountingOutputStream}
 import com.google.common.reflect.ClassPath
 import com.google.protobuf.Message
@@ -28,10 +28,9 @@ import com.twitter.chill.algebird.AlgebirdRegistrar
 import com.twitter.chill.protobuf.ProtobufSerializer
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.specific.SpecificRecordBase
-import org.apache.beam.sdk.coders.Coder.Context
 import org.apache.beam.sdk.coders._
 import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder
-import org.apache.beam.sdk.util.VarInt
+import org.apache.beam.sdk.util.{EmptyOnDeserializationThreadLocal, VarInt}
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver
 import org.joda.time.{LocalDate, LocalDateTime}
 import org.slf4j.LoggerFactory
@@ -71,60 +70,74 @@ private object KryoRegistrarLoader {
 }
 
 private[scio] class KryoAtomicCoder[T] extends AtomicCoder[T] {
+  private val bufferSize = 64 * 1024
 
   import KryoAtomicCoder.logger
 
-  @transient
-  private lazy val kryo: ThreadLocal[Kryo] = new ThreadLocal[Kryo] {
-    override def initialValue(): Kryo = {
-      val k = KryoSerializer.registered.newKryo()
+  private val kryoState: ThreadLocal[KryoState] =
+    new EmptyOnDeserializationThreadLocal[KryoState] {
+      override def initialValue(): KryoState = {
+        val k = KryoSerializer.registered.newKryo()
 
-      k.forClass(new CoderSerializer(InstantCoder.of()))
-      k.forClass(new CoderSerializer(TableRowJsonCoder.of()))
+        k.forClass(new CoderSerializer(InstantCoder.of()))
+        k.forClass(new CoderSerializer(TableRowJsonCoder.of()))
 
-      // java.lang.Iterable.asScala returns JIterableWrapper which causes problem.
-      // Treat it as standard Iterable instead.
-      k.register(classOf[JIterableWrapper[_]], new JIterableWrapperSerializer())
+        // java.lang.Iterable.asScala returns JIterableWrapper which causes problem.
+        // Treat it as standard Iterable instead.
+        k.register(classOf[JIterableWrapper[_]], new JIterableWrapperSerializer())
 
-      k.forSubclass[SpecificRecordBase](new SpecificAvroSerializer)
-      k.forSubclass[GenericRecord](new GenericAvroSerializer)
-      k.forSubclass[Message](new ProtobufSerializer)
+        k.forSubclass[SpecificRecordBase](new SpecificAvroSerializer)
+        k.forSubclass[GenericRecord](new GenericAvroSerializer)
+        k.forSubclass[Message](new ProtobufSerializer)
 
-      k.forSubclass[LocalDateTime](new JodaLocalDateTimeSerializer)
-      k.forSubclass[LocalDate](new JodaLocalDateSerializer)
+        k.forSubclass[LocalDateTime](new JodaLocalDateTimeSerializer)
+        k.forSubclass[LocalDate](new JodaLocalDateSerializer)
 
-      k.forClass(new KVSerializer)
-      // TODO:
-      // TimestampedValueCoder
+        k.forClass(new KVSerializer)
+        // TODO:
+        // TimestampedValueCoder
 
-      new AlgebirdRegistrar()(k)
-      KryoRegistrarLoader.load(k)
+        new AlgebirdRegistrar()(k)
+        KryoRegistrarLoader.load(k)
 
-      k
+        val input = new InputChunked(bufferSize)
+        val output = new OutputChunked(bufferSize)
+
+        KryoState(k, input, output)
+      }
     }
-  }
 
+  private val header = -1
 
-  override def encode(value: T, outStream: OutputStream): Unit = {
+  override def encode(value: T, os: OutputStream): Unit = {
     if (value == null) {
       throw new CoderException("cannot encode a null value")
     }
-    val os = new BufferedPrefixOutputStream(outStream)
-    val output = new Output(os)
-    kryo.get().writeClassAndObject(output, value)
-    output.flush()
-    os.finish()
+
+    VarInt.encode(header, os)
+
+    val state = kryoState.get()
+
+    val chunked = state.output
+    chunked.setOutputStream(os)
+
+    state.kryo.writeClassAndObject(chunked, value)
+    chunked.endChunks()
+    chunked.flush()
   }
 
-  override def decode(inStream: InputStream): T = {
-    val o = if (VarInt.decodeInt(inStream) == -1) {
-      val is = new BufferedPrefixInputStream(inStream)
-      val obj = kryo.get().readClassAndObject(new Input(is))
-      is.finish()
-      obj
+  override def decode(is: InputStream): T = {
+    val state = kryoState.get()
+
+    val o = if (VarInt.decodeInt(is) == header) {
+      val chunked = state.input
+      chunked.setInputStream(is)
+
+      state.kryo.readClassAndObject(chunked)
     } else {
-      kryo.get().readClassAndObject(new Input(inStream))
+      state.kryo.readClassAndObject(new Input(state.input.getBuffer))
     }
+
     o.asInstanceOf[T]
   }
 
@@ -178,118 +191,20 @@ private[scio] class KryoAtomicCoder[T] extends AtomicCoder[T] {
   private def kryoEncodedElementByteSize(obj: Any): Long = {
     val s = new CountingOutputStream(ByteStreams.nullOutputStream())
     val output = new Output(s)
-    kryo.get().writeClassAndObject(output, obj)
+    kryoState.get().kryo.writeClassAndObject(output, obj)
     output.flush()
     s.getCount + VarInt.getLength(s.getCount)
   }
 
 }
 
+/** Used for sharing Kryo instance and buffers */
+private[scio] final case class KryoState(kryo: Kryo, input: InputChunked, output: OutputChunked)
+
 private[scio] object KryoAtomicCoder {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   def apply[T]: Coder[T] = new KryoAtomicCoder[T]
-
-}
-
-/**
- * Buffered output stream that adds length prefix to each buffer block. Useful for large objects
- * or collections. Based on [[org.apache.beam.sdk.util.BufferedElementCountingOutputStream]].
- */
-private class BufferedPrefixOutputStream(private val os: OutputStream)
-  extends OutputStream {
-
-  private val buffer = ByteBuffer.allocate(64 * 1024)
-  private var finished = false
-
-  VarInt.encode(-1, os)
-
-  override def write(b: Int): Unit = {
-    require(!finished, "Stream has been finished. Can not add any more data.")
-    if (!buffer.hasRemaining) {
-      outputBuffer()
-    }
-    buffer.put(b.toByte)
-  }
-
-  override def write(b: Array[Byte], off: Int, len: Int): Unit = {
-    require(!finished, "Stream has been finished. Can not add any more data.")
-    if (buffer.remaining() >= len) {
-      buffer.put(b, off, len)
-    } else {
-      outputBuffer()
-      if (len < buffer.capacity()) {
-        buffer.put(b, off, len)
-      } else {
-        VarInt.encode(len, os)
-        os.write(b, off, len)
-      }
-    }
-  }
-
-  override def flush(): Unit = if (!finished) {
-    outputBuffer()
-    os.flush()
-  }
-
-  def finish(): Unit = if (!finished) {
-    flush()
-    VarInt.encode(0, os)
-    finished = true
-  }
-
-  private def outputBuffer(): Unit = if (buffer.position() > 0) {
-    VarInt.encode(buffer.position(), os)
-    os.write(buffer.array(), buffer.arrayOffset(), buffer.position())
-    buffer.clear()
-  }
-
-}
-
-/** Counterpart for [[BufferedPrefixOutputStream]]. */
-private class BufferedPrefixInputStream(private val is: InputStream) extends InputStream {
-  inputBuffer()
-
-  private var buffer: Array[Byte] = _
-  private var bais: ByteArrayInputStream = _
-  private var finished = false
-
-  override def read(): Int = {
-    inputBuffer()
-    bais.read()
-  }
-
-  override def read(b: Array[Byte], off: Int, len: Int): Int = {
-    var bytesRead = 0
-    var n = 0
-    do {
-      inputBuffer()
-      n = bais.read(b, off + bytesRead, len - bytesRead)
-      if (n > 0) {
-        bytesRead += n
-      }
-    } while (n > 0)
-    bytesRead
-  }
-
-  private def inputBuffer(): Unit = if (!finished) {
-    if (bais == null || bais.available() <= 0) {
-      val len = VarInt.decodeInt(is)
-      if (len == 0) {
-        finished = true
-      } else {
-        if (buffer == null || buffer.length < len) {
-          buffer = Array.ofDim[Byte](math.max(len, 64 * 1024))
-        }
-        is.read(buffer, 0, len)
-        bais = new ByteArrayInputStream(buffer, 0, len)
-      }
-    }
-  }
-
-  def finish(): Unit = if (!finished) {
-    require(VarInt.decodeInt(is) == 0, "Invalid end of input stream")
-  }
 
 }

--- a/scio-jmh/src/test/scala/com/spotify/scio/jmh/KryoAtomicCoderBenchmark.scala
+++ b/scio-jmh/src/test/scala/com/spotify/scio/jmh/KryoAtomicCoderBenchmark.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.jmh
+
+import java.io.{InputStream, OutputStream}
+import java.util.concurrent.TimeUnit
+
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import com.spotify.scio.coders._
+import com.twitter.chill.IKryoRegistrar
+import org.apache.beam.sdk.coders.{AtomicCoder, ByteArrayCoder, SerializableCoder, StringUtf8Coder}
+import org.apache.beam.sdk.util.CoderUtils
+import org.openjdk.jmh.annotations._
+
+final case class UserId(bytes: Array[Byte])
+final case class User(id: UserId, username: String, email: String)
+final case class SpecializedUser(id: UserId, username: String, email: String)
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+class KryoAtomicCoderBenchmark {
+
+  // please don't use arrays outside of benchmarks
+  val userId = UserId(Array[Byte](1, 2, 3, 4))
+
+  // use standard coders
+  val user = User(userId, "johndoe", "johndoe@spotify.com")
+
+  // use hand-optimized coders
+  val specializedUser = SpecializedUser(userId, "johndoe", "johndoe@spotify.com")
+
+  val kryoCoder = KryoAtomicCoder[User]
+  val javaCoder = SerializableCoder.of(classOf[User])
+  val specializedCoder = new SpecializedCoder
+  val specializedKryoCoder = KryoAtomicCoder[SpecializedUser]
+
+  @Benchmark
+  def kryoEncode: Array[Byte] = {
+    CoderUtils.encodeToByteArray(kryoCoder, user)
+  }
+
+  @Benchmark
+  def javaEncode: Array[Byte] = {
+    CoderUtils.encodeToByteArray(javaCoder, user)
+  }
+
+  @Benchmark
+  def customEncode: Array[Byte] = {
+    CoderUtils.encodeToByteArray(specializedCoder, specializedUser)
+  }
+
+  @Benchmark
+  def customKryoEncode: Array[Byte] = {
+    CoderUtils.encodeToByteArray(specializedKryoCoder, specializedUser)
+  }
+
+  val kryoEncoded = kryoEncode
+  val javaEncoded = javaEncode
+  val customEncoded = customEncode
+  val customKryoEncoded = customKryoEncode
+
+  @Benchmark
+  def kryoDecode: User = {
+    CoderUtils.decodeFromByteArray(kryoCoder, kryoEncoded)
+  }
+
+  @Benchmark
+  def javaDecode: User = {
+    CoderUtils.decodeFromByteArray(javaCoder, javaEncoded)
+  }
+
+  @Benchmark
+  def customDecode: SpecializedUser = {
+    CoderUtils.decodeFromByteArray(specializedCoder, customEncoded)
+  }
+
+  @Benchmark
+  def customKryoDecode: SpecializedUser = {
+    CoderUtils.decodeFromByteArray(specializedKryoCoder, customKryoEncoded)
+  }
+}
+
+final class SpecializedCoder extends AtomicCoder[SpecializedUser] {
+  def encode(value: SpecializedUser, os: OutputStream): Unit = {
+    ByteArrayCoder.of().encode(value.id.bytes, os)
+    StringUtf8Coder.of().encode(value.username, os)
+    StringUtf8Coder.of().encode(value.email, os)
+  }
+
+  def decode(is: InputStream): SpecializedUser = {
+    SpecializedUser(
+      UserId(ByteArrayCoder.of().decode(is)),
+      StringUtf8Coder.of().decode(is),
+      StringUtf8Coder.of().decode(is)
+    )
+  }
+}
+
+final class SpecializedKryoSerializer extends Serializer[SpecializedUser] {
+  def read(kryo: Kryo, input: Input, tpe: Class[SpecializedUser]): SpecializedUser = {
+    val len = input.readInt()
+    val array = new Array[Byte](len)
+
+    input.readBytes(array)
+
+    val username = input.readString()
+    val email = input.readString()
+
+    SpecializedUser(UserId(array), username, email)
+  }
+
+  def write(kryo: Kryo, output: Output, obj: SpecializedUser): Unit = {
+    output.writeInt(obj.id.bytes.length)
+    output.writeBytes(obj.id.bytes)
+    output.writeString(obj.username)
+    output.writeString(obj.email)
+  }
+}
+
+@KryoRegistrar
+class KryoRegistrar extends IKryoRegistrar {
+  def apply(k: Kryo): Unit = {
+    k.register(classOf[User])
+    k.register(classOf[SpecializedUser], new SpecializedKryoSerializer)
+    k.register(classOf[UserId])
+    k.register(classOf[Array[Byte]])
+
+    k.setRegistrationRequired(true)
+  }
+}


### PR DESCRIPTION
Looks like there is performance regression introduced in https://github.com/spotify/scio/pull/478. With this fix, shuffle takes 5-10 times less. Add `scio-jmh` project for micro benchmarks for further improvements.

In one of our pipelines, a shuffle of ~1B records with 16 bytes key takes 4.5 hours instead of 22 hours before.

I propose to handle the case of 400 Mb key separately, cover it with benchmarks, and check if there is a regression in benchmarks for the case of a small key. One of other ways would be to explicitly ask users to specify different coder in case key is huge.

This fix is going to save us approximately 800,000 vCPU hours in an upcoming month, I don't mind backporting if we can ship it as 0.4.0.1.

## Benchmark

```
jmh:run -i 20 -wi 20 -f4 -t1
```

## Before

```
Benchmark                                  Mode  Cnt     Score     Error  Units
KryoAtomicCoderBenchmark.customDecode      avgt   80   286.811 ±   7.392  ns/op
KryoAtomicCoderBenchmark.customEncode      avgt   80   847.654 ±  11.846  ns/op
KryoAtomicCoderBenchmark.customKryoDecode  avgt   80  6184.079 ± 100.342  ns/op
KryoAtomicCoderBenchmark.customKryoEncode  avgt   80  6490.695 ± 196.628  ns/op
KryoAtomicCoderBenchmark.javaDecode        avgt   80  7787.809 ±  58.954  ns/op
KryoAtomicCoderBenchmark.javaEncode        avgt   80  6309.093 ± 105.909  ns/op
KryoAtomicCoderBenchmark.kryoDecode        avgt   80  5851.015 ± 126.595  ns/op
KryoAtomicCoderBenchmark.kryoEncode        avgt   80  6510.682 ± 155.126  ns/op
```

## After

```
Benchmark                                  Mode  Cnt     Score    Error  Units
KryoAtomicCoderBenchmark.customDecode      avgt   80   259.765 ±  1.359  ns/op
KryoAtomicCoderBenchmark.customEncode      avgt   80   813.831 ±  5.095  ns/op
KryoAtomicCoderBenchmark.customKryoDecode  avgt   80   224.362 ±  8.869  ns/op
KryoAtomicCoderBenchmark.customKryoEncode  avgt   80   998.436 ±  8.312  ns/op
KryoAtomicCoderBenchmark.javaDecode        avgt   80  7745.240 ± 54.849  ns/op
KryoAtomicCoderBenchmark.javaEncode        avgt   80  5854.949 ± 51.330  ns/op
KryoAtomicCoderBenchmark.kryoDecode        avgt   80   318.231 ±  2.674  ns/op
KryoAtomicCoderBenchmark.kryoEncode        avgt   80  1055.268 ±  6.411  ns/op
```