### PR TITLE
Add example of FileIO#writeDynamic (#1164)

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.examples.extra
+
+import com.spotify.scio.ContextAndArgs
+import com.spotify.scio.examples.common.ExampleData
+import org.apache.beam.sdk.coders.StringUtf8Coder
+import org.apache.beam.sdk.io.{FileIO, TextIO}
+import org.apache.beam.sdk.transforms.Contextful
+
+// `sbt runMain "com.spotify.scio.examples.extra.WriteDynamicExample
+// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --input=gs://apache-beam-samples/shakespeare/kinglear.txt
+// --output=[OUTPUT]"
+object WriteDynamicExample {
+  case class LinesPerCharacter(name: String, lines: Long)
+
+  def main(cmdlineArgs: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(cmdlineArgs)
+
+    // Group records according to first letter of the character's name
+    // All characters starting with letter A will share an output path, etc
+    val dynamicOutput: FileIO.Write[String, LinesPerCharacter] = FileIO
+      .writeDynamic[String, LinesPerCharacter]()
+      .by((linesPerCharacter: LinesPerCharacter) =>
+        linesPerCharacter.name.charAt(0).toString
+      )
+      .withNaming((characterFirstLetter: String) =>
+        FileIO.Write.defaultNaming(s"characters-starting-with-$characterFirstLetter", ".txt")
+      )
+      .withDestinationCoder(StringUtf8Coder.of())
+      .withNumShards(1) // Since input is small, restrict to one file per bucket
+      .via(
+        Contextful.fn[LinesPerCharacter, String]((lines: LinesPerCharacter) => lines.toString),
+        TextIO.sink() // Serialize LinesPerCharacter records as Strings
+      )
+      .to(args("output"))
+
+    // Compute # of times each character speaks in the King Lear text
+    sc.textFile(args.getOrElse("input", ExampleData.KING_LEAR))
+      .flatMap(line => {
+        val characterAndFirstLine = line.split("\t").filter(_.nonEmpty)
+        if (characterAndFirstLine.size != 2) { None }
+        else { Some(characterAndFirstLine(0)) }
+      })
+      .countByValue
+      .map { case (character, count) => LinesPerCharacter(character, count) }
+      .saveAsCustomOutput("dynamicWriteExample", dynamicOutput)
+
+    sc.close()
+  }
+}

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
@@ -37,9 +37,9 @@ object WriteDynamicExample {
     // All characters starting with letter A will share an output path, etc
     val dynamicOutput: FileIO.Write[String, LinesPerCharacter] = FileIO
       .writeDynamic[String, LinesPerCharacter]()
-      .by((linesPerCharacter: LinesPerCharacter) =>
-        linesPerCharacter.name.charAt(0).toString
-      )
+      .by(Contextful.fn[LinesPerCharacter, String]((linesPerCharacter: LinesPerCharacter) =>
+        linesPerCharacter.name.charAt(0).toString.toUpperCase
+      ))
       .withNaming((characterFirstLetter: String) =>
         FileIO.Write.defaultNaming(s"characters-starting-with-$characterFirstLetter", ".txt")
       )

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
@@ -72,7 +72,7 @@ object WriteDynamicExample {
     sc.textFile(args.getOrElse("input", ExampleData.KING_LEAR))
       .flatMap { line =>
         line.split(kingLearTextSplitter).filter(_.nonEmpty).toList match {
-          case name::dialogue::restOfList => Some(name)
+          case name::dialogue::Nil => Some(name)
           case _ => None
         }
       }

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
@@ -27,6 +27,7 @@ package com.spotify.scio.examples.extra
 import com.spotify.scio.ContextAndArgs
 import com.spotify.scio.examples.common.ExampleData
 import org.apache.beam.sdk.coders.StringUtf8Coder
+import org.apache.beam.sdk.io.FileIO.Write.FileNaming
 import org.apache.beam.sdk.io.{FileIO, TextIO}
 import org.apache.beam.sdk.transforms.{Contextful, SerializableFunction}
 
@@ -49,8 +50,12 @@ object WriteDynamicExample {
           input.name.charAt(0).toString.toUpperCase
         }
       })
-      .withNaming((characterFirstLetter: String) =>
-        FileIO.Write.defaultNaming(s"characters-starting-with-$characterFirstLetter", ".txt")
+      .withNaming(
+        new SerializableFunction[String, FileNaming] {
+          override def apply(firstLetter: String): FileNaming = {
+            FileIO.Write.defaultNaming(s"characters-starting-with-$firstLetter", ".txt")
+          }
+        }
       )
       .withDestinationCoder(StringUtf8Coder.of())
       .withNumShards(1) // Since input is small, restrict to one file per bucket


### PR DESCRIPTION
`TextIO` couldn't support this use case so no unit test right now. I ran the job on Dataflow using the King Lear text and the output was as expected.