### PR TITLE
decouple Dataflow runner, fix 779

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -256,6 +256,7 @@ lazy val scioTest: Project = Project(
   description := "Scio helpers for ScalaTest",
   libraryDependencies ++= Seq(
     "org.apache.beam" % "beam-runners-direct-java" % beamVersion,
+    "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion % "it",
     "org.apache.beam" % "beam-sdks-java-core" % beamVersion % "test" classifier "tests",
     "org.scalatest" %% "scalatest" % scalatestVersion,
     "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
@@ -535,6 +536,7 @@ lazy val scioRepl: Project = Project(
   commonSettings,
   libraryDependencies ++= Seq(
     "org.apache.beam" % "beam-runners-direct-java" % beamVersion,
+    "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion,
     "org.slf4j" % "slf4j-simple" % slf4jVersion,
     "jline" % "jline" % jlineVersion,
     "org.scala-lang" % "scala-compiler" % scalaVersion.value,

--- a/build.sbt
+++ b/build.sbt
@@ -174,10 +174,6 @@ lazy val assemblySettings = Seq(
 
 lazy val paradiseDependency =
   "org.scalamacros" % "paradise" % scalaMacrosVersion cross CrossVersion.full
-lazy val beamDependencies = Seq(
-  "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
-  "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion
-)
 
 lazy val macroSettings = Seq(
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
@@ -229,8 +225,9 @@ lazy val scioCore: Project = Project(
 ).settings(
   commonSettings ++ macroSettings,
   description := "Scio - A Scala API for Apache Beam and Google Cloud Dataflow",
-  libraryDependencies ++= beamDependencies,
   libraryDependencies ++= Seq(
+    "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
+    "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion % "provided",
     "com.twitter" %% "algebird-core" % algebirdVersion,
     "com.twitter" %% "chill" % chillVersion,
     "com.twitter" %% "chill-algebird" % chillVersion,

--- a/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
@@ -37,10 +37,8 @@ package object metrics {
   case class Metrics(version: String,
                      scalaVersion: String,
                      jobName: String,
-                     jobId: String,
                      state: String,
-                     beamMetrics: BeamMetrics,
-                     cloudMetrics: Iterable[DFServiceMetrics])
+                     beamMetrics: BeamMetrics)
 
   case class BeamMetrics(counters: Iterable[BeamMetric[Long]],
                          distributions: Iterable[BeamMetric[BeamDistribution]],
@@ -48,8 +46,5 @@ package object metrics {
   case class BeamMetric[T](namespace: String, name: String, value: MetricValue[T])
   case class BeamDistribution(sum: Long, count: Long, min: Long, max: Long, mean: Double)
   case class BeamGauge(value: Long, timestamp: Instant)
-
-  case class DFServiceMetrics(name: DFMetricName, scalar: AnyRef, updateTime: String)
-  case class DFMetricName(name: String, origin: String, context: Map[String, String])
 
 }

--- a/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/metrics/package.scala
@@ -28,23 +28,23 @@ package object metrics {
    * @param attempted The value across all attempts of executing all parts of the pipeline.
    * @param committed The value across all successfully completed parts of the pipeline.
    */
-  case class MetricValue[T](attempted: T, committed: Option[T])
+  final case class MetricValue[T](attempted: T, committed: Option[T])
 
   /**
    * Case class holding metadata and service-level metrics of the job. See
    * [[ScioResult.getMetrics]].
    */
-  case class Metrics(version: String,
-                     scalaVersion: String,
-                     jobName: String,
-                     state: String,
-                     beamMetrics: BeamMetrics)
+  final case class Metrics(version: String,
+                           scalaVersion: String,
+                           appName: String,
+                           state: String,
+                           beamMetrics: BeamMetrics)
 
-  case class BeamMetrics(counters: Iterable[BeamMetric[Long]],
-                         distributions: Iterable[BeamMetric[BeamDistribution]],
-                         gauges: Iterable[BeamMetric[BeamGauge]])
-  case class BeamMetric[T](namespace: String, name: String, value: MetricValue[T])
-  case class BeamDistribution(sum: Long, count: Long, min: Long, max: Long, mean: Double)
-  case class BeamGauge(value: Long, timestamp: Instant)
+  final case class BeamMetrics(counters: Iterable[BeamMetric[Long]],
+                               distributions: Iterable[BeamMetric[BeamDistribution]],
+                               gauges: Iterable[BeamMetric[BeamGauge]])
+  final case class BeamMetric[T](namespace: String, name: String, value: MetricValue[T])
+  final case class BeamDistribution(sum: Long, count: Long, min: Long, max: Long, mean: Double)
+  final case class BeamGauge(value: Long, timestamp: Instant)
 
 }

--- a/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowContext.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.runners.dataflow
+
+import java.io.File
+import java.net.URLClassLoader
+import java.util.jar.{Attributes, JarFile}
+
+import com.spotify.scio.RunnerContext
+import org.apache.beam.runners.dataflow.DataflowRunner
+import org.apache.beam.runners.dataflow.options.DataflowPipelineWorkerPoolOptions
+import org.apache.beam.sdk.options.PipelineOptions
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+
+/** Dataflow runner specific context. */
+case object DataflowContext extends RunnerContext {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  override def prepareOptions(options: PipelineOptions, artifacts: List[String]): Unit = {
+    options.as(classOf[DataflowPipelineWorkerPoolOptions])
+      .setFilesToStage(getFilesToStage(artifacts).asJava)
+  }
+
+  // =======================================================================
+  // Extra artifacts - jars/files etc
+  // =======================================================================
+
+  /** Compute list of local files to make available to workers. */
+  private def getFilesToStage(extraLocalArtifacts: List[String]): List[String] = {
+    val finalLocalArtifacts = detectClassPathResourcesToStage(
+      classOf[DataflowRunner].getClassLoader) ++ extraLocalArtifacts
+
+    logger.debug(s"Final list of extra artifacts: ${finalLocalArtifacts.mkString(":")}")
+    finalLocalArtifacts
+  }
+
+  /** Borrowed from DataflowRunner. */
+  private def detectClassPathResourcesToStage(classLoader: ClassLoader): List[String] = {
+    require(classLoader.isInstanceOf[URLClassLoader],
+      "Current ClassLoader is '" + classLoader + "' only URLClassLoaders are supported")
+
+    // exclude jars from JAVA_HOME and files from current directory
+    val javaHome = new File(sys.props("java.home")).getCanonicalPath
+    val userDir = new File(sys.props("user.dir")).getCanonicalPath
+
+    val classPathJars = classLoader.asInstanceOf[URLClassLoader]
+      .getURLs
+      .map(url => new File(url.toURI).getCanonicalPath)
+      .filter(p => !p.startsWith(javaHome) && p != userDir)
+      .toList
+
+    // fetch jars from classpath jar's manifest Class-Path if present
+    val manifestJars =  classPathJars
+      .filter(_.endsWith(".jar"))
+      .map(p => (p, new JarFile(p).getManifest))
+      .filter { case (p, manifest) =>
+        manifest != null && manifest.getMainAttributes.containsKey(Attributes.Name.CLASS_PATH)}
+      .map { case (p, manifest) => (new File(p).getParentFile,
+        manifest.getMainAttributes.getValue(Attributes.Name.CLASS_PATH).split(" ")) }
+      .flatMap { case (parent, jars) => jars.map(jar =>
+        if (jar.startsWith("/")) {
+          jar // accept absolute path as is
+        } else {
+          new File(parent, jar).getCanonicalPath  // relative path
+        })
+      }
+
+    logger.debug(s"Classpath jars: ${classPathJars.mkString(":")}")
+    logger.debug(s"Manifest jars: ${manifestJars.mkString(":")}")
+
+    // no need to care about duplicates here - should be solved by the SDK uploader
+    classPathJars ++ manifestJars
+  }
+
+}

--- a/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowResult.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.runners.dataflow
+
+import com.google.api.services.dataflow.model.{Job, JobMetrics}
+import com.spotify.scio.RunnerResult
+import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions
+import org.apache.beam.runners.dataflow.{DataflowClient, DataflowPipelineJob}
+import org.apache.beam.sdk.PipelineResult
+import org.apache.beam.sdk.options.PipelineOptionsFactory
+
+/** Represent a Dataflow runner specific result. */
+class DataflowResult(val internal: DataflowPipelineJob) extends RunnerResult {
+  def this(result: PipelineResult) = this(result.asInstanceOf[DataflowPipelineJob])
+
+  private val client = DataflowClient.create(DataflowResult.getOptions(internal.getProjectId))
+
+  /**  Get Dataflow [[Job]]. */
+  def getJob: Job = client.getJob(internal.getJobId)
+
+  /**  Get Dataflow [[JobMetrics]]. */
+  def getJobMetrics: JobMetrics = client.getJobMetrics(internal.getJobId)
+}
+
+/** Companion object for [[DataflowResult]]. */
+object DataflowResult {
+  /** Create a new [[DataflowResult]] instance. */
+  def apply(projectId: String, jobId: String): DataflowResult = {
+    val options = getOptions(projectId)
+    val client = DataflowClient.create(options)
+    val job = new DataflowPipelineJob(client, jobId, options, null)
+    new DataflowResult(job)
+  }
+
+  private def getOptions(projectId: String): DataflowPipelineOptions = {
+    val options = PipelineOptionsFactory.create().as(classOf[DataflowPipelineOptions])
+    options.setProject(projectId)
+    options
+  }
+}

--- a/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
@@ -22,17 +22,11 @@ import java.util.UUID
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.google.api.client.googleapis.services.AbstractGoogleClientRequest
-import com.google.api.services.dataflow.Dataflow
-import com.google.api.services.dataflow.model.JobMetrics
 import com.spotify.scio.ScioContext
-import org.apache.beam.runners.dataflow.options._
-import org.apache.beam.sdk.{PipelineResult, PipelineRunner}
 import org.apache.beam.sdk.coders.{Coder, CoderRegistry}
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions
-import org.apache.beam.sdk.io.gcp.bigquery.PatchedBigQueryTableRowIterator
-import org.apache.beam.sdk.options.PipelineOptions
 import org.apache.beam.sdk.util.Transport
+import org.apache.beam.sdk.{PipelineResult, PipelineRunner}
 import org.slf4j.LoggerFactory
 
 import scala.reflect.ClassTag
@@ -68,24 +62,6 @@ private[scio] object ScioUtil {
   }
 
   def getScalaJsonMapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
-
-  def getDataflowServiceClient(options: PipelineOptions): Dataflow =
-    options.as(classOf[DataflowPipelineDebugOptions]).getDataflowClient
-
-  def executeWithBackOff[T](request: AbstractGoogleClientRequest[T], errorMsg: String): T = {
-    // Reuse util method from BigQuery
-    PatchedBigQueryTableRowIterator.executeWithBackOff(request, errorMsg)
-  }
-
-  def getDataflowServiceMetrics(options: DataflowPipelineOptions, jobId: String): JobMetrics = {
-    val getMetrics = ScioUtil.getDataflowServiceClient(options)
-      .projects()
-      .jobs()
-      .getMetrics(options.getProject, jobId)
-
-    ScioUtil.executeWithBackOff(getMetrics,
-      s"Could not get dataflow metrics of ${getMetrics.getJobId} in ${getMetrics.getProjectId}")
-  }
 
   def addPartSuffix(path: String, ext: String = ""): String =
     if (path.endsWith("/")) s"${path}part-*$ext" else s"$path/part-*$ext"

--- a/scio-test/src/it/scala/DataflowIT.scala
+++ b/scio-test/src/it/scala/DataflowIT.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.spotify.scio._
+import com.spotify.scio.runners.dataflow._
+import org.scalatest._
+
+import scala.collection.JavaConverters._
+
+object DataflowIT {
+  val projectId = "scio-playground"
+
+  def run(): ScioResult = {
+    val (sc, _) = ContextAndArgs(Array(s"--project=$projectId", "--runner=DataflowRunner"))
+    val c = ScioMetrics.counter("count")
+    sc.parallelize(1 to 100)
+      .map { x =>
+        c.inc()
+        x
+      }
+      .filter { x =>
+        c.inc()
+        true
+      }
+    sc.close().waitUntilDone()
+  }
+}
+
+class DataflowIT extends FlatSpec with Matchers {
+
+  private val scioResult = DataflowIT.run()
+  private val dfResult = scioResult.as[DataflowResult]
+
+  "DataflowResult" should "have Dataflow data" in {
+    dfResult.internal.getState shouldBe scioResult.state
+    dfResult.getJob.getProjectId shouldBe DataflowIT.projectId
+    dfResult.getJobMetrics.getMetrics.asScala should not be empty
+  }
+
+  it should "round trip ScioResult" in {
+    val r = dfResult.asScioResult
+    r.state shouldBe scioResult.state
+    r.getMetrics shouldBe scioResult.getMetrics
+    r.allCountersAtSteps shouldBe scioResult.allCountersAtSteps
+  }
+
+  it should "work independently" in {
+    val r = DataflowResult(dfResult.internal.getProjectId, dfResult.internal.getJobId)
+    r.getJob.getProjectId shouldBe dfResult.internal.getProjectId
+    r.getJobMetrics.getMetrics.asScala should not be empty
+    r.asScioResult.state shouldBe scioResult.state
+    r.asScioResult.getMetrics shouldBe scioResult.getMetrics
+    r.asScioResult.allCountersAtSteps shouldBe scioResult.allCountersAtSteps
+  }
+
+}


### PR DESCRIPTION
Todo:
- [x] load `RunnerContext` via reflection
- [x] remove DF runner from ScioContextTest
- [x] ~remove DF runner from ScioContextIT~
- [x] verify that scio-examples and scio-repl work without DF runner
- [x] Support #850, allow creating ScioResult independently

Summary:
- `scio-core` depends on DF runner as `"provided"`
- `scio-test` depends on DF runner as `"it"`, in `ScioContextIT` (can be removed by making a dummy `FakeRemoteRunner`), and `ScioBenchmark` (how do we remove this?)
- `scio-repl` depends on DF runner, so it supports DF out of the box
- Runner specific logic in `ScioContext` are moved to `RunnerContext`, and loaded via reflection
- Runner specific logic in `ScioResult` are moved to `RunnerResult`, and loaded via `ScioResult#as`
- DF specific context and result are under `com.spotify.scio.runners.dataflow` in `scio-core`. Nothing is statically initialized so it should be fine without DF runner dependency.