### PR TITLE
Add job cancellation option to ScioResult#waitUntilDone (#1056)

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
@@ -65,15 +65,15 @@ abstract class ScioResult private[scio] (val internal: PipelineResult) {
   /** Get metrics of the finished pipeline. */
   def getMetrics: Metrics
 
-  /** Wait until the pipeline finishes. If timeout duration is exceeded and `doCancelJob` is set,
+  /** Wait until the pipeline finishes. If timeout duration is exceeded and `cancelJob` is set,
     * cancel the internal [[PipelineResult]]. */
-  def waitUntilFinish(duration: Duration = Duration.Inf, doCancelJob: Boolean = false):
+  def waitUntilFinish(duration: Duration = Duration.Inf, cancelJob: Boolean = false):
   ScioResult = {
     try {
       Await.ready(finalState, duration)
     } catch {
       case e: TimeoutException =>
-        if (doCancelJob) {
+        if (cancelJob) {
           internal.cancel()
           throw new PipelineExecutionException(
             new Exception(s"Job cancelled after exceeding timeout value $duration"))
@@ -86,8 +86,8 @@ abstract class ScioResult private[scio] (val internal: PipelineResult) {
    * Wait until the pipeline finishes with the State `DONE` (as opposed to `CANCELLED` or
    * `FAILED`). Throw exception otherwise.
    */
-  def waitUntilDone(duration: Duration = Duration.Inf, doCancelJob: Boolean = false): ScioResult = {
-    waitUntilFinish(duration, doCancelJob)
+  def waitUntilDone(duration: Duration = Duration.Inf, cancelJob: Boolean = false): ScioResult = {
+    waitUntilFinish(duration, cancelJob)
 
     if (!this.state.equals(State.DONE)) {
       throw new PipelineExecutionException(new Exception(s"Job finished with state ${this.state}"))

--- a/scio-test/src/test/scala/com/spotify/scio/ScioResultTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioResultTest.scala
@@ -29,6 +29,7 @@ import org.joda.time
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class ScioResultTest extends PipelineSpec {
 
@@ -39,16 +40,15 @@ class ScioResultTest extends PipelineSpec {
   }
 
   it should "respect waitUntilDone() with doCancelJob passed in" in {
-    import scala.concurrent.ExecutionContext.Implicits.global
     val mockPipeline = new PipelineResult {
-      private var _state = State.RUNNING
+      private var state = State.RUNNING
       override def cancel(): State = {
-        _state = State.CANCELLED
-        _state
+        state = State.CANCELLED
+        state
       }
       override def waitUntilFinish(duration: time.Duration): State = null
       override def waitUntilFinish(): State = null
-      override def getState: State = _state
+      override def getState: State = state
       override def metrics(): MetricResults = null
     }
 

--- a/scio-test/src/test/scala/com/spotify/scio/ScioResultTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioResultTest.scala
@@ -39,7 +39,7 @@ class ScioResultTest extends PipelineSpec {
     r.state shouldBe State.DONE
   }
 
-  it should "respect waitUntilDone() with doCancelJob passed in" in {
+  it should "respect waitUntilDone() with cancelJob passed in" in {
     val mockPipeline = new PipelineResult {
       private var state = State.RUNNING
       override def cancel(): State = {
@@ -65,7 +65,7 @@ class ScioResultTest extends PipelineSpec {
     val nanos = Duration.create(10L, TimeUnit.NANOSECONDS)
 
     the[PipelineExecutionException] thrownBy {
-      mockScioResult.waitUntilDone(nanos, doCancelJob = true)
+      mockScioResult.waitUntilDone(nanos, cancelJob = true)
     } should have message s"java.lang.Exception: Job cancelled after exceeding timeout value $nanos"
 
     mockScioResult.state shouldBe State.CANCELLED


### PR DESCRIPTION
Integration-tested in my own Scio batch pipelines, as well as unit tested. let me know if you want me to scrap the unit test, since including hardcoded timeouts in automated tests can be kind of finicky  ¯\\\_(ツ)_/¯
