### PR TITLE
[WIP] Improved arguments parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ val sparkeyVersion = "2.3.0"
 val tensorFlowVersion = "1.8.0"
 val zoltarVersion = "0.4.0"
 val grpcVersion = "1.7.0"
+val caseappVersion = "2.0.0-M3"
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts :=
@@ -324,7 +325,8 @@ lazy val scioCore: Project = Project(
     "com.google.protobuf" % "protobuf-java" % protobufVersion,
     "me.lyh" %% "protobuf-generic" % protobufGenericVersion,
     "org.apache.xbean" % "xbean-asm5-shaded" % asmVersion,
-    "io.grpc" % "grpc-all" % grpcVersion exclude("io.opencensus", "opencensus-api")
+    "io.grpc" % "grpc-all" % grpcVersion exclude("io.opencensus", "opencensus-api"),
+    "com.github.alexarchambault" %% "case-app" % caseappVersion
   )
 ).dependsOn(
   scioAvro,

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/MinimalWordCountTypedArguments.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/MinimalWordCountTypedArguments.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Example: Minimal Word Count Example
+// Usage:
+
+// `sbt runMain "com.spotify.scio.examples.MinimalWordCount
+// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --input=gs://apache-beam-samples/shakespeare/kinglear.txt
+// --output=gs://[BUCKET]/[PATH]/minimal_wordcount"`
+package com.spotify.scio.examples
+
+import com.spotify.scio._
+import com.spotify.scio.examples.common.ExampleData
+import caseapp._
+
+object MinimalWordCountTypedArguments {
+
+  @AppName("Scio Examples")
+  @AppVersion(BuildInfo.version)
+  @ProgName("com.spotify.scio.examples.MinimalWordCount")
+  case class Arguments(
+    @HelpMessage("Path of the file to read from")
+    @ExtraName("i")
+    input: String = ExampleData.KING_LEAR,
+    @HelpMessage("Path of the file to write to")
+    @ExtraName("o")
+    output: String)
+
+  def main(cmdlineArgs: Array[String]): Unit = {
+    // Parse command line arguments, create `ScioContext` and `Args`.
+    // `ScioContext` is the entry point to a Scio pipeline. User arguments, e.g.
+    // `--input=gs://[BUCKET]/[PATH]/input.txt`, are accessed via `Args`.
+    val (sc, args) = ContextAndArgs.typed[Arguments](cmdlineArgs)
+
+    // Open text file as `SCollection[String]`. The input can be either a single file or a
+    // wildcard matching multiple files.
+    sc.textFile(args.input)
+      // Split input lines, filter out empty tokens and expand into a collection of tokens
+      .flatMap(_.split("[^a-zA-Z']+").filter(_.nonEmpty))
+      // Count occurrences of each unique `String` to get `(String, Long)`
+      .countByValue
+      // Map `(String, Long)` tuples into strings
+      .map(t => t._1 + ": " + t._2)
+
+      // Save result as text files under the output path
+      .saveAsTextFile(args.output)
+
+    // Close the context and execute the pipeline
+    sc.close()
+  }
+}


### PR DESCRIPTION
Here's a possible solution to #1116 .

`--usage` gives the following output:

```
sbt:scio-examples> runMain com.spotify.scio.examples.MinimalWordCount --usage
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
[info] Running com.spotify.scio.examples.MinimalWordCount --usage
Scio Examples 0.5.7-SNAPSHOT
Usage: com.spotify.scio.examples.MinimalWordCount [options]
  --input | -i  <string>
        Path of the file to read from
  --output | -o  <string>
        Path of the file to write to
```

`--help` gives a complete list of all supported options (including beams)

```
sbt:scio-examples> runMain com.spotify.scio.examples.MinimalWordCount --help
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
[info] Running com.spotify.scio.examples.MinimalWordCount --help
Scio Examples 0.5.7-SNAPSHOT
Usage: com.spotify.scio.examples.MinimalWordCount [options]
  --input | -i  <string>
        Path of the file to read from
  --output | -o  <string>
        Path of the file to write to

org.apache.beam.sdk.options.PipelineOptions:

  --jobName=<String>
    Default: JobNameFactory
    Name of the pipeline execution.It must match the regular expression
    '[a-z]([-a-z0-9]{0,38}[a-z0-9])?'.It defaults to
    ApplicationName-UserName-Date-RandomInteger
  --metricsHttpSinkUrl=<String>
    MetricsHttpSink url
  --metricsPushPeriod=<Long>
    Default: 5
    The metrics push period in seconds
  --metricsSink=<Class>
    Default: NoOpMetricsSink
    The beam sink class to which the metrics will be pushed
  --optionsId=<long>
    Default: AtomicLongFactory
  --runner=<Class>
    Default: DirectRunner
    The pipeline runner that will be used to execute the pipeline. For
    registered runners, the class name can be specified, otherwise the fully
    qualified name needs to be specified.
  --stableUniqueNames=<OFF | WARNING | ERROR>
    Default: WARNING
    Whether to check for stable unique names on each transform. This is
    necessary to support updating of pipelines.
  --tempLocation=<String>
    A pipeline level default location for storing temporary files.
  --userAgent=<String>
    Default: UserAgentFactory
    A user agent string describing the pipeline to external services. The format
    should follow RFC2616. This option defaults to "[name]/[version]" where name
    and version are properties of the Apache Beam release.

org.apache.beam.sdk.options.SdkHarnessOptions:
    Options that are used to control configuration of the SDK harness.

  --defaultSdkHarnessLogLevel=<OFF | ERROR | WARN | INFO | DEBUG | TRACE>
    Default: INFO
    Controls the default log level of all loggers without a log level override.
  --sdkHarnessLogLevelOverrides=<SdkHarnessLogLevelOverrides>
    This option controls the log levels for specifically named loggers. The
    expected format is {"Name":"LogLevel",...}. The SDK harness supports a
    logging hierarchy based off of names that are '.' separated. For example, by
    specifying the value {"a.b.c.Foo":"DEBUG"}, the logger for the class
    'a.b.c.Foo' will be configured to output logs at the DEBUG level. Similarly,
    by specifying the value {"a.b.c":"WARN"}, all loggers underneath the 'a.b.c'
    package will be configured to output logs at the WARN level. System.out and
    System.err levels are configured via loggers of the corresponding name.
    Also, note that when multiple overrides are specified, the exact name
    followed by the closest parent takes precedence.
...
```

Alias to options are supported:

```
sbt:scio-examples> runMain com.spotify.scio.examples.MinimalWordCount --input=/Users/julient/Documents/Spotify/scio/build.sbt -o=/tmp/wc.out --runner=DirectRunner
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
[info] Running com.spotify.scio.examples.MinimalWordCount --input=/Users/julient/Documents/Spotify/scio/build.sbt -o=/tmp/wc.out --runner=DirectRunner
[run-main-5e] WARN com.spotify.scio.VersionUtil$ - Using a SNAPSHOT version of Scio: 0.5.7-SNAPSHOT
...
```

It also gives a simple error message when required options are missing:

```
sbt:scio-examples> runMain com.spotify.scio.examples.MinimalWordCount --input=/Users/julient/Documents/Spotify/scio/build.sbt  --runner=DirectRunner
[warn] Multiple main classes detected.  Run 'show discoveredMainClasses' to see the list
[info] Running com.spotify.scio.examples.MinimalWordCount --input=/Users/julient/Documents/Spotify/scio/build.sbt --runner=DirectRunner
Required option --output / -o not specified
```

@nevillelyh @regadas wdyt ?