### PR TITLE
Refactor subtract, fix deduplication

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -470,9 +470,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @group transform
    */
   def subtract(that: SCollection[T]): SCollection[T] = this.transform {
-    _.map((_, 1)).cogroup(that.map((_, 1))).flatMap { t =>
-      if (t._2._1.nonEmpty && t._2._2.isEmpty) Seq(t._1) else Seq.empty
-    }
+    _.map((_, ())).subtractByKey(that).keys
   }
 
   /**

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -336,7 +336,7 @@ class SCollectionTest extends PipelineSpec {
       val p1 = sc.parallelize(Seq(1, 2, 3, 4, 5, 1, 3, 5))
       val p2 = sc.parallelize(Seq(2, 4, 6, 8, 10))
       val p = p1.subtract(p2)
-      p should containInAnyOrder (Seq(1, 3, 5))
+      p should containInAnyOrder (Seq(1, 3, 5, 1, 3, 5))
     }
   }
 


### PR DESCRIPTION
NOTICE: change of semantic, subtract now won't deduplicate the LHS.