### PR TITLE
Make default for `args.getOrElse` call-by-name

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/Args.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/Args.scala
@@ -86,7 +86,7 @@ class Args private (private val m: Map[String, List[String]]) extends Serializab
   def apply(key: String): String = required(key)
 
   /** Shortcut for `optional(key).getOrElse(default)`. */
-  def getOrElse(key: String, default: String): String = optional(key).getOrElse(default)
+  def getOrElse(key: String, default: => String): String = optional(key).getOrElse(default)
 
   /** Get the list of values for a given key. */
   def list(key: String): List[String] = m.getOrElse(key, Nil)


### PR DESCRIPTION
- Enables usage like `args.getOrElse("arg", args("alternateArg"))`