### PR TITLE
Add BigTable-specific SCollectionMatchers to scio-test

### DIFF
--- a/scio-test/src/main/scala/com/spotify/scio/testing/BigTableMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/BigTableMatchers.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.testing
+
+import java.lang.{Iterable => JIterable}
+import java.util.{Map => JMap}
+
+import com.google.bigtable.v2.Mutation
+import com.google.bigtable.v2.Mutation.MutationCase
+import com.google.protobuf.ByteString
+import com.spotify.scio.values.SCollection
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import scala.reflect.ClassTag
+
+/**
+  * Trait with ScalaTest [[org.scalatest.matchers.Matcher Matcher]]s for
+  * [[com.spotify.scio.values.SCollection SCollection]]s specific to BigTable output.
+  */
+trait BigTableMatchers extends SCollectionMatchers {
+  type BTRow = (ByteString, Iterable[Mutation])
+  type BTCollection = SCollection[BTRow]
+
+  // Provide an implicit BT serializer for common cell value type String
+  implicit val stringBTSerializer: String => ByteString = ByteString.copyFromUtf8
+
+  /** Check that the BT collection contains only the given keys, in any order. */
+  def containRowKeys(expectedKeys: String*): Matcher[BTCollection] =
+    new Matcher[BTCollection] {
+      override def apply(left: BigTableMatchers.this.BTCollection): MatchResult = {
+        containInAnyOrder(expectedKeys).apply(left.keys.map(_.toStringUtf8))
+      }
+    }
+
+  /** Check that the BT collection contains only the given column families, unique, in any order. */
+  def containColumnFamilies(expectedCFs: String*): Matcher[BTCollection] =
+    new Matcher[BTCollection] {
+      override def apply(left: BigTableMatchers.this.BTCollection): MatchResult = {
+        val foundCFs = left.flatMap {
+          case (key, cells) =>
+            cells.map(_.getSetCell.getFamilyName)
+        }
+
+        containInAnyOrder(expectedCFs).apply(foundCFs.distinct)
+      }
+    }
+
+  /**
+    * Check that the BT collection contains a cell with the given row key, column family, and
+    * deserialized cell value. Column qualifier defaults to the same as column family.
+    */
+  def containSetCellValue[V: ClassTag](key: String, cf: String, value: V)
+                                    (implicit ser: V => ByteString): Matcher[BTCollection] =
+    containSetCellValue(key, cf, cf, value)
+
+  /**
+    * Check that the BT collection contains a cell with the given row key, column family,
+    * column qualifier, and deserialized cell value.
+    * @param key Row key the cell should be in
+    * @param cf Column family the cell should have
+    * @param cq Column qualifier the cell should have
+    * @param value Deserialized value of the set cell
+    * @param ser Serializer to convert value type V to ByteString for BT format
+    * @tparam V Class of expected value
+    * @return Whether the collection contains this cell, with no assumptions made about the
+    *         contents of the collection.
+    */
+  def containSetCellValue[V: ClassTag](key: String, cf: String, cq: String, value: V)
+                                    (implicit ser: V => ByteString): Matcher[BTCollection] =
+    new Matcher[BTCollection] {
+      override def apply(left: BTCollection): MatchResult = {
+        val flattenedRows = left.flatMap {
+          case (rowKey, rowValue) => rowValue.map(cell => {
+            (
+              rowKey,
+              cell.getSetCell.getFamilyName,
+              cell.getSetCell.getColumnQualifier,
+              cell.getSetCell.getValue
+            )
+        })}
+
+        containValue((
+          ByteString.copyFromUtf8(key),
+          cf,
+          ByteString.copyFromUtf8(cq),
+          ser.apply(value)
+          )).apply(flattenedRows)
+      }
+    }
+
+  /** Check that the BT collection contains a cell with the given row key and enumerated
+    * MutationCase, making no assumptions about the contents of the rest of the collection. */
+  def containCellMutationCase[V: ClassTag](key: String, mutation: MutationCase):
+  Matcher[BTCollection] =
+    new Matcher[BTCollection] {
+      override def apply(left: BTCollection): MatchResult = {
+        val flattenedRows = left.flatMap {
+          case (rowKey, rowValue) => rowValue.map(cell => {
+            (
+              rowKey,
+              cell.getMutationCase
+            )
+          })}
+
+        containValue((
+          ByteString.copyFromUtf8(key),
+          mutation
+        )).apply(flattenedRows)
+      }
+    }
+}

