### PR TITLE
Use a different strategy to fix transitive dependencies conflicts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,7 +166,8 @@ val commonSettings = Sonatype.sonatypeSettings ++ assemblySettings ++ Seq(
     val bootClasspath = System.getProperty("sun.boot.class.path").split(sys.props("path.separator")).map(file(_))
     val jdkMapping = Map(bootClasspath.find(_.getPath.endsWith("rt.jar")).get -> url("http://docs.oracle.com/javase/8/docs/api/"))
     docMappings.flatMap((mappingFn _).tupled).toMap ++ jdkMapping
-  }
+  },
+  conflictManager := ConflictManager.latestTime,
 ) ++ mimaSettings
 
 lazy val itSettings = Defaults.itSettings ++ Seq(


### PR DESCRIPTION
Replace the current strategy used by sbt to resolve conflicts with `ConflictManager.latestTime` which will compare publication time instead of comparing version numbers. This strategy is more reliable and fixes most of the eviction warnings. There's still a couple of problematic dependencies:

```
[warn] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[warn] 	* com.google.guava:guava:20.0 is selected over {19.0, 18.0}
[warn] 	    +- com.spotify:scio-core_2.11:0.5.6-SNAPSHOT          (depends on 20.0)
[warn] 	    +- org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0 (depends on 20.0)
[warn] 	    +- com.google.auth:google-auth-library-appengine:0.7.0 (depends on 19.0)
[warn] 	    +- com.google.protobuf:protobuf-java-util:3.2.0       (depends on 19.0)
[warn] 	    +- com.google.cloud.bigtable:bigtable-protos:1.0.0-pre3 (depends on 19.0)
[warn] 	    +- com.google.cloud.bigtable:bigtable-client-core:1.0.0 (depends on 19.0)
[warn] 	    +- com.google.cloud:google-cloud-core:1.0.2           (depends on 19.0)
[warn] 	    +- com.google.auth:google-auth-library-oauth2-http:0.7.1 (depends on 19.0)
[warn] 	    +- com.google.cloud.bigdataoss:gcsio:1.4.5            (depends on 19.0)
[warn] 	    +- io.grpc:grpc-protobuf:1.6.1                        (depends on 19.0)
[warn] 	    +- com.google.cloud:google-cloud-core-grpc:1.2.0      (depends on 19.0)
[warn] 	    +- io.grpc:grpc-protobuf:1.2.0                        (depends on 19.0)
[warn] 	    +- io.grpc:grpc-protobuf-nano:1.2.0                   (depends on 19.0)
[warn] 	    +- io.grpc:grpc-core:1.2.0                            (depends on 19.0)
[warn] 	    +- com.google.protobuf:protobuf-java-util:3.3.1       (depends on 19.0)
[warn] 	    +- io.grpc:grpc-protobuf-lite:1.6.1                   (depends on 19.0)
[warn] 	    +- com.google.auto:auto-common:0.3                    (depends on 19.0)
[warn] 	    +- com.google.api:api-common:1.1.0                    (depends on 19.0)
[warn] 	    +- com.google.cloud.datastore:datastore-v1-proto-client:1.4.0 (depends on 19.0)
[warn] 	    +- io.opencensus:opencensus-api:0.7.0                 (depends on 19.0)
[warn] 	    +- com.google.api:gax:1.3.1                           (depends on 19.0)
[warn] 	    +- io.grpc:grpc-protobuf-lite:1.2.0                   (depends on 19.0)
[warn] 	    +- com.google.api:gax-grpc:0.20.0                     (depends on 19.0)
[warn] 	    +- com.google.auto.service:auto-service:1.0-rc3       (depends on 19.0)
[warn] 	    +- com.google.cloud.bigdataoss:util:1.4.5             (depends on 19.0)
[warn] 	* com.google.protobuf:protobuf-java is evicted completely
[warn] 	    +- com.google.protobuf:protobuf-java-util:3.3.1       (depends on 3.3.1)
[warn] 	    +- com.google.cloud.bigtable:bigtable-protos:1.0.0-pre3 (depends on 3.3.1)
[warn] 	    +- com.google.cloud.datastore:datastore-v1-protos:1.3.0 (depends on 3.2.0)
[warn] 	    +- com.google.api.grpc:proto-google-cloud-pubsub-v1:0.1.18 (depends on 3.2.0)
[warn] 	    +- com.google.protobuf:protobuf-java-util:3.2.0       (depends on 3.2.0)
[warn] 	    +- com.google.cloud.bigtable:bigtable-client-core:1.0.0 (depends on 3.2.0)
[warn] 	    +- com.google.api.grpc:proto-google-iam-v1:0.1.18     (depends on 3.2.0)
[warn] 	    +- com.google.api.grpc:proto-google-cloud-spanner-v1:0.1.11b (depends on 3.2.0)
[warn] 	    +- org.apache.beam:beam-sdks-java-extensions-protobuf:2.4.0 (depends on 3.2.0)
[warn] 	    +- io.grpc:grpc-protobuf:1.6.1                        (depends on 3.2.0)
[warn] 	    +- com.google.cloud:google-cloud-core-grpc:1.2.0      (depends on 3.2.0)
[warn] 	    +- com.google.api.grpc:proto-google-cloud-spanner-admin-database-v1:0.1.9 (depends on 3.2.0)
[warn] 	    +- io.grpc:grpc-protobuf:1.2.0                        (depends on 3.2.0)
[warn] 	    +- com.spotify:scio-core_2.11:0.5.6-SNAPSHOT          (depends on 3.2.0)
[warn] 	    +- com.google.api.grpc:grpc-google-common-protos:0.1.0 (depends on 3.2.0)
[warn] 	    +- com.google.http-client:google-http-client-protobuf:1.20.0 (depends on 3.2.0)
[warn] 	    +- com.google.api.grpc:proto-google-longrunning-v1:0.1.11 (depends on 3.2.0)
[warn] 	    +- com.google.api.grpc:proto-google-cloud-spanner-admin-instance-v1:0.1.11 (depends on 3.2.0)
[warn] 	    +- com.google.api.grpc:proto-google-common-protos:0.1.9 (depends on 3.2.0)
[warn] 	    +- org.apache.beam:beam-sdks-java-io-google-cloud-platform:2.4.0 (depends on 3.2.0)
```

and 

```
[warn] Found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[warn] 	* com.google.apis:google-api-services-storage:v1-rev131-1.22.0 is selected over {v1-rev71-1.22.0, v1-rev35-1.20.0}
[warn] 	    +- com.spotify:scio-tensorflow_2.11:0.5.6-SNAPSHOT    (depends on v1-rev131-1.22.0)
[warn] 	    +- com.google.cloud.bigdataoss:util:1.4.5             (depends on v1-rev35-1.20.0)
[warn] 	    +- org.apache.beam:beam-sdks-java-extensions-google-cloud-platform-core:2.4.0 (depends on v1-rev71-1.22.0)
[warn] 	    +- com.google.cloud.bigdataoss:gcsio:1.4.5            (depends on v1-rev71-1.22.0)
[warn] Run 'evicted' to see detailed eviction warnings
```

But appart from that it should improve the situation. It should also fix https://github.com/spotify/scio/pull/1208.