### PR TITLE
Add a partition according to predicate combinator to SCollection

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -221,6 +221,20 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     this.applyInternal(Partition.of[T](numPartitions, Functions.partitionFn[T](numPartitions, f)))
       .getAll.asScala.map(p => context.wrap(p))
 
+  /**
+   * Partition this SCollection into a pair of SCollections according to a predicate.
+   *
+   * @param p predicate on which to partition
+   * @return a pair of SCollections: the first SCollection consists of all elements that satisfy
+   * the predicate p and the second consists of all element that do not.
+   * @group collection
+   */
+  def partition(p: T => Boolean): (SCollection[T], SCollection[T]) = {
+    val Seq(left, right) = partition(2, t => if (p(t)) 0 else 1)
+    (left, right)
+  }
+
+
   // =======================================================================
   // Transformations
   // =======================================================================

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -170,6 +170,14 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
+  it should "support partition() according to a predicate" in {
+    runWithContext { sc =>
+      val (p1, p2) = sc.parallelize(Seq(1, 2, 3, 4, 5, 6)).partition(_ % 2 == 0)
+      p1 should containInAnyOrder (Seq(2, 4, 6))
+      p2 should containInAnyOrder (Seq(1, 3, 5))
+    }
+  }
+
   it should "support aggregate()" in {
     runWithContext { sc =>
       val p = sc.parallelize(1 to 100)


### PR DESCRIPTION
I always end up redefining it so I thought it would make sense to have it upstream, happy to be told otherwise :+1: 