### PR TITLE
Prepend withName to the saveAsTypedBigQuery inner transform

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1105,7 +1105,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
       import scala.concurrent.ExecutionContext.Implicits.global
       this
         .map(bqt.toTableRow)
-        .saveAsBigQuery(
+        .withName(s"${this.tfName.replaceFirst("@.*", "")}$$Write").saveAsBigQuery(
           table,
           bqt.schema,
           writeDisposition,

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1102,10 +1102,11 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
       }
     } else {
       val bqt = BigQueryType[T]
+      val initialTfName = this.tfName
       import scala.concurrent.ExecutionContext.Implicits.global
       this
         .map(bqt.toTableRow)
-        .withName(s"${this.tfName.replaceFirst("@.*", "")}$$Write").saveAsBigQuery(
+        .withName(s"$initialTfName$$Write").saveAsBigQuery(
           table,
           bqt.schema,
           writeDisposition,


### PR DESCRIPTION
Solves https://github.com/spotify/scio/issues/1061 and includes:
- [x] implementation
- [ ] tests

Additional `.withName` is prepended to the inner (second) transform of the `saveAsTypedBigQuery` function in order to override the default callsite naming scheme.

The name of the transform is changed so that file name and line number are removed completely. The resulting name looks like this: `saveAsTypedBigQuery$Write`. Let me know if this is inappropriate.

The tests are not included as I wasn't able to find any existing `saveAsTypedBigQuery` tests.