### PR TITLE
Add timer to scalatest tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,8 +100,9 @@ val commonSettings = Sonatype.sonatypeSettings ++ assemblySettings ++ Seq(
   resolvers += Resolver.sonatypeRepo("public"),
 
   scalastyleSources in Compile ++= (unmanagedSourceDirectories in Test).value,
-  testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v"),
-  testOptions ++= {
+  testOptions in Test += Tests.Argument("-oD"),
+  testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-q", "-v"),
+  testOptions in Test ++= {
     if (sys.env.contains("SLOW")) {
       Nil
     } else {


### PR DESCRIPTION
I think this can be usefull, wdyt?
```
[info] BigtableDoFn
[info] - should work (1 second, 343 milliseconds)
[info] - should work with cache (77 milliseconds)
[info] - should work with failures (25 milliseconds)
```