### PR TITLE
[WIP] Refactor TextIO with ScioIO

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
@@ -31,7 +31,7 @@ import scala.concurrent.Future
  */
 trait ScioIO[T] {
 
-// abstract types for read/write params.
+  // abstract types for read/write params.
   type ReadP
   type WriteP
 

--- a/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
@@ -18,18 +18,24 @@
 package com.spotify.scio.nio
 
 import com.spotify.scio.ScioContext
+import com.spotify.scio.io.Tap
 import com.spotify.scio.values.SCollection
+
+import scala.concurrent.Future
 
 /**
  * Base trait for all Read Write IO classes, every IO connector must implement this.
- * This trait has two abstract implicit methods #read, #write that need be implement
- * in every subtype. Look at the [[com.spotify.scio.nio.TextIO]] sub class as reference
+ * This trait has two abstract implicit methods #read, #write that need be implemented
+ * in every subtype. Look at the [[com.spotify.scio.nio.TextIO]] subclass as reference
  * implementation.
  */
 trait ScioIO[T] {
 
-  implicit def read(context: ScioContext): Any
+// abstract types for read/write params.
+  type ReadP
+  type WriteP
 
-  implicit def write(collection: SCollection[T]): Any
+  def read(sc: ScioContext, params: ReadP): SCollection[T]
 
+  def write(data: SCollection[T], params: WriteP): Future[Tap[T]]
 }

--- a/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.nio
+
+import com.spotify.scio.ScioContext
+import com.spotify.scio.values.SCollection
+
+/**
+ * Base trait for all Read Write IO classes, every IO connector must implement this.
+ * This trait has two abstract implicit methods #read, #write that need be implement
+ * in every subtype. Look at the [[com.spotify.scio.nio.TextIO]] sub class as reference
+ * implementation.
+ */
+trait ScioIO[T] {
+
+  implicit def read(context: ScioContext): Any
+
+  implicit def write(collection: SCollection[T]): Any
+
+}

--- a/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
@@ -1,104 +1,61 @@
-/*
- * Copyright 2016 Spotify AB.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package com.spotify.scio.nio
 
 import com.spotify.scio.ScioContext
 import com.spotify.scio.io.{FileStorage, Tap}
-import com.spotify.scio.testing.TestIO
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
-import org.apache.beam.sdk.io.{Compression, FileBasedSink}
-import org.apache.beam.sdk.{io => bio}
+import org.apache.beam.sdk.io.{Compression, FileBasedSink, TextIO => BTextIO}
 
 import scala.concurrent.Future
-import scala.language.implicitConversions
 
-case class TextIO(path: String) extends TestIO[String](path) with Tap[String] {
+case class TextIO(name: String, path: String) extends ScioIO[String] with Tap[String] {
+
+  case class ReadParams(compression: Compression = Compression.AUTO)
+
+  case class WriteParams(suffix: String = ".txt",
+                         numShards: Int = 0,
+                         compression: Compression = Compression.UNCOMPRESSED)
+
+  type ReadP = ReadParams
+  type WriteP = WriteParams
+
+  def read(sc: ScioContext, params: ReadParams): SCollection[String] = sc.requireNotClosed {
+    if(sc.isTest) {
+      // TODO: support test
+      throw new UnsupportedOperationException("TextIO test is not yet supported")
+    } else {
+      sc.wrap(sc.applyInternal(BTextIO.read().from(path)
+        .withCompression(params.compression))).setName(name)
+    }
+  }
+
+  def write(pipeline: SCollection[String], params: WriteParams): Future[Tap[String]] = {
+    if (pipeline.context.isTest) {
+      // TODO: support test
+      throw new UnsupportedOperationException("TextIO test is not yet supported")
+    } else {
+      pipeline.applyInternal(textOut(path, params))
+      pipeline.context.makeFuture(TextIO(name, ScioUtil.addPartSuffix(path)))
+    }
+  }
 
   /** Read data set into memory. */
   def value: Iterator[String] = FileStorage(path).textFile
 
   /** Open data set as an [[com.spotify.scio.values.SCollection SCollection]]. */
-  def open(sc: ScioContext): SCollection[String] = sc.textFile(path)
-}
+  def open(sc: ScioContext): SCollection[String] = read(sc, ReadParams())
 