--- a/scio-test/src/test/scala/com/spotify/scio/testing/BigTableMatchersTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/BigTableMatchersTest.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.testing
+
+import com.google.bigtable.v2.Mutation.{MutationCase, SetCell}
+import com.google.bigtable.v2._
+import com.google.protobuf.ByteString
+
+// scalastyle:off no.whitespace.before.left.bracket
+class BigTableMatchersTest extends PipelineSpec with BigTableMatchers {
+  private lazy val key1 = "k1"
+  private lazy val key2 = "k2"
+  private lazy val emptyCell = Seq(Mutation.newBuilder().build())
+
+  "BigTableMatchers" should "support containRowKeys" in {
+    val tableData: Seq[BTRow] = Seq(
+      (ByteString.copyFromUtf8(key1), emptyCell),
+      (ByteString.copyFromUtf8(key2), emptyCell)
+    )
+
+    // should cases
+    runWithContext {
+      _.parallelize(tableData) should containRowKeys(key1, key2)
+    }
+
+    an [AssertionError] should be thrownBy {
+      runWithContext {
+        _.parallelize(tableData) should containRowKeys (key1)
+      }
+    }
+
+    // should not cases
+    runWithContext {
+      _.parallelize(tableData) shouldNot containRowKeys(key1)
+    }
+
+    an [AssertionError] should be thrownBy {
+      runWithContext {
+        _.parallelize(tableData) shouldNot containRowKeys(key1, key2)
+      }
+    }
+  }
+
+  private lazy val columnFamily1 = "cf1"
+  private lazy val columnFamily2 = "cf2"
+
+  it should "support containColumnFamilies" in {
+    val cell1 = Mutation.newBuilder()
+      .setSetCell(SetCell.newBuilder()
+      .setFamilyName(columnFamily1))
+      .build()
+
+    val cell2 = Mutation.newBuilder()
+      .setSetCell(SetCell.newBuilder()
+        .setFamilyName(columnFamily2))
+      .build()
+
+    val tableData: Seq[BTRow] = Seq(
+      (ByteString.copyFromUtf8(key1), Seq(cell1)),
+      (ByteString.copyFromUtf8(key2), Seq(cell2))
+    )
+
+    // should cases
+    runWithContext {
+      _.parallelize(tableData) should containColumnFamilies(columnFamily1, columnFamily2)
+    }
+
+    an [AssertionError] should be thrownBy {
+      runWithContext {
+        _.parallelize(tableData) should containColumnFamilies (columnFamily1)
+      }
+    }
+
+    // should not cases
+    runWithContext {
+      _.parallelize(tableData) shouldNot containColumnFamilies(columnFamily1)
+    }
+
+    an [AssertionError] should be thrownBy {
+      runWithContext {
+        _.parallelize(tableData) shouldNot containColumnFamilies (columnFamily1, columnFamily2)
+      }
+    }
+  }
+
+  val cellValue1 = "cv1"
+  val cellValue2 = "cv2"
+
+  it should "support containSetCellValue" in {
+    val cell1 = Mutation.newBuilder()
+      .setSetCell(SetCell.newBuilder()
+        .setFamilyName(columnFamily1)
+        .setColumnQualifier(columnFamily1)
+        .setValue(ByteString.copyFromUtf8(cellValue1))
+      ).build()
+
+    val cell2 = Mutation.newBuilder()
+      .setSetCell(SetCell.newBuilder()
+        .setFamilyName(columnFamily2)
+        .setColumnQualifier(columnFamily2)
+        .setValue(ByteString.copyFromUtf8(cellValue2))
+      ).build()
+
+    val tableData: Seq[BTRow] = Seq(
+      (ByteString.copyFromUtf8(key1), Seq(cell1, cell2))
+    )
+
+    // should cases
+    runWithContext { sc =>
+      sc.parallelize(tableData) should containSetCellValue(key1, columnFamily1, cellValue1)
+      sc.parallelize(tableData) should containSetCellValue(key1, columnFamily2, cellValue2)
+    }
+
+    an [AssertionError] should be thrownBy {
+      runWithContext {
+        _.parallelize(tableData) should containSetCellValue(key2, columnFamily1, cellValue1)
+      }
+    }
+
+    // should not cases
+    runWithContext {
+      _.parallelize(tableData) shouldNot containSetCellValue(key2, columnFamily1, cellValue1)
+    }
+
+    an [AssertionError] should be thrownBy {
+      runWithContext {
+        _.parallelize(tableData) shouldNot containSetCellValue(key1, columnFamily1, cellValue1)
+      }
+    }
+  }
+
+  it should "support containCellMutationCase" in {
+    val cell = Mutation.newBuilder()
+      .setDeleteFromRow(Mutation.DeleteFromRow.newBuilder().build())
+      .build()
+
+    val tableData: Seq[BTRow] = Seq(
+      (ByteString.copyFromUtf8(key1), Seq(cell))
+    )
+
+    // should cases
+    runWithContext {
+      _.parallelize(tableData) should containCellMutationCase(key1, MutationCase.DELETE_FROM_ROW)
+    }
+
+    an [AssertionError] should be thrownBy {
+      runWithContext {
+        _.parallelize(tableData) should containCellMutationCase(key1, MutationCase.SET_CELL)
+      }
+    }
+
+    // should not cases
+    runWithContext {
+      _.parallelize(tableData) shouldNot containCellMutationCase(key1, MutationCase.SET_CELL)
+    }
+
+    an [AssertionError] should be thrownBy {
+      runWithContext {
+        _.parallelize(tableData) shouldNot containCellMutationCase(key1,
+          MutationCase.DELETE_FROM_ROW)
+      }
+    }
+  }
+}
+// scalastyle:on no.whitespace.before.left.bracket

