### PR TITLE
Add unionAll on ScioContext to support empty lists.

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -48,7 +48,7 @@ import org.apache.beam.sdk.io.gcp.{bigquery => bqio, datastore => dsio, pubsub =
 import org.apache.beam.sdk.metrics.Counter
 import org.apache.beam.sdk.options._
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement
-import org.apache.beam.sdk.transforms.{Create, DoFn, PTransform, SerializableFunction}
+import org.apache.beam.sdk.transforms._
 import org.apache.beam.sdk.util.CoderUtils
 import org.apache.beam.sdk.values._
 import org.apache.beam.sdk.{Pipeline, PipelineResult, io => gio}
@@ -839,6 +839,15 @@ class ScioContext private[scio] (val options: PipelineOptions,
     val maxLength = 256
     if (name.length <= maxLength) name else name.substring(0, maxLength - 3) + "..."
   }
+
+  /** Create a union of multiple SCollections. Supports empty lists. */
+  def unionAll[T: ClassTag](scs: Iterable[SCollection[T]]): SCollection[T] = scs match {
+    case Nil => empty()
+    case contents => SCollection.unionAll(contents)
+  }
+
+  /** Form a empty SCollection. */
+  def empty[T: ClassTag](): SCollection[T] = parallelize(Seq())
 
   /**
    * Distribute a local Scala `Iterable` to form an SCollection.

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -846,7 +846,7 @@ class ScioContext private[scio] (val options: PipelineOptions,
     case contents => SCollection.unionAll(contents)
   }
 
-  /** Form a empty SCollection. */
+  /** Form an empty SCollection. */
   def empty[T: ClassTag](): SCollection[T] = parallelize(Seq())
 
   /**

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -64,9 +64,12 @@ import scala.reflect.runtime.universe._
 /** Convenience functions for creating SCollections. */
 object SCollection {
 
-  /** Create a union of multiple SCollections.
-    * Will throw an exception if the provided iterable is empty.
-    * For a version that accepts an empty list, call unionAll on a ScioContext instance. */
+  /**
+   * Create a union of multiple [[SCollection]] instances.
+   * 
+   * Will throw an exception if the provided iterable is empty.
+   * For a version that accepts empty iterables, see [[ScioContext#unionAll]].
+   */
   def unionAll[T: ClassTag](scs: Iterable[SCollection[T]]): SCollection[T] = {
     val o = PCollectionList
       .of(scs.map(_.internal).asJava)

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -66,7 +66,6 @@ object SCollection {
 
   /**
    * Create a union of multiple [[SCollection]] instances.
-   * 
    * Will throw an exception if the provided iterable is empty.
    * For a version that accepts empty iterables, see [[ScioContext#unionAll]].
    */

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -64,7 +64,9 @@ import scala.reflect.runtime.universe._
 /** Convenience functions for creating SCollections. */
 object SCollection {
 
-  /** Create a union of multiple SCollections */
+  /** Create a union of multiple SCollections.
+    * Will throw an exception if the provided iterable is empty.
+    * For a version that accepts an empty list, call unionAll on a ScioContext instance. */
   def unionAll[T: ClassTag](scs: Iterable[SCollection[T]]): SCollection[T] = {
     val o = PCollectionList
       .of(scs.map(_.internal).asJava)

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -103,6 +103,23 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
+  it should "support unionAll() when called on ScioContext" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq("a", "b", "c"))
+      val p2 = sc.parallelize(Seq("d", "e", "f"))
+      val p3 = sc.parallelize(Seq("g", "h", "i"))
+      val r = sc.unionAll(Seq(p1, p2, p3))
+      val expected = Seq("a", "b", "c", "d", "e", "f", "g", "h", "i")
+      r should containInAnyOrder (expected)
+    }
+  }
+
+  it should "support unionAll() with an empty list" in {
+    runWithContext { sc =>
+      sc.unionAll(Seq()) should beEmpty
+    }
+  }
+
   it should "support ++ operator" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq("a", "b", "c"))


### PR DESCRIPTION
Resolves #1092. @nevillelyh and @andrewsmartin for review. 

`SCollection#unionAll` throws an exception when passed an empty list. To prevent this, this PR adds a `#unionAll`method on `ScioContext` that will return `ScioContext#empty` (i.e.: `sc.parallelize(Seq.empty)`) if the input iterable is empty, and return `SCollection#unionAll` if it is not.