-object TextIO extends ScioIO[String] {
-  /** Implicitly convert ScioContext to have all TextIO read helper functions. */
-  implicit def read(sc: ScioContext): TextScioContext = new TextScioContext(sc)
-
-  /**
-   * Implicitly convert [[com.spotify.scio.values.SCollection SCollection[String]]] to
-   * have all TextIO write helper functions
-   */
-  implicit def write(scol: SCollection[String]): TextSCollection = new TextSCollection(scol)
+  private[scio] def textOut(path: String,
+                            params: WriteParams) = {
+    BTextIO.write()
+      .to(pathWithShards(path))
+      .withSuffix(params.suffix)
+      .withNumShards(params.numShards)
+      .withWritableByteChannelFactory(
+        FileBasedSink.CompressionType.fromCanonical(params.compression))
+  }
 
   private[scio] def pathWithShards(path: String) = path.replaceAll("\\/+$", "") + "/part"
 
-  class TextScioContext(@transient val self: ScioContext) extends Serializable {
-
-    /**
-     * Get an SCollection for a text file.
-     *
-     * @group input
-     */
-    def textFile(path: String,
-                 compression: Compression = Compression.AUTO)
-    : SCollection[String] = self.requireNotClosed {
-      if (self.isTest) {
-        self.getTestInput(TextIO(path))
-      } else {
-        self.wrap(self.applyInternal(bio.TextIO.read().from(path)
-          .withCompression(compression))).setName(path)
-      }
-    }
-  }
-
-  class TextSCollection(@transient val self: SCollection[String]) extends Serializable {
-
-    /**
-     * Save this SCollection as a text file. Note that elements must be of type `String`.
-     *
-     * @group output
-     */
-    def saveAsTextFile(path: String,
-                       suffix: String = ".txt",
-                       numShards: Int = 0,
-                       compression: Compression = Compression.UNCOMPRESSED)
-    : Future[Tap[String]] = {
-      if (self.context.isTest) {
-        self.context.testOut(TextIO(path))(self)
-        self.saveAsInMemoryTap
-      } else {
-        self.applyInternal(textOut(path, suffix, numShards, compression))
-        self.context.makeFuture(TextIO(ScioUtil.addPartSuffix(path)))
-      }
-    }
-
-    private[scio] def textOut(path: String,
-                              suffix: String,
-                              numShards: Int,
-                              compression: Compression) = {
-      bio.TextIO.write()
-        .to(pathWithShards(path))
-        .withSuffix(suffix)
-        .withNumShards(numShards)
-        .withWritableByteChannelFactory(FileBasedSink.CompressionType.fromCanonical(compression))
-    }
-  }
-
 }
+

--- a/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.scio.nio
 
 import com.spotify.scio.ScioContext

