### PR TITLE
Add array field to avro records used for testing.

### DIFF
--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroInOutTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroInOutTest.scala
@@ -20,11 +20,14 @@ package com.spotify.scio.examples.extra
 import com.spotify.scio.avro.{Account, TestRecord}
 import com.spotify.scio.testing._
 
+import scala.collection.JavaConverters._
+
+
 class AvroInOutTest extends PipelineSpec {
 
   val input = Seq(
-    new TestRecord(1, 0L, 0F, 1000.0, false, "Alice"),
-    new TestRecord(2, 0L, 0F, 1500.0, false, "Bob"))
+    new TestRecord(1, 0L, 0F, 1000.0, false, "Alice", List[CharSequence]("a").asJava),
+    new TestRecord(2, 0L, 0F, 1500.0, false, "Bob", List[CharSequence]("b").asJava))
 
   val expected = Seq(
     new Account(1, "checking", "Alice", 1000.0),

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroTest.scala
@@ -73,7 +73,7 @@ class ParquetAvroTest extends TapSpec with BeforeAndAfterAll {
     data.map(_.getIntField.toInt) should containInAnyOrder (1 to 10)
     data.map(identity) should forAll[TestRecord] { r =>
       r.getLongField == null && r.getFloatField == null && r.getDoubleField == null &&
-        r.getBooleanField == null && r.getStringField == null
+        r.getBooleanField == null && r.getStringField == null && r.getArrayField.size() == 0
     }
     sc.close()
   }
@@ -94,7 +94,7 @@ class ParquetAvroTest extends TapSpec with BeforeAndAfterAll {
     data.map(_.getIntField.toInt) should containInAnyOrder (1 to 5)
     data.map(identity) should forAll[TestRecord] { r =>
       r.getLongField == null && r.getFloatField == null && r.getDoubleField == null &&
-        r.getBooleanField == null && r.getStringField == null
+        r.getBooleanField == null && r.getStringField == null && r.getArrayField.size() == 0
     }
     sc.close()
   }

--- a/scio-schemas/src/main/avro/schema.avsc
+++ b/scio-schemas/src/main/avro/schema.avsc
@@ -55,6 +55,7 @@
         {"name": "float_field", "type": ["null", "float"], "default": null},
         {"name": "double_field", "type": ["null", "double"], "default": null},
         {"name": "boolean_field", "type": ["null", "boolean"], "default": null},
-        {"name": "string_field", "type": ["null", "string"], "default": null}
+        {"name": "string_field", "type": ["null", "string"], "default": null},
+        {"name": "array_field", "type": {"type": "array", "items": "string"}, "default": null}
     ]
 }]

--- a/scio-schemas/src/main/scala/com/spotify/scio/avro/AvroUtils.scala
+++ b/scio-schemas/src/main/scala/com/spotify/scio/avro/AvroUtils.scala
@@ -30,6 +30,13 @@ object AvroUtils {
       Schema.createUnion(List(Schema.create(Schema.Type.NULL), Schema.create(tpe)).asJava),
       null: String, null: AnyRef)
 
+  private def fArr(name: String, tpe: Schema.Type) = {
+    new Schema.Field(
+      name,
+      Schema.createArray(Schema.create(tpe)),
+      null: String, null: AnyRef)
+  }
+
   val schema = Schema.createRecord("GenericTestRecord", null, null, false)
   schema.setFields(List(
     f("int_field", Schema.Type.INT),
@@ -37,7 +44,8 @@ object AvroUtils {
     f("float_field", Schema.Type.FLOAT),
     f("double_field", Schema.Type.DOUBLE),
     f("boolean_field", Schema.Type.BOOLEAN),
-    f("string_field", Schema.Type.STRING)
+    f("string_field", Schema.Type.STRING),
+    fArr("array_field", Schema.Type.STRING)
   ).asJava)
 
   def newGenericRecord(i: Int): GenericRecord = {
@@ -48,10 +56,12 @@ object AvroUtils {
     r.put("double_field", 1.0 * i)
     r.put("boolean_field", true)
     r.put("string_field", "hello")
+    r.put("array_field", List[CharSequence]("a", "b", "c").asJava)
     r
   }
 
   def newSpecificRecord(i: Int): TestRecord =
-    new TestRecord(i, i.toLong, i.toFloat, i.toDouble, true, "hello")
+    new TestRecord(i, i.toLong, i.toFloat, i.toDouble, true, "hello",
+      List[CharSequence]("a", "b", "c").asJava)
 
 }

--- a/scio-test/src/test/scala/com/spotify/scio/RichCoderRegistryTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/RichCoderRegistryTest.scala
@@ -19,7 +19,7 @@ package com.spotify.scio
 
 import com.google.protobuf.Timestamp
 import com.spotify.scio.avro.AvroUtils._
-import com.spotify.scio.avro.{Account, TestRecord}
+import com.spotify.scio.avro.Account
 import com.spotify.scio.coders.CoderTestUtils._
 import com.spotify.scio.testing.PipelineSpec
 import org.apache.beam.sdk.coders.CoderRegistry
@@ -75,7 +75,7 @@ class RichCoderRegistryTest extends PipelineSpec {
   }
 
   it should "support Avro SpecificRecord" in {
-    val r = new TestRecord(1, 1L, 1F, 1.0, true, "hello")
+    val r = newSpecificRecord(1)
     registry should roundTrip (r)
     registry should roundTrip (("key", r))
     registry should roundTrip (CaseClassWithSpecificRecord("record", 10, r))

--- a/scio-test/src/test/scala/com/spotify/scio/coders/KryoAtomicCoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/KryoAtomicCoderTest.scala
@@ -23,13 +23,12 @@ import com.google.api.services.bigquery.model.TableRow
 import com.google.common.collect.ImmutableList
 import com.spotify.scio.ScioContext
 import com.spotify.scio.avro.AvroUtils._
-import com.spotify.scio.avro.TestRecord
 import com.spotify.scio.coders.CoderTestUtils._
 import com.spotify.scio.testing.PipelineSpec
 import com.twitter.chill._
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException
 import org.apache.beam.sdk.coders.Coder
-import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
+import org.apache.beam.sdk.options.PipelineOptionsFactory
 import org.apache.beam.sdk.util.CoderUtils
 import org.apache.beam.sdk.values.KV
 import org.joda.time.Instant
@@ -89,7 +88,7 @@ class KryoAtomicCoderTest extends PipelineSpec {
   }
 
   it should "support Avro SpecificRecord" in {
-    val r = new TestRecord(1, 1L, 1F, 1.0, true, "hello")
+    val r = newSpecificRecord(1)
     cf should roundTrip (r)
     cf should roundTrip (("key", r))
     cf should roundTrip (CaseClassWithSpecificRecord("record", 10, r))


### PR DESCRIPTION
This also (seemingly) confirms that https://github.com/spotify/scio/issues/915 is a no-op, since these records successfully round-trip in existing tests.
  