### PR TITLE
Enforce protobuf-java 3.3.1 for scio-tensorflow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -565,6 +565,10 @@ lazy val scioTensorFlow: Project = Project(
     "com.spotify" % "zoltar-api" % zoltarVersion,
     "com.spotify" % "zoltar-tensorflow" % zoltarVersion
   ),
+  dependencyOverrides ++= Seq(
+    "com.google.protobuf" % "protobuf-java" % protobufVersion,
+    "com.google.protobuf" % "protobuf-java-util" % protobufVersion
+  ),
   libraryDependencies ++= Seq(
     "io.circe" %% "circe-core",
     "io.circe" %% "circe-generic",


### PR DESCRIPTION
Fix #1239 

This enforces that the compilation of the protos is done with scio protobuf pinned version.