### PR TITLE
make AsyncLookupDoFn.Try have public constructor for better testability

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/AsyncLookupDoFn.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/AsyncLookupDoFn.java
@@ -220,13 +220,13 @@ public abstract class AsyncLookupDoFn<A, B, C> extends DoFn<A, KV<A, AsyncLookup
     private final A value;
     private final Throwable exception;
 
-    private Try(A value) {
+    public Try(A value) {
       isSuccess = true;
       this.value = value;
       this.exception = null;
     }
 
-    private Try(Throwable exception) {
+    public Try(Throwable exception) {
       isSuccess = false;
       this.value = null;
       this.exception = exception;


### PR DESCRIPTION
This change helps me to test `AsyncLookupDoFn.Try`. 