### PR TITLE
Add basic linting scalac options (see: #1097)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,14 +88,8 @@ val commonSettings = Sonatype.sonatypeSettings ++ assemblySettings ++ Seq(
 
   scalaVersion       := "2.12.6",
   crossScalaVersions := Seq("2.11.12", "2.12.6"),
-  scalacOptions                   ++= {
-    Seq("-Xmax-classfile-name", "100", "-target:jvm-1.8", "-deprecation", "-feature", "-unchecked") ++
-      (if (scalaBinaryVersion.value == "2.12") Seq("-Ydelambdafy:inline") else Nil)
-    },
-  scalacOptions in (Compile, doc) ++= {
-    Seq("-skip-packages", "org.apache") ++
-      (if (scalaBinaryVersion.value == "2.12") Seq("-no-java-comments") else Nil)
-    },
+  scalacOptions                   ++= Scalac.commonsOptions.value,
+  scalacOptions in (Compile, doc) ++= Scalac.compileDocOptions.value,
   javacOptions                    ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
   javacOptions in (Compile, doc)  := Seq("-source", "1.8"),
 

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import sbt._, Keys._
+
+object Scalac {
+
+  // see: https://tpolecat.github.io/2017/04/25/scalac-flags.html
+  val extraOptions = List(
+    "-encoding", "utf-8", // Specify character encoding used by source files.
+    "-explaintypes", // Explain type errors in more detail.
+    // "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
+    // "-language:experimental.macros", // Allow macro definition (besides implementation and application)
+    // "-language:higherKinds", // Allow higher-kinded types
+    // "-language:implicitConversions", // Allow definition of implicit functions called views
+    "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
+    // "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+    // "-Xfuture", // Turn on future language features.
+    "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+    // "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+    // "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
+    // "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+    "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+    "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+    "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
+    "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
+    "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+    // "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
+    "-Xlint:option-implicit", // Option.apply used implicit view.
+    // "-Xlint:package-object-classes", // Class or object defined in package object.
+    "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+    "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+    "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+    "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+    "-Xlint:unsound-match", // Pattern match may not be typesafe.
+    // "-Ypartial-unification", // Enable partial unification in type constructor inference
+    // "-Ywarn-dead-code", // Warn when dead code is identified.
+    "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+    "-Ywarn-infer-any", // Warn when a type argument is inferred to be `Any`.
+    // "-Ywarn-numeric-widen", // Warn when numerics are widened.
+    // "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
+    // "-Ywarn-unused:locals", // Warn if a local definition is unused.
+    // "-Ywarn-unused:params", // Warn if a value parameter is unused.
+    // "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
+    // "-Ywarn-unused:privates", // Warn if a private member is unused.
+    // "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
+  )
+
+  def scala212settings = Def.setting {
+    if (scalaBinaryVersion.value == "2.12")
+      List(
+        "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
+        "-Ywarn-extra-implicit" // Warn when more than one implicit parameter section is defined.
+      )
+    else Nil
+  }
+
+  def baseScioOptions = Def.setting {
+    List(
+      "-Xmax-classfile-name", "100",
+      "-target:jvm-1.8",
+      "-deprecation", // Emit warning and location for usages of deprecated APIs.
+      "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+      "-unchecked") ++ // Enable additional warnings where generated code depends on assumptions.
+      (if (scalaBinaryVersion.value == "2.12") List("-Ydelambdafy:inline") else Nil)
+  }
+
+  def commonsOptions = Def.setting {
+    baseScioOptions.value ++ extraOptions ++ scala212settings.value
+  }
+
+  def compileDocOptions = Def.setting {
+    List("-skip-packages", "org.apache") ++
+      (if (scalaBinaryVersion.value == "2.12") List("-no-java-comments") else Nil)
+  }
+
+}

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/ConverterProvider.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/ConverterProvider.scala
@@ -21,7 +21,6 @@ import com.google.protobuf.ByteString
 import com.spotify.scio.avro.types.MacroUtil._
 import org.apache.avro.generic.GenericRecord
 
-import scala.language.experimental.macros
 import scala.reflect.macros._
 
 private[types] object ConverterProvider {

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryClient.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryClient.scala
@@ -856,7 +856,7 @@ class BigQueryClient private (private val projectId: String,
     var pendingJobs = jobs.flatMap {
       job =>
         job.jobReference match {
-          case Some(reference) => Some(job, reference)
+          case Some(reference) => Some((job, reference))
           case None => None
         }
     }

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -24,7 +24,6 @@ import com.spotify.scio.bigquery.validation.{OverrideTypeProvider, OverrideTypeP
 import org.apache.avro.generic.GenericRecord
 import org.joda.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 
-import scala.language.experimental.macros
 import scala.reflect.macros._
 
 private[types] object ConverterProvider {

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/BigQueryUtilTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/BigQueryUtilTest.scala
@@ -19,7 +19,6 @@ package com.spotify.scio.bigquery
 
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.JavaConverters._

--- a/scio-cassandra3/src/main/scala/com/spotify/scio/cassandra/DataTypeExternalizer.scala
+++ b/scio-cassandra3/src/main/scala/com/spotify/scio/cassandra/DataTypeExternalizer.scala
@@ -25,7 +25,6 @@ import com.google.common.collect.{ImmutableList, ImmutableSet, Lists}
 import com.twitter.chill._
 
 import scala.collection.JavaConverters._
-import scala.language.higherKinds
 
 private[cassandra] object DataTypeExternalizer {
   def apply(dt: DataType): DataTypeExternalizer = {

--- a/scio-core/src/main/scala/com/spotify/scio/Implicits.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/Implicits.scala
@@ -25,7 +25,6 @@ import org.apache.beam.sdk.coders._
 import org.apache.beam.sdk.options.PipelineOptions
 import org.apache.beam.sdk.values.KV
 
-import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 private[scio] object Implicits {

--- a/scio-core/src/main/scala/com/spotify/scio/ScioMetrics.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioMetrics.scala
@@ -18,8 +18,6 @@
 package com.spotify.scio
 
 import org.apache.beam.sdk.metrics.{Counter, Distribution, Gauge, Metrics}
-
-import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 /**

--- a/scio-core/src/main/scala/com/spotify/scio/coders/AvroSerializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/AvroSerializer.scala
@@ -24,7 +24,6 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.specific.SpecificRecordBase
 import org.apache.beam.sdk.coders.AvroCoder
-import org.apache.beam.sdk.coders.Coder.Context
 
 import scala.collection.mutable.{Map => MMap}
 import scala.util.Try

--- a/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
@@ -96,7 +96,7 @@ private[scio] class FileStorage(protected[scio] val path: String) {
     val nums = metadata.flatMap { meta =>
       val m = partPattern.findAllIn(meta.resourceId().toString)
       if (m.hasNext) {
-        Some(m.group(1).toInt, m.group(2).toInt)
+        Some((m.group(1).toInt, m.group(2).toInt))
       } else {
         None
       }

--- a/scio-core/src/main/scala/com/spotify/scio/io/Taps.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/Taps.scala
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory
 import scala.concurrent.{Future, Promise}
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
-import scala.util.Try
 
 /** Exception for when a tap is not available. */
 class TapNotAvailableException(msg: String) extends Exception(msg)

--- a/scio-core/src/main/scala/com/spotify/scio/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/package.scala
@@ -22,7 +22,6 @@ import com.twitter.algebird.Monoid
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
-import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 /**

--- a/scio-core/src/main/scala/com/spotify/scio/util/MultiJoin.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/MultiJoin.scala
@@ -26,7 +26,6 @@
 
 package com.spotify.scio.util
 
-import com.google.common.collect.Lists
 import com.spotify.scio.values.SCollection
 import org.apache.beam.sdk.transforms.join.{CoGroupByKey, KeyedPCollectionTuple}
 import org.apache.beam.sdk.values.TupleTag

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithHotKeyFanout.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithHotKeyFanout.scala
@@ -34,11 +34,11 @@ class SCollectionWithHotKeyFanout[K: ClassTag, V: ClassTag] private[values]
  private val hotKeyFanout: Either[K => Int, Int])
   extends TransformNameable {
 
-  private def withFanout[K, I, O](combine: Combine.PerKey[K, I, O])
-  : PerKeyWithHotKeyFanout[K, I, O] = this.hotKeyFanout match {
+  private def withFanout[K0, I, O](combine: Combine.PerKey[K0, I, O])
+  : PerKeyWithHotKeyFanout[K0, I, O] = this.hotKeyFanout match {
     case Left(f) =>
       combine.withHotKeyFanout(
-        Functions.serializableFn(f).asInstanceOf[SerializableFunction[K, java.lang.Integer]])
+        Functions.serializableFn(f).asInstanceOf[SerializableFunction[K0, java.lang.Integer]])
     case Right(f) =>
       combine.withHotKeyFanout(f)
   }

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithSideInput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithSideInput.scala
@@ -40,7 +40,7 @@ class SCollectionWithSideInput[T: ClassTag] private[values] (val internal: PColl
 
   val ct: ClassTag[T] = implicitly[ClassTag[T]]
 
-  private def parDo[T, U](fn: DoFn[T, U]) = ParDo.of(fn).withSideInputs(sides.map(_.view).asJava)
+  private def parDo[T0, U](fn: DoFn[T0, U]) = ParDo.of(fn).withSideInputs(sides.map(_.view).asJava)
 
   /** [[SCollection.filter]] with an additional [[SideInputContext]] argument. */
   def filter(f: (T, SideInputContext[T]) => Boolean): SCollectionWithSideInput[T] = {

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TopWikipediaSessions.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TopWikipediaSessions.scala
@@ -31,8 +31,6 @@ import com.spotify.scio.values.SCollection
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow
 import org.joda.time.{Duration, Instant}
 
-import scala.util.Try
-
 object TopWikipediaSessions {
   def main(cmdlineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdlineArgs)

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficRoutes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficRoutes.scala
@@ -21,7 +21,6 @@ import com.spotify.scio._
 import com.spotify.scio.bigquery._
 import com.spotify.scio.examples.common.ExampleData
 import org.apache.beam.examples.common.{ExampleOptions, ExampleUtils}
-import org.apache.beam.sdk.options.StreamingOptions
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{Duration, Instant}
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/CloudSqlExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/CloudSqlExample.scala
@@ -21,8 +21,6 @@ package com.spotify.scio.examples.extra
 import com.spotify.scio.ScioContext
 import com.spotify.scio.jdbc._
 
-import scala.language.existentials
-
 // Read from Google Cloud SQL database table and write to a different table in the same database
 object CloudSqlExample {
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TapExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TapExample.scala
@@ -22,9 +22,6 @@ package com.spotify.scio.examples.extra
 
 import com.spotify.scio._
 
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
-
 object TapExample {
   def main(cmdlineArgs: Array[String]): Unit = {
     // Each `ScioContext` instance maps to a unique pipeline

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/complete/game/HourlyTeamScoreTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/complete/game/HourlyTeamScoreTest.scala
@@ -17,7 +17,6 @@
 
 package com.spotify.scio.examples.complete.game
 
-import com.spotify.scio.bigquery.TableRow
 import com.spotify.scio.examples.complete.game.HourlyTeamScore.TeamScoreSums
 import com.spotify.scio.testing._
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/cookbook/DistinctExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/cookbook/DistinctExampleTest.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.examples.cookbook
 
-import com.spotify.scio.testing.{JobTest, PipelineSpec, TextIO}
+import com.spotify.scio.testing.{PipelineSpec, TextIO}
 
 class DistinctExampleTest extends PipelineSpec {
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AlgebirdSpec.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AlgebirdSpec.scala
@@ -160,7 +160,7 @@ class AlgebirdSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matc
       val minOp = Aggregator.min[Double].composePrepare[C](_._3)
       val avgOp = AveragedValue.aggregator.composePrepare[C](_._4)
       // Combine 4 Aggregator[C, Double, Double] into 1 Aggregator[C, C, C]
-      val colAgg = MultiAggregator(sumOp, maxOp, minOp, avgOp)
+      val colAgg = MultiAggregator((sumOp, maxOp, minOp, avgOp))
 
       val expected = (
         xs.internal.map(_._1).sum,
@@ -181,7 +181,7 @@ class AlgebirdSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matc
       val maxOp = Aggregator.max[Double]
       val minOp = Aggregator.min[Double]
       val momentsOp = Moments.aggregator
-      val colAgg = MultiAggregator(maxOp, minOp, momentsOp)
+      val colAgg = MultiAggregator((maxOp, minOp, momentsOp))
         .andThenPresent { case (max, min, moments) =>
           // Present mean and stddev in Moments
           (max, min, moments.mean, moments.stddev)

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroExampleTest.scala
@@ -20,7 +20,6 @@ package com.spotify.scio.examples.extra
 import com.spotify.scio.avro.Account
 import com.spotify.scio.examples.extra.AvroExample.{AccountFromSchema, AccountToSchema}
 import com.spotify.scio.testing.{AvroIO, PipelineSpec, TextIO}
-import org.apache.avro.generic.{GenericData, GenericRecord}
 
 class AvroExampleTest extends PipelineSpec {
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ProtobufExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ProtobufExampleTest.scala
@@ -19,7 +19,7 @@ package com.spotify.scio.examples.extra
 
 import com.spotify.scio.proto.SimpleV2.SimplePB
 import com.spotify.scio.proto.Track.TrackPB
-import com.spotify.scio.testing.{JobTest, PipelineSpec, ProtobufIO}
+import com.spotify.scio.testing.{PipelineSpec, ProtobufIO}
 
 class ProtobufExampleTest extends PipelineSpec {
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TableRowJsonInOutTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/TableRowJsonInOutTest.scala
@@ -18,7 +18,7 @@
 package com.spotify.scio.examples.extra
 
 import com.spotify.scio.bigquery.TableRow
-import com.spotify.scio.testing.{JobTest, PipelineSpec, TableRowJsonIO}
+import com.spotify.scio.testing.{PipelineSpec, TableRowJsonIO}
 
 class TableRowJsonInOutTest extends PipelineSpec {
 

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/checkpoint/CheckpointTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/checkpoint/CheckpointTest.scala
@@ -49,19 +49,19 @@ class CheckpointTest extends FlatSpec with Matchers {
 
   "checkpoint" should "work on path" in {
     val tmpDir = Files.createTempDirectory("checkpoint-").resolve("checkpoint").toString
-    runJob(tmpDir) shouldBe (10L, 10L)
-    runJob(tmpDir) shouldBe (0L, 10L)
+    runJob(tmpDir) shouldBe ((10L, 10L))
+    runJob(tmpDir) shouldBe ((0L, 10L))
     File(tmpDir).deleteRecursively()
-    runJob(tmpDir) shouldBe (10L, 10L)
+    runJob(tmpDir) shouldBe ((10L, 10L))
   }
 
   it should "work on name/file" in {
     val checkpointName = "c1"
     val tempLocation = Files.createTempDirectory("temp-location-").toString
-    runJob(checkpointName, tempLocation) shouldBe (10L, 10L)
-    runJob(checkpointName, tempLocation) shouldBe (0L, 10L)
+    runJob(checkpointName, tempLocation) shouldBe ((10L, 10L))
+    runJob(checkpointName, tempLocation) shouldBe ((0L, 10L))
     File(s"$tempLocation/$checkpointName").deleteRecursively()
-    runJob(checkpointName, tempLocation) shouldBe (10L, 10L)
+    runJob(checkpointName, tempLocation) shouldBe ((10L, 10L))
   }
 
 }

--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/package.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/package.scala
@@ -27,7 +27,6 @@ import org.apache.beam.sdk.io.jdbc.JdbcIO.DataSourceConfiguration
 import org.apache.beam.sdk.io.{jdbc => jio}
 
 import scala.concurrent.Future
-import scala.language.existentials
 import scala.reflect.ClassTag
 
 /**

--- a/scio-jmh/src/test/scala/com/spotify/scio/jmh/JoinBenchmark.scala
+++ b/scio-jmh/src/test/scala/com/spotify/scio/jmh/JoinBenchmark.scala
@@ -83,20 +83,20 @@ class JoinBenchmark {
 
   def artisan(as: JIterable[Int], bs: JIterable[Int], c: Context[(Int, Int)]): Unit = {
     (peak(as), peak(bs)) match {
-      case ((1, a), (1, b)) => c.output(a, b)
+      case ((1, a), (1, b)) => c.output((a, b))
       case ((1, a), (2, _)) =>
         val i = bs.iterator()
-        while (i.hasNext) c.output(a, i.next())
+        while (i.hasNext) c.output((a, i.next()))
       case ((2, _), (1, b)) =>
         val i = as.iterator()
-        while (i.hasNext) c.output(i.next(), b)
+        while (i.hasNext) c.output((i.next(), b))
       case ((2, _), (2, _)) =>
         val i = as.iterator()
         while (i.hasNext) {
           val a = i.next()
           val j = bs.iterator()
           while (j.hasNext) {
-            c.output(a, j.next())
+            c.output((a, j.next()))
           }
         }
       case _ => ()
@@ -116,18 +116,18 @@ class JoinBenchmark {
       val a1 = !ai.hasNext
       val b1 = !bi.hasNext
       if (a1 && b1) {
-        c.output(a, b)
+        c.output((a, b))
       } else if (a1 && !b1) {
-        c.output(a, b)
-        c.output(a, bi.next())
+        c.output((a, b))
+        c.output((a, bi.next()))
         while (bi.hasNext) {
-          c.output(a, bi.next())
+          c.output((a, bi.next()))
         }
       } else if (!a1 && b1) {
-        c.output(a, b)
-        c.output(ai.next(), b)
+        c.output((a, b))
+        c.output((ai.next(), b))
         while (ai.hasNext) {
-          c.output((ai.next(), b))
+          c.output(((ai.next(), b)))
         }
       } else {
         ai = as.iterator()
@@ -135,7 +135,7 @@ class JoinBenchmark {
           a = ai.next()
           bi = bs.iterator()
           while (bi.hasNext) {
-            c.output(a, bi.next())
+            c.output((a, bi.next()))
           }
         }
       }
@@ -152,7 +152,7 @@ class JoinBenchmark {
       val a = ai.next()
       val bi = bs.iterator()
       while (bi.hasNext) {
-        c.output(a, bi.next())
+        c.output((a, bi.next()))
       }
     }
   }

--- a/scio-test/src/main/scala/com/spotify/scio/testing/BigTableMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/BigTableMatchers.scala
@@ -17,9 +17,6 @@
 
 package com.spotify.scio.testing
 
-import java.lang.{Iterable => JIterable}
-import java.util.{Map => JMap}
-
 import com.google.bigtable.v2.Mutation
 import com.google.bigtable.v2.Mutation.MutationCase
 import com.google.protobuf.ByteString

--- a/scio-test/src/test/scala/com/spotify/scio/values/WindowedSCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/WindowedSCollectionTest.scala
@@ -18,7 +18,7 @@
 package com.spotify.scio.values
 
 import com.spotify.scio.testing.PipelineSpec
-import org.joda.time.{Duration, Instant}
+import org.joda.time.Instant
 
 class WindowedSCollectionTest extends PipelineSpec {
 


### PR DESCRIPTION
Add a few linting Scalac options as suggested in https://github.com/spotify/scio/issues/1097.

The changes I made in the source are about:

- Avoiding shadowing types
- Getting rid of automatic type adaptations ie: things like `Some(x, y)` become `Some((x, y))`
- Removing unused imports

Those changes should not have any impact whatsoever. 
There're other warnings but fixing them may have some impact. Mostly because we use a couple of deprecated methods from beam's API a lot in tests. Not sure if it's intended.

They're a bunch of other problems that are detected if we add more linting options. They may be more impactful therefore I'm not activating them for now:

- There're a lot of implicit numeric widening. It usually have no impact but we may want to manually checks that none are accidental.
- A few classes are overriding `private[scio]` defs. We probably want to make those classes final.
- There's class declarations inside `package object` which is discouraged.