--- a/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.nio
+
+import com.spotify.scio.ScioContext
+import com.spotify.scio.io.{FileStorage, Tap}
+import com.spotify.scio.testing.TestIO
+import com.spotify.scio.util.ScioUtil
+import com.spotify.scio.values.SCollection
+import org.apache.beam.sdk.io.{Compression, FileBasedSink}
+import org.apache.beam.sdk.{io => bio}
+
+import scala.concurrent.Future
+import scala.language.implicitConversions
+
+case class TextIO(path: String) extends TestIO[String](path) with Tap[String] {
+
+  /** Read data set into memory. */
+  def value: Iterator[String] = FileStorage(path).textFile
+
+  /** Open data set as an [[com.spotify.scio.values.SCollection SCollection]]. */
+  def open(sc: ScioContext): SCollection[String] = sc.textFile(path)
+}
+
+object TextIO extends ScioIO[String] {
+  /** Implicitly convert ScioContext to have all TextIO read helper functions. */
+  implicit def read(sc: ScioContext): TextScioContext = new TextScioContext(sc)
+
+  /**
+   * Implicitly convert [[com.spotify.scio.values.SCollection SCollection[String]]] to
+   * have all TextIO write helper functions
+   */
+  implicit def write(scol: SCollection[String]): TextSCollection = new TextSCollection(scol)
+
+  private[scio] def pathWithShards(path: String) = path.replaceAll("\\/+$", "") + "/part"
+
+  class TextScioContext(@transient val self: ScioContext) extends Serializable {
+
+    /**
+     * Get an SCollection for a text file.
+     *
+     * @group input
+     */
+    def textFile(path: String,
+                 compression: Compression = Compression.AUTO)
+    : SCollection[String] = self.requireNotClosed {
+      if (self.isTest) {
+        self.getTestInput(TextIO(path))
+      } else {
+        self.wrap(self.applyInternal(bio.TextIO.read().from(path)
+          .withCompression(compression))).setName(path)
+      }
+    }
+  }
+
+  class TextSCollection(@transient val self: SCollection[String]) extends Serializable {
+
+    /**
+     * Save this SCollection as a text file. Note that elements must be of type `String`.
+     *
+     * @group output
+     */
+    def saveAsTextFile(path: String,
+                       suffix: String = ".txt",
+                       numShards: Int = 0,
+                       compression: Compression = Compression.UNCOMPRESSED)
+    : Future[Tap[String]] = {
+      if (self.context.isTest) {
+        self.context.testOut(TextIO(path))(self)
+        self.saveAsInMemoryTap
+      } else {
+        self.applyInternal(textOut(path, suffix, numShards, compression))
+        self.context.makeFuture(TextIO(ScioUtil.addPartSuffix(path)))
+      }
+    }
+
+    private[scio] def textOut(path: String,
+                              suffix: String,
+                              numShards: Int,
+                              compression: Compression) = {
+      bio.TextIO.write()
+        .to(pathWithShards(path))
+        .withSuffix(suffix)
+        .withNumShards(numShards)
+        .withWritableByteChannelFactory(FileBasedSink.CompressionType.fromCanonical(compression))
+    }
+  }
+
+}

--- a/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
@@ -25,7 +25,7 @@ import org.apache.beam.sdk.io.{Compression, FileBasedSink, TextIO => BTextIO}
 
 import scala.concurrent.Future
 
-case class TextIO(name: String, path: String) extends ScioIO[String] with Tap[String] {
+case class TextIO(path: String) extends ScioIO[String] with Tap[String] {
 
   case class ReadParams(compression: Compression = Compression.AUTO)
 
@@ -37,12 +37,12 @@ case class TextIO(name: String, path: String) extends ScioIO[String] with Tap[St
   type WriteP = WriteParams
 
   def read(sc: ScioContext, params: ReadParams): SCollection[String] = sc.requireNotClosed {
-    if(sc.isTest) {
+    if (sc.isTest) {
       // TODO: support test
       throw new UnsupportedOperationException("TextIO test is not yet supported")
     } else {
       sc.wrap(sc.applyInternal(BTextIO.read().from(path)
-        .withCompression(params.compression))).setName(name)
+        .withCompression(params.compression))).setName(path)
     }
   }
 
@@ -52,7 +52,7 @@ case class TextIO(name: String, path: String) extends ScioIO[String] with Tap[St
       throw new UnsupportedOperationException("TextIO test is not yet supported")
     } else {
       pipeline.applyInternal(textOut(path, params))
-      pipeline.context.makeFuture(TextIO(name, ScioUtil.addPartSuffix(path)))
+      pipeline.context.makeFuture(TextIO(ScioUtil.addPartSuffix(path)))
     }
   }
 


### PR DESCRIPTION
Introduce new IO base class `ScioIO[T]` and Implement TextIO. 

~All code related to TextIO from `ScioContext`, `SCollection`, `Tap` and `TestDataManager`  has been moved to new `TextIO[String]` class.~ This didn't add new api to `JobTest`, for now `TextIO[String]` is implement `TestIO[String]`, in next steps we can fix it.

This implementation is a bit different than what @nevillelyh suggested in the issue https://github.com/spotify/scio/issues/575 , thought to get some feedback ~while I am trying to fix the text failures/compilation issues.~

~TODO: There are few test compilations and failures that need to be fixed.~

PS: Update PR to have just nio package with `ScioIO[T]` and `TextIO` and revert all other changes.