### PR TITLE
Workaround asymmetry between distCache and distCache mocking

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -856,7 +856,7 @@ class DistCacheScioContext private[scio] (self: ScioContext) {
    */
   def distCache[F](uri: String)(initFn: File => F): DistCache[F] = self.requireNotClosed {
     if (self.isTest) {
-      new MockDistCache(testDistCache(DistCacheIO(uri)))
+      new MockDistCacheFunc(testDistCache(DistCacheIO(uri)))
     } else {
       new DistCacheSingle(new URI(uri), initFn, self.optionsAs[GcsOptions])
     }
@@ -871,7 +871,7 @@ class DistCacheScioContext private[scio] (self: ScioContext) {
   def distCache[F](uris: Seq[String])(initFn: Seq[File] => F): DistCache[F] =
     self.requireNotClosed {
       if (self.isTest) {
-        new MockDistCache(testDistCache(DistCacheIO(uris)))
+        new MockDistCacheFunc(testDistCache(DistCacheIO(uris)))
       } else {
         new DistCacheMulti(uris.map(new URI(_)), initFn, self.optionsAs[GcsOptions])
       }

--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -70,12 +70,12 @@ private[scio] class TestOutput(val m: Map[TestIO[_], SCollection[_] => Unit]) {
 
 private[scio] class TestDistCache(val m: Map[DistCacheIO[_], _]) {
   val s: MSet[DistCacheIO[_]] = MSet.empty
-  def apply[T](key: DistCacheIO[T]): T = {
+  def apply[T](key: DistCacheIO[T]): () => T = {
     require(
       m.contains(key),
       s"Missing test dist cache: $key, available: ${m.keys.mkString("[", ", ", "]")}")
     s.add(key)
-    m(key).asInstanceOf[T]
+    m(key).asInstanceOf[() => T]
   }
   def validate(): Unit = {
     val d = m.keySet -- s

--- a/scio-core/src/main/scala/com/spotify/scio/values/DistCache.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/DistCache.scala
@@ -59,8 +59,25 @@ private[scio] class MockDistCache[F](val value: F) extends DistCache[F] {
   override def apply(): F = value
 }
 
+private[scio] class MockDistCacheFunc[F](val value: () => F) extends DistCache[F] {
+  override def apply(): F = value()
+}
+
 object MockDistCache {
+
+  /**
+   * Mock distCache by returning given value.
+   *
+   * @param value mock value, must be serializable.
+   */
   def apply[F](value: F): DistCache[F] = new MockDistCache(value)
+
+  /**
+   * Mock distCache by returning result of given init function.
+   *
+   * @param initFn init function, must be serializable.
+   */
+  def apply[F](initFn: () => F): DistCache[F] = new MockDistCacheFunc[F](initFn)
 }
 
 private[scio] class DistCacheSingle[F](val uri: URI,

--- a/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
@@ -122,10 +122,25 @@ object JobTest {
      * Feed an distributed cache to the pipeline being tested. Note that `DistCacheIO[T]` must
      * match the one used inside the pipeline, e.g. `DistCacheIO[Set[String]]("dc.txt")` with
      * `sc.distCache("dc.txt")(f => scala.io.Source.fromFile(f).getLines().toSet)`.
+     *
+     * @param value mock value, must be serializable.
      */
     def distCache[T](key: DistCacheIO[T], value: T): Builder = {
       require(!state.distCaches.contains(key), "Duplicate test dist cache: " + key)
-      state = state.copy(distCaches = state.distCaches + (key -> value))
+      state = state.copy(distCaches = state.distCaches + (key -> (() => value)))
+      this
+    }
+
+    /**
+     * Feed an distributed cache to the pipeline being tested. Note that `DistCacheIO[T]` must
+     * match the one used inside the pipeline, e.g. `DistCacheIO[Set[String]]("dc.txt")` with
+     * `sc.distCache("dc.txt")(f => scala.io.Source.fromFile(f).getLines().toSet)`.
+     *
+     * @param initFn init function, must be serializable.
+     */
+    def distCacheFunc[T](key: DistCacheIO[T], initFn: () => T): Builder = {
+      require(!state.distCaches.contains(key), "Duplicate test dist cache: " + key)
+      state = state.copy(distCaches = state.distCaches + (key -> initFn))
       this
     }
 


### PR DESCRIPTION
`distCache` requires that `initFn` is serializable, while `distCache` mock
requires that mocking value itself is serializable, which is not the
same. An example could be to a non-serializable client which requires
data to be available on all workers, pseudo code:

```
sc.distCache("init-data-file")(f => new NonSerializableClient(f))
```

Here `NonSerializableClient` does not need to be `Serializable`, but it's
not possible to test such job (at least without magic), even tho it's
perfectly fine job from `distCache` contract perspective.