### PR TITLE
propagate grpc context in ScioResult

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ val elasticsearch5Version = "5.5.0"
 val featranVersion = "0.1.26"
 val gcsConnectorVersion = "1.6.3-hadoop2"
 val gcsVersion = "1.8.0"
+val grpcContextVersion = "1.2.0"
 val guavaVersion = "20.0"
 val hadoopVersion = "2.7.3"
 val hamcrestVersion = "1.3"
@@ -296,7 +297,8 @@ lazy val scioCore: Project = Project(
     "com.google.protobuf" % "protobuf-java" % protobufVersion,
     "me.lyh" %% "protobuf-generic" % protobufGenericVersion,
     "org.apache.xbean" % "xbean-asm5-shaded" % asmVersion,
-    "org.apache.commons" % "commons-pool2" %  commonsPoolVersion
+    "org.apache.commons" % "commons-pool2" %  commonsPoolVersion,
+    "io.grpc" % "grpc-context" % grpcContextVersion
   )
 ).dependsOn(
   scioAvro,

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -396,7 +396,7 @@ class ScioContext private[scio] (val options: PipelineOptions,
       val f = Future(r.call())
       f.onComplete {
         case Success(_) => Unit
-        case Failure(NonFatal(_)) => context.updateFutures(r)
+        case Failure(NonFatal(_)) => context.updateFutures(state)
       }
       f
     }

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -24,6 +24,7 @@ import java.io.File
 import java.net.URI
 import java.nio.file.Files
 
+import _root_.io.grpc.{Context => GrpcContext}
 import com.google.api.services.bigquery.model.TableReference
 import com.google.datastore.v1.{Entity, Query}
 import com.google.protobuf.Message
@@ -383,7 +384,7 @@ class ScioContext private[scio] (val options: PipelineOptions,
                                   val context: ScioContext) extends ScioResult(internal) {
     override val finalState: Future[State] = {
       import scala.concurrent.ExecutionContext.Implicits.global
-      val r = _root_.io.grpc.Context.current().wrap(() => {
+      val r = GrpcContext.current().wrap(() => {
         val state = internal.waitUntilFinish()
         context.updateFutures(state)
         val metricsLocation = context.optionsAs[ScioOptions].getMetricsLocation

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -20,6 +20,7 @@
 package com.spotify.scio
 
 import java.beans.Introspector
+import java.util.concurrent.Callable
 import java.io.File
 import java.net.URI
 import java.nio.file.Files
@@ -384,14 +385,16 @@ class ScioContext private[scio] (val options: PipelineOptions,
                                   val context: ScioContext) extends ScioResult(internal) {
     override val finalState: Future[State] = {
       import scala.concurrent.ExecutionContext.Implicits.global
-      val r = GrpcContext.current().wrap(() => {
-        val state = internal.waitUntilFinish()
-        context.updateFutures(state)
-        val metricsLocation = context.optionsAs[ScioOptions].getMetricsLocation
-        if (metricsLocation != null) {
-          saveMetrics(metricsLocation)
+      val r = GrpcContext.current().wrap(new Callable[State]() {
+        override def call(): State = {
+          val state = internal.waitUntilFinish()
+          context.updateFutures(state)
+          val metricsLocation = context.optionsAs[ScioOptions].getMetricsLocation
+          if (metricsLocation != null) {
+            saveMetrics(metricsLocation)
+          }
+          ContextScioResult.this.state
         }
-        this.state
       })
       val f = Future(r.call())
       f.onComplete {

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -383,7 +383,7 @@ class ScioContext private[scio] (val options: PipelineOptions,
                                   val context: ScioContext) extends ScioResult(internal) {
     override val finalState: Future[State] = {
       import scala.concurrent.ExecutionContext.Implicits.global
-      val r = __root__.io.grpc.Context.current().wrap(() => {
+      val r = _root_.io.grpc.Context.current().wrap(() => {
         val state = internal.waitUntilFinish()
         context.updateFutures(state)
         val metricsLocation = context.optionsAs[ScioOptions].getMetricsLocation

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -383,7 +383,7 @@ class ScioContext private[scio] (val options: PipelineOptions,
                                   val context: ScioContext) extends ScioResult(internal) {
     override val finalState: Future[State] = {
       import scala.concurrent.ExecutionContext.Implicits.global
-      val r = io.grpc.Context.current().wrap(() => {
+      val r = __root__.io.grpc.Context.current().wrap(() => {
         val state = internal.waitUntilFinish()
         context.updateFutures(state)
         val metricsLocation = context.optionsAs[ScioOptions].getMetricsLocation


### PR DESCRIPTION
Ensure grpc context metadata is available to logging in `org.apache.beam.sdk.PipelineResult.waitUntilFinish()`.