### PR TITLE
use Avro inputs when reading from BigQueryIO, fix #964

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -293,8 +293,8 @@ lazy val scioTest: Project = Project(
     "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion % "it",
     "org.apache.beam" % "beam-sdks-java-core" % beamVersion % "test" classifier "tests",
     "org.scalatest" %% "scalatest" % scalatestVersion,
-    "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
-    "org.slf4j" % "slf4j-simple" % slf4jVersion % "test,it",
+    "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test,it",
+    "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % scalacheckShapelessVersion % "test,it",
     // DataFlow testing requires junit and hamcrest
     "org.hamcrest" % "hamcrest-all" % hamcrestVersion,
     "com.spotify" % "annoy" % annoyVersion % "test",

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -255,6 +255,7 @@ private[types] object TypeProvider {
   private def converters(c: blackbox.Context)(name: c.TypeName): Seq[c.Tree] = {
     import c.universe._
     List(
+      q"override def fromAvro: (_root_.org.apache.avro.generic.GenericRecord => $name) = ${p(c, SType)}.fromAvro[$name]",
       q"override def fromTableRow: (${p(c, GModel)}.TableRow => $name) = ${p(c, SType)}.fromTableRow[$name]",
       q"override def toTableRow: ($name => ${p(c, GModel)}.TableRow) = ${p(c, SType)}.toTableRow[$name]")
   }

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
@@ -18,12 +18,12 @@
 package com.spotify.scio.bigquery.types
 
 import com.google.protobuf.ByteString
-import shapeless.datatype.record._
 import org.joda.time.{Instant, LocalDate, LocalDateTime, LocalTime}
-import org.scalacheck._
 import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck._
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import shapeless.datatype.record._
 
 class ConverterProviderSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
 
@@ -33,9 +33,9 @@ class ConverterProviderSpec extends PropSpec with GeneratorDrivenPropertyChecks 
 
   import Schemas._
 
-  implicit val arbInstant = Arbitrary(Gen.const(Instant.now()))
   implicit val arbByteArray = Arbitrary(Gen.alphaStr.map(_.getBytes))
   implicit val arbByteString = Arbitrary(Gen.alphaStr.map(ByteString.copyFromUtf8))
+  implicit val arbInstant = Arbitrary(Gen.const(Instant.now()))
   implicit val arbDate = Arbitrary(Gen.const(LocalDate.now()))
   implicit val arbTime = Arbitrary(Gen.const(LocalTime.now()))
   implicit val arbDatetime = Arbitrary(Gen.const(LocalDateTime.now()))
@@ -49,7 +49,6 @@ class ConverterProviderSpec extends PropSpec with GeneratorDrivenPropertyChecks 
       RecordMatcher[Required](r1, r2) shouldBe true
     }
   }
