### PR TITLE
Add jobTimeout as a command line option (#1055)

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/options/ScioOptions.java
+++ b/scio-core/src/main/java/com/spotify/scio/options/ScioOptions.java
@@ -39,6 +39,10 @@ public interface ScioOptions extends PipelineOptions, KryoOptions {
   boolean isBlocking();
   void setBlocking(boolean value);
 
+  @Description("Time period in scala.concurrent.duration.Duration style to wait for job completion")
+  String getJobTimeout();
+  void setJobTimeout(String value);
+
   @Description("Custom application arguments")
   String getAppArguments();
   void setAppArguments(String arguments);

--- a/scio-core/src/main/java/com/spotify/scio/options/ScioOptions.java
+++ b/scio-core/src/main/java/com/spotify/scio/options/ScioOptions.java
@@ -39,9 +39,9 @@ public interface ScioOptions extends PipelineOptions, KryoOptions {
   boolean isBlocking();
   void setBlocking(boolean value);
 
-  @Description("Time period in scala.concurrent.duration.Duration style to wait for job completion")
-  String getJobTimeout();
-  void setJobTimeout(String value);
+  @Description("Time period in scala.concurrent.duration.Duration style to block for job completion")
+  String getBlockFor();
+  void setBlockFor(String value);
 
   @Description("Custom application arguments")
   String getAppArguments();

--- a/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
@@ -66,11 +66,11 @@ abstract class ScioResult private[scio] (val internal: PipelineResult) {
   def getMetrics: Metrics
 
   /** Get the timeout period of the Scio job. Default to `Duration.Inf`. */
-  def getJobTimeout: Duration = Duration.Inf
+  def getAwaitDuration: Duration = Duration.Inf
 
   /** Wait until the pipeline finishes. If timeout duration is exceeded and `cancelJob` is set,
     * cancel the internal [[PipelineResult]]. */
-  def waitUntilFinish(duration: Duration = getJobTimeout, cancelJob: Boolean = false):
+  def waitUntilFinish(duration: Duration = getAwaitDuration, cancelJob: Boolean = false):
   ScioResult = {
     try {
       Await.ready(finalState, duration)
@@ -89,7 +89,8 @@ abstract class ScioResult private[scio] (val internal: PipelineResult) {
    * Wait until the pipeline finishes with the State `DONE` (as opposed to `CANCELLED` or
    * `FAILED`). Throw exception otherwise.
    */
-  def waitUntilDone(duration: Duration = getJobTimeout, cancelJob: Boolean = false): ScioResult = {
+  def waitUntilDone(duration: Duration = getAwaitDuration, cancelJob: Boolean = false):
+  ScioResult = {
     waitUntilFinish(duration, cancelJob)
 
     if (!this.state.equals(State.DONE)) {

--- a/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
@@ -65,9 +65,12 @@ abstract class ScioResult private[scio] (val internal: PipelineResult) {
   /** Get metrics of the finished pipeline. */
   def getMetrics: Metrics
 
+  /** Get the timeout period of the Scio job. Default to `Duration.Inf`. */
+  def getJobTimeout: Duration = Duration.Inf
+
   /** Wait until the pipeline finishes. If timeout duration is exceeded and `cancelJob` is set,
     * cancel the internal [[PipelineResult]]. */
-  def waitUntilFinish(duration: Duration = Duration.Inf, cancelJob: Boolean = false):
+  def waitUntilFinish(duration: Duration = getJobTimeout, cancelJob: Boolean = false):
   ScioResult = {
     try {
       Await.ready(finalState, duration)
@@ -86,7 +89,7 @@ abstract class ScioResult private[scio] (val internal: PipelineResult) {
    * Wait until the pipeline finishes with the State `DONE` (as opposed to `CANCELLED` or
    * `FAILED`). Throw exception otherwise.
    */
-  def waitUntilDone(duration: Duration = Duration.Inf, cancelJob: Boolean = false): ScioResult = {
+  def waitUntilDone(duration: Duration = getJobTimeout, cancelJob: Boolean = false): ScioResult = {
     waitUntilFinish(duration, cancelJob)
 
     if (!this.state.equals(State.DONE)) {

--- a/scio-test/src/test/scala/com/spotify/scio/ScioResultTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioResultTest.scala
@@ -63,7 +63,7 @@ class ScioResultTest extends PipelineSpec {
         State.DONE
       }
 
-      override def getJobTimeout: Duration = nanos
+      override def getAwaitDuration: Duration = nanos
     }
 
     the[PipelineExecutionException] thrownBy {

--- a/scio-test/src/test/scala/com/spotify/scio/ScioResultTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioResultTest.scala
@@ -52,6 +52,9 @@ class ScioResultTest extends PipelineSpec {
       override def metrics(): MetricResults = null
     }
 
+    // Give the ScioResult a 10 nanosecond timeout and verify job is cancelled after timeout
+    val nanos = Duration.create(10L, TimeUnit.NANOSECONDS)
+
     // Mock Scio result takes 100 milliseconds to complete
     val mockScioResult = new ScioResult(mockPipeline) {
       override def getMetrics: metrics.Metrics = null
@@ -59,13 +62,12 @@ class ScioResultTest extends PipelineSpec {
         Thread.sleep(100L)
         State.DONE
       }
+
+      override def getJobTimeout: Duration = nanos
     }
 
-    // Give the ScioResult a 10 nanosecond timeout and verify job is cancelled after timeout
-    val nanos = Duration.create(10L, TimeUnit.NANOSECONDS)
-
     the[PipelineExecutionException] thrownBy {
-      mockScioResult.waitUntilDone(nanos, cancelJob = true)
+      mockScioResult.waitUntilDone(cancelJob = true)
     } should have message s"java.lang.Exception: Job cancelled after exceeding timeout value $nanos"
 
     mockScioResult.state shouldBe State.CANCELLED


### PR DESCRIPTION
I set `jobTimeout` as a string serialized from `scala.concurrent.duration.Duration` type, so it's passed in as "1h", "10min" etc.

also, I updated `ScioContext` so if you do pass in a `jobTimeout` param, you don't have to also override the `--blocking=true` to false - it assumes that's what you want to do. thoughts?