### PR TITLE
use window as side input cache key, fix #959

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithSideInput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithSideInput.scala
@@ -20,25 +20,21 @@ package com.spotify.scio.util
 import com.spotify.scio.values.SideInputContext
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow
 
 private[scio] object FunctionsWithSideInput {
 
   trait SideInputDoFn[T, U] extends NamedDoFn[T, U] {
-    private var ctx: SideInputContext[T] = _
-    def sideInputContext(c: DoFn[T, U]#ProcessContext): SideInputContext[T] = {
-      if (ctx == null || ctx.context.ne(c)) {
+    def sideInputContext(c: DoFn[T, U]#ProcessContext, w: BoundedWindow): SideInputContext[T] =
         // Workaround for type inference limit
-        ctx = new SideInputContext(c.asInstanceOf[DoFn[T, AnyRef]#ProcessContext])
-      }
-      ctx
-    }
+        new SideInputContext(c.asInstanceOf[DoFn[T, AnyRef]#ProcessContext], w)
   }
 
   def filterFn[T](f: (T, SideInputContext[T]) => Boolean): DoFn[T, T] = new SideInputDoFn[T, T] {
     val g = ClosureCleaner(f)  // defeat closure
     @ProcessElement
-    private[scio] def processElement(c: DoFn[T, T]#ProcessContext): Unit =
-      if (g(c.element(), sideInputContext(c))) {
+    private[scio] def processElement(c: DoFn[T, T]#ProcessContext, w: BoundedWindow): Unit =
+      if (g(c.element(), sideInputContext(c, w))) {
         c.output(c.element())
       }
   }
@@ -47,8 +43,8 @@ private[scio] object FunctionsWithSideInput {
   : DoFn[T, U] = new SideInputDoFn[T, U] {
     val g = ClosureCleaner(f)  // defeat closure
     @ProcessElement
-    private[scio] def processElement(c: DoFn[T, U]#ProcessContext): Unit = {
-      val i = g(c.element(), sideInputContext(c)).toIterator
+    private[scio] def processElement(c: DoFn[T, U]#ProcessContext, w: BoundedWindow): Unit = {
+      val i = g(c.element(), sideInputContext(c, w)).toIterator
       while (i.hasNext) c.output(i.next())
     }
   }
@@ -56,8 +52,8 @@ private[scio] object FunctionsWithSideInput {
   def mapFn[T, U](f: (T, SideInputContext[T]) => U): DoFn[T, U] = new SideInputDoFn[T, U] {
     val g = ClosureCleaner(f)  // defeat closure
     @ProcessElement
-    private[scio] def processElement(c: DoFn[T, U]#ProcessContext): Unit =
-      c.output(g(c.element(), sideInputContext(c)))
+    private[scio] def processElement(c: DoFn[T, U]#ProcessContext, w: BoundedWindow): Unit =
+      c.output(g(c.element(), sideInputContext(c, w)))
   }
 
 }

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithSideInput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithSideInput.scala
@@ -21,6 +21,7 @@ import com.spotify.scio.ScioContext
 import com.spotify.scio.util.FunctionsWithSideInput.SideInputDoFn
 import com.spotify.scio.util.{ClosureCleaner, FunctionsWithSideInput}
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow
 import org.apache.beam.sdk.transforms.{DoFn, ParDo}
 import org.apache.beam.sdk.values.{PCollection, TupleTag, TupleTagList}
 
@@ -92,9 +93,9 @@ class SCollectionWithSideInput[T: ClassTag] private[values] (val internal: PColl
       val g = ClosureCleaner(f) // defeat closure
 
       @ProcessElement
-      private[scio] def processElement(c: DoFn[T, T]#ProcessContext): Unit = {
+      private[scio] def processElement(c: DoFn[T, T]#ProcessContext, w: BoundedWindow): Unit = {
         val elem = c.element()
-        val partition = g(elem, sideInputContext(c))
+        val partition = g(elem, sideInputContext(c, w))
         if (!partitions.exists(_.tupleTag == partition.tupleTag)) {
           throw new IllegalStateException(s"""${partition.tupleTag.getId} is not part of
             ${partitions.map(_.tupleTag.getId).mkString}""")


### PR DESCRIPTION
Without this fix, we have cache miss for every element in https://github.com/spotify/scio/blob/master/scio-core/src/main/scala/com/spotify/scio/values/SideInput.scala#L36

With the fix, cache only gets invalidated when window on the main collection changes.

~However I'm not sure how it handles cases where main and side have different windowing. Need to run more tests.~
Actually it shouldn't matter, each main window is mapped to a unique side window, so it doesn't matter which side window. Main window along determines which side window is retrieved.