-
 
   property("round trip optional primitive types") {
     forAll { r1: Optional =>

--- a/scio-core/src/main/scala/com/spotify/scio/coders/JodaSerializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/JodaSerializer.scala
@@ -19,7 +19,7 @@ package com.spotify.scio.coders
 
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.{Kryo, Serializer}
-import org.joda.time.{LocalDate, LocalDateTime}
+import org.joda.time.{LocalDate, LocalDateTime, LocalTime}
 import org.joda.time.chrono.ISOChronology
 
 class JodaLocalDateTimeSerializer extends Serializer[LocalDateTime] {
@@ -51,6 +51,24 @@ class JodaLocalDateTimeSerializer extends Serializer[LocalDateTime] {
     new LocalDateTime(year, month, day, hour, minute, second, ms)
   }
 }
+
+class JodaLocalTimeSerializer extends Serializer[LocalTime] {
+  setImmutable(true)
+
+  def write(kryo: Kryo, output: Output, lt: LocalTime): Unit = {
+    output.writeInt(lt.getMillisOfDay, /*optimizePositive=*/ false)
+
+    val chronology = lt.getChronology
+    if (chronology != null && chronology != ISOChronology.getInstanceUTC) {
+      sys.error(s"Unsupported chronology: $chronology")
+    }
+  }
+
+  def read(kryo: Kryo, input: Input, tpe: Class[LocalTime]): LocalTime = {
+    LocalTime.fromMillisOfDay(input.readInt(/*optimizePositive=*/ false))
+  }
+}
+
 
 class JodaLocalDateSerializer extends Serializer[LocalDate] {
   setImmutable(true)

--- a/scio-core/src/main/scala/com/spotify/scio/coders/KryoAtomicCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/KryoAtomicCoder.scala
@@ -34,7 +34,7 @@ import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder
 import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver
 import org.apache.beam.sdk.util.{EmptyOnDeserializationThreadLocal, VarInt}
-import org.joda.time.{LocalDate, LocalDateTime}
+import org.joda.time.{LocalDate, LocalDateTime, LocalTime}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -104,8 +104,9 @@ private[scio] class KryoAtomicCoder[T](private val options: KryoOptions) extends
         k.forSubclass[GenericRecord](new GenericAvroSerializer)
         k.forSubclass[Message](new ProtobufSerializer)
 
-        k.forSubclass[LocalDateTime](new JodaLocalDateTimeSerializer)
         k.forSubclass[LocalDate](new JodaLocalDateSerializer)
+        k.forSubclass[LocalTime](new JodaLocalTimeSerializer)
+        k.forSubclass[LocalDateTime](new JodaLocalDateTimeSerializer)
 
         k.forClass(new KVSerializer)
         // TODO:

--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -143,7 +143,7 @@ case class ObjectFileIO[T](path: String) extends TestIO[T](path)
 
 case class AvroIO[T](path: String) extends TestIO[T](path)
 
-case class BigQueryIO(tableSpecOrQuery: String) extends TestIO[TableRow](tableSpecOrQuery)
+case class BigQueryIO[T](tableSpecOrQuery: String) extends TestIO[T](tableSpecOrQuery)
 
 case class DatastoreIO(projectId: String, query: Query = null, namespace: String = null)
   extends TestIO[Entity](projectId)

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/complete/game/HourlyTeamScoreTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/complete/game/HourlyTeamScoreTest.scala
@@ -17,6 +17,7 @@
 
 package com.spotify.scio.examples.complete.game
 
+import com.spotify.scio.bigquery.TableRow
 import com.spotify.scio.examples.complete.game.HourlyTeamScore.TeamScoreSums
 import com.spotify.scio.testing._
 
@@ -51,14 +52,13 @@ class HourlyTeamScoreTest extends PipelineSpec {
     TeamScoreSums("BananaEmu", 25, "2015-11-19 12:00:00.000"),
     TeamScoreSums("BisqueBilby", 14, "2015-11-19 09:00:00.000"),
     TeamScoreSums("MagentaKangaroo", 3, "2015-11-19 09:00:00.000"),
-    TeamScoreSums("MagentaKangaroo", 4, "2015-11-19 12:00:00.000")
-  ).map(TeamScoreSums.toTableRow)
+    TeamScoreSums("MagentaKangaroo", 4, "2015-11-19 12:00:00.000"))
 
   "HourlyTeamScore" should "work" in {
     JobTest[com.spotify.scio.examples.complete.game.HourlyTeamScore.type]
       .args("--input=in.txt", "--output=dataset.table")
       .input(TextIO("in.txt"), inData)
-      .output(BigQueryIO("dataset.table"))(_ should containInAnyOrder (expected))
+      .output(BigQueryIO[TeamScoreSums]("dataset.table"))(_ should containInAnyOrder (expected))
       .run()
   }
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/complete/game/UserScoreTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/complete/game/UserScoreTest.scala
@@ -45,14 +45,13 @@ class UserScoreTest extends PipelineSpec {
     UserScoreSums("user6_AmberNumbat", 11),
     UserScoreSums("user7_AlmondWallaby", 15),
     UserScoreSums("user7_AndroidGreenKookaburra", 23),
-    UserScoreSums("user19_BisqueBilby", 14)
-  ).map(UserScoreSums.toTableRow)
+    UserScoreSums("user19_BisqueBilby", 14))
 
   "UserScore" should "work" in {
     JobTest[com.spotify.scio.examples.complete.game.UserScore.type]
       .args("--input=in.txt", "--output=dataset.table")
       .input(TextIO("in.txt"), inData1)
-      .output(BigQueryIO("dataset.table"))(_ should containInAnyOrder (expected))
+      .output(BigQueryIO[UserScoreSums]("dataset.table"))(_ should containInAnyOrder (expected))
       .run()
   }
 
@@ -60,7 +59,7 @@ class UserScoreTest extends PipelineSpec {
     JobTest[com.spotify.scio.examples.complete.game.UserScore.type]
       .args("--input=in.txt", "--output=dataset.table")
       .input(TextIO("in.txt"), inData2)
-      .output(BigQueryIO("dataset.table"))(_ should beEmpty)
+      .output(BigQueryIO[UserScoreSums]("dataset.table"))(_ should beEmpty)
       .run()
   }
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/cookbook/BigQueryTornadoesTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/cookbook/BigQueryTornadoesTest.scala
@@ -38,7 +38,7 @@ class BigQueryTornadoesTest extends PipelineSpec {
     JobTest[com.spotify.scio.examples.cookbook.BigQueryTornadoes.type]
       .args("--input=publicdata:samples.gsod", "--output=dataset.table")
       .input(BigQueryIO("publicdata:samples.gsod"), inData)
-      .output(BigQueryIO("dataset.table"))(_ should containInAnyOrder (expected))
+      .output(BigQueryIO[TableRow]("dataset.table"))(_ should containInAnyOrder (expected))
       .run()
   }
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/cookbook/CombinePerKeyExamplesTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/cookbook/CombinePerKeyExamplesTest.scala
@@ -44,7 +44,7 @@ class CombinePerKeyExamplesTest extends PipelineSpec {
     JobTest[com.spotify.scio.examples.cookbook.CombinePerKeyExamples.type]
       .args("--output=dataset.table")
       .input(BigQueryIO(ExampleData.SHAKESPEARE_TABLE), input)
-      .output(BigQueryIO("dataset.table"))(_ should containInAnyOrder (expected))
+      .output(BigQueryIO[TableRow]("dataset.table"))(_ should containInAnyOrder (expected))
       .run()
   }
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/cookbook/FilterExamplesTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/cookbook/FilterExamplesTest.scala
@@ -41,7 +41,7 @@ class FilterExamplesTest extends PipelineSpec {
     JobTest[com.spotify.scio.examples.cookbook.FilterExamples.type]
       .args("--output=dataset.table")
       .input(BigQueryIO(ExampleData.WEATHER_SAMPLES_TABLE), input)
-      .output(BigQueryIO("dataset.table"))(_ should containInAnyOrder (expected))
+      .output(BigQueryIO[TableRow]("dataset.table"))(_ should containInAnyOrder (expected))
       .run()
   }
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/cookbook/MaxPerKeyExamplesTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/cookbook/MaxPerKeyExamplesTest.scala
@@ -33,7 +33,7 @@ class MaxPerKeyExamplesTest extends PipelineSpec {
     JobTest[com.spotify.scio.examples.cookbook.MaxPerKeyExamples.type]
       .args("--output=dataset.table")
       .input(BigQueryIO(ExampleData.WEATHER_SAMPLES_TABLE), input)
-      .output(BigQueryIO("dataset.table"))(_ should containInAnyOrder (expected))
+      .output(BigQueryIO[TableRow]("dataset.table"))(_ should containInAnyOrder (expected))
       .run()
   }
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TypedBigQueryTornadoesTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TypedBigQueryTornadoesTest.scala
@@ -29,16 +29,15 @@ class TypedBigQueryTornadoesTest extends PipelineSpec {
     Row(Some(false), 2),
     Row(Some(true), 3),
     Row(Some(true), 4),
-    Row(Some(true), 4)
-  ).map(Row.toTableRow)
+    Row(Some(true), 4))
 
