### PR TITLE
Log exception in AsyncLookupDoFn if cache put fails

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/AsyncLookupDoFn.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/AsyncLookupDoFn.java
@@ -152,10 +152,15 @@ public abstract class AsyncLookupDoFn<A, B, C> extends DoFn<A, KV<A, AsyncLookup
       @Nullable
       @Override
       public B apply(@Nullable B output) {
-        cacheSupplier.put(instanceId, input, output);
-        results.add(new Result(input, new Try<>(output), c.timestamp(), window));
-        futures.remove(uuid);
-        return output;
+        try {
+          cacheSupplier.put(instanceId, input, output);
+          results.add(new Result(input, new Try<>(output), c.timestamp(), window));
+          futures.remove(uuid);
+          return output;
+        } catch (Exception e) {
+          LOG.error("Failed to cache result", e);
+          throw e;
+        }
       }
     });
 


### PR DESCRIPTION
If an exception is thrown when putting a value into the cache, the result will
not be added to the result queue, and finishBundle will fail the precondition
that requestCount == resultCount. The original exception happens in a transform
and does not get logged, so it's not clear to the user what went wrong.

This happens if the user caches a null value, which is not supported by the Guava
cache. This PR modifies the transform so the exception is logged.