### PR TITLE
add TFRecordSpec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -506,7 +506,12 @@ lazy val scioTensorFlow: Project = Project(
     "org.tensorflow" % "tensorflow" % tensorFlowVersion,
     "org.tensorflow" % "proto" % tensorFlowVersion,
     "me.lyh" %% "shapeless-datatype-tensorflow" % shapelessDatatypeVersion
-  )
+  ),
+  libraryDependencies ++= Seq(
+    "io.circe" %% "circe-core",
+    "io.circe" %% "circe-generic",
+    "io.circe" %% "circe-parser"
+  ).map(_ % circeVersion)
 ).dependsOn(
   scioCore,
   scioTest % "test->test"

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TFExampleExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TFExampleExample.scala
@@ -58,8 +58,8 @@ object TFExampleExample {
       .map(featuresType.toExample(_))
       .saveAsTfExampleFile(
         args("output"),
-        FeatureDesc.fromCaseClass[WordCountFeatures],
-        featureDescPath = args.optional("feature-desc-path").orNull)
+        TFRecordSpec.fromCaseClass[WordCountFeatures],
+        tfRecordSpecPath = args.optional("feature-desc-path").orNull)
     sc.close()
   }
 }

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TFExampleExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TFExampleExampleTest.scala
@@ -27,23 +27,25 @@ class TFExampleExampleTest extends PipelineSpec {
   val input = Seq("foo", "bar", "foo")
   val output = Seq(WordCountFeatures(3.0f, 2.0f), WordCountFeatures(3.0f, 1.0f))
     .map(featuresType.toExample(_))
-  val featureNameDesc = Seq("wordLength", "count")
+  val featureNameDesc = Seq("{\"version\":1," +
+    "\"features\":[[\"FloatList\",\"count\"],[\"FloatList\",\"wordLength\"]]," +
+    "\"compression\":\"DEFLATE\"}")
 
   "TFExampleExample" should "work" in {
     JobTest[com.spotify.scio.examples.extra.TFExampleExample.type]
       .args("--input=in", "--output=out")
       .input(TextIO("in"), input)
       .output(TFExampleIO("out"))(_ should containInAnyOrder (output))
-      .output(TextIO("out/_feature_desc"))(_ should containInAnyOrder (featureNameDesc))
+      .output(TextIO("out/_tf_record_spec.json"))(_ should containInAnyOrder (featureNameDesc))
       .run()
   }
 
   it should "work with custom feature desc path" in {
     JobTest[com.spotify.scio.examples.extra.TFExampleExample.type]
-      .args("--input=in", "--output=out", "--feature-desc-path=out/custom_path_features")
+      .args("--input=in", "--output=out", "--feature-desc-path=out/my_tf_record_spec.json")
       .input(TextIO("in"), input)
       .output(TFExampleIO("out"))(_ should containInAnyOrder (output))
-      .output(TextIO("out/custom_path_features"))(_ should containInAnyOrder (featureNameDesc))
+      .output(TextIO("out/my_tf_record_spec.json"))(_ should containInAnyOrder (featureNameDesc))
       .run()
   }
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TFExampleExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TFExampleExampleTest.scala
@@ -27,9 +27,9 @@ class TFExampleExampleTest extends PipelineSpec {
   val input = Seq("foo", "bar", "foo")
   val output = Seq(WordCountFeatures(3.0f, 2.0f), WordCountFeatures(3.0f, 1.0f))
     .map(featuresType.toExample(_))
-  val featureNameDesc = Seq("{\"version\":1," +
-    "\"features\":[[\"FloatList\",\"count\"],[\"FloatList\",\"wordLength\"]]," +
-    "\"compression\":\"DEFLATE\"}")
+  val featureNameDesc = Seq("""{"version":1,""" +
+    """"features":[["FloatList","count"],["FloatList","wordLength"]],""" +
+    """"compression":"DEFLATE"}""")
 
   "TFExampleExample" should "work" in {
     JobTest[com.spotify.scio.examples.extra.TFExampleExample.type]

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TFExampleExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TFExampleExampleTest.scala
@@ -28,7 +28,7 @@ class TFExampleExampleTest extends PipelineSpec {
   val output = Seq(WordCountFeatures(3.0f, 2.0f), WordCountFeatures(3.0f, 1.0f))
     .map(featuresType.toExample(_))
   val featureNameDesc = Seq("""{"version":1,""" +
-    """"features":[["FloatList","count"],["FloatList","wordLength"]],""" +
+    """"features":[["count","FloatList",{}],["wordLength","FloatList",{}]],""" +
     """"compression":"DEFLATE"}""")
 
   "TFExampleExample" should "work" in {

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/FeatureKind.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/FeatureKind.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.tensorflow
+
+import com.google.protobuf.ByteString
+import com.spotify.scio.tensorflow.FeatureKind.FeatureKind
+
+import scala.reflect.runtime.universe._
+
+object FeatureKind extends Enumeration {
+  type FeatureKind = Value
+  val BytesList, FloatList, Int64List = Value
+
+  // scalastyle:off cyclomatic.complexity
+  def apply(t: Type): FeatureKind = t match {
+    case t if t.erasure =:= typeOf[Option[_]].erasure => this (t.typeArgs.head)
+    case t if t.erasure <:< typeOf[Traversable[_]].erasure ||
+      t.erasure <:< typeOf[Array[_]] => this (t.typeArgs.head)
+    case t if t =:= typeOf[Boolean] => FeatureKind.Int64List
+    case t if t =:= typeOf[Long] => FeatureKind.Int64List
+    case t if t =:= typeOf[Int] => FeatureKind.Int64List
+    case t if t =:= typeOf[Float] => FeatureKind.FloatList
+    case t if t =:= typeOf[Double] => FeatureKind.FloatList
+    case t if t =:= typeOf[String] => FeatureKind.BytesList
+    case t if t =:= typeOf[ByteString] => FeatureKind.BytesList
+    case t if t =:= typeOf[Byte] => FeatureKind.BytesList
+  }
+
+  // scalastyle:on cyclomatic.complexity
+}

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/FeatureKind.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/FeatureKind.scala
@@ -18,11 +18,10 @@
 package com.spotify.scio.tensorflow
 
 import com.google.protobuf.ByteString
-import com.spotify.scio.tensorflow.FeatureKind.FeatureKind
 
 import scala.reflect.runtime.universe._
 
-object FeatureKind extends Enumeration {
+private object FeatureKind extends Enumeration {
   type FeatureKind = Value
   val BytesList, FloatList, Int64List = Value
 

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TFRecordSpec.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TFRecordSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.tensorflow
+
+import com.spotify.scio.tensorflow.FeatureKind._
+import com.spotify.scio.values.SCollection
+import io.circe.generic.auto._
+import io.circe.syntax._
+import org.apache.beam.sdk.io.Compression
+
+object TFRecordSpec {
+
+  import scala.reflect.runtime.universe._
+
+
+  def fromCaseClass[T: TypeTag]: TFRecordSpec = fromCaseClass(Compression.DEFLATE)
+
+  def fromCaseClass[T: TypeTag](compression: Compression): TFRecordSpec = {
+    require(typeOf[T].typeSymbol.isClass && typeOf[T].typeSymbol.asClass.isCaseClass,
+      "Type must be a case class")
+
+    val s = typeOf[T].members.collect {
+      case m: MethodSymbol if m.isCaseAccessor => (
+        FeatureKind(m.returnType),
+        m.name.decodedName.toString)
+    }.toSeq
+    CaseClassTFRecordSpec(s, compression)
+  }
+
+  def fromFeatran(featureNames: SCollection[Seq[String]],
+                  compression: Compression = Compression.DEFLATE): TFRecordSpec = {
+    FeatranTFRecordSpec(
+      featureNames.map(_.map(n => (FeatureKind.FloatList, n))),
+      compression)
+  }
+}
+
+
+sealed trait TFRecordSpec {
+  def compression: Compression
+}
+
+final case class CaseClassTFRecordSpec(x: Seq[(FeatureKind, String)],
+                                       compression: Compression) extends TFRecordSpec
+
+final case class FeatranTFRecordSpec(x: SCollection[Seq[(FeatureKind, String)]],
+                                     compression: Compression) extends TFRecordSpec
+
+private final case class TFRecordSpecConfig(version: Int,
+                                            features: Seq[(FeatureKind, String)],
+                                            compression: Compression) {
+
+  // Circe struggles with Compression (Java Enum)
+  case class Str(version: Int,
+                 features: Seq[(String, String)],
+                 compression: String)
+
+
+  def asJson: String = Str(version,
+    features.map(t => (t._1.toString, t._2)),
+    compression.toString
+  ).asJson.noSpaces
+
+}
+
+
+

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowSCollectionFunctions.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowSCollectionFunctions.scala
@@ -75,7 +75,7 @@ private class PredictDoFn[T, V](graphBytes: DistCache[Array[Byte]],
       val outTensors = runner.run()
       try {
         import scala.collection.breakOut
-        c.output(outFn(input, (fetchOp zip outTensors.asScala)(breakOut)))
+        c.output(outFn(input, (fetchOp zip outTensors.asScala) (breakOut)))
       } finally {
         log.debug("Closing down output tensors")
         outTensors.asScala.foreach(_.close())
@@ -106,25 +106,25 @@ private class PredictDoFn[T, V](graphBytes: DistCache[Array[Byte]],
 }
 
 /**
- * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with TensorFlow methods.
- */
+  * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with TensorFlow methods.
+  */
 class TensorFlowSCollectionFunctions[T: ClassTag](@transient val self: SCollection[T])
   extends Serializable {
 
   /**
-   * Predict/infer/forward-pass on pre-trained GraphDef.
-   *
-   * @param graphUri URI of pre-trained/saved TensorFlow model
-   * @param fetchOps names of [[org.tensorflow.Operation]]s to fetch the results from
-   * @param config configuration parameters for the session specified as a serialized
-   *               `org.tensorflow.framework.ConfigProto` protocol buffer.
-   * @param inFn translates input elements of T to map of input-operation ->
-   *             [[org.tensorflow.Tensor Tensor]]. This method takes ownership of the
-   *             [[org.tensorflow.Tensor Tensor]]s.
-   * @param outFn translates output of prediction from map of output-operation ->
-   *              [[org.tensorflow.Tensor Tensor]], to elements of V. This method takes ownership
-   *              of the [[org.tensorflow.Tensor Tensor]]s.
-   */
+    * Predict/infer/forward-pass on pre-trained GraphDef.
+    *
+    * @param graphUri URI of pre-trained/saved TensorFlow model
+    * @param fetchOps names of [[org.tensorflow.Operation]]s to fetch the results from
+    * @param config   configuration parameters for the session specified as a serialized
+    *                 `org.tensorflow.framework.ConfigProto` protocol buffer.
+    * @param inFn     translates input elements of T to map of input-operation ->
+    *                 [[org.tensorflow.Tensor Tensor]]. This method takes ownership of the
+    *                 [[org.tensorflow.Tensor Tensor]]s.
+    * @param outFn    translates output of prediction from map of output-operation ->
+    *                 [[org.tensorflow.Tensor Tensor]], to elements of V. This method takes
+    *                 ownership of the [[org.tensorflow.Tensor Tensor]]s.
+    */
   def predict[V: ClassTag](graphUri: String,
                            fetchOps: Seq[String],
                            config: Array[Byte] = null)
@@ -135,105 +135,54 @@ class TensorFlowSCollectionFunctions[T: ClassTag](@transient val self: SCollecti
   }
 }
 
-private[scio] object TFExampleSCollectionFunctions {
-
-  sealed trait FeatureDesc
-  final case class SeqStrFeatureDesc(x: Seq[String]) extends FeatureDesc
-  final case class SColSeqStrFeatureDesc(x: SCollection[Seq[String]]) extends FeatureDesc
-
-  /**
-   * Feature description factory for [[TFExampleSCollectionFunctions.saveAsTfExampleFile]].
-   * In most cases you want to use [[https://github.com/spotify/featran featran]] and
-   * [[FeatureDesc.fromSCollection]], which would give you feature description for free.
-   */
-  object FeatureDesc {
-
-    /**
-     * [[Seq]] based feature description.
-     *
-     * @param seq [[Seq]] containing feature descriptions.
-     */
-    def fromSeq(seq: Seq[String]): FeatureDesc = SeqStrFeatureDesc(seq)
-
-    /**
-     * [[SCollection]] based feature description.
-     *
-     * @param scol [[SCollection]] with a single element of [[Seq]] containing feature
-     *             description.
-     */
-    def fromSCollection(scol: SCollection[Seq[String]]): FeatureDesc = SColSeqStrFeatureDesc(scol)
-
-    /**
-     * Case class field name based feature description.
-     *
-     * @note uses reflection to fetch field names, should not be used in performance critical path.
-     */
-    import scala.reflect.runtime.universe._
-    def fromCaseClass[T: TypeTag]: FeatureDesc = {
-      require(typeOf[T].typeSymbol.isClass && typeOf[T].typeSymbol.asClass.isCaseClass,
-        "Type must be a case class")
-      val s = typeOf[T].members.collect {
-        case m: MethodSymbol if m.isCaseAccessor => m.name.decodedName.toString
-      }.toSeq
-      SeqStrFeatureDesc(s)
-    }
-  }
-
-}
-
 class TFExampleSCollectionFunctions[T <: Example](val self: SCollection[T]) {
-  import TFExampleSCollectionFunctions._
 
   /**
-   * Save this SCollection of `org.tensorflow.example.Example` as a TensorFlow TFRecord file.
-   *
-   * @param featureDesc     feature description for the Examples, use the
-   *                        [[com.spotify.scio.tensorflow.FeatureDesc]] to define a description.
-   * @param featureDescPath path to save the feature description to, by default it will be
-   *                        `<PATH>/_feature_desc`
-   *
-   * @group output
-   */
+    * Save this SCollection of `org.tensorflow.example.Example` as a TensorFlow TFRecord file.
+    *
+    * @param tFRecordSpec     TF Record description for the Examples, use the
+    *                         [[com.spotify.scio.tensorflow.TFRecordSpec]] to define a description.
+    * @param tfRecordSpecPath path to save the TF Record description to, by default it will be
+    *                         `<PATH>/.tf_record_spec.json`
+    * @group output
+    */
   def saveAsTfExampleFile(path: String,
-                          featureDesc: FeatureDesc,
+                          tFRecordSpec: TFRecordSpec,
                           suffix: String = ".tfrecords",
-                          compression: Compression = Compression.UNCOMPRESSED,
                           numShards: Int = 0,
-                          featureDescPath: String = null)
+                          tfRecordSpecPath: String = null)
                          (implicit ev: T <:< Example)
   : (Future[Tap[Example]], Future[Tap[String]]) = {
-    require(featureDesc != null, "Feature spec can't be null")
+    require(tFRecordSpec != null, "TFRecord spec can't be null")
     require(path != null, "Path can't be null")
-    val _featureSpecPath =
-      Option(featureDescPath).getOrElse(path.replaceAll("\\/+$", "") + "/_feature_desc")
+    val _tfRecordSpecPath =
+      Option(tfRecordSpecPath).getOrElse(path.replaceAll("\\/+$", "") + "/_tf_record_spec.json")
     import scala.concurrent.ExecutionContext.Implicits.global
-    val fs: SCollection[Seq[String]] = featureDesc match {
-      case SeqStrFeatureDesc(x) => self.context.parallelize(Seq(x))
-      case SColSeqStrFeatureDesc(x) => x
+
+    val tfrs: SCollection[String] = tFRecordSpec match {
+      case CaseClassTFRecordSpec(x, c) => self.context.parallelize(Seq(
+        TFRecordSpecConfig(1, x, c).asJson))
+      case FeatranTFRecordSpec(x, c) => x.map(TFRecordSpecConfig(1, _, c).asJson)
     }
-    val singletonFeatureSpec = fs
-      .groupBy(_ => ())
-      .flatMap { case (_, e) =>
-        require(e.size == 1, "Feature description must contain a single element")
-        e
-      }
+
     if (self.context.isTest) {
-      self.context.testOut(TextIO(_featureSpecPath))(fs.flatMap(identity))
+      self.context.testOut(TextIO(_tfRecordSpecPath))(tfrs)
       self.context.testOut(TFExampleIO(path))(self.asInstanceOf[SCollection[Example]])
       (self.saveAsInMemoryTap.asInstanceOf[Future[Tap[Example]]],
-        singletonFeatureSpec.saveAsInMemoryTap.asInstanceOf[Future[Tap[String]]])
+        tfrs.saveAsInMemoryTap.asInstanceOf[Future[Tap[String]]])
     } else {
-      singletonFeatureSpec.map { e =>
-        val featureSpecResource = FileSystems.matchNewResource(_featureSpecPath, false)
+      tfrs.map { e =>
+        val featureSpecResource = FileSystems.matchNewResource(_tfRecordSpecPath, false)
         val writer = FileSystems.create(featureSpecResource, MimeTypes.TEXT)
         try {
-          e.foreach(p => writer.write(ByteBuffer.wrap(s"$p\n".getBytes(Charsets.UTF_8))))
+          writer.write(ByteBuffer.wrap(s"$e\n".getBytes(Charsets.UTF_8)))
         } finally {
           writer.close()
         }
       }
-      val featureSpecFuture = Future(TextTap(_featureSpecPath))
-      val r = self.map(_.toByteArray).saveAsTfRecordFile(path, suffix, compression, numShards)
+      val featureSpecFuture = Future(TextTap(_tfRecordSpecPath))
+      val r = self.map(_.toByteArray).saveAsTfRecordFile(
+        path, suffix, tFRecordSpec.compression, numShards)
       (r.map(_.map(Example.parseFrom)), featureSpecFuture)
     }
   }
@@ -243,11 +192,12 @@ class TFExampleSCollectionFunctions[T <: Example](val self: SCollection[T]) {
 class TFRecordSCollectionFunctions[T <: Array[Byte]](val self: SCollection[T]) {
 
   /**
-   * Save this SCollection as a TensorFlow TFRecord file. Note that elements must be of type
-   * `Array[Byte]`. The recommended record encoding is `org.tensorflow.example.Example` protocol
-   * buffers (which contain `org.tensorflow.example.Features` as a field) serialized as bytes.
-   * @group output
-   */
+    * Save this SCollection as a TensorFlow TFRecord file. Note that elements must be of type
+    * `Array[Byte]`. The recommended record encoding is `org.tensorflow.example.Example` protocol
+    * buffers (which contain `org.tensorflow.example.Features` as a field) serialized as bytes.
+    *
+    * @group output
+    */
   def saveAsTfRecordFile(path: String,
                          suffix: String = ".tfrecords",
                          compression: Compression = Compression.UNCOMPRESSED,

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowSCollectionFunctions.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowSCollectionFunctions.scala
@@ -106,25 +106,25 @@ private class PredictDoFn[T, V](graphBytes: DistCache[Array[Byte]],
 }
 
 /**
-  * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with TensorFlow methods.
-  */
+ * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with TensorFlow methods.
+ */
 class TensorFlowSCollectionFunctions[T: ClassTag](@transient val self: SCollection[T])
   extends Serializable {
 
   /**
-    * Predict/infer/forward-pass on pre-trained GraphDef.
-    *
-    * @param graphUri URI of pre-trained/saved TensorFlow model
-    * @param fetchOps names of [[org.tensorflow.Operation]]s to fetch the results from
-    * @param config   configuration parameters for the session specified as a serialized
-    *                 `org.tensorflow.framework.ConfigProto` protocol buffer.
-    * @param inFn     translates input elements of T to map of input-operation ->
-    *                 [[org.tensorflow.Tensor Tensor]]. This method takes ownership of the
-    *                 [[org.tensorflow.Tensor Tensor]]s.
-    * @param outFn    translates output of prediction from map of output-operation ->
-    *                 [[org.tensorflow.Tensor Tensor]], to elements of V. This method takes
-    *                 ownership of the [[org.tensorflow.Tensor Tensor]]s.
-    */
+   * Predict/infer/forward-pass on pre-trained GraphDef.
+   *
+   * @param graphUri URI of pre-trained/saved TensorFlow model
+   * @param fetchOps names of [[org.tensorflow.Operation]]s to fetch the results from
+   * @param config   configuration parameters for the session specified as a serialized
+   *                 `org.tensorflow.framework.ConfigProto` protocol buffer.
+   * @param inFn     translates input elements of T to map of input-operation ->
+   *                 [[org.tensorflow.Tensor Tensor]]. This method takes ownership of the
+   *                 [[org.tensorflow.Tensor Tensor]]s.
+   * @param outFn    translates output of prediction from map of output-operation ->
+   *                 [[org.tensorflow.Tensor Tensor]], to elements of V. This method takes
+   *                 ownership of the [[org.tensorflow.Tensor Tensor]]s.
+   */
   def predict[V: ClassTag](graphUri: String,
                            fetchOps: Seq[String],
                            config: Array[Byte] = null)
@@ -138,14 +138,14 @@ class TensorFlowSCollectionFunctions[T: ClassTag](@transient val self: SCollecti
 class TFExampleSCollectionFunctions[T <: Example](val self: SCollection[T]) {
 
   /**
-    * Save this SCollection of `org.tensorflow.example.Example` as a TensorFlow TFRecord file.
-    *
-    * @param tFRecordSpec     TF Record description for the Examples, use the
-    *                         [[com.spotify.scio.tensorflow.TFRecordSpec]] to define a description.
-    * @param tfRecordSpecPath path to save the TF Record description to, by default it will be
-    *                         `<PATH>/.tf_record_spec.json`
-    * @group output
-    */
+   * Save this SCollection of `org.tensorflow.example.Example` as a TensorFlow TFRecord file.
+   *
+   * @param tFRecordSpec     TF Record description for the Examples, use the
+   *                         [[com.spotify.scio.tensorflow.TFRecordSpec]] to define a description.
+   * @param tfRecordSpecPath path to save the TF Record description to, by default it will be
+   *                         `<PATH>/.tf_record_spec.json`
+   * @group output
+   */
   def saveAsTfExampleFile(path: String,
                           tFRecordSpec: TFRecordSpec,
                           suffix: String = ".tfrecords",
@@ -192,12 +192,12 @@ class TFExampleSCollectionFunctions[T <: Example](val self: SCollection[T]) {
 class TFRecordSCollectionFunctions[T <: Array[Byte]](val self: SCollection[T]) {
 
   /**
-    * Save this SCollection as a TensorFlow TFRecord file. Note that elements must be of type
-    * `Array[Byte]`. The recommended record encoding is `org.tensorflow.example.Example` protocol
-    * buffers (which contain `org.tensorflow.example.Features` as a field) serialized as bytes.
-    *
-    * @group output
-    */
+   * Save this SCollection as a TensorFlow TFRecord file. Note that elements must be of type
+   * `Array[Byte]`. The recommended record encoding is `org.tensorflow.example.Example` protocol
+   * buffers (which contain `org.tensorflow.example.Features` as a field) serialized as bytes.
+   *
+   * @group output
+   */
   def saveAsTfRecordFile(path: String,
                          suffix: String = ".tfrecords",
                          compression: Compression = Compression.UNCOMPRESSED,

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/package.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/package.scala
@@ -32,12 +32,6 @@ package object tensorflow {
   case class TFExampleIO(path: String) extends TestIO[Example](path)
 
   /**
-   * Expose `com.spotify.scio.tensorflow.TFExampleSCollectionFunctions.FeatureDesc`.
-   */
-  val FeatureDesc: TFExampleSCollectionFunctions.FeatureDesc.type =
-    TFExampleSCollectionFunctions.FeatureDesc
-
-  /**
    * Implicit conversion from [[com.spotify.scio.values.SCollection SCollection]] to
    * [[TensorFlowSCollectionFunctions]].
    */

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFTapTest.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFTapTest.scala
@@ -21,8 +21,6 @@ import java.util.UUID
 
 import com.spotify.scio.ScioContext
 import com.spotify.scio.io.TapSpec
-import org.apache.beam.sdk.Pipeline.PipelineExecutionException
-import org.apache.beam.sdk.io.Compression
 import org.apache.commons.io.FileUtils
 import shapeless.datatype.tensorflow._
 
@@ -30,7 +28,9 @@ class TFTapTest extends TapSpec {
 
   object TestFeatureSpec {
     val featuresType: TensorFlowType[TestFeatures] = TensorFlowType[TestFeatures]
+
     case class TestFeatures(f1: Float, f2: Float)
+
   }
 
   private def getDummyExample = {
@@ -58,22 +58,20 @@ class TFTapTest extends TapSpec {
   it should "support saveAsTfExampleFile with case class or Seq feature spec" in {
     val examples = getDummyExample
     import org.apache.beam.sdk.io.{Compression => CType}
-    for (
-      compressionType <- Seq(CType.UNCOMPRESSED, CType.DEFLATE, CType.GZIP);
-      featureSpec <- Seq(
-        FeatureDesc.fromCaseClass[TestFeatureSpec.TestFeatures],
-        FeatureDesc.fromSeq(Seq("f1", "f2")))
-        ) {
+    for (compressionType <- Seq(CType.UNCOMPRESSED, CType.DEFLATE, CType.GZIP)) {
       val dir = tmpDir
       val sc = ScioContext()
       val (out, spec) = sc.parallelize(examples)
-          .saveAsTfExampleFile(
-            dir.getPath,
-            featureSpec,
-            compression = compressionType)
+        .saveAsTfExampleFile(
+          dir.getPath,
+          TFRecordSpec.fromCaseClass[TestFeatureSpec.TestFeatures](compressionType))
       sc.close().waitUntilDone()
       verifyTap(out.waitForResult(), examples.toSet)
-      verifyTap(spec.waitForResult(), Set("f1", "f2"))
+      verifyTap(spec.waitForResult(), Set(
+        s"""{"version":1,""" +
+          """"features":[["FloatList","f2"],["FloatList","f1"]],""" +
+          s""""compression":"$compressionType"}"""
+      ))
       FileUtils.deleteDirectory(dir)
     }
   }
@@ -88,35 +86,16 @@ class TFTapTest extends TapSpec {
       val (out, spec) = sc.parallelize(examples)
         .saveAsTfExampleFile(
           dir.getPath,
-          FeatureDesc.fromSCollection(featureSpec),
-          compression = compressionType)
+          TFRecordSpec.fromFeatran(featureSpec, compressionType))
       sc.close().waitUntilDone()
       verifyTap(out.waitForResult(), examples.toSet)
-      verifyTap(spec.waitForResult(), Set("f1", "f2"))
+      verifyTap(spec.waitForResult(), Set(
+        s"""{"version":1,""" +
+          """"features":[["FloatList","f1"],["FloatList","f2"]],""" +
+          s""""compression":"$compressionType"}"""
+      ))
       FileUtils.deleteDirectory(dir)
     }
-  }
-
-  it should "throw on multiple feature specifications" in {
-    val examples = getDummyExample
-    val dir = tmpDir
-    // using my own ScioContext cause error is thrown during the pipeline execution not, not DAG
-    // construction. Also don't want to specify expected in/out.
-    val sc = ScioContext()
-    // scalastyle:off no.whitespace.before.left.bracket
-    // scalastyle:off line.size.limit
-    the [PipelineExecutionException] thrownBy {
-      val featureSpec = sc.parallelize(Seq(Seq("f1", "f2"), Seq("f1", "f3")))
-      sc.parallelize(examples)
-        .saveAsTfExampleFile(
-          dir.getPath,
-          FeatureDesc.fromSCollection(featureSpec),
-          compression = Compression.UNCOMPRESSED)
-      sc.close()
-    } should have message s"java.lang.IllegalArgumentException: requirement failed: Feature description must contain a single element"
-    // scalastyle:on no.whitespace.before.left.bracket
-    // scalastyle:off line.size.limit
-    FileUtils.deleteDirectory(dir)
   }
 
 }


### PR DESCRIPTION
Dumps more metadata (along with the TFRecords) to simplify the reading API.
In addition to the feature names, we now dump:
* Each feature's type
* the compression type used
* this data is now stored in a versioned json file (instead of a flat file)
