### PR TITLE
Rename FeatureSpec to FeatureDesc

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TFExampleExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TFExampleExample.scala
@@ -41,7 +41,7 @@ runMain
   --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
   --input=gs://dataflow-samples/shakespeare/kinglear.txt
   --output=gs://[BUCKET]/[PATH]/tf-example-features
-  --feature-spec-path=gs://[BUCKET]/[PATH]/tf-example-features/_features
+  --feature-desc-path=gs://[BUCKET]/[PATH]/tf-example-features/_features
 */
 
 object TFExampleExample {
@@ -58,8 +58,8 @@ object TFExampleExample {
       .map(featuresType.toExample(_))
       .saveAsTfExampleFile(
         args("output"),
-        FeatureSpec.fromCaseClass[WordCountFeatures],
-        featureSpecPath = args.optional("feature-spec-path").orNull)
+        FeatureDesc.fromCaseClass[WordCountFeatures],
+        featureDescPath = args.optional("feature-desc-path").orNull)
     sc.close()
   }
 }

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TFExampleExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TFExampleExampleTest.scala
@@ -27,23 +27,23 @@ class TFExampleExampleTest extends PipelineSpec {
   val input = Seq("foo", "bar", "foo")
   val output = Seq(WordCountFeatures(3.0f, 2.0f), WordCountFeatures(3.0f, 1.0f))
     .map(featuresType.toExample(_))
-  val featureNameSpec = Seq("wordLength", "count")
+  val featureNameDesc = Seq("wordLength", "count")
 
   "TFExampleExample" should "work" in {
     JobTest[com.spotify.scio.examples.extra.TFExampleExample.type]
       .args("--input=in", "--output=out")
       .input(TextIO("in"), input)
       .output(TFExampleIO("out"))(_ should containInAnyOrder (output))
-      .output(TextIO("out/_feature_spec"))(_ should containInAnyOrder (featureNameSpec))
+      .output(TextIO("out/_feature_desc"))(_ should containInAnyOrder (featureNameDesc))
       .run()
   }
 
-  it should "work with custom feature spec path" in {
+  it should "work with custom feature desc path" in {
     JobTest[com.spotify.scio.examples.extra.TFExampleExample.type]
-      .args("--input=in", "--output=out", "--feature-spec-path=out/custom_path_features")
+      .args("--input=in", "--output=out", "--feature-desc-path=out/custom_path_features")
       .input(TextIO("in"), input)
       .output(TFExampleIO("out"))(_ should containInAnyOrder (output))
-      .output(TextIO("out/custom_path_features"))(_ should containInAnyOrder (featureNameSpec))
+      .output(TextIO("out/custom_path_features"))(_ should containInAnyOrder (featureNameDesc))
       .run()
   }
 

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/package.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/package.scala
@@ -32,9 +32,9 @@ package object tensorflow {
 
   case class TFExampleIO(path: String) extends TestIO[Example](path)
 
-  /** Expose [[TFExampleSCollectionFunctions.FeatureSpec]]. */
-  val FeatureSpec: TFExampleSCollectionFunctions.FeatureSpec.type =
-    TFExampleSCollectionFunctions.FeatureSpec
+  /** Expose [[TFExampleSCollectionFunctions.FeatureDesc]]. */
+  val FeatureDesc: TFExampleSCollectionFunctions.FeatureDesc.type =
+    TFExampleSCollectionFunctions.FeatureDesc
 
   /** Implicit conversion from [[SCollection]] to [[TensorFlowSCollectionFunctions]]. */
   implicit def makeTensorFlowSCollectionFunctions[T: ClassTag](s: SCollection[T])

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/io/TFTapTest.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/io/TFTapTest.scala
@@ -64,8 +64,8 @@ class TFTapTest extends TapSpec {
     for (
       compressionType <- Seq(CType.NONE, CType.ZLIB, CType.GZIP);
       featureSpec <- Seq(
-        FeatureSpec.fromCaseClass[TestFeatureSpec.TestFeatures],
-        FeatureSpec.fromSeq(Seq("f1", "f2")))
+        FeatureDesc.fromCaseClass[TestFeatureSpec.TestFeatures],
+        FeatureDesc.fromSeq(Seq("f1", "f2")))
         ) {
       val dir = tmpDir
       val sc = ScioContext()
@@ -92,7 +92,7 @@ class TFTapTest extends TapSpec {
       val (out, spec) = sc.parallelize(examples)
         .saveAsTfExampleFile(
           dir.getPath,
-          FeatureSpec.fromSCollection(featureSpec),
+          FeatureDesc.fromSCollection(featureSpec),
           compressionType = compressionType)
       sc.close().waitUntilDone()
       verifyTap(out.waitForResult(), examples.toSet)
@@ -115,10 +115,10 @@ class TFTapTest extends TapSpec {
       sc.parallelize(examples)
         .saveAsTfExampleFile(
           dir.getPath,
-          FeatureSpec.fromSCollection(featureSpec),
+          FeatureDesc.fromSCollection(featureSpec),
           compressionType = CompressionType.NONE)
       sc.close()
-    } should have message s"java.lang.IllegalArgumentException: requirement failed: Feature specification must contain a single element"
+    } should have message s"java.lang.IllegalArgumentException: requirement failed: Feature description must contain a single element"
     // scalastyle:on no.whitespace.before.left.bracket
     // scalastyle:off line.size.limit
     FileUtils.deleteDirectory(dir)


### PR DESCRIPTION
There is already FeatureSpec in Featran, so to make it less confusing,
and also mitigate the import errors lets rename FeatureSpec to
FeatureDesc (as in feature description).