### PR TITLE
Fix #834. Use default scala for scio-repl (2.12.x)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ deployment:
     tag: /v.*/
     commands:
       - go get -u github.com/tcnksm/ghr
-      - ./scripts/circleci_parallel_run.sh 'sbt ++2.11.11 "project scio-repl" clean assembly'
+      - ./scripts/circleci_parallel_run.sh 'sbt "project scio-repl" clean assembly'
       - mkdir "$CIRCLE_ARTIFACTS/repl"
       - cp scio-repl/target/scala-*/scio-repl-*.jar "$CIRCLE_ARTIFACTS/repl/"
       - ghr -u spotify -draft $CIRCLE_TAG "$CIRCLE_ARTIFACTS/repl"


### PR DESCRIPTION
Currently it's 2.12.3.