-  val expected = Seq(Result(1, 1), Result(3, 1), Result(4, 2)).map(Result.toTableRow)
+  val expected = Seq(Result(1, 1), Result(3, 1), Result(4, 2))
 
   "TypedBigQueryTornadoes" should "work" in {
     JobTest[com.spotify.scio.examples.extra.TypedBigQueryTornadoes.type]
       .args("--output=dataset.table")
       .input(BigQueryIO(TypedBigQueryTornadoes.Row.query), inData)
-      .output(BigQueryIO("dataset.table"))(_ should containInAnyOrder (expected))
+      .output(BigQueryIO[Result]("dataset.table"))(_ should containInAnyOrder (expected))
       .run()
   }
 

--- a/scio-test/src/it/scala/com/spotify/scio/bigquery/TypedBigQueryIT.scala
+++ b/scio-test/src/it/scala/com/spotify/scio/bigquery/TypedBigQueryIT.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.bigquery
+
+import com.google.protobuf.ByteString
+import com.spotify.scio._
+import com.spotify.scio.testing._
+import org.apache.beam.sdk.options.PipelineOptionsFactory
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.{Instant, LocalDate, LocalDateTime, LocalTime}
+import org.scalacheck._
+import org.scalacheck.ScalacheckShapeless._
+import org.scalatest._
+
+import scala.util.Random
+
+object TypedBigQueryIT {
+  @BigQueryType.toTable
+  case class Record(bool: Boolean, int: Int, long: Long, float: Float, double: Double,
+                    string: String, byteString: ByteString,
+                    timestamp: Instant, date: LocalDate, time: LocalTime, datetime: LocalDateTime)
+
+  // Workaround for millis rounding error
+  val epochGen = Gen.chooseNum[Long](0L, 1000000000000L).map(x => x / 1000 * 1000)
+  implicit val arbByteString = Arbitrary(Gen.alphaStr.map(ByteString.copyFromUtf8))
+  implicit val arbInstant = Arbitrary(epochGen.map(new Instant(_)))
+  implicit val arbDate = Arbitrary(epochGen.map(new LocalDate(_)))
+  implicit val arbTime = Arbitrary(epochGen.map(new LocalTime(_)))
+  implicit val arbDatetime = Arbitrary(epochGen.map(new LocalDateTime(_)))
+
+  private val recordGen = {
+    implicitly[Arbitrary[Record]].arbitrary
+  }
+}
+
+class TypedBigQueryIT extends PipelineSpec with BeforeAndAfterAll {
+
+  import TypedBigQueryIT._
+
+  private val table = {
+    val TIME_FORMATTER = DateTimeFormat.forPattern("yyyyMMddHHmmss")
+    val now = Instant.now().toString(TIME_FORMATTER)
+    "data-integration-test:bigquery_avro_it.records_" + now + "_" + Random.nextInt(Int.MaxValue)
+  }
+  private val records = Gen.listOfN(1000, recordGen).sample.get
+
+  override protected def beforeAll(): Unit = {
+    val bq = BigQueryClient.defaultInstance()
+    bq.writeTypedRows[Record](table, records)
+  }
+
+  private val options = PipelineOptionsFactory
+    .fromArgs(
+      "--project=data-integration-test",
+      "--tempLocation=gs://data-integration-test-us/temp")
+    .create()
+
+  "TypedBigQuery" should "work" in {
+    val sc = ScioContext(options)
+    sc.typedBigQuery[Record](table) should containInAnyOrder (records)
+    sc.close()
+  }
+
+}

