### PR TITLE
Set Jdbc statement which is removed by #1040

### DIFF
--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/package.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/package.scala
@@ -156,6 +156,7 @@ package object jdbc {
         val connOpts = writeOptions.connectionOptions
         var transform = jio.JdbcIO.write[T]()
           .withDataSourceConfiguration(getDataSourceConfig(writeOptions.connectionOptions))
+          .withStatement(writeOptions.statement)
         if (writeOptions.preparedStatementSetter != null) {
           transform = transform
             .withPreparedStatementSetter(new jio.JdbcIO.PreparedStatementSetter[T] {


### PR DESCRIPTION
This will set the statement when saving to jdbcIO which is removed by #1040 

In long run best to have integration test runs with IOs.