--- a/scio-test/src/test/scala/com/spotify/scio/testing/BigTableMatchersTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/BigTableMatchersTest.scala
@@ -23,14 +23,14 @@ import com.google.protobuf.ByteString
 
 // scalastyle:off no.whitespace.before.left.bracket
 class BigTableMatchersTest extends PipelineSpec with BigTableMatchers {
-  private lazy val key1 = "k1"
-  private lazy val key2 = "k2"
+  private lazy val key1 = ByteString.copyFromUtf8("k1")
+  private lazy val key2 = ByteString.copyFromUtf8("k2")
   private lazy val emptyCell = Seq(Mutation.newBuilder().build())
 
   "BigTableMatchers" should "support containRowKeys" in {
     val tableData: Seq[BTRow] = Seq(
-      (ByteString.copyFromUtf8(key1), emptyCell),
-      (ByteString.copyFromUtf8(key2), emptyCell)
+      (key1, emptyCell),
+      (key2, emptyCell)
     )
 
     // should cases
@@ -71,8 +71,8 @@ class BigTableMatchersTest extends PipelineSpec with BigTableMatchers {
       .build()
 
     val tableData: Seq[BTRow] = Seq(
-      (ByteString.copyFromUtf8(key1), Seq(cell1)),
-      (ByteString.copyFromUtf8(key2), Seq(cell2))
+      (key1, Seq(cell1)),
+      (key2, Seq(cell2))
     )
 
     // should cases
@@ -117,7 +117,7 @@ class BigTableMatchersTest extends PipelineSpec with BigTableMatchers {
       ).build()
 
     val tableData: Seq[BTRow] = Seq(
-      (ByteString.copyFromUtf8(key1), Seq(cell1, cell2))
+      (key1, Seq(cell1, cell2))
     )
 
     // should cases
@@ -150,7 +150,7 @@ class BigTableMatchersTest extends PipelineSpec with BigTableMatchers {
       .build()
 
     val tableData: Seq[BTRow] = Seq(
-      (ByteString.copyFromUtf8(key1), Seq(cell))
+      (key1, Seq(cell))
     )
 
     // should cases

--- a/scio-test/src/test/scala/com/spotify/scio/testing/SCollectionMatchersTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/SCollectionMatchersTest.scala
@@ -85,6 +85,21 @@ class SCollectionMatchersTest extends PipelineSpec {
     }
   }
 
+  it should "support containValue" in {
+    // should cases
+    runWithContext { _.parallelize(Seq(1, 2, 3)) should containValue (1) }
+
+    an [AssertionError] should be thrownBy {
+      runWithContext { _.parallelize(Seq(1)) should containValue (10) }
+    }
+    // shouldNot cases
+    runWithContext { _.parallelize(Seq(1, 2, 3)) shouldNot containValue (4) }
+
+    an [AssertionError] should be thrownBy {
+      runWithContext { _.parallelize(Seq(1, 2, 3)) shouldNot containValue (1) }
+    }
+  }
+
   it should "support beEmpty" in {
     // should cases
     runWithContext { _.parallelize(Seq.empty[Int]) should beEmpty }


### PR DESCRIPTION
Adds scalatest `Matchers` for BigTable abstractions like row keys, column families, set cell values, and mutation types. This trait extends `SCollectionMatchers`.

I also added a `containValue` function to `SCollectionMatchers` to check for presence of a single item within a collection without making assumptions about the rest of the collection. The rest of the `contains__` matchers required you to specify every item present in the collection which can be hard to read and write, or outside the scope of a specific test.

added unit tests for all modified code