### PR TITLE
Double lock get/cache of side input

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SideInput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SideInput.scala
@@ -34,8 +34,14 @@ trait SideInput[T] extends Serializable {
   private[values] def get[I, O](context: DoFn[I, O]#ProcessContext): T
   def getCache[I, O](context: DoFn[I, O]#ProcessContext): T = {
     if (cache == null || this.context.ne(context)) {
-      this.context = context
-      cache = get(context)
+      // TODO(rav): reference equality might be too strict, we might want to check pane equality
+      //            instead.
+      context.synchronized {
+        if (cache == null || this.context.ne(context)) {
+          this.context = context
+          cache = get(context)
+        }
+      }
     }
     cache
   }


### PR DESCRIPTION
Without double locking it is possible multiple instance of DoFns will
try to materialize side input.