### PR TITLE
Fix typo on cannot find Beam version

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
@@ -46,7 +46,7 @@ private[scio] object VersionUtil {
       .filter(_.startsWith("val beamVersion = ")).next()
     """val beamVersion = "([^"]+)"""".r.findFirstMatchIn(line) match {
       case Some(m) => m.group(1)
-      case None => throw new IllegalStateException("Cannot find Scio version")
+      case None => throw new IllegalStateException("Cannot find Beam version")
     }
   }
 


### PR DESCRIPTION
Also, can you clarify what is the expected behavior when `val beamVersion = ` is not present? Would all this exceptions turn into warnings?

PTAL @nevillelyh 