### PR TITLE
Add support for beam parameters in JobTest

### DIFF
--- a/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
@@ -67,6 +67,8 @@ import scala.util.control.NonFatal
  */
 object JobTest {
 
+  case class BeamOptions(opts: List[String])
+
   private case class BuilderState(className: String,
                                   cmdlineArgs: Array[String],
                                   inputs: Map[TestIO[_], Iterable[_]],
@@ -229,15 +231,17 @@ object JobTest {
   }
 
   /** Create a new JobTest.Builder instance. */
-  def apply(className: String): Builder =
+  def apply(className: String)(implicit bm: BeamOptions): Builder =
     new Builder(BuilderState(
       className, Array(), Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty))
+        .args(bm.opts:_*)
 
   /** Create a new JobTest.Builder instance. */
-  def apply[T: ClassTag]: Builder = {
+  def apply[T: ClassTag](implicit bm: BeamOptions): Builder = {
     val className= ScioUtil.classOf[T].getName.replaceAll("\\$$", "")
     new Builder(BuilderState(
       className, Array(), Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty))
+        .args(bm.opts:_*)
   }
 
 }

--- a/scio-test/src/main/scala/com/spotify/scio/testing/RunEnforcementJobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/RunEnforcementJobTest.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
 /**
  * Trait that enforces [[JobTest.Builder.run]] is called.
  */
-trait RunEnforcementJobTest extends FlatSpec { this: Suite =>
+trait RunEnforcementJobTest extends FlatSpec { this: PipelineSpec =>
 
   private val tests = ArrayBuffer.empty[InnerJobTest.Builder]
 


### PR DESCRIPTION
This PR add the ability to dynamically set pipeline arguments when running test written with `JobTest`.
Thanks to this, it becomes possible to run tests in a flink instances embedded in the JVM.

Note that Flink currently does not support Scala 2.12. It's therefore necessary to set the version to scala 2.11.

Here's a SBT session demoing running all `scio-examples'` tests in Flink:

```sbt
sbt:scio-test> project scio-examples
sbt:scio-examples> ++ 2.11.12
sbt:scio-examples> set testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-Dbeam.flink=true")
sbt:scio-examples> set libraryDependencies += "org.apache.beam" %% "beam-runners-flink" % "2.4.0"
sbt:scio-examples> test
```

It's also possible to directly pass parameters with `testOnly`

```sbt
sbt:scio-test> project scio-examples
sbt:scio-examples> ++ 2.11.12
sbt:scio-examples> set libraryDependencies += "org.apache.beam" %% "beam-runners-flink" % "2.4.0"
sbt:scio-examples> testOnly com.spotify.scio.examples.WordCountTest -- -Dbeam.flink=true
```

------

Currently `com.spotify.scio.examples.extra.AnnoySideInputExampleTest` fails when run with Flink.

Also, the following NPE is thrown without affecting the test:

```java
[pool-14-thread-7-ScalaTest-running-WordCountTest] WARN com.spotify.scio.VersionUtil$ - Failed to get version for FlinkRunner
java.lang.NullPointerException
  at java.util.Properties$LineReader.readLine(Properties.java:434)
  at java.util.Properties.load0(Properties.java:353)
  at java.util.Properties.load(Properties.java:341)
  at com.spotify.scio.VersionUtil$$anonfun$getRunnerVersion$1.apply(VersionUtil.scala:128)
  at com.spotify.scio.VersionUtil$$anonfun$getRunnerVersion$1.apply(VersionUtil.scala:109)
  at scala.util.Try$.apply(Try.scala:192)
  at com.spotify.scio.VersionUtil$.getRunnerVersion(VersionUtil.scala:109)
  at com.spotify.scio.VersionUtil$.checkRunnerVersion(VersionUtil.scala:136)
  at com.spotify.scio.ScioContext.<init>(ScioContext.scala:236)
  at com.spotify.scio.ContextAndArgs$.apply(ScioContext.scala:112)
  at com.spotify.scio.examples.WordCount$.main(WordCount.scala:39)
  at com.spotify.scio.examples.WordCount.main(WordCount.scala)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at com.spotify.scio.testing.JobTest$Builder.run(JobTest.scala:215)
  at com.spotify.scio.examples.WordCountTest$$anonfun$1.apply$mcV$sp(WordCountTest.scala:33)
  at com.spotify.scio.examples.WordCountTest$$anonfun$1.apply(WordCountTest.scala:33)
  at com.spotify.scio.examples.WordCountTest$$anonfun$1.apply(WordCountTest.scala:33)
  at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
  at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
  at org.scalatest.Transformer.apply(Transformer.scala:22)
  at org.scalatest.Transformer.apply(Transformer.scala:20)
  at org.scalatest.FlatSpecLike$$anon$1.apply(FlatSpecLike.scala:1682)
  at org.scalatest.TestSuite$class.withFixture(TestSuite.scala:196)
  at com.spotify.scio.examples.WordCountTest.com$spotify$scio$testing$RunEnforcementJobTest$$super$withFixture(WordCountTest.scala:23)
  at com.spotify.scio.testing.RunEnforcementJobTest$class.withFixture(RunEnforcementJobTest.scala:61)
  at com.spotify.scio.examples.WordCountTest.withFixture(WordCountTest.scala:23)
  at org.scalatest.FlatSpecLike$class.invokeWithFixture$1(FlatSpecLike.scala:1679)
  at org.scalatest.FlatSpecLike$$anonfun$runTest$1.apply(FlatSpecLike.scala:1692)
  at org.scalatest.FlatSpecLike$$anonfun$runTest$1.apply(FlatSpecLike.scala:1692)
  at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
  at org.scalatest.FlatSpecLike$class.runTest(FlatSpecLike.scala:1692)
  at org.scalatest.FlatSpec.runTest(FlatSpec.scala:1685)
  at org.scalatest.FlatSpecLike$$anonfun$runTests$1.apply(FlatSpecLike.scala:1750)
  at org.scalatest.FlatSpecLike$$anonfun$runTests$1.apply(FlatSpecLike.scala:1750)
  at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:396)
  at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
  at scala.collection.immutable.List.foreach(List.scala:392)
  at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
  at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:373)
  at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:410)
  at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:384)
  at scala.collection.immutable.List.foreach(List.scala:392)
  at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
  at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:379)
  at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
  at org.scalatest.FlatSpecLike$class.runTests(FlatSpecLike.scala:1750)
  at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1685)
  at org.scalatest.Suite$class.run(Suite.scala:1147)
  at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1685)
  at org.scalatest.FlatSpecLike$$anonfun$run$1.apply(FlatSpecLike.scala:1795)
  at org.scalatest.FlatSpecLike$$anonfun$run$1.apply(FlatSpecLike.scala:1795)
  at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
  at org.scalatest.FlatSpecLike$class.run(FlatSpecLike.scala:1795)
  at com.spotify.scio.examples.WordCountTest.org$scalatest$BeforeAndAfterAllConfigMap$$super$run(WordCountTest.scala:23)
  at org.scalatest.BeforeAndAfterAllConfigMap$class.liftedTree1$1(BeforeAndAfterAllConfigMap.scala:248)
  at org.scalatest.BeforeAndAfterAllConfigMap$class.run(BeforeAndAfterAllConfigMap.scala:245)
  at com.spotify.scio.examples.WordCountTest.run(WordCountTest.scala:23)
  at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)
  at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:480)
  at sbt.TestRunner.runTest$1(TestFramework.scala:106)
  at sbt.TestRunner.run(TestFramework.scala:117)
  at sbt.TestFramework$$anon$2$$anonfun$$lessinit$greater$1.$anonfun$apply$1(TestFramework.scala:262)
  at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:233)
  at sbt.TestFramework$$anon$2$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:262)
  at sbt.TestFramework$$anon$2$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:262)
  at sbt.TestFunction.apply(TestFramework.scala:271)
  at sbt.Tests$.$anonfun$toTask$1(Tests.scala:281)
  at sbt.std.Transform$$anon$3.$anonfun$apply$2(System.scala:46)
  at sbt.std.Transform$$anon$4.work(System.scala:66)
  at sbt.Execute.$anonfun$submit$2(Execute.scala:262)
  at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
  at sbt.Execute.work(Execute.scala:271)
  at sbt.Execute.$anonfun$submit$1(Execute.scala:262)
  at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:174)
  at sbt.CompletionService$$anon$2.call(CompletionService.scala:36)
  at java.util.concurrent.FutureTask.run(FutureTask.java:266)
  at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
  at java.util.concurrent.FutureTask.run(FutureTask.java:266)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  at java.lang.Thread.run(Thread.java:748)
```