### PR TITLE
Add string id to the ScioIO[T] trait

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -456,7 +456,7 @@ class ScioContext private[scio] (val options: PipelineOptions,
   private[scio] def getTestInput[T: ClassTag](key: TestIO[T]): SCollection[T] =
     this.parallelize(testIn(key).asInstanceOf[Seq[T]])
 
-  private[scio] def getTestInputNio[T: ClassTag](key: ScioIO[T]): SCollection[T] =
+  private[scio] def getTestInputNio[T: ClassTag](key: String): SCollection[T] =
     this.parallelize(testInNio(key).asInstanceOf[Seq[T]])
   // =======================================================================
   // Read operations
@@ -845,7 +845,7 @@ class ScioContext private[scio] (val options: PipelineOptions,
    */
   def read[T: ClassTag](io: ScioIO[T])(params: io.ReadP): SCollection[T] = requireNotClosed {
     if (this.isTest) {
-      this.getTestInputNio(io)
+      this.getTestInputNio(io.id)
     } else {
       io.read(this, params)
     }

--- a/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/ScioIO.scala
@@ -41,4 +41,6 @@ trait ScioIO[T] {
 
   def tap(read: ReadP): Tap[T]
 
+  def id: String
+
 }

--- a/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/nio/TextIO.scala
@@ -48,7 +48,7 @@ case class TextIO(path: String) extends ScioIO[String] {
 
   def read(sc: ScioContext, params: ReadParams): SCollection[String] = sc.requireNotClosed {
     if (sc.isTest) {
-      sc.getTestInputNio(this)
+      sc.getTestInputNio(this.id)
     } else {
       sc.wrap(sc.applyInternal(BTextIO.read().from(path)
         .withCompression(params.compression))).setName(path)
@@ -57,7 +57,7 @@ case class TextIO(path: String) extends ScioIO[String] {
 
   def write(pipeline: SCollection[String], params: WriteParams): Future[Tap[String]] = {
     if (pipeline.context.isTest) {
-      pipeline.context.testOutNio(this)(pipeline)
+      pipeline.context.testOutNio(this.id)(pipeline)
       // TODO: replace this with ScioIO[T] subclass when we have nio InMemoryIO[T]
       pipeline.saveAsInMemoryTap
     } else {
@@ -90,6 +90,7 @@ case class TextIO(path: String) extends ScioIO[String] {
 
   private[scio] def pathWithShards(path: String) = path.replaceAll("\\/+$", "") + "/part"
 
+  def id: String = path
 }
 
 object TextIO {

--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -70,10 +70,10 @@ private[scio] class TestOutput(val m: Map[TestIO[_], SCollection[_] => Unit]) {
 }
 
 /* Inputs are Scala Iterables to be parallelized for TestPipeline */
-private[scio] class TestInputNio(val m: Map[ScioIO[_], Iterable[_]]) {
-  val s: MSet[ScioIO[_]] = MSet.empty
+private[scio] class TestInputNio(val m: Map[String, Iterable[_]]) {
+  val s: MSet[String] = MSet.empty
 
-  def apply[T](key: ScioIO[T]): Iterable[T] = {
+  def apply[T](key: String): Iterable[T] = {
     require(
       m.contains(key),
       s"Missing test input: $key, available: ${m.keys.mkString("[", ", ", "]")}")
@@ -91,10 +91,10 @@ private[scio] class TestInputNio(val m: Map[ScioIO[_], Iterable[_]]) {
 }
 
 /* Outputs are lambdas that apply assertions on SCollections */
-private[scio] class TestOutputNio(val m: Map[ScioIO[_], SCollection[_] => Unit]) {
-  val s: MSet[ScioIO[_]] = MSet.empty
+private[scio] class TestOutputNio(val m: Map[String, SCollection[_] => Unit]) {
+  val s: MSet[String] = MSet.empty
 
-  def apply[T](key: ScioIO[T]): SCollection[T] => Unit = {
+  def apply[T](key: String): SCollection[T] => Unit = {
     // TODO: support Materialize outputs, maybe Materialized[T]?
     require(
       m.contains(key),
@@ -156,8 +156,8 @@ private[scio] object TestDataManager {
   def setup(testId: String,
             ins: Map[TestIO[_], Iterable[_]],
             outs: Map[TestIO[_], SCollection[_] => Unit],
-            inNios: Map[ScioIO[_], Iterable[_]],
-            outNios: Map[ScioIO[_], SCollection[_] => Unit],
+            inNios: Map[String, Iterable[_]],
+            outNios: Map[String, SCollection[_] => Unit],
             dcs: Map[DistCacheIO[_], _]): Unit = {
     inputs += (testId -> new TestInput(ins))
     outputs += (testId -> new TestOutput(outs))

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1317,7 +1317,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    */
   def write(io: ScioIO[T])(params: io.WriteP): Future[Tap[T]] = {
     if (context.isTest) {
-      context.testOutNio(io)
+      context.testOutNio(io.id)
       this.saveAsInMemoryTap
     } else {
       io.write(this, params)

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/nio/WordCountNioTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/nio/WordCountNioTest.scala
@@ -18,7 +18,7 @@
 package com.spotify.scio.examples.nio
 
 import com.spotify.scio.nio.{TextIO => NTextIO}
-import com.spotify.scio.testing._
+import com.spotify.scio.testing.PipelineSpec
 
 class WordCountNioTest extends PipelineSpec {
 
@@ -28,8 +28,8 @@ class WordCountNioTest extends PipelineSpec {
   "WordCount" should "works with nio JobTest inputs" in {
     JobTest[com.spotify.scio.examples.nio.WordCountNio.type]
       .args("--input=in.txt", "--output=out.txt")
-      .inputNio(NTextIO("in.txt"), inData)
-      .outputNio(NTextIO("out.txt"))(_ should containInAnyOrder (expected))
+      .inputNio(NTextIO("in.txt").id, inData)
+      .outputNio[String](NTextIO("out.txt").id)(_ should containInAnyOrder (expected))
       .run()
   }
 }

--- a/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
@@ -72,8 +72,8 @@ object JobTest {
                                   cmdlineArgs: Array[String] = Array(),
                                   inputs: Map[TestIO[_], Iterable[_]] = Map.empty,
                                   outputs: Map[TestIO[_], SCollection[_] => Unit] = Map.empty,
-                                  inputNio: Map[ScioIO[_], Iterable[_]] = Map.empty,
-                                  outputNio: Map[ScioIO[_], SCollection[_] => Unit] = Map.empty,
+                                  inputNio: Map[String, Iterable[_]] = Map.empty,
+                                  outputNio: Map[String, SCollection[_] => Unit] = Map.empty,
                                   distCaches: Map[DistCacheIO[_], _] = Map.empty,
                                   counters: Map[bm.Counter, Long => Unit] = Map.empty,
                                   // scalastyle:off line.size.limit
@@ -125,13 +125,13 @@ object JobTest {
      * Feed an input to the pipeline being tested, Note that `ScioIO[T]` must match the one used
      * inside the pipeline. e.g.
      * TODO: add an example once we have complete nio integration with ScioContext
-     * @param nio an implementation of `ScioIO[T]`.
+     * @param id input identifier.
      * @param value iterable to return when this input nio is called
      * @return
      */
-    def inputNio[T](nio: ScioIO[T], value: Iterable[T]): Builder = {
-      require(!state.inputNio.contains(nio), s"Duplicate nio test input: $nio")
-      state = state.copy(inputNio = state.inputNio + (nio -> value))
+    def inputNio[T](id: String, value: Iterable[T]): Builder = {
+      require(!state.inputNio.contains(id), s"Duplicate nio test input: $id")
+      state = state.copy(inputNio = state.inputNio + (id -> value))
       this
     }
 
@@ -139,16 +139,16 @@ object JobTest {
      * Evaluate and outptu of the pipeline being tested. Note that `ScioIO[T]` must match the one
      * used inside the pipeline, e.g
      * TODO: add and example once we have complete nio integration with SCollection
-     * @param nio an implementation of `ScioIO[T]`.
+     * @param id output identifier.
      * @param assertion assertion for output data. See [[SCollectionMatchers]] for available
      *                  matchers on an [[com.spotify.scio.values.SCollection SCollection]].
      * @tparam T
      * @return
      */
-    def outputNio[T](nio: ScioIO[T])(assertion: SCollection[T] => Unit): Builder = {
-      require(!state.outputNio.contains(nio), s"Duplicate nio test output $nio")
+    def outputNio[T](id: String)(assertion: SCollection[T] => Unit): Builder = {
+      require(!state.outputNio.contains(id), s"Duplicate nio test output $id")
       state = state
-        .copy(outputNio = state.outputNio + (nio -> assertion.asInstanceOf[SCollection[_] => Unit]))
+        .copy(outputNio = state.outputNio + (id -> assertion.asInstanceOf[SCollection[_] => Unit]))
       this
     }
 


### PR DESCRIPTION
Nio JobTest inputs/outputs were using `ScioIO[T]` as test inputs/outputs key, this replaces it with newly introduce abstract `id` in the base trait. 

@nevillelyh 