### PR TITLE
Add flatten and flattenValues to SCollection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Don't hesitate to create [GitHub issues](https://github.com/spotify/scio/issues)
 
 # Submitting Pull Requests
 
-Before opening a pull request, make sure `sbt scalastyle test` runs successfully. It's usually a good idea to keep changes simple and small. Please also be consistent with the code base and our [style guide](https://github.com/spotify/scio/wiki/Style-Guide). 
+Before opening a pull request, make sure `sbt scalastyle test` runs successfully. It's usually a good idea to keep changes simple and small. Please also be consistent with the code base and our [style guide](https://github.com/spotify/scio/wiki/Style-Guide).
 
 If there is already a GitHub issue for the task you are working on, leave a comment to let people know that you are working on it. If there isn't already an issue and it is a non-trivial task, it's a good idea to create one (and note that you're working on it). This prevents contributors from duplicating effort.
 

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -707,6 +707,13 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)])
   // Scala lambda is simpler and more powerful than transforms.Values
   def values: SCollection[V] = self.map(_._2)
 
+  /**
+   * Return an SCollection having its values flattened
+   * @group transform
+   */
+  def flattenValues[U: ClassTag](implicit ev: V <:< TraversableOnce[U]): SCollection[(K, U)] =
+    self.flatMapValues(_.asInstanceOf[TraversableOnce[U]])
+
   // =======================================================================
   // Side input operations
   // =======================================================================

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -312,6 +312,13 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     this.parDo(Functions.flatMapFn(f))
 
   /**
+   * Return a new SCollection[U] by flattening each element of an SCollection[Traversable[U]]
+   * @group transform
+   */
+  def flatten[U: ClassTag](implicit ev: T <:< TraversableOnce[U]): SCollection[U] =
+    flatMap(_.asInstanceOf[TraversableOnce[U]])
+
+  /**
    * Aggregate the elements using a given associative function and a neutral "zero value". The
    * function op(t1, t2) is allowed to modify t1 and return it as its result value to avoid object
    * allocation; however, it should not modify t2.

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -436,6 +436,13 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
+  it should "support flattenValues()" in {
+    runWithContext { sc =>
+      val p = sc.parallelize(Seq(("a", Seq(1, 2, 3)), ("b", Seq(4, 5, 6)))).flattenValues
+      p should containInAnyOrder (Seq(("a", 1), ("a", 2), ("a", 3), ("b", 4), ("b", 5), ("b", 6)))
+    }
+  }
+
   it should "support hashJoin()" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -194,6 +194,13 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
+  it should "support flatten()" in {
+    runWithContext { sc =>
+      val p = sc.parallelize(Seq(Seq("a b", "c d"), Seq("e f", "g h"))).flatten
+      p should containInAnyOrder(Seq("a b", "c d", "e f", "g h"))
+    }
+  }
+
   it should "support fold()" in {
     runWithContext { sc =>
       val p = sc.parallelize(1 to 100)


### PR DESCRIPTION
I noticed that `SCollection` did not have `flatten` and `flattenValues`. This PR adds them.