### PR TITLE
Make build work with IntelliJ out of the box, fix #1199

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -168,7 +168,15 @@ val commonSettings = Sonatype.sonatypeSettings ++ assemblySettings ++ Seq(
 ) ++ mimaSettings
 
 lazy val itSettings = Defaults.itSettings ++ Seq(
-  scalastyleSources in Compile ++= (unmanagedSourceDirectories in IntegrationTest).value
+  scalastyleSources in Compile ++= (unmanagedSourceDirectories in IntegrationTest).value,
+  // exclude all sources if we don't have GCP credentials
+  (excludeFilter in unmanagedSources) in IntegrationTest := {
+    if (BuildCredentials.exists) {
+      HiddenFileFilter
+    } else {
+      HiddenFileFilter || "*.scala"
+    }
+  }
 )
 
 lazy val noPublishSettings = Seq(
@@ -595,6 +603,14 @@ lazy val scioExamples: Project = Project(
     "org.mockito" % "mockito-all" % mockitoVersion % "test"
   ),
   addCompilerPlugin(paradiseDependency),
+  // exclude problematic sources if we don't have GCP credentials
+  excludeFilter in unmanagedSources := {
+    if (BuildCredentials.exists) {
+      HiddenFileFilter
+    } else {
+      HiddenFileFilter || "TypedBigQueryTornadoes*.scala"
+    }
+  },
   sources in doc in Compile := List()
 ).dependsOn(
   scioCore,

--- a/build.sbt
+++ b/build.sbt
@@ -514,11 +514,20 @@ lazy val scioJdbc: Project = Project(
   scioTest % "test"
 )
 
+val ensureSourceManaged = taskKey[Unit]("ensureSourceManaged")
+
 lazy val scioParquet: Project = Project(
   "scio-parquet",
   file("scio-parquet")
 ).settings(
   commonSettings,
+  // change annotation processor output directory so IntelliJ can pick them up
+  ensureSourceManaged := IO.createDirectory(sourceManaged.value / "main"),
+  (compile in Compile) := Def.task {
+    ensureSourceManaged.value
+    (compile in Compile).value
+  }.value,
+  javacOptions ++= Seq("-s", (sourceManaged.value / "main").toString),
   description := "Scio add-on for Parquet",
   libraryDependencies ++= Seq(
     "me.lyh" %% "parquet-avro-extra" % parquetAvroExtraVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -96,6 +96,8 @@ val commonSettings = Sonatype.sonatypeSettings ++ assemblySettings ++ Seq(
 
   // protobuf-lite is an older subset of protobuf-java and causes issues
   excludeDependencies += "com.google.protobuf" % "protobuf-lite",
+  // hamcrest-core overlaps with hamcrest-all and causes issues in IntelliJ
+  excludeDependencies += "org.hamcrest" % "hamcrest-core",
 
   resolvers += Resolver.sonatypeRepo("public"),
 

--- a/build.sbt
+++ b/build.sbt
@@ -402,7 +402,7 @@ lazy val scioCassandra2: Project = Project(
 ).settings(
   commonSettings ++ itSettings,
   description := "Scio add-on for Apache Cassandra 2.x",
-  scalaSource in Compile := (baseDirectory in ThisBuild).value / "scio-cassandra3/src/main/scala",
+  scalaSource in Compile := ((scalaSource in Compile) in scioCassandra3).value,
   libraryDependencies ++= Seq(
     "com.datastax.cassandra" % "cassandra-driver-core" % "2.1.10.3",
     "org.apache.cassandra" % "cassandra-all" % "2.0.17",

--- a/project/BuildCredentials.scala
+++ b/project/BuildCredentials.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Ported from
+// https://github.com/google/google-api-java-client/blob/master/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProvider.java
+
+import java.io.File
+import java.util.Locale
+
+object BuildCredentials {
+
+  private val CREDENTIAL_ENV_VAR = "GOOGLE_APPLICATION_CREDENTIALS"
+  private val CLOUDSDK_CONFIG_DIRECTORY = "gcloud"
+  private val WELL_KNOWN_CREDENTIALS_FILE = "application_default_credentials.json"
+
+  def exists: Boolean = runningUsingEnvironmentVariable || runningUsingWellKnownFile
+
+  private def runningUsingEnvironmentVariable: Boolean = {
+    val credentialsPath = sys.env.getOrElse(CREDENTIAL_ENV_VAR, null)
+    if (credentialsPath == null || credentialsPath.length == 0) {
+      false
+    } else {
+      val credentialsFile = new File(credentialsPath)
+      fileExists(credentialsFile)
+    }
+  }
+
+  private def runningUsingWellKnownFile: Boolean = {
+    val os = sys.props.getOrElse("os.name", "").toLowerCase(Locale.US)
+    val cloudConfigPath = if (os.contains("windows")) {
+      val appDataPath = new File(sys.env("APPDATA"))
+      new File(appDataPath, CLOUDSDK_CONFIG_DIRECTORY)
+    } else {
+      val configPath = new File(sys.props.getOrElse("user.home", ""), ".config")
+      new File(configPath, CLOUDSDK_CONFIG_DIRECTORY)
+    }
+    val credentialFilePath = new File(cloudConfigPath, WELL_KNOWN_CREDENTIALS_FILE)
+    fileExists(credentialFilePath)
+  }
+
+  private def fileExists(file: File): Boolean = file.exists() && !file.isDirectory
+
+}

--- a/scio-avro/src/test/scala/com/spotify/scio/avro/types/TypeProviderTest.scala
+++ b/scio-avro/src/test/scala/com/spotify/scio/avro/types/TypeProviderTest.scala
@@ -761,13 +761,16 @@ class TypeProviderTest extends FlatSpec with Matchers {
 
   @AvroType.fromSchemaFile(
     """
+      |https://raw.githubusercontent.com/spotify/scio/master/
       |scio-avro/src/test/avro/
       |scio-avro-test.avsc
     """.stripMargin)
   class FromResourceMultiLine
 
-  @AvroType.fromSchemaFile("scio-avro/src/test/avro/scio-avro-test.avsc")
+  // scalastyle:off line.size.limit
+  @AvroType.fromSchemaFile("https://raw.githubusercontent.com/spotify/scio/master/scio-avro/src/test/avro/scio-avro-test.avsc")
   class FromResource
+  // scalastyle:on line.size.limit
 
   "AvroType.fromSchemaFile" should "support reading schema from multiline resource" in {
     val r = FromResourceMultiLine(1)
@@ -789,19 +792,23 @@ class TypeProviderTest extends FlatSpec with Matchers {
       .map(_.tree.tpe)
       .containsSlice(Seq(typeOf[Annotation1], typeOf[Annotation2])) shouldBe true
 
+  // scalastyle:off line.size.limit
   @Annotation1
-  @AvroType.fromSchemaFile("scio-avro/src/test/avro/scio-avro-test.avsc")
+  @AvroType.fromSchemaFile("https://raw.githubusercontent.com/spotify/scio/master/scio-avro/src/test/avro/scio-avro-test.avsc")
   @Annotation2
   class FromResourceWithSurroundingAnnotations
+  // scalastyle:on line.size.limit
 
   it should "preserve surrounding user defined annotations" in {
     containsAllAnnotTypes[FromResourceWithSurroundingAnnotations]
   }
 
-  @AvroType.fromSchemaFile("scio-avro/src/test/avro/scio-avro-test.avsc")
+  // scalastyle:off line.size.limit
+  @AvroType.fromSchemaFile("https://raw.githubusercontent.com/spotify/scio/master/scio-avro/src/test/avro/scio-avro-test.avsc")
   @Annotation1
   @Annotation2
   class FromResourceWithSequentialAnnotations
+  // scalastyle:on line.size.limit
 
   it should "preserve sequential user defined annotations" in {
     containsAllAnnotTypes[FromResourceWithSequentialAnnotations]


### PR DESCRIPTION
This seems to work for me for the most part.

- Using a brand new user (no gcloud credentials) locally, `sbt compile test:compile it:compile` works and any sources that require GCP access are skipped
- In CircleCI everything works and sources that require GCP access are compiled ([build](https://circleci.com/workflow-run/cbc5e635-e39d-4e72-b008-3e4097aa613d))
- In IntelliJ, "Build Project" failed in `BigQueryValidationTest` again with the following message.

```
Error:(48, 4) Unsupported type: com.spotify.scio.bigquery.validation.Country @com.spotify.scio.bigquery.types.BigQueryTag
  @BigQueryType.toTable
Error:(54, 44) type mismatch;
 found   : com.spotify.scio.bigquery.validation.Country
 required: String
    val countryInput = CountryInput(Country("US"), "UK", "No Country")
Error:(68, 27) type mismatch;
 found   : com.spotify.scio.bigquery.validation.Country
 required: String
      CountryInput(Country("USA"), "UK", "No Country")
```

@jbigred1 can you look into the last issue?