### PR TITLE
Update new bigquery datetime and timestamp specification and remove "Fixme" 

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/package.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/package.scala
@@ -176,10 +176,9 @@ package object bigquery {
 
   /** Utility for BigQuery `TIMESTAMP` type. */
   object Timestamp {
-
-    // FIXME: verify that these match BigQuery specification
-    // YYYY-[M]M-[D]D[ [H]H:[M]M:[S]S[.DDDDDD]][time zone]
+    // YYYY-[M]M-[D]D[( |T)[H]H:[M]M:[S]S[.DDDDDD]][time zone]
     private val formatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS ZZZ")
+
     private val parser = new DateTimeFormatterBuilder()
       .append(DateTimeFormat.forPattern("yyyy-MM-dd"))
       .appendOptional(new DateTimeFormatterBuilder()
@@ -238,8 +237,9 @@ package object bigquery {
 
   /** Utility for BigQuery `DATETIME` type. */
   object DateTime {
-    // YYYY-[M]M-[D]D[ [H]H:[M]M:[S]S[.DDDDDD]]
+    // YYYY-[M]M-[D]D[( |T)[H]H:[M]M:[S]S[.DDDDDD]]
     private val formatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
+
     private val parser = new DateTimeFormatterBuilder()
       .append(DateTimeFormat.forPattern("yyyy-MM-dd"))
       .appendOptional(new DateTimeFormatterBuilder()


### PR DESCRIPTION
Big query standard-sql and legacy-sql support both datetime and timestamp formats with 'T' and ' ' (space) as time separator. 

Standard-sql: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#datetime-type

Legacy-sql: https://cloud.google.com/bigquery/data-types