### PR TITLE
Make runWithLocalOutput public to allow more generic testing

### DIFF
--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
@@ -127,7 +127,16 @@ trait PipelineTestUtils {
     }
   }
 
-  private def runWithLocalOutput[U](fn: ScioContext => SCollection[U]): Seq[U] = {
+  /**
+   * Test pipeline components with materialized resulting collection.
+   *
+   * The result [[com.spotify.scio.values.SCollection SCollection]] from `fn` is extracted and to be
+   * verified.
+   *
+   * @param fn Scio Job
+   * @return Job results in an in-memory Scala list
+   */
+  def runWithLocalOutput[U](fn: ScioContext => SCollection[U]): Seq[U] = {
     val sc = ScioContext()
     val f = fn(sc).materialize
     sc.close().waitUntilFinish()  // block non-test runner

--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
@@ -128,13 +128,13 @@ trait PipelineTestUtils {
   }
 
   /**
-   * Test pipeline components with materialized resulting collection.
+   *  Test pipeline components with a [[ScioContext]] and materialized resulting collection.
    *
    * The result [[com.spotify.scio.values.SCollection SCollection]] from `fn` is extracted and to be
    * verified.
    *
    * @param fn transform to be tested
-   * @return Scio Result Object and Job results in an in-memory Scala list
+   * @return a tuple containing the [[ScioResult]] and the materialized result of fn as a [[Seq[T]]]
    */
   def runWithLocalOutput[U](fn: ScioContext => SCollection[U]): (ScioResult, Seq[U]) = {
     val sc = ScioContext()

--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
@@ -128,13 +128,13 @@ trait PipelineTestUtils {
   }
 
   /**
-   *  Test pipeline components with a [[ScioContext]] and materialized resulting collection.
+   * Test pipeline components with a [[ScioContext]] and materialized resulting collection.
    *
    * The result [[com.spotify.scio.values.SCollection SCollection]] from `fn` is extracted and to be
    * verified.
    *
    * @param fn transform to be tested
-   * @return a tuple containing the [[ScioResult]] and the materialized result of fn as a [[Seq[T]]]
+   * @return a tuple containing the [[ScioResult]] and the materialized result of fn as a [[Seq[U]]]
    */
   def runWithLocalOutput[U](fn: ScioContext => SCollection[U]): (ScioResult, Seq[U]) = {
     val sc = ScioContext()

--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
@@ -60,7 +60,7 @@ trait PipelineTestUtils {
    */
   def runWithData[T: ClassTag, U: ClassTag](data: Iterable[T])
                                            (fn: SCollection[T] => SCollection[U]): Seq[U] = {
-    runWithLocalOutput { sc => fn(sc.parallelize(data)) }
+    runWithLocalOutput { sc => fn(sc.parallelize(data)) }._2
   }
 
   /**
@@ -80,7 +80,7 @@ trait PipelineTestUtils {
   (fn: (SCollection[T1], SCollection[T2]) => SCollection[U]): Seq[U] = {
     runWithLocalOutput { sc =>
       fn(sc.parallelize(data1), sc.parallelize(data2))
-    }
+    }._2
   }
 
   /**
@@ -101,7 +101,7 @@ trait PipelineTestUtils {
   (fn: (SCollection[T1], SCollection[T2], SCollection[T3]) => SCollection[U]): Seq[U] = {
     runWithLocalOutput { sc =>
       fn(sc.parallelize(data1), sc.parallelize(data2), sc.parallelize(data3))
-    }
+    }._2
   }
 
   /**
@@ -124,7 +124,7 @@ trait PipelineTestUtils {
   : Seq[U] = {
     runWithLocalOutput { sc =>
       fn(sc.parallelize(data1), sc.parallelize(data2), sc.parallelize(data3), sc.parallelize(data4))
-    }
+    }._2
   }
 
   /**
@@ -134,13 +134,13 @@ trait PipelineTestUtils {
    * verified.
    *
    * @param fn transform to be tested
-   * @return Job results in an in-memory Scala list
+   * @return Scio Result Object and Job results in an in-memory Scala list
    */
-  def runWithLocalOutput[U](fn: ScioContext => SCollection[U]): Seq[U] = {
+  def runWithLocalOutput[U](fn: ScioContext => SCollection[U]): (ScioResult, Seq[U]) = {
     val sc = ScioContext()
     val f = fn(sc).materialize
-    sc.close().waitUntilFinish()  // block non-test runner
-    f.waitForResult().value.toSeq
+    val result = sc.close().waitUntilFinish()  // block non-test runner
+    (result, f.waitForResult().value.toSeq)
   }
 
 }

--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
@@ -133,7 +133,7 @@ trait PipelineTestUtils {
    * The result [[com.spotify.scio.values.SCollection SCollection]] from `fn` is extracted and to be
    * verified.
    *
-   * @param fn Scio Job
+   * @param fn transform to be tested
    * @return Job results in an in-memory Scala list
    */
   def runWithLocalOutput[U](fn: ScioContext => SCollection[U]): Seq[U] = {


### PR DESCRIPTION
I find myself writing the body of this function often in my projects.  The runWithData methods are very useful for more thorough testing logic but sometimes my functions accept arguments other than SCollections.

This PR makes the lower level function public to allow for testing with local results.