### PR TITLE
check scio dependency consistency

### DIFF
--- a/scio-maven-dependency-consistency-check/pom.xml
+++ b/scio-maven-dependency-consistency-check/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test</groupId>
+  <artifactId>scio-maven-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>scio-maven-test</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>scio-core_2.11</artifactId>
+      <version>0.5.5</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps />
+              </rules>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
It seems the internal dependencies of scio are conflicting.

A maven pom with only a dependency on `com.spotify:scio-core_2.11:0.5.5` fails a maven enforcer RequireUpperBoundDeps check.

```
cd scio-maven-dependency-consistency-check
mvn validate
```

```
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building scio-maven-test 1.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce) @ scio-maven-test ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for com.thoughtworks.paranamer:paranamer:2.7 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.avro:avro:1.8.2
        +-com.thoughtworks.paranamer:paranamer:2.7
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.fasterxml.jackson.module:jackson-module-scala_2.11:2.9.2
      +-com.fasterxml.jackson.module:jackson-module-paranamer:2.9.2
        +-com.thoughtworks.paranamer:paranamer:2.8
,
Require upper bound dependencies error for com.google.api-client:google-api-client:1.22.0 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api-client:google-api-client:1.22.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-org.apache.beam:beam-sdks-java-extensions-google-cloud-platform-core:2.4.0
          +-com.google.api-client:google-api-client:1.22.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.apis:google-api-services-bigquery:v2-rev374-1.22.0
          +-com.google.api-client:google-api-client:1.22.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.apis:google-api-services-pubsub:v1-rev10-1.22.0
          +-com.google.api-client:google-api-client:1.22.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-proto-client:1.4.0
          +-com.google.api-client:google-api-client:1.20.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-com.google.api-client:google-api-client:1.23.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-org.apache.beam:beam-sdks-java-extensions-google-cloud-platform-core:2.4.0
          +-com.google.apis:google-api-services-cloudresourcemanager:v1-rev6-1.22.0
            +-com.google.api-client:google-api-client:1.22.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-org.apache.beam:beam-sdks-java-extensions-google-cloud-platform-core:2.4.0
          +-com.google.apis:google-api-services-storage:v1-rev71-1.22.0
            +-com.google.api-client:google-api-client:1.22.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigdataoss:util:1.4.5
          +-com.google.api-client:google-api-client-java6:1.20.0
            +-com.google.api-client:google-api-client:1.20.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigdataoss:util:1.4.5
          +-com.google.api-client:google-api-client-jackson2:1.20.0
            +-com.google.api-client:google-api-client:1.20.0
,
Require upper bound dependencies error for com.google.code.findbugs:jsr305:3.0.1 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-org.apache.beam:beam-sdks-java-core:2.4.0
      +-com.google.code.findbugs:jsr305:3.0.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.code.findbugs:jsr305:3.0.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-org.apache.beam:beam-sdks-java-extensions-google-cloud-platform-core:2.4.0
          +-com.google.code.findbugs:jsr305:3.0.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.grpc:grpc-core:1.2.0
          +-com.google.code.findbugs:jsr305:3.0.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api:gax-grpc:0.20.0
          +-com.google.code.findbugs:jsr305:3.0.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigdataoss:util:1.4.5
          +-com.google.code.findbugs:jsr305:2.0.3
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.code.findbugs:jsr305:3.0.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-protos:1.0.0-pre3
          +-com.google.code.findbugs:jsr305:3.0.2
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-com.google.code.findbugs:jsr305:3.0.2
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.http-client:google-http-client:1.22.0
          +-com.google.code.findbugs:jsr305:1.3.9
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-org.apache.beam:beam-sdks-java-extensions-google-cloud-platform-core:2.4.0
          +-com.google.cloud.bigdataoss:gcsio:1.4.5
            +-com.google.code.findbugs:jsr305:2.0.3
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.grpc:grpc-core:1.2.0
          +-com.google.instrumentation:instrumentation-api:0.3.0
            +-com.google.code.findbugs:jsr305:3.0.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api:gax-grpc:0.20.0
          +-com.google.api:api-common:1.1.0
            +-com.google.code.findbugs:jsr305:3.0.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api:gax-grpc:0.20.0
          +-com.google.api:gax:1.3.1
            +-com.google.code.findbugs:jsr305:3.0.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigdataoss:util:1.4.5
          +-com.google.oauth-client:google-oauth-client:1.20.0
            +-com.google.code.findbugs:jsr305:1.3.9
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-io.opencensus:opencensus-contrib-grpc-util:0.7.0
            +-com.google.code.findbugs:jsr305:3.0.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-io.opencensus:opencensus-contrib-grpc-util:0.7.0
            +-io.opencensus:opencensus-api:0.7.0
              +-com.google.code.findbugs:jsr305:3.0.1
,
Require upper bound dependencies error for com.google.oauth-client:google-oauth-client:1.20.0 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigdataoss:util:1.4.5
          +-com.google.oauth-client:google-oauth-client:1.20.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-proto-client:1.4.0
          +-com.google.oauth-client:google-oauth-client:1.20.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api-client:google-api-client:1.22.0
          +-com.google.oauth-client:google-oauth-client:1.22.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-org.apache.beam:beam-sdks-java-extensions-google-cloud-platform-core:2.4.0
          +-com.google.cloud.bigdataoss:gcsio:1.4.5
            +-com.google.oauth-client:google-oauth-client:1.20.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigdataoss:util:1.4.5
          +-com.google.oauth-client:google-oauth-client-java6:1.20.0
            +-com.google.oauth-client:google-oauth-client:1.20.0
,
Require upper bound dependencies error for com.google.http-client:google-http-client:1.22.0 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.http-client:google-http-client:1.22.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-org.apache.beam:beam-sdks-java-extensions-google-cloud-platform-core:2.4.0
          +-com.google.http-client:google-http-client:1.22.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-proto-client:1.4.0
          +-com.google.http-client:google-http-client:1.20.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-com.google.http-client:google-http-client:1.23.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.http-client:google-http-client-jackson2:1.22.0
          +-com.google.http-client:google-http-client:1.22.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.auth:google-auth-library-oauth2-http:0.7.1
          +-com.google.http-client:google-http-client:1.19.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigdataoss:util:1.4.5
          +-com.google.oauth-client:google-oauth-client:1.20.0
            +-com.google.http-client:google-http-client:1.20.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-proto-client:1.4.0
          +-com.google.http-client:google-http-client-protobuf:1.20.0
            +-com.google.http-client:google-http-client:1.20.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-proto-client:1.4.0
          +-com.google.http-client:google-http-client-jackson:1.20.0
            +-com.google.http-client:google-http-client:1.20.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-com.google.auth:google-auth-library-appengine:0.7.0
            +-com.google.http-client:google-http-client:1.19.0
,
Require upper bound dependencies error for com.fasterxml.jackson.core:jackson-annotations:2.8.9 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-org.apache.beam:beam-sdks-java-core:2.4.0
      +-com.fasterxml.jackson.core:jackson-annotations:2.8.9
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.fasterxml.jackson.module:jackson-module-scala_2.11:2.9.2
      +-com.fasterxml.jackson.core:jackson-annotations:2.9.2
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-org.apache.beam:beam-sdks-java-core:2.4.0
      +-com.fasterxml.jackson.core:jackson-databind:2.8.9
        +-com.fasterxml.jackson.core:jackson-annotations:2.8.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-org.apache.beam:beam-sdks-java-extensions-google-cloud-platform-core:2.4.0
          +-com.fasterxml.jackson.core:jackson-annotations:2.8.9
,
Require upper bound dependencies error for com.fasterxml.jackson.core:jackson-databind:2.8.9 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-org.apache.beam:beam-sdks-java-core:2.4.0
      +-com.fasterxml.jackson.core:jackson-databind:2.8.9
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.fasterxml.jackson.module:jackson-module-scala_2.11:2.9.2
      +-com.fasterxml.jackson.core:jackson-databind:2.9.2
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.fasterxml.jackson.core:jackson-databind:2.8.9
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.fasterxml.jackson.module:jackson-module-scala_2.11:2.9.2
      +-com.fasterxml.jackson.module:jackson-module-paranamer:2.9.2
        +-com.fasterxml.jackson.core:jackson-databind:2.9.2
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-org.apache.beam:beam-sdks-java-extensions-google-cloud-platform-core:2.4.0
          +-com.fasterxml.jackson.core:jackson-databind:2.8.9
,
Require upper bound dependencies error for com.google.protobuf:protobuf-java:3.3.1 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.google.protobuf:protobuf-java:3.3.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.protobuf:protobuf-java:3.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-org.apache.beam:beam-sdks-java-extensions-protobuf:2.4.0
          +-com.google.protobuf:protobuf-java:3.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-core-grpc:1.2.0
          +-com.google.protobuf:protobuf-java:3.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api.grpc:proto-google-cloud-pubsub-v1:0.1.18
          +-com.google.protobuf:protobuf-java:3.3.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-protos:1.3.0
          +-com.google.protobuf:protobuf-java:3.0.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-protos:1.0.0-pre3
          +-com.google.protobuf:protobuf-java:3.3.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-com.google.protobuf:protobuf-java:3.4.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api.grpc:proto-google-cloud-spanner-admin-database-v1:0.1.9
          +-com.google.protobuf:protobuf-java:3.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api.grpc:proto-google-common-protos:0.1.9
          +-com.google.protobuf:protobuf-java:3.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api:gax-grpc:0.20.0
          +-io.grpc:grpc-protobuf:1.2.0
            +-com.google.protobuf:protobuf-java:3.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-core-grpc:1.2.0
          +-com.google.protobuf:protobuf-java-util:3.2.0
            +-com.google.protobuf:protobuf-java:3.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api.grpc:proto-google-cloud-pubsub-v1:0.1.18
          +-com.google.api.grpc:proto-google-iam-v1:0.1.18
            +-com.google.protobuf:protobuf-java:3.3.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-proto-client:1.4.0
          +-com.google.http-client:google-http-client-protobuf:1.20.0
            +-com.google.protobuf:protobuf-java:2.4.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-protos:1.3.0
          +-com.google.api.grpc:grpc-google-common-protos:0.1.0
            +-com.google.protobuf:protobuf-java:3.0.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:proto-google-cloud-spanner-v1:0.1.11b
            +-com.google.protobuf:protobuf-java:3.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:proto-google-cloud-spanner-admin-instance-v1:0.1.11
            +-com.google.protobuf:protobuf-java:3.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:grpc-google-longrunning-v1:0.1.11
            +-com.google.api.grpc:proto-google-longrunning-v1:0.1.11
              +-com.google.protobuf:protobuf-java:3.2.0
,
Require upper bound dependencies error for io.grpc:grpc-core:1.2.0 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.grpc:grpc-core:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.grpc:grpc-auth:1.2.0
          +-io.grpc:grpc-core:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.grpc:grpc-netty:1.2.0
          +-io.grpc:grpc-core:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.grpc:grpc-stub:1.2.0
          +-io.grpc:grpc-core:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-protos:1.0.0-pre3
          +-io.grpc:grpc-core:1.5.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-io.grpc:grpc-core:1.7.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api:gax-grpc:0.20.0
          +-io.grpc:grpc-protobuf:1.2.0
            +-io.grpc:grpc-core:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-io.opencensus:opencensus-contrib-grpc-util:0.7.0
            +-io.grpc:grpc-core:1.6.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api:gax-grpc:0.20.0
          +-io.grpc:grpc-protobuf:1.2.0
            +-io.grpc:grpc-protobuf-lite:1.2.0
              +-io.grpc:grpc-core:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-protos:1.3.0
          +-com.google.api.grpc:grpc-google-common-protos:0.1.0
            +-io.grpc:grpc-all:1.2.0
              +-io.grpc:grpc-core:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-protos:1.3.0
          +-com.google.api.grpc:grpc-google-common-protos:0.1.0
            +-io.grpc:grpc-all:1.2.0
              +-io.grpc:grpc-protobuf-nano:1.0.1
                +-io.grpc:grpc-core:1.0.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-protos:1.3.0
          +-com.google.api.grpc:grpc-google-common-protos:0.1.0
            +-io.grpc:grpc-all:1.2.0
              +-io.grpc:grpc-okhttp:1.0.1
                +-io.grpc:grpc-core:1.2.0
,
Require upper bound dependencies error for com.google.errorprone:error_prone_annotations:2.0.11 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.grpc:grpc-core:1.2.0
          +-com.google.errorprone:error_prone_annotations:2.0.11
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-io.opencensus:opencensus-contrib-grpc-util:0.7.0
            +-com.google.errorprone:error_prone_annotations:2.0.19
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-io.opencensus:opencensus-contrib-grpc-util:0.7.0
            +-io.opencensus:opencensus-api:0.7.0
              +-com.google.errorprone:error_prone_annotations:2.0.19
,
Require upper bound dependencies error for io.grpc:grpc-context:1.2.0 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.grpc:grpc-core:1.2.0
          +-io.grpc:grpc-context:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-protos:1.3.0
          +-com.google.api.grpc:grpc-google-common-protos:0.1.0
            +-io.grpc:grpc-all:1.2.0
              +-io.grpc:grpc-context:1.0.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-io.opencensus:opencensus-contrib-grpc-util:0.7.0
            +-io.opencensus:opencensus-api:0.7.0
              +-io.grpc:grpc-context:1.6.1
,
Require upper bound dependencies error for io.grpc:grpc-stub:1.2.0 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.grpc:grpc-stub:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api:gax-grpc:0.20.0
          +-io.grpc:grpc-stub:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.18
          +-io.grpc:grpc-stub:1.6.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-io.grpc:grpc-stub:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-protos:1.0.0-pre3
          +-io.grpc:grpc-stub:1.5.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-io.grpc:grpc-stub:1.7.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:grpc-google-cloud-spanner-v1:0.1.11b
            +-io.grpc:grpc-stub:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:grpc-google-cloud-spanner-admin-database-v1:0.1.11
            +-io.grpc:grpc-stub:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:grpc-google-cloud-spanner-admin-instance-v1:0.1.11
            +-io.grpc:grpc-stub:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:grpc-google-longrunning-v1:0.1.11
            +-io.grpc:grpc-stub:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-protos:1.3.0
          +-com.google.api.grpc:grpc-google-common-protos:0.1.0
            +-io.grpc:grpc-all:1.2.0
              +-io.grpc:grpc-stub:1.0.1
,
Require upper bound dependencies error for io.grpc:grpc-netty:1.2.0 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.grpc:grpc-netty:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api:gax-grpc:0.20.0
          +-io.grpc:grpc-netty:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-io.grpc:grpc-netty:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-io.grpc:grpc-netty:1.7.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-protos:1.3.0
          +-com.google.api.grpc:grpc-google-common-protos:0.1.0
            +-io.grpc:grpc-all:1.2.0
              +-io.grpc:grpc-netty:1.0.1
,
Require upper bound dependencies error for io.grpc:grpc-protobuf:1.2.0 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api:gax-grpc:0.20.0
          +-io.grpc:grpc-protobuf:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-core-grpc:1.2.0
          +-io.grpc:grpc-protobuf:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.18
          +-io.grpc:grpc-protobuf:1.6.1
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-protos:1.0.0-pre3
          +-io.grpc:grpc-protobuf:1.5.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:grpc-google-cloud-spanner-v1:0.1.11b
            +-io.grpc:grpc-protobuf:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:grpc-google-cloud-spanner-admin-database-v1:0.1.11
            +-io.grpc:grpc-protobuf:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:grpc-google-cloud-spanner-admin-instance-v1:0.1.11
            +-io.grpc:grpc-protobuf:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:grpc-google-longrunning-v1:0.1.11
            +-io.grpc:grpc-protobuf:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-protos:1.3.0
          +-com.google.api.grpc:grpc-google-common-protos:0.1.0
            +-io.grpc:grpc-all:1.2.0
              +-io.grpc:grpc-protobuf:1.0.1
,
Require upper bound dependencies error for io.grpc:grpc-auth:1.2.0 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.grpc:grpc-auth:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api:gax-grpc:0.20.0
          +-io.grpc:grpc-auth:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-io.grpc:grpc-auth:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-io.grpc:grpc-auth:1.7.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-protos:1.3.0
          +-com.google.api.grpc:grpc-google-common-protos:0.1.0
            +-io.grpc:grpc-all:1.2.0
              +-io.grpc:grpc-auth:1.0.1
,
Require upper bound dependencies error for com.google.api.grpc:proto-google-common-protos:0.1.9 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api.grpc:proto-google-common-protos:0.1.9
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api:gax-grpc:0.20.0
          +-com.google.api.grpc:proto-google-common-protos:0.1.11
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api.grpc:proto-google-cloud-pubsub-v1:0.1.18
          +-com.google.api.grpc:proto-google-common-protos:0.1.18
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-core:1.0.2
          +-com.google.api.grpc:proto-google-common-protos:0.1.11
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api.grpc:proto-google-cloud-spanner-admin-database-v1:0.1.9
          +-com.google.api.grpc:proto-google-common-protos:0.1.9
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api.grpc:proto-google-cloud-pubsub-v1:0.1.18
          +-com.google.api.grpc:proto-google-iam-v1:0.1.18
            +-com.google.api.grpc:proto-google-common-protos:0.1.18
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:proto-google-cloud-spanner-v1:0.1.11b
            +-com.google.api.grpc:proto-google-common-protos:0.1.11
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:proto-google-cloud-spanner-admin-instance-v1:0.1.11
            +-com.google.api.grpc:proto-google-common-protos:0.1.11
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:grpc-google-longrunning-v1:0.1.11
            +-com.google.api.grpc:proto-google-longrunning-v1:0.1.11
              +-com.google.api.grpc:proto-google-common-protos:0.1.11
,
Require upper bound dependencies error for com.google.cloud:google-cloud-core:1.0.2 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-core:1.0.2
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-core-grpc:1.2.0
          +-com.google.cloud:google-cloud-core:1.2.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.cloud:google-cloud-core:1.2.0
,
Require upper bound dependencies error for com.google.api.grpc:grpc-google-common-protos:0.1.0 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.datastore:datastore-v1-protos:1.3.0
          +-com.google.api.grpc:grpc-google-common-protos:0.1.0
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-protos:1.0.0-pre3
          +-com.google.api.grpc:grpc-google-common-protos:0.1.9
,
Require upper bound dependencies error for io.netty:netty-tcnative-boringssl-static:1.1.33.Fork26 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-io.netty:netty-tcnative-boringssl-static:1.1.33.Fork26
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-io.netty:netty-tcnative-boringssl-static:1.1.33.Fork26
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud.bigtable:bigtable-client-core:1.0.0
          +-io.netty:netty-tcnative-boringssl-static:2.0.6.Final
,
Require upper bound dependencies error for com.google.api.grpc:proto-google-cloud-spanner-admin-database-v1:0.1.9 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.api.grpc:proto-google-cloud-spanner-admin-database-v1:0.1.9
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:proto-google-cloud-spanner-admin-database-v1:0.1.11
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.cloud:google-cloud-spanner:0.20.0b-beta
          +-com.google.api.grpc:grpc-google-cloud-spanner-admin-database-v1:0.1.11
            +-com.google.api.grpc:proto-google-cloud-spanner-admin-database-v1:0.1.11
,
Require upper bound dependencies error for com.fasterxml.jackson.core:jackson-core:2.8.9 paths to dependency are:
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-org.apache.beam:beam-sdks-java-core:2.4.0
      +-com.fasterxml.jackson.core:jackson-core:2.8.9
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.fasterxml.jackson.module:jackson-module-scala_2.11:2.9.2
      +-com.fasterxml.jackson.core:jackson-core:2.9.2
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-org.apache.beam:beam-sdks-java-core:2.4.0
      +-com.fasterxml.jackson.core:jackson-databind:2.8.9
        +-com.fasterxml.jackson.core:jackson-core:2.8.9
and
+-test:scio-maven-test:1.0-SNAPSHOT
  +-com.spotify:scio-core_2.11:0.5.5
    +-com.spotify:scio-avro_2.11:0.5.5
      +-org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0
        +-com.google.http-client:google-http-client-jackson2:1.22.0
          +-com.fasterxml.jackson.core:jackson-core:2.1.3
]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.599 s
[INFO] Finished at: 2018-06-14T10:48:25+09:00
[INFO] Final Memory: 19M/440M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:1.4.1:enforce (enforce) on project scio-maven-test: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```
