### PR TITLE
add convenience methods to randomSpit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,6 @@ defaults: &defaults
     - run: ./scripts/circleci_test.sh
     - run: ./scripts/circleci_repl.sh
     - run:
-        name: Publishing SNAPSHOTs
-        command: |
-          if ( [ $CIRCLE_BRANCH = "master" ] && $(grep -q SNAPSHOT version.sbt) ); then
-            sbt ++$SCALA_VERSION publish
-          fi
-    - run:
         name: Packing sbt cache
         command: |
           find ~/.sbt -name "*.lock" -delete

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -437,6 +437,35 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   }
 
   /**
+   * Randomly splits this SCollection in two parts.
+   *
+   * @param weight weight for left hand side SCollection. Should be 0 < w < 1
+   * @return split SCollections in a Tuple2
+   * @group transform
+   */
+  def randomSplit(weight: Double): (SCollection[T], SCollection[T]) = {
+    require(weight > 0d && weight < 1d)
+    val splits = randomSplit(Array(weight, 1d - weight))
+    (splits(0), splits(1))
+  }
+
+  /**
+   * Randomly splits this SCollection in three parts.
+   * Note: 0 < weightA + weightB < 1
+   *
+   * @param weightA weight for first SCollection. Should be 0 < w < 1
+   * @param weightB weight for second SCollection. Should be 0 < w < 1
+   * @return split SCollections in a Tuple3
+   * @group transform
+   */
+  def randomSplit(weightA: Double, weightB: Double):
+  (SCollection[T], SCollection[T], SCollection[T]) = {
+    require(weightA > 0d && weightB > 0d && (weightA + weightB) < 1d)
+    val splits = randomSplit(Array(weightA, weightB, 1d - (weightA + weightB)))
+    (splits(0), splits(1), splits(2))
+  }
+
+  /**
    * Reduce the elements of this SCollection using the specified commutative and associative
    * binary operator.
    * @group transform

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -284,6 +284,14 @@ class SCollectionTest extends PipelineSpec {
       p2(0).count.map(round) should containSingleValue (200L)
       p2(1).count.map(round) should containSingleValue (300L)
       p2(2).count.map(round) should containSingleValue (500L)
+
+      val (pa, pb) = sc.parallelize(0 to 1000).randomSplit(0.3)
+      val (pc, pd, pe) = sc.parallelize(0 to 1000).randomSplit(0.2, 0.3)
+      pa.count.map(round) should containSingleValue (300L)
+      pb.count.map(round) should containSingleValue (700L)
+      pc.count.map(round) should containSingleValue (200L)
+      pd.count.map(round) should containSingleValue (300L)
+      pe.count.map(round) should containSingleValue (500L)
     }
   }
 


### PR DESCRIPTION
In ML it's very common to randomly split a dataset in 2 (or 3) chunks: train, (crossVal,) test. 

I'm not a big fan of the syntax (even if it's the way spark does it):
```scala
val splits = features.randomSplit(Array(.9, .1))
splits(0).saveAsTfExampleFile(args("output") + "/train", features)
splits(1).saveAsTfExampleFile(args("output") + "/test", features)
```
I'd rather have:
```scala
val (train, test) = features.randomSplit(.9)
train.saveAsTfExampleFile(args("output") + "/train", features)
test.saveAsTfExampleFile(args("output") + "/test", features)
```
Thoughts?