### PR TITLE
Fix #726 ProjectId nonEmpty string check in BigQueryClient

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryClient.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryClient.scala
@@ -74,6 +74,9 @@ private[scio] trait QueryJob {
 class BigQueryClient private (private val projectId: String,
                               _credentials: Credentials = null) { self =>
 
+  require(projectId != null && projectId.nonEmpty, "Invalid projectId. " +
+    "It should be a non-empty string")
+
   def this(projectId: String, secretFile: File) =
     this(
       projectId,

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/BigQueryClientTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/BigQueryClientTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.bigquery
+
+import org.scalacheck.Gen
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class BigQueryClientTest extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  "BigQueryClient" should "throw an exception when an empty or null ProjectId is provided" in {
+    assertThrows[IllegalArgumentException] {
+      BigQueryClient("")
+    }
+
+    assertThrows[IllegalArgumentException] {
+      BigQueryClient(null)
+    }
+  }
+
+  it should "work with non-empty ProjectId" in {
+
+    val projectIdGen = Gen.alphaNumStr.suchThat(_.nonEmpty)
+
+    forAll(projectIdGen) {
+      (projectId: String) => {
+        BigQueryClient(projectId)
+      }
+    }
+  }
+}


### PR DESCRIPTION
To fail on client creation, rather than later, if the projectId is either null or an empty
string. Fixes #726