### PR TITLE
Optional arguments validation

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -140,7 +140,8 @@ object ScioContext {
 
   /** Parse PipelineOptions and application arguments from command line arguments. */
   @tailrec
-  def parseArguments[T <: PipelineOptions : ClassTag](cmdlineArgs: Array[String])
+  def parseArguments[T <: PipelineOptions : ClassTag](cmdlineArgs: Array[String],
+                                                      withValidation: Boolean = false)
   : (T, Args) = {
     val optClass = ScioUtil.classOf[T]
 
@@ -162,7 +163,12 @@ object ScioContext {
     val (optArgs, appArgs) =
       cmdlineArgs.partition(arg => optPatterns.exists(_.findFirstIn(arg).isDefined))
 
-    val pipelineOpts = PipelineOptionsFactory.fromArgs(optArgs: _*).as(optClass)
+    val pipelineOpts = if(withValidation) {
+      PipelineOptionsFactory.fromArgs(optArgs: _*).withValidation().as(optClass)
+    } else {
+      PipelineOptionsFactory.fromArgs(optArgs: _*).as(optClass)
+    }
+
     val optionsFile = pipelineOpts.as(classOf[ScioOptions]).getOptionsFile
     if (optionsFile != null) {
       log.info(s"Appending options from $optionsFile")

--- a/scio-examples/src/main/java/org/apache/beam/examples/complete/TfIdf.java
+++ b/scio-examples/src/main/java/org/apache/beam/examples/complete/TfIdf.java
@@ -220,7 +220,7 @@ public class TfIdf {
                   URI uri = c.element().getKey();
                   String line = c.element().getValue();
                   for (String word : line.split("\\W+")) {
-                    // Log INFO messages when the word “love” is found.
+                    // Log INFO messages when the word "love" is found.
                     if (word.toLowerCase().equals("love")) {
                       LOG.info("Found {}", word.toLowerCase());
                     }

--- a/scio-test/src/test/java/com/spotify/scio/testing/TestValidationOptions.java
+++ b/scio-test/src/test/java/com/spotify/scio/testing/TestValidationOptions.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spotify.scio.testing;
+
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.Validation;
+import scala.reflect.ClassTag;
+
+/**
+ * Options provided to test {@link com.spotify.scio.ScioContext#parseArguments(String[], boolean, ClassTag)}
+ */
+public interface TestValidationOptions extends PipelineOptions {
+
+  @Validation.Required
+  @Description("Required argumet to test validation")
+  String getRequiredArgument();
+  void setRequiredArgument(String requiredArgument);
+}

--- a/scio-test/src/test/java/com/spotify/scio/testing/TestValidationOptions.java
+++ b/scio-test/src/test/java/com/spotify/scio/testing/TestValidationOptions.java
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag;
 public interface TestValidationOptions extends PipelineOptions {
 
   @Validation.Required
-  @Description("Required argumet to test validation")
+  @Description("Required argument to test validation")
   String getRequiredArgument();
   void setRequiredArgument(String requiredArgument);
 }

--- a/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -23,7 +23,7 @@ import java.nio.file.Files
 import com.google.common.collect.Lists
 import com.spotify.scio.metrics.Metrics
 import com.spotify.scio.options.ScioOptions
-import com.spotify.scio.testing.PipelineSpec
+import com.spotify.scio.testing.{PipelineSpec, TestValidationOptions}
 import com.spotify.scio.util.ScioUtil
 import org.apache.beam.runners.direct.DirectRunner
 import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
@@ -134,6 +134,12 @@ class ScioContextTest extends PipelineSpec {
     val (_, arg) = ScioContext.parseArguments[PipelineOptions](
       Array(s"--optionsFile=${optionsFile.getAbsolutePath}"))
     arg("foo") shouldBe "bar"
+  }
+
+  it should "invalidate options in which required arguments is missing" in {
+    assertThrows[IllegalArgumentException] {
+      ScioContext.parseArguments[TestValidationOptions](Array("--foo=bar"), true)
+    }
   }
 
 }

--- a/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -136,7 +136,7 @@ class ScioContextTest extends PipelineSpec {
     arg("foo") shouldBe "bar"
   }
 
-  it should "invalidate options in which required arguments is missing" in {
+  it should "invalidate options where required arguments are missing" in {
     assertThrows[IllegalArgumentException] {
       ScioContext.parseArguments[TestValidationOptions](Array("--foo=bar"), true)
     }


### PR DESCRIPTION
I noticed that Apache Beam arguments validation was missing in Scio so this is my proposal to improve it.