### PR TITLE
Optimize kryo serialization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ val chillVersion = "0.9.2"
 val circeVersion = "0.9.1"
 val commonsIoVersion = "2.6"
 val commonsMath3Version = "3.6.1"
-val commonsPoolVersion = "2.5.0"
 val elasticsearch2Version = "2.1.0"
 val elasticsearch5Version = "5.5.0"
 val featranVersion = "0.1.27"
@@ -303,8 +302,7 @@ lazy val scioCore: Project = Project(
     "com.google.guava" % "guava" % guavaVersion,
     "com.google.protobuf" % "protobuf-java" % protobufVersion,
     "me.lyh" %% "protobuf-generic" % protobufGenericVersion,
-    "org.apache.xbean" % "xbean-asm5-shaded" % asmVersion,
-    "org.apache.commons" % "commons-pool2" %  commonsPoolVersion
+    "org.apache.xbean" % "xbean-asm5-shaded" % asmVersion
   )
 ).dependsOn(
   scioAvro,

--- a/scio-core/src/main/scala/com/spotify/scio/coders/KryoAtomicCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/KryoAtomicCoder.scala
@@ -27,7 +27,6 @@ import com.google.common.reflect.ClassPath
 import com.google.protobuf.{ByteString, Message}
 import com.spotify.scio.coders.serializers._
 import com.spotify.scio.options.ScioOptions
-import com.spotify.scio.util.Functions
 import com.twitter.chill._
 import com.twitter.chill.algebird.AlgebirdRegistrar
 import com.twitter.chill.protobuf.ProtobufSerializer
@@ -36,14 +35,8 @@ import org.apache.avro.specific.SpecificRecordBase
 import org.apache.beam.sdk.coders.{AtomicCoder, CoderException, InstantCoder}
 import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder
 import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
-import org.apache.beam.sdk.util.VarInt
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver
-import org.apache.commons.pool2.impl.{
-  DefaultPooledObject,
-  GenericObjectPool,
-  GenericObjectPoolConfig
-}
-import org.apache.commons.pool2.{BasePooledObjectFactory, ObjectPool, PooledObject}
+import org.apache.beam.sdk.util.{EmptyOnDeserializationThreadLocal, VarInt}
 import org.joda.time.{DateTime, LocalDate, LocalDateTime, LocalTime}
 import org.slf4j.LoggerFactory
 
@@ -52,16 +45,15 @@ import scala.collection.convert.Wrappers
 import scala.collection.mutable
 
 private object KryoRegistrarLoader {
-
-  private[this] val logger = LoggerFactory.getLogger(this.getClass)
+  private[this] val Log = LoggerFactory.getLogger(this.getClass)
 
   def load(k: Kryo): Unit = {
-    logger.debug("Loading KryoRegistrars: " + registrars.mkString(", "))
+    Log.debug("Loading KryoRegistrars: " + registrars.mkString(", "))
     registrars.foreach(_(k))
   }
 
   private val registrars: Seq[IKryoRegistrar] = {
-    logger.debug("Initializing KryoRegistrars")
+    Log.debug("Initializing KryoRegistrars")
     val classLoader = Thread.currentThread().getContextClassLoader
     ClassPath
       .from(classLoader)
@@ -85,14 +77,17 @@ private object KryoRegistrarLoader {
   }
 }
 
+object ScioKryoRegistrar {
+  private val Log = LoggerFactory.getLogger(this.getClass)
+}
+
 /** serializers we've written in Scio and want to add to Kryo serialization
  * @see com.spotify.scio.coders.serializers */
-private class ScioKryoRegistrar extends IKryoRegistrar {
-
-  private[this] val logger = LoggerFactory.getLogger(this.getClass)
+private final class ScioKryoRegistrar extends IKryoRegistrar {
+  import ScioKryoRegistrar.Log
 
   override def apply(k: Kryo): Unit = {
-    logger.debug("Loading common Kryo serializers...")
+    Log.debug("Loading common Kryo serializers...")
     k.forClass(new CoderSerializer(InstantCoder.of()))
     k.forClass(new CoderSerializer(TableRowJsonCoder.of()))
     // Java Iterable/Collection are missing proper equality check, use custom CBF as a
@@ -121,17 +116,16 @@ private class ScioKryoRegistrar extends IKryoRegistrar {
   }
 }
 
-private[scio] class KryoAtomicCoder[T](private val options: KryoOptions) extends AtomicCoder[T] {
+private[scio] final class KryoAtomicCoder[T](private val options: KryoOptions)
+    extends AtomicCoder[T] {
   import KryoAtomicCoder._
-
-  private[this] val header = -1
 
   override def encode(value: T, os: OutputStream): Unit = withKryoState(options) { kryoState =>
     if (value == null) {
       throw new CoderException("cannot encode a null value")
     }
 
-    VarInt.encode(header, os)
+    VarInt.encode(Header, os)
     val chunked = kryoState.outputChunked
     chunked.setOutputStream(os)
 
@@ -153,7 +147,7 @@ private[scio] class KryoAtomicCoder[T](private val options: KryoOptions) extends
 
   override def decode(is: InputStream): T = withKryoState(options) { kryoState =>
     val chunked = kryoState.inputChunked
-    val o = if (VarInt.decodeInt(is) == header) {
+    val o = if (VarInt.decodeInt(is) == Header) {
       chunked.setInputStream(is)
 
       kryoState.kryo.readClassAndObject(chunked)
@@ -188,7 +182,7 @@ private[scio] class KryoAtomicCoder[T](private val options: KryoOptions) extends
           val elapsed = System.currentTimeMillis() - start
           if (elapsed > abortThreshold) {
             aborted = true
-            logger.warn(
+            Log.warn(
               s"Aborting size estimation for ${wrapper.underlying.getClass}, " +
                 s"elapsed: $elapsed ms, count: $count, bytes: $bytes")
             wrapper.underlying match {
@@ -196,15 +190,15 @@ private[scio] class KryoAtomicCoder[T](private val options: KryoOptions) extends
                 // extrapolate remaining bytes in the collection
                 val remaining = (bytes.toDouble / count * (c.size - count)).toLong
                 observer.update(remaining)
-                logger.warn(
+                Log.warn(
                   s"Extrapolated size estimation for ${wrapper.underlying.getClass} " +
                     s"count: ${c.size}, bytes: ${bytes + remaining}")
               case _ =>
-                logger.warn("Can't get size of internal collection, thus can't extrapolate size")
+                Log.warn("Can't get size of internal collection, thus can't extrapolate size")
             }
           } else if (elapsed > warningThreshold && !warned) {
             warned = true
-            logger.warn(
+            Log.warn(
               s"Slow size estimation for ${wrapper.underlying.getClass}, " +
                 s"elapsed: $elapsed ms, count: $count, bytes: $bytes")
           }
@@ -231,27 +225,14 @@ private[scio] final case class KryoState(kryo: Kryo,
                                          outputChunked: OutputChunked)
 
 private[scio] object KryoAtomicCoder {
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  private val Log = LoggerFactory.getLogger(this.getClass)
+  private val Header = -1
 
-  private[this] val defaultPoolConfig = {
-    val config = new GenericObjectPoolConfig()
-    config.setMaxTotal(Integer.MAX_VALUE)
-    config.setJmxEnabled(false)
-    config.setMaxIdle(Integer.MAX_VALUE)
-    config.setMinIdle(Integer.MAX_VALUE)
-    config
-  }
+  private[this] val kryoState: ThreadLocal[KryoState] =
+    new EmptyOnDeserializationThreadLocal[KryoState]
 
-  final case class KryStatePoolFactory(f: () => KryoState)
-      extends BasePooledObjectFactory[KryoState] {
-    override def create(): KryoState = f()
-
-    override def wrap(obj: KryoState): PooledObject[KryoState] =
-      new DefaultPooledObject[KryoState](obj)
-  }
-
-  private[this] val kryoPool: KryoOptions => ObjectPool[KryoState] = Functions.memoize { options =>
-    val factory = KryStatePoolFactory(() => {
+  def withKryoState[R](options: KryoOptions)(f: KryoState => R): R = {
+    val ks = Option(kryoState.get()).getOrElse {
       val k = KryoSerializer.registered.newKryo()
       k.setReferences(options.referenceTracking)
       k.setRegistrationRequired(options.registrationRequired)
@@ -264,29 +245,22 @@ private[scio] object KryoAtomicCoder {
       val input = new InputChunked(options.bufferSize)
       val output = new OutputChunked(options.bufferSize)
 
-      KryoState(k, input, output)
-    })
-
-    new GenericObjectPool[KryoState](factory, defaultPoolConfig)
-  }
-
-  def withKryoState[R](options: KryoOptions)(f: KryoState => R): R = {
-    val kryoState = kryoPool(options).borrowObject()
-    try {
-      f(kryoState)
-    } finally {
-      kryoPool(options).returnObject(kryoState)
+      val state = KryoState(k, input, output)
+      kryoState.set(state)
+      state
     }
+
+    f(ks)
   }
 }
 
-private[scio] case class KryoOptions(bufferSize: Int,
-                                     maxBufferSize: Int,
-                                     referenceTracking: Boolean,
-                                     registrationRequired: Boolean)
+private[scio] final case class KryoOptions(bufferSize: Int,
+                                           maxBufferSize: Int,
+                                           referenceTracking: Boolean,
+                                           registrationRequired: Boolean)
 
 private[scio] object KryoOptions {
-  def apply(): KryoOptions = KryoOptions(PipelineOptionsFactory.create())
+  @inline def apply(): KryoOptions = KryoOptions(PipelineOptionsFactory.create())
 
   def apply(options: PipelineOptions): KryoOptions = {
     val o = options.as(classOf[ScioOptions])

--- a/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
@@ -18,8 +18,6 @@
 package com.spotify.scio.util
 
 import java.lang.{Iterable => JIterable}
-import java.util.concurrent.ConcurrentHashMap
-import java.util.function.Function
 import java.util.{List => JList}
 
 import com.google.common.collect.Lists
@@ -200,11 +198,4 @@ private[scio] object Functions {
       _mon.sumOption(accumulator).orElse(Some(_mon.zero))
   }
 
-  def memoize[T, U](f: T => U): T => U = {
-    lazy val cache = new ConcurrentHashMap[T, U]()
-    t =>
-      cache.computeIfAbsent(t, new Function[T, U] {
-        override def apply(tt: T): U = f(tt)
-      })
-  }
 }


### PR DESCRIPTION
### master
```
[info] Benchmark                                  Mode  Cnt     Score     Error  Units
[info] KryoAtomicCoderBenchmark.customDecode      avgt   80   235.947 ±  16.055  ns/op
[info] KryoAtomicCoderBenchmark.customEncode      avgt   80   804.571 ±  15.781  ns/op
[info] KryoAtomicCoderBenchmark.customKryoDecode  avgt   80   663.201 ±  17.165  ns/op
[info] KryoAtomicCoderBenchmark.customKryoEncode  avgt   80  1502.096 ±  19.122  ns/op
[info] KryoAtomicCoderBenchmark.javaDecode        avgt   80  7810.390 ± 110.794  ns/op
[info] KryoAtomicCoderBenchmark.javaEncode        avgt   80  5993.367 ± 108.613  ns/op
[info] KryoAtomicCoderBenchmark.kryoDecode        avgt   80   761.828 ±   8.562  ns/op
[info] KryoAtomicCoderBenchmark.kryoEncode        avgt   80  1603.633 ±  16.763  ns/op
```
### PR
``` 
[info] Benchmark                                  Mode  Cnt     Score     Error  Units
[info] KryoAtomicCoderBenchmark.customDecode      avgt   80   232.563 ±   5.763  ns/op
[info] KryoAtomicCoderBenchmark.customEncode      avgt   80   785.640 ±   5.570  ns/op
[info] KryoAtomicCoderBenchmark.customKryoDecode  avgt   80   192.968 ±   3.797  ns/op
[info] KryoAtomicCoderBenchmark.customKryoEncode  avgt   80  1085.145 ±  16.238  ns/op
[info] KryoAtomicCoderBenchmark.javaDecode        avgt   80  8033.934 ± 161.660  ns/op
[info] KryoAtomicCoderBenchmark.javaEncode        avgt   80  6498.303 ± 891.901  ns/op
[info] KryoAtomicCoderBenchmark.kryoDecode        avgt   80   313.482 ±   6.569  ns/op
[info] KryoAtomicCoderBenchmark.kryoEncode        avgt   80  1130.998 ±  16.154  ns/op
```

This was also test against a long running streaming pipeline to make sure we don't have memory leaks!