### PR TITLE
ScioIO mixin with Tap, moved FileStorage code to TextIO object

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
@@ -29,7 +29,7 @@ import scala.concurrent.Future
  * in every subtype. Look at the [[com.spotify.scio.nio.TextIO]] subclass as reference
  * implementation.
  */
-trait ScioIO[T] {
+trait ScioIO[T] extends Tap[T] {
 
   // abstract types for read/write params.
   type ReadP

--- a/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
@@ -29,7 +29,7 @@ import scala.concurrent.Future
  * in every subtype. Look at the [[com.spotify.scio.nio.TextIO]] subclass as reference
  * implementation.
  */
-trait ScioIO[T] extends Tap[T] {
+trait ScioIO[T] {
 
   // abstract types for read/write params.
   type ReadP
@@ -38,4 +38,7 @@ trait ScioIO[T] extends Tap[T] {
   def read(sc: ScioContext, params: ReadP): SCollection[T]
 
   def write(data: SCollection[T], params: WriteP): Future[Tap[T]]
+
+  def tap(read: ReadP): Tap[T]
+
 }

--- a/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
@@ -17,15 +17,25 @@
 
 package com.spotify.scio.nio
 
+import java.io.{BufferedInputStream, InputStream, SequenceInputStream}
+import java.nio.channels.Channels
+import java.util.Collections
+
+import com.google.api.client.util.Charsets
 import com.spotify.scio.ScioContext
-import com.spotify.scio.io.{FileStorage, InMemorySink, InMemoryTap, Tap}
+import com.spotify.scio.io.Tap
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
-import org.apache.beam.sdk.io.{Compression, FileBasedSink, TextIO => BTextIO}
+import org.apache.beam.sdk.io.fs.MatchResult.Metadata
+import org.apache.beam.sdk.io.{Compression, FileBasedSink, FileSystems, TextIO => BTextIO}
+import org.apache.commons.compress.compressors.CompressorStreamFactory
+import org.apache.commons.io.IOUtils
 
+import scala.collection.JavaConverters._
 import scala.concurrent.Future
+import scala.util.Try
 
-case class TextIO(path: String) extends ScioIO[String] with Tap[String] {
+case class TextIO(path: String) extends ScioIO[String] {
 
   case class ReadParams(compression: Compression = Compression.AUTO)
 
@@ -57,7 +67,7 @@ case class TextIO(path: String) extends ScioIO[String] with Tap[String] {
   }
 
   /** Read data set into memory. */
-  def value: Iterator[String] = FileStorage(path).textFile
+  def value: Iterator[String] = TextIO.textFile(path)
 
   /** Open data set as an [[com.spotify.scio.values.SCollection SCollection]]. */
   def open(sc: ScioContext): SCollection[String] = read(sc, ReadParams())
@@ -74,5 +84,33 @@ case class TextIO(path: String) extends ScioIO[String] with Tap[String] {
 
   private[scio] def pathWithShards(path: String) = path.replaceAll("\\/+$", "") + "/part"
 
+}
+
+object TextIO {
+
+  /** Read all files in the path line by line and return it as `Iterator[String]` */
+  def textFile(path: String): Iterator[String] = {
+    val factory = new CompressorStreamFactory()
+
+    def wrapInputStream(in: InputStream) = {
+      val buffered = new BufferedInputStream(in)
+      Try(factory.createCompressorInputStream(buffered)).getOrElse(buffered)
+    }
+
+    val input = getDirectoryInputStream(path, wrapInputStream)
+    IOUtils.lineIterator(input, Charsets.UTF_8).asScala
+  }
+
+  private[scio] def getDirectoryInputStream(path: String,
+                                            wrapperFn: InputStream => InputStream = identity)
+  : InputStream = {
+    val inputs = listFiles(path).map(getObjectInputStream).map(wrapperFn).asJava
+    new SequenceInputStream(Collections.enumeration(inputs))
+  }
+
+  private def listFiles(path: String): Seq[Metadata] = FileSystems.`match`(path).metadata().asScala
+
+  private def getObjectInputStream(meta: Metadata): InputStream =
+    Channels.newInputStream(FileSystems.open(meta.resourceId()))
 }
 


### PR DESCRIPTION
Refactor: Copy all TextIO related code from FileStorage to TextIO companion object.
Make ~`ScioIO[T]` extends  `Tap[T]`~ and `TextIO` extends `ScioIO[T]` 

PS: add a new abstract method `def tap(read: ReadP): Tap[T]` to `ScioIO[T]`  instead of mixin `Tap[T]` with `ScioIO[T]`. 

Note: Here we need to pass `ReadP` to `tap` because `Tap.open` only take `ScioContext`
