### PR TITLE
Update JobTest to support new io implementations.

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -422,11 +422,15 @@ class ScioContext private[scio] (val options: PipelineOptions,
 
   private[scio] def testIn: TestInput = TestDataManager.getInput(testId.get)
   private[scio] def testOut: TestOutput = TestDataManager.getOutput(testId.get)
+  private[scio] def testInNio: TestInputNio = TestDataManager.getInputNio(testId.get)
+  private[scio] def testOutNio: TestOutputNio = TestDataManager.getOutputNio(testId.get)
   private[scio] def testDistCache: TestDistCache = TestDataManager.getDistCache(testId.get)
 
   private[scio] def getTestInput[T: ClassTag](key: TestIO[T]): SCollection[T] =
     this.parallelize(testIn(key).asInstanceOf[Seq[T]])
 
+  private[scio] def getTestInputNio[T: ClassTag](key: ScioIO[T]): SCollection[T] =
+    this.parallelize(testInNio(key).asInstanceOf[Seq[T]])
   // =======================================================================
   // Read operations
   // =======================================================================
@@ -808,10 +812,9 @@ class ScioContext private[scio] (val options: PipelineOptions,
    * @param io     an implementation of `ScioIO[T]` trait
    * @param params configurations need to pass to perform underline read implementation
    */
-  def read[T](io: ScioIO[T])(params: io.ReadP): SCollection[T] = requireNotClosed {
+  def read[T: ClassTag](io: ScioIO[T])(params: io.ReadP): SCollection[T] = requireNotClosed {
     if (this.isTest) {
-      // TODO: support test with nio
-      throw new UnsupportedOperationException("Test on nio is not supported yet")
+      this.getTestInputNio(io)
     } else {
       io.read(this, params)
     }

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1285,8 +1285,8 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    */
   def write(io: ScioIO[T])(params: io.WriteP): Future[Tap[T]] = {
     if (context.isTest) {
-      // TODO: support test with nio
-      throw new UnsupportedOperationException("Test on nio is not supported yet")
+      context.testOutNio(io)
+      this.saveAsInMemoryTap
     } else {
       io.write(this, params)
     }

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/nio/WordCountNio.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/nio/WordCountNio.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Example: Word Count Example with Metrics and nio read/write
+// Usage:
+
+// `sbt runMain "com.spotify.scio.examples.nio.WordCountNio
+// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --input=gs://apache-beam-samples/shakespeare/kinglear.txt
+// --output=gs://[BUCKET]/[PATH]/wordcount"`
+package com.spotify.scio.examples.nio
+
+import com.spotify.scio._
+import com.spotify.scio.examples.common.ExampleData
+import com.spotify.scio.nio.TextIO
+import org.slf4j.LoggerFactory
+
+object WordCountNio {
+
+  // Logger is an object instance, i.e. statically initialized and thus can be used safely in an
+  // anonymous function without serialization issue
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  def main(cmdlineArgs: Array[String]): Unit = {
+    // Create `ScioContext` and `Args`
+    val (sc, args) = ContextAndArgs(cmdlineArgs)
+
+    // Parse input and output path from command line arguments
+    val input = args.getOrElse("input", ExampleData.KING_LEAR)
+    val output = args("output")
+
+    // Create a distribution and two counter metrics. `Distribution` tracks min, max, sum, min,
+    // etc. and `Counter` tracks count.
+    val lineDist = ScioMetrics.distribution("lineLength")
+    val sumNonEmpty = ScioMetrics.counter("nonEmptyLines")
+    val sumEmpty = ScioMetrics.counter("emptyLines")
+
+    // Create IO classes to read and write
+    val inputTextIO = TextIO(input)
+    val outputTextIO = TextIO(output)
+
+    // Open text files as an `SCollection[String]` passing io read params
+    sc.read(inputTextIO)(inputTextIO.ReadParams())
+      .map { w =>
+        // Trim input lines, update distribution metric
+        val trimmed = w.trim
+        lineDist.update(trimmed.length)
+        trimmed
+      }
+      .filter { w =>
+        // Filter out empty lines, update counter metrics
+        val r = w.nonEmpty
+        if (r) sumNonEmpty.inc() else sumEmpty.inc()
+        r
+      }
+      // Split input lines, filter out empty tokens and expand into a collection of tokens
+      .flatMap(_.split("[^a-zA-Z']+").filter(_.nonEmpty))
+      // Count occurrences of each unique `String` to get `(String, Long)`
+      .countByValue
+      // Map `(String, Long)` tuples into final "word: count" strings
+      .map { case (word, count) => word + ": " + count }
+      // Save result as text files under the output path by passing write params
+      .write(outputTextIO)(outputTextIO.WriteParams())
+
+    // Close the context, execute the pipeline and block until it finishes
+    val result = sc.close().waitUntilFinish()
+
+    // Retrieve metric values
+    logger.info("Max: " + result.distribution(lineDist).committed.map(_.max()))
+    logger.info("Min: " + result.distribution(lineDist).committed.map(_.min()))
+    logger.info("Sum non-empty: " + result.counter(sumNonEmpty).committed)
+    logger.info("Sum empty: " + result.counter(sumEmpty).committed)
+  }
+}

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/nio/WordCountNioTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/nio/WordCountNioTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.examples.nio
+
+import com.spotify.scio.nio.{TextIO => NTextIO}
+import com.spotify.scio.testing._
+
+class WordCountNioTest extends PipelineSpec {
+
+  val inData = Seq("a b c d e", "a b a b", "")
+  val expected = Seq("a: 3", "b: 3", "c: 1", "d: 1", "e: 1")
+
+  "WordCount" should "works with nio JobTest inputs" in {
+    JobTest[com.spotify.scio.examples.nio.WordCountNio.type]
+      .args("--input=in.txt", "--output=out.txt")
+      .inputNio(NTextIO("in.txt"), inData)
+      .outputNio(NTextIO("out.txt"))(_ should containInAnyOrder (expected))
+      .run()
+  }
+}

--- a/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
@@ -20,6 +20,7 @@ package com.spotify.scio.testing
 import java.lang.reflect.InvocationTargetException
 
 import com.spotify.scio.ScioResult
+import com.spotify.scio.nio.ScioIO
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
 import org.apache.beam.sdk.{metrics => bm}
@@ -68,15 +69,17 @@ import scala.util.control.NonFatal
 object JobTest {
 
   private case class BuilderState(className: String,
-                                  cmdlineArgs: Array[String],
-                                  inputs: Map[TestIO[_], Iterable[_]],
-                                  outputs: Map[TestIO[_], SCollection[_] => Unit],
-                                  distCaches: Map[DistCacheIO[_], _],
-                                  counters: Map[bm.Counter, Long => Unit],
+                                  cmdlineArgs: Array[String] = Array(),
+                                  inputs: Map[TestIO[_], Iterable[_]] = Map.empty,
+                                  outputs: Map[TestIO[_], SCollection[_] => Unit] = Map.empty,
+                                  inputNio: Map[ScioIO[_], Iterable[_]] = Map.empty,
+                                  outputNio: Map[ScioIO[_], SCollection[_] => Unit] = Map.empty,
+                                  distCaches: Map[DistCacheIO[_], _] = Map.empty,
+                                  counters: Map[bm.Counter, Long => Unit] = Map.empty,
                                   // scalastyle:off line.size.limit
-                                  distributions: Map[bm.Distribution, bm.DistributionResult => Unit],
+                                  distributions: Map[bm.Distribution, bm.DistributionResult => Unit] = Map.empty,
                                   // scalastyle:on line.size.limit
-                                  gauges: Map[bm.Gauge, bm.GaugeResult => Unit],
+                                  gauges: Map[bm.Gauge, bm.GaugeResult => Unit] = Map.empty,
                                   wasRunInvoked: Boolean = false)
 
   class Builder(private var state: BuilderState) {
@@ -115,6 +118,37 @@ object JobTest {
       require(!state.outputs.contains(key), "Duplicate test output: " + key)
       state = state
         .copy(outputs = state.outputs + (key -> assertion.asInstanceOf[SCollection[_] => Unit]))
+      this
+    }
+
+    /**
+     * Feed an input to the pipeline being tested, Note that `ScioIO[T]` must match the one used
+     * inside the pipeline. e.g.
+     * TODO: add an example once we have complete nio integration with ScioContext
+     * @param nio an implementation of `ScioIO[T]`.
+     * @param value iterable to return when this input nio is called
+     * @return
+     */
+    def inputNio[T](nio: ScioIO[T], value: Iterable[T]): Builder = {
+      require(!state.inputNio.contains(nio), s"Duplicate nio test input: $nio")
+      state = state.copy(inputNio = state.inputNio + (nio -> value))
+      this
+    }
+
+    /**
+     * Evaluate and outptu of the pipeline being tested. Note that `ScioIO[T]` must match the one
+     * used inside the pipeline, e.g
+     * TODO: add and example once we have complete nio integration with SCollection
+     * @param nio an implementation of `ScioIO[T]`.
+     * @param assertion assertion for output data. See [[SCollectionMatchers]] for available
+     *                  matchers on an [[com.spotify.scio.values.SCollection SCollection]].
+     * @tparam T
+     * @return
+     */
+    def outputNio[T](nio: ScioIO[T])(assertion: SCollection[T] => Unit): Builder = {
+      require(!state.outputNio.contains(nio), s"Duplicate nio test output $nio")
+      state = state
+        .copy(outputNio = state.outputNio + (nio -> assertion.asInstanceOf[SCollection[_] => Unit]))
       this
     }
 
@@ -185,8 +219,8 @@ object JobTest {
      * Set up test wiring. Use this only if you have custom pipeline wiring and are bypassing
      * [[run]]. Make sure [[tearDown]] is called afterwards.
      */
-    def setUp(): Unit =
-      TestDataManager.setup(testId, state.inputs, state.outputs, state.distCaches)
+    def setUp(): Unit = TestDataManager.setup(testId,
+      state.inputs, state.outputs, state.inputNio, state.outputNio, state.distCaches)
 
     /**
      * Tear down test wiring. Use this only if you have custom pipeline wiring and are bypassing
@@ -230,14 +264,12 @@ object JobTest {
 
   /** Create a new JobTest.Builder instance. */
   def apply(className: String): Builder =
-    new Builder(BuilderState(
-      className, Array(), Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty))
+    new Builder(BuilderState(className))
 
   /** Create a new JobTest.Builder instance. */
   def apply[T: ClassTag]: Builder = {
     val className= ScioUtil.classOf[T].getName.replaceAll("\\$$", "")
-    new Builder(BuilderState(
-      className, Array(), Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty))
+    apply(className)
   }
 
 }

--- a/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -22,6 +22,7 @@ import java.nio.file.Files
 
 import com.google.common.collect.Lists
 import com.spotify.scio.metrics.Metrics
+import com.spotify.scio.nio.TextIO
 import com.spotify.scio.options.ScioOptions
 import com.spotify.scio.testing.{PipelineSpec, TestValidationOptions}
 import com.spotify.scio.util.ScioUtil
@@ -91,6 +92,20 @@ class ScioContextTest extends PipelineSpec {
 
     val sc = ScioContext()
     sc.parallelize(Seq("a", "b", "c")).saveAsTextFile(output.toString)
+    output.exists() shouldBe false
+
+    sc.close()
+    output.exists() shouldBe true
+    output.delete()
+  }
+
+  it should "[nio] create local output directory on close()" in {
+    val output = Files.createTempDirectory("scio-output-").toFile
+    output.delete()
+
+    val sc = ScioContext()
+    val textIO = TextIO(output.getAbsolutePath)
+    sc.parallelize(Seq("a", "b", "c")).write(textIO)(textIO.WriteParams())
     output.exists() shouldBe false
 
     sc.close()


### PR DESCRIPTION

- [x] Update `JobTest` and `TestDataManager` classes to support nio implemenations. 
- [x] Update `ScioContext` and `SCollection` to invoke nio test inputs/outputs 
- [x] Add a new word count example to use new `TextIO`
- [x] Write a `JobTest` to test new word count example.