--- a/scio-test/src/test/scala/com/spotify/scio/coders/JodaSerializerTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/JodaSerializerTest.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.coders
 
-import org.joda.time.{LocalDate, LocalDateTime}
+import org.joda.time.{LocalDate, LocalDateTime, LocalTime}
 import org.scalacheck._
 import org.scalatest._
 import org.scalatest.prop.Checkers
@@ -49,6 +49,10 @@ class JodaSerializerTest extends FlatSpec with Checkers {
     } yield attempt
   }
 
+  implicit val localTimeArb = Arbitrary {
+    Arbitrary.arbitrary[LocalDateTime].map(_.toLocalTime)
+  }
+
   implicit val localDateArb = Arbitrary {
     Arbitrary.arbitrary[LocalDateTime].map(_.toLocalDate)
   }
@@ -61,6 +65,10 @@ class JodaSerializerTest extends FlatSpec with Checkers {
 
   "KryoAtomicCoder" should "roundtrip LocalDate" in {
     check(roundTripProp[LocalDate] _)
+  }
+
+  it should "roundtrip LocalTime" in {
+    check(roundTripProp[LocalTime] _)
   }
 
   it should "roundtrip LocalDateTime" in {

--- a/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
@@ -272,7 +272,7 @@ class JobTestTest extends PipelineSpec {
     JobTest[BigQueryJob.type]
       .args("--input=table.in", "--output=table.out")
       .input(BigQueryIO("table.in"), (1 to 3).map(newTableRow))
-      .output(BigQueryIO("table.out"))(_ should containInAnyOrder (xs))
+      .output(BigQueryIO[TableRow]("table.out"))(_ should containInAnyOrder (xs))
       .run()
   }
 


### PR DESCRIPTION
This is a breaking change and should probably go into 0.5.x

- `BigQueryIO` now requires a type param in `JobTest`. On the plus side, tests with `TableRow` vs macro are cleaner, no more `.map(MyType.toTableRow)` in test fixtures.
- Not sure about the `useAvro: Boolean = false` flag since it's a breaking change anyway. Should be on by default if we test thoroughly and maybe make a few pre-releases?