### PR TITLE
add in long-running, hourly polled streaming benchmark

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,18 @@ jobs:
     environment:
       - SCALA_VERSION: *scala_212_version
 
+  bench_streaming_metrics:
+    <<: *common_settings
+    steps:
+      - checkout
+      - restore_cache: *restore_cache_settings
+      - run:
+          command: ./scripts/circleci_streaming_bench_metrics.sh
+          no_output_timeout: 30m
+      - save_cache: *save_cache_settings
+    environment:
+      - SCALA_VERSION: *scala_212_version
+
 ####################
 # Workflows
 ####################
@@ -183,3 +195,13 @@ workflows:
                 - master
     jobs:
       - bench
+  bench_streaming_metrics:
+    triggers:
+      - schedule:
+          cron: "0 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - bench_streaming_metrics

--- a/scio-bench/src/main/scala/com/spotify/ScioBatchBenchmark.scala
+++ b/scio-bench/src/main/scala/com/spotify/ScioBatchBenchmark.scala
@@ -1,0 +1,1 @@
+scio-test/src/it/scala/com/spotify/ScioBatchBenchmark.scala

--- a/scio-bench/src/main/scala/com/spotify/ScioStreamingBenchmark.scala
+++ b/scio-bench/src/main/scala/com/spotify/ScioStreamingBenchmark.scala
@@ -1,0 +1,1 @@
+scio-test/src/it/scala/com/spotify/ScioStreamingBenchmark.scala

--- a/scio-test/src/it/scala/com/spotify/ScioBatchBenchmark.scala
+++ b/scio-test/src/it/scala/com/spotify/ScioBatchBenchmark.scala
@@ -1,0 +1,351 @@
+/*
+ * Copyright 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify
+
+import java.util.UUID
+
+import com.google.common.reflect.ClassPath
+import com.spotify.scio._
+import com.spotify.scio.values.SCollection
+import com.twitter.algebird.Aggregator
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement
+import org.apache.beam.sdk.transforms.{DoFn, ParDo}
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.DateTimeZone
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+import scala.language.higherKinds
+import scala.util.{Random, Try}
+
+// @Todo fix symlink
+
+/** Batch benchmark jobs, run once daily and logged to DataStore.
+ *
+ * This file is symlinked to scio-bench/src/main/scala/com/spotify/ScioBenchmark.scala so that it
+ * can run with past Scio releases.
+ * */
+object ScioBatchBenchmark {
+  import ScioBenchmarkSettings._
+
+  def main(args: Array[String]): Unit = {
+    val argz = Args(args)
+    val name = argz("name")
+    val regex = argz.getOrElse("regex", ".*")
+    val projectId = argz.getOrElse("project", ScioBenchmarkSettings.defaultProjectId)
+    val timestamp = DateTimeFormat.forPattern("yyyyMMddHHmmss")
+      .withZone(DateTimeZone.UTC)
+      .print(System.currentTimeMillis())
+    val prefix = s"ScioBenchmark-$name-$timestamp"
+    val results = benchmarks
+      .filter(_.name.matches(regex)).take(1)
+      .flatMap(_.run(projectId, prefix, commonArgs()))
+
+    val logger = ScioBenchmarkLogger[Try](
+      ConsoleLogger(),
+      new DatastoreLogger(BatchMetrics)
+    )
+
+    val future = Future.sequence(results.map(_.map(logger.log(_))))
+    Await.result(future, Duration.Inf)
+  }
+
+  // =======================================================================
+  // Benchmarks
+  // =======================================================================
+
+  private val benchmarks = ClassPath.from(Thread.currentThread().getContextClassLoader)
+    .getAllClasses
+    .asScala
+    .filter(_.getName.matches("com\\.spotify\\.ScioBatchBenchmark\\$[\\w]+\\$"))
+    .flatMap { ci =>
+      val cls = ci.load()
+      if (classOf[Benchmark] isAssignableFrom cls) {
+        Some(cls.newInstance().asInstanceOf[Benchmark])
+      } else {
+        None
+      }
+    }
+
+  // ===== Combine =====
+
+  // 100M items, into a set of 1000 unique items
+
+  object Reduce extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).map(Set(_)).reduce(_ ++ _)
+  }
+
+  object Sum extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).map(Set(_)).sum
+  }
+
+  object Fold extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).map(Set(_)).fold(Set.empty[Int])(_ ++ _)
+  }
+
+  object FoldMonoid extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).map(Set(_)).fold
+  }
+
+  object Aggregate extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).aggregate(Set.empty[Int])(_ + _, _ ++ _)
+  }
+
+  object AggregateAggregator extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000)
+        .aggregate(Aggregator.fromMonoid[Set[Int]].composePrepare[Int](Set(_)))
+  }
+
+  object Combine extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).combine(Set(_))(_ + _)(_ ++ _)
+  }
+
+  // ===== CombineByKey =====
+
+  // 100M items, 10K keys, into a set of 1000 unique items per key
+
+  object ReduceByKey extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
+        .mapValues(Set(_)).reduceByKey(_ ++ _)
+  }
+
+  object SumByKey extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
+        .mapValues(Set(_)).sumByKey
+  }
+
+  object FoldByKey extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
+        .mapValues(Set(_)).foldByKey(Set.empty[Int])(_ ++ _)
+  }
+
+  object FoldByKeyMonoid extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
+        .mapValues(Set(_)).foldByKey
+  }
+
+  object AggregateByKey extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
+        .aggregateByKey(Set.empty[Int])(_ + _, _ ++ _)
+  }
+
+  object AggregateByKeyAggregator extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
+        .aggregateByKey(Aggregator.fromMonoid[Set[Int]].composePrepare[Int](Set(_)))
+  }
+
+  object CombineByKey extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
+        .combineByKey(Set(_))(_ + _)(_ ++ _)
+  }
+
+  // ===== GroupByKey =====
+
+  // 100M items, 10K keys, average 10K values per key
+  object GroupByKey extends Benchmark(shuffleConf) {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 100 * M).groupBy(_ => Random.nextInt(10 * K)).values.map(_.size)
+  }
+
+  // 10M items, 1 key
+  object GroupAll extends Benchmark(shuffleConf) {
+    override def run(sc: ScioContext): Unit =
+      randomUUIDs(sc, 10 * M).groupBy(_ => 0).values.map(_.size)
+  }
+
+  // ===== Join =====
+
+  // LHS: 100M items, 10M keys, average 10 values per key
+  // RHS: 50M items, 5M keys, average 10 values per key
+  object Join extends Benchmark(shuffleConf) {
+    override def run(sc: ScioContext): Unit =
+      randomKVs(sc, 100 * M, 10 * M) join randomKVs(sc, 50 * M, 5 * M)
+  }
+
+  // LHS: 100M items, 10M keys, average 1 values per key
+  // RHS: 50M items, 5M keys, average 1 values per key
+  object JoinOne extends Benchmark(shuffleConf) {
+    override def run(sc: ScioContext): Unit =
+      randomKVs(sc, 100 * M, 100 * M) join randomKVs(sc, 50 * M, 50 * M)
+  }
+
+  // LHS: 100M items, 10M keys, average 10 values per key
+  // RHS: 1M items, 100K keys, average 10 values per key
+  object HashJoin extends Benchmark {
+    override def run(sc: ScioContext): Unit =
+      randomKVs(sc, 100 * M, 10 * M) hashJoin randomKVs(sc, M, 100 * K)
+  }
+
+  // ===== SideInput =====
+
+  // Main: 100M, side: 1M
+
+  object SingletonSideInput extends Benchmark {
+    override def run(sc: ScioContext): Unit = {
+      val main = randomUUIDs(sc, 100 * M)
+      val side = randomUUIDs(sc, 1 * M).map(Set(_)).sum.asSingletonSideInput
+      main.withSideInputs(side).map { case (x, s) => (x, s(side).size) }
+    }
+  }
+
+  object IterableSideInput extends Benchmark {
+    override def run(sc: ScioContext): Unit = {
+      val main = randomUUIDs(sc, 100 * M)
+      val side = randomUUIDs(sc, 1 * M).asIterableSideInput
+      main.withSideInputs(side).map { case (x, s) => (x, s(side).head) }
+    }
+  }
+
+  object ListSideInput extends Benchmark {
+    override def run(sc: ScioContext): Unit = {
+      val main = randomUUIDs(sc, 100 * M)
+      val side = randomUUIDs(sc, 1 * M).asListSideInput
+      main.withSideInputs(side)
+        .map { case (x, s) => (x, s(side).head) }
+    }
+  }
+
+  // Main: 1M, side: 100K
+
+  object MapSideInput extends Benchmark {
+    override def run(sc: ScioContext): Unit = {
+      val main = randomUUIDs(sc, 1 * M)
+      val side = main
+        .sample(withReplacement = false, 0.1)
+        .map((_, UUID.randomUUID().toString))
+        .asMapSideInput
+      main.withSideInputs(side).map { case (x, s) => s(side).get(x) }
+    }
+  }
+
+  object MultiMapSideInput extends Benchmark {
+    override def run(sc: ScioContext): Unit = {
+      val main = randomUUIDs(sc, 1 * M)
+      val side = main
+        .sample(withReplacement = false, 0.1)
+        .map((_, UUID.randomUUID().toString))
+        .asMultiMapSideInput
+      main.withSideInputs(side).map { case (x, s) => s(side).get(x) }
+    }
+  }
+
+  // =======================================================================
+  // Utilities
+  // =======================================================================
+
+  private val M = 1000000
+  private val K = 1000
+
+  final case class Elem[T](elem: T)
+
+  def partitions(n: Long,
+                 numPartitions: Int = 100,
+                 numOfWorkers: Int = numOfWorkers): Iterable[Iterable[Long]] = {
+    val chunks = numPartitions * numOfWorkers
+
+    def loop(n: Long): Seq[Long] = {
+      n match {
+        case 0                    => Nil
+        case x if x < chunks      => Seq(x)
+        case x if x % chunks == 0 => Seq.fill(chunks)(x / chunks)
+        case x =>
+          val r = x % chunks
+          loop(r) ++ loop(x - r)
+      }
+    }
+
+    loop(n).grouped(numOfWorkers).toIterable
+  }
+
+  private def randomUUIDs(sc: ScioContext, n: Long): SCollection[Elem[String]] =
+    sc.parallelize(partitions(n))
+      .flatten
+      .applyTransform(ParDo.of(new FillDoFn(() => UUID.randomUUID().toString)))
+      .map(Elem(_))
+
+  private def randomKVs(sc: ScioContext,
+                        n: Long, numUniqueKeys: Int): SCollection[(String, Elem[String])] =
+    sc.parallelize(partitions(n))
+      .flatten
+      .applyTransform(ParDo.of(new FillDoFn(() =>
+        ("key" + Random.nextInt(numUniqueKeys), UUID.randomUUID().toString)
+      )))
+      .mapValues(Elem(_))
+
+  private class FillDoFn[T](val f: () => T) extends DoFn[Long, T] {
+    @ProcessElement
+    def processElement(c: DoFn[Long, T]#ProcessContext): Unit = {
+      var i = 0L
+      val n = c.element()
+      while (i < n) {
+        c.output(f())
+        i += 1
+      }
+    }
+  }
+
+}
+
+abstract class Benchmark(val extraConfs: Map[String, Array[String]] = null) {
+  val name: String = this.getClass.getSimpleName.replaceAll("\\$$", "")
+
+  private val configurations: Map[String, Array[String]] = {
+    val base = Map(name -> Array.empty[String])
+    val extra = if (extraConfs == null) {
+      Map.empty
+    } else {
+      extraConfs.map(kv => (s"$name${kv._1}", kv._2))
+    }
+    base ++ extra
+  }
+
+  def run(projectId: String,
+          prefix: String,
+          args: Array[String]): Iterable[Future[BenchmarkResult]] = {
+    val username = sys.props("user.name")
+    configurations
+      .map {
+        case (confName, extraArgs) =>
+          val (sc, _) =
+            ContextAndArgs(Array(s"--project=$projectId") ++ args ++ extraArgs)
+          sc.setAppName(confName)
+          sc.setJobName(s"$prefix-$confName-$username".toLowerCase())
+          run(sc)
+          val result = sc.close()
+          result.finalState.map(_ => BenchmarkResult.batch(confName, extraArgs, result))
+      }
+  }
+
+  def run(sc: ScioContext): Unit
+}

--- a/scio-test/src/it/scala/com/spotify/ScioBatchBenchmark.scala
+++ b/scio-test/src/it/scala/com/spotify/ScioBatchBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Spotify AB.
+ * Copyright 2018 Spotify AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,13 +35,12 @@ import scala.concurrent.{Await, Future}
 import scala.language.higherKinds
 import scala.util.{Random, Try}
 
-// @Todo fix symlink
-
-/** Batch benchmark jobs, run once daily and logged to DataStore.
+/**
+ * Batch benchmark jobs, run once daily and logged to DataStore.
  *
- * This file is symlinked to scio-bench/src/main/scala/com/spotify/ScioBenchmark.scala so that it
- * can run with past Scio releases.
- * */
+ * This file is symlinked to scio-bench/src/main/scala/com/spotify/ScioBatchBenchmark.scala so
+ * that it can run with past Scio releases.
+ */
 object ScioBatchBenchmark {
   import ScioBenchmarkSettings._
 

--- a/scio-test/src/it/scala/com/spotify/ScioBenchmark.scala
+++ b/scio-test/src/it/scala/com/spotify/ScioBenchmark.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Spotify AB.
+ * Copyright 2018 Spotify AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,11 +36,12 @@ import scala.collection.JavaConverters._
 import scala.language.higherKinds
 import scala.util.{Failure, Success, Try}
 
-
-/** Shared functions to manage benchmark jobs and write metrics to DataStore. */
-
-final case class CircleCIEnv(buildNum: Long, gitHash: String)
-
+/**
+ * Shared functions to manage benchmark jobs and write metrics to DataStore
+ *
+ * This file is symlinked to scio-bench/src/main/scala/com/spotify/ScioBenchmark.scala so
+ * that it can run with past Scio releases.
+ */
 object ScioBenchmarkSettings {
   val defaultProjectId: String = "data-integration-test"
   val numOfWorkers = 4
@@ -76,6 +77,8 @@ object ScioBenchmarkSettings {
     "TotalMemoryUsage", "TotalPdUsage", "TotalShuffleDataProcessed", "TotalSsdUsage",
     "TotalStreamingDataProcessed", "TotalVcpuTime")
 }
+
+final case class CircleCIEnv(buildNum: Long, gitHash: String)
 
 object DataflowProvider {
   val dataflow: Dataflow = {

--- a/scio-test/src/it/scala/com/spotify/ScioBenchmark.scala
+++ b/scio-test/src/it/scala/com/spotify/ScioBenchmark.scala
@@ -17,331 +17,37 @@
 
 package com.spotify
 
-import java.util.UUID
-
-import com.google.api.services.dataflow.model.Job
-import com.google.common.reflect.ClassPath
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.services.dataflow.Dataflow
+import com.google.api.services.dataflow.model.{Job, JobMetrics}
 import com.google.datastore.v1._
 import com.google.datastore.v1.client.{Datastore, DatastoreHelper}
 import com.spotify.scio._
 import com.spotify.scio.runners.dataflow.DataflowResult
-import com.spotify.scio.values.SCollection
-import com.twitter.algebird.Aggregator
-import org.apache.beam.sdk.transforms.DoFn.ProcessElement
-import org.apache.beam.sdk.transforms.{DoFn, ParDo}
-import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat, PeriodFormat}
-import org.joda.time.{DateTimeZone, Instant, LocalDateTime, Seconds}
+import org.apache.beam.sdk.PipelineResult.State
+import org.joda.time.format.{ISODateTimeFormat, PeriodFormat}
+import org.joda.time.{Instant, LocalDateTime, Seconds}
+import shapeless.datatype.datastore.DatastoreType
 import shapeless.datatype.datastore._
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future}
 import scala.language.higherKinds
-import scala.util.{Failure, Random, Success, Try}
+import scala.util.{Failure, Success, Try}
 
-// This file is symlinked to scio-bench/src/main/scala/com/spotify/ScioBenchmark.scala so that it
-// can run with past Scio releases.
 
-// scalastyle:off number.of.types
-// scalastyle:off number.of.methods
-object ScioBenchmark {
-  import ScioBenchmarkSettings._
-
-  def main(args: Array[String]): Unit = {
-    val argz = Args(args)
-    val name = argz("name")
-    val regex = argz.getOrElse("regex", ".*")
-    val projectId = argz.getOrElse("project", ScioBenchmarkSettings.defaultProjectId)
-    val timestamp = DateTimeFormat.forPattern("yyyyMMddHHmmss")
-      .withZone(DateTimeZone.UTC)
-      .print(System.currentTimeMillis())
-    val prefix = s"ScioBenchmark-$name-$timestamp"
-    val results = benchmarks
-      .filter(_.name.matches(regex))
-      .flatMap(_.run(projectId, prefix, commonArgs))
-
-    val logger = ScioBenchmarkLogger[Try](ConsoleLogger(), DatastoreLogger(circleCIEnv))
-
-    val future = Future.sequence(results.map(_.map(logger.log(_))))
-    Await.result(future, Duration.Inf)
-  }
-
-  // =======================================================================
-  // Benchmarks
-  // =======================================================================
-
-  private val benchmarks = ClassPath.from(Thread.currentThread().getContextClassLoader)
-    .getAllClasses
-    .asScala
-    .filter(_.getName.matches("com\\.spotify\\.ScioBenchmark\\$[\\w]+\\$"))
-    .flatMap { ci =>
-      val cls = ci.load()
-      if (classOf[Benchmark] isAssignableFrom cls) {
-        Some(cls.newInstance().asInstanceOf[Benchmark])
-      } else {
-        None
-      }
-    }
-
-  // ===== Combine =====
-
-  // 100M items, into a set of 1000 unique items
-
-  object Reduce extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).map(Set(_)).reduce(_ ++ _)
-  }
-
-  object Sum extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).map(Set(_)).sum
-  }
-
-  object Fold extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).map(Set(_)).fold(Set.empty[Int])(_ ++ _)
-  }
-
-  object FoldMonoid extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).map(Set(_)).fold
-  }
-
-  object Aggregate extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).aggregate(Set.empty[Int])(_ + _, _ ++ _)
-  }
-
-  object AggregateAggregator extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000)
-        .aggregate(Aggregator.fromMonoid[Set[Int]].composePrepare[Int](Set(_)))
-  }
-
-  object Combine extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).map(_.hashCode % 1000).combine(Set(_))(_ + _)(_ ++ _)
-  }
-
-  // ===== CombineByKey =====
-
-  // 100M items, 10K keys, into a set of 1000 unique items per key
-
-  object ReduceByKey extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
-        .mapValues(Set(_)).reduceByKey(_ ++ _)
-  }
-
-  object SumByKey extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
-        .mapValues(Set(_)).sumByKey
-  }
-
-  object FoldByKey extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
-        .mapValues(Set(_)).foldByKey(Set.empty[Int])(_ ++ _)
-  }
-
-  object FoldByKeyMonoid extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
-        .mapValues(Set(_)).foldByKey
-  }
-
-  object AggregateByKey extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
-        .aggregateByKey(Set.empty[Int])(_ + _, _ ++ _)
-  }
-
-  object AggregateByKeyAggregator extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
-        .aggregateByKey(Aggregator.fromMonoid[Set[Int]].composePrepare[Int](Set(_)))
-  }
-
-  object CombineByKey extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).keyBy(_ => Random.nextInt(10 * K)).mapValues(_.hashCode % 1000)
-        .combineByKey(Set(_))(_ + _)(_ ++ _)
-  }
-
-  // ===== GroupByKey =====
-
-  // 100M items, 10K keys, average 10K values per key
-  object GroupByKey extends Benchmark(shuffleConf) {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 100 * M).groupBy(_ => Random.nextInt(10 * K)).values.map(_.size)
-  }
-
-  // 10M items, 1 key
-  object GroupAll extends Benchmark(shuffleConf) {
-    override def run(sc: ScioContext): Unit =
-      randomUUIDs(sc, 10 * M).groupBy(_ => 0).values.map(_.size)
-  }
-
-  // ===== Join =====
-
-  // LHS: 100M items, 10M keys, average 10 values per key
-  // RHS: 50M items, 5M keys, average 10 values per key
-  object Join extends Benchmark(shuffleConf) {
-    override def run(sc: ScioContext): Unit =
-      randomKVs(sc, 100 * M, 10 * M) join randomKVs(sc, 50 * M, 5 * M)
-  }
-
-  // LHS: 100M items, 10M keys, average 1 values per key
-  // RHS: 50M items, 5M keys, average 1 values per key
-  object JoinOne extends Benchmark(shuffleConf) {
-    override def run(sc: ScioContext): Unit =
-      randomKVs(sc, 100 * M, 100 * M) join randomKVs(sc, 50 * M, 50 * M)
-  }
-
-  // LHS: 100M items, 10M keys, average 10 values per key
-  // RHS: 1M items, 100K keys, average 10 values per key
-  object HashJoin extends Benchmark {
-    override def run(sc: ScioContext): Unit =
-      randomKVs(sc, 100 * M, 10 * M) hashJoin randomKVs(sc, M, 100 * K)
-  }
-
-  // ===== SideInput =====
-
-  // Main: 100M, side: 1M
-
-  object SingletonSideInput extends Benchmark {
-    override def run(sc: ScioContext): Unit = {
-      val main = randomUUIDs(sc, 100 * M)
-      val side = randomUUIDs(sc, 1 * M).map(Set(_)).sum.asSingletonSideInput
-      main.withSideInputs(side).map { case (x, s) => (x, s(side).size) }
-    }
-  }
-
-  object IterableSideInput extends Benchmark {
-    override def run(sc: ScioContext): Unit = {
-      val main = randomUUIDs(sc, 100 * M)
-      val side = randomUUIDs(sc, 1 * M).asIterableSideInput
-      main.withSideInputs(side).map { case (x, s) => (x, s(side).head) }
-    }
-  }
-
-  object ListSideInput extends Benchmark {
-    override def run(sc: ScioContext): Unit = {
-      val main = randomUUIDs(sc, 100 * M)
-      val side = randomUUIDs(sc, 1 * M).asListSideInput
-      main.withSideInputs(side)
-        .map { case (x, s) => (x, s(side).head) }
-    }
-  }
-
-  // Main: 1M, side: 100K
-
-  object MapSideInput extends Benchmark {
-    override def run(sc: ScioContext): Unit = {
-      val main = randomUUIDs(sc, 1 * M)
-      val side = main
-        .sample(withReplacement = false, 0.1)
-        .map((_, UUID.randomUUID().toString))
-        .asMapSideInput
-      main.withSideInputs(side).map { case (x, s) => s(side).get(x) }
-    }
-  }
-
-  object MultiMapSideInput extends Benchmark {
-    override def run(sc: ScioContext): Unit = {
-      val main = randomUUIDs(sc, 1 * M)
-      val side = main
-        .sample(withReplacement = false, 0.1)
-        .map((_, UUID.randomUUID().toString))
-        .asMultiMapSideInput
-      main.withSideInputs(side).map { case (x, s) => s(side).get(x) }
-    }
-  }
-
-  // =======================================================================
-  // Utilities
-  // =======================================================================
-
-  private val M = 1000000
-  private val K = 1000
-
-  final case class Elem[T](elem: T)
-
-  def partitions(n: Long,
-                 numPartitions: Int = 100,
-                 numOfWorkers: Int = numOfWorkers): Iterable[Iterable[Long]] = {
-    val chunks = numPartitions * numOfWorkers
-
-    def loop(n: Long): Seq[Long] = {
-      n match {
-        case 0                    => Nil
-        case x if x < chunks      => Seq(x)
-        case x if x % chunks == 0 => Seq.fill(chunks)(x / chunks)
-        case x =>
-          val r = x % chunks
-          loop(r) ++ loop(x - r)
-      }
-    }
-
-    loop(n).grouped(numOfWorkers).toIterable
-  }
-
-  private def randomUUIDs(sc: ScioContext, n: Long): SCollection[Elem[String]] =
-    sc.parallelize(partitions(n))
-      .flatten
-      .applyTransform(ParDo.of(new FillDoFn(() => UUID.randomUUID().toString)))
-      .map(Elem(_))
-
-  private def randomKVs(sc: ScioContext,
-                        n: Long, numUniqueKeys: Int): SCollection[(String, Elem[String])] =
-    sc.parallelize(partitions(n))
-      .flatten
-      .applyTransform(ParDo.of(new FillDoFn(() =>
-        ("key" + Random.nextInt(numUniqueKeys), UUID.randomUUID().toString)
-      )))
-      .mapValues(Elem(_))
-
-  private class FillDoFn[T](val f: () => T) extends DoFn[Long, T] {
-    @ProcessElement
-    def processElement(c: DoFn[Long, T]#ProcessContext): Unit = {
-      var i = 0L
-      val n = c.element()
-      while (i < n) {
-        c.output(f())
-        i += 1
-      }
-    }
-  }
-
-}
-// scalastyle:on number.of.methods
-// scalastyle:on number.of.types
-
-private[this] object PrettyPrint {
-  @inline def printSeparator(numChars: Int = 80): Unit = {
-    // scalastyle:off regex
-    println("=" * numChars)
-    // scalastyle:on regex
-  }
-
-  @inline def print(k: String, v: String): Unit = {
-    // scalastyle:off regex
-    println("%-30s: %s".format(k, v))
-    // scalastyle:on regex
-  }
-}
+/** Shared functions to manage benchmark jobs and write metrics to DataStore. */
 
 final case class CircleCIEnv(buildNum: Long, gitHash: String)
 
 object ScioBenchmarkSettings {
   val defaultProjectId: String = "data-integration-test"
   val numOfWorkers = 4
-  val commonArgs = Array(
+  def commonArgs(machineType: String = "n1-standard-4"): Array[String] = Array(
     "--runner=DataflowRunner",
     s"--numWorkers=$numOfWorkers",
-    "--workerMachineType=n1-standard-4",
+    s"--workerMachineType=$machineType",
     "--autoscalingAlgorithm=NONE")
 
   val shuffleConf = Map("ShuffleService" -> Array("--experiments=shuffle_mode=service"))
@@ -362,66 +68,22 @@ object ScioBenchmarkSettings {
       None
     }
   }
+
+  val BatchMetrics = Set("Elapsed", "TotalMemoryUsage", "TotalPdUsage",
+    "TotalShuffleDataProcessed", "TotalSsdUsage", "TotalStreamingDataProcessed", "TotalVcpuTime")
+
+  val StreamingMetrics = Set("CurrentMemoryUsage", "CurrentPdUsage", "CurrentVcpuCount",
+    "TotalMemoryUsage", "TotalPdUsage", "TotalShuffleDataProcessed", "TotalSsdUsage",
+    "TotalStreamingDataProcessed", "TotalVcpuTime")
 }
 
-abstract class Benchmark(val extraConfs: Map[String, Array[String]] = null) {
-  val name: String = this.getClass.getSimpleName.replaceAll("\\$$", "")
-
-  private val configurations: Map[String, Array[String]] = {
-    val base = Map(name -> Array.empty[String])
-    val extra = if (extraConfs == null) {
-      Map.empty
-    } else {
-      extraConfs.map(kv => (s"$name${kv._1}", kv._2))
-    }
-    base ++ extra
+object DataflowProvider {
+  val dataflow: Dataflow = {
+    val transport = GoogleNetHttpTransport.newTrustedTransport()
+    val jackson = JacksonFactory.getDefaultInstance
+    val credential = GoogleCredential.getApplicationDefault
+    new Dataflow.Builder(transport, jackson, credential).build()
   }
-
-  def run(projectId: String,
-          prefix: String,
-          args: Array[String]): Iterable[Future[BenchmarkResult]] = {
-    val username = sys.props("user.name")
-    configurations
-      .map {
-        case (confName, extraArgs) =>
-          val (sc, _) =
-            ContextAndArgs(Array(s"--project=$projectId") ++ args ++ extraArgs)
-          sc.setAppName(confName)
-          sc.setJobName(s"$prefix-$confName-$username".toLowerCase())
-          run(sc)
-          val result = sc.close()
-          result.finalState.map(_ => BenchmarkResult(confName, extraArgs, result))
-      }
-  }
-
-  def run(sc: ScioContext): Unit
-}
-
-object BenchmarkResult {
-  private val dateTimeParser = ISODateTimeFormat.dateTimeParser()
-}
-
-case class BenchmarkResult(name: String,
-                           extraArgs: Array[String],
-                           scioResult: ScioResult) {
-  import BenchmarkResult._
-  require(scioResult.isCompleted)
-
-  val job: Job = scioResult.as[DataflowResult].getJob
-  val startTime: LocalDateTime = dateTimeParser.parseLocalDateTime(job.getCreateTime)
-  val finishTime: LocalDateTime = dateTimeParser.parseLocalDateTime(job.getCurrentStateTime)
-  val elapsedTime: Seconds = Seconds.secondsBetween(startTime, finishTime)
-
-  val metrics: Map[String, String] = scioResult.as[DataflowResult]
-    .getJobMetrics
-    .getMetrics
-    .asScala
-    .filter { m =>
-      m.getName.getName.startsWith("Total") && !m.getName.getContext.containsKey("tentative")
-    }
-    .map(m => (m.getName.getName, m.getScalar.toString))
-    .sortBy(_._1)
-    .toMap
 }
 
 trait BenchmarkLogger[F[_]] {
@@ -433,29 +95,73 @@ final case class ScioBenchmarkLogger[F[_]](loggers: BenchmarkLogger[F]*) {
     loggers.map(_.log(benchmarks))
 }
 
-object DatastoreLogger {
+case class BenchmarkResult(
+                            name: String,
+                            elapsed: Option[Seconds],
+                            startTime: LocalDateTime,
+                            finishTime: Option[LocalDateTime],
+                            state: State,
+                            extraArgs: Array[String],
+                            metrics: Map[String, String]
+                          )
+
+object BenchmarkResult {
+  import ScioBenchmarkSettings._
+  private val dateTimeParser = ISODateTimeFormat.dateTimeParser()
+
+  def batch(name: String,
+            extraArgs: Array[String],
+            scioResult: ScioResult): BenchmarkResult = {
+    require(scioResult.isCompleted)
+
+    val job: Job = scioResult.as[DataflowResult].getJob
+    val startTime: LocalDateTime = dateTimeParser.parseLocalDateTime(job.getCreateTime)
+    val finishTime: LocalDateTime = dateTimeParser.parseLocalDateTime(job.getCurrentStateTime)
+    val elapsedTime: Seconds = Seconds.secondsBetween(startTime, finishTime)
+
+    val metrics: Map[String, String] = scioResult.as[DataflowResult]
+      .getJobMetrics
+      .getMetrics
+      .asScala
+      .filter(metric => BatchMetrics.contains(metric.getName.getName))
+      .map(m => (m.getName.getName, m.getScalar.toString))
+      .sortBy(_._1)
+      .toMap
+
+    BenchmarkResult(
+      name, Some(elapsedTime), startTime, Some(finishTime),
+      scioResult.state, extraArgs, metrics)
+  }
+
+  def streaming(name: String,
+                createTime: String,
+                jobMetrics: JobMetrics): BenchmarkResult = {
+    val startTime: LocalDateTime = dateTimeParser.parseLocalDateTime(createTime)
+
+    val metrics = jobMetrics.getMetrics.asScala
+      .filter(metric => StreamingMetrics.contains(metric.getName.getName))
+      .map(m => (m.getName.getName, m.getScalar.toString))
+      .sortBy(_._1)
+      .toMap
+
+    BenchmarkResult(name, None, startTime, None, State.RUNNING, Array(), metrics)
+  }
+}
+
+class DatastoreLogger(metricsToCompare: Set[String]) extends BenchmarkLogger[Try] {
+  import ScioBenchmarkSettings.circleCIEnv
+
   final case class ScioBenchmarkRun(timestamp: Instant,
                                     gitHash: String,
                                     buildNum: Long,
                                     operation: String)
-
-  private lazy val Storage: Datastore = DatastoreHelper.getDatastoreFromEnv
-
-  private val Kind = "Benchmarks"
-
-  private val OrderByBuildNumQuery =
-    s"SELECT * from ${Kind}_%s ORDER BY buildNum DESC LIMIT 2"
-
-  private val Metrics = Set("Elapsed", "TotalMemoryUsage", "TotalPdUsage",
-    "TotalShuffleDataProcessed", "TotalSsdUsage", "TotalStreamingDataProcessed", "TotalVcpuTime")
-}
-
-final case class DatastoreLogger(circleCIEnv: Option[CircleCIEnv]) extends BenchmarkLogger[Try] {
-  import DatastoreLogger._
+  val Storage: Datastore = DatastoreHelper.getDatastoreFromEnv
+  val Kind = "Benchmarks"
+  val OrderByBuildNumQuery = s"SELECT * from ${Kind}_%s ORDER BY timestamp DESC LIMIT 2"
 
   // Save metrics to integration testing Datastore instance. Can't make this into a
   // transaction because DS limit is 25 entities per transaction.
-  override def log(benchmarks: Iterable[BenchmarkResult]): Try[Unit] = {
+  def log(benchmarks: Iterable[BenchmarkResult]): Try[Unit] = {
     circleCIEnv.map { env =>
       val now = new Instant()
       val dt = DatastoreType[ScioBenchmarkRun]
@@ -464,11 +170,13 @@ final case class DatastoreLogger(circleCIEnv: Option[CircleCIEnv]) extends Bench
         val entity = dt
           .toEntityBuilder(
             ScioBenchmarkRun(now, env.gitHash, env.buildNum, benchmark.name))
-          .setKey(DatastoreHelper.makeKey(
-            s"${Kind}_${benchmark.name}", env.buildNum.toString))
+          .setKey(DatastoreHelper
+            .makeKey(s"${Kind}_${benchmark.name}", dsKeyId(benchmark, env)).build())
 
-        val metrics = ("Elapsed", benchmark.elapsedTime.getSeconds.toString) :: benchmark.metrics
-          .filter(metric => Metrics.contains(metric._1)).toList
+        val metrics = benchmark.elapsed match {
+          case Some(period) => Map("Elapsed" -> period.getSeconds.toString) ++ benchmark.metrics
+          case _ => benchmark.metrics
+        }
 
         metrics.foreach {
           case (key, value) =>
@@ -495,14 +203,15 @@ final case class DatastoreLogger(circleCIEnv: Option[CircleCIEnv]) extends Bench
           case (f @ Failure(_), _) => f
         }
         .map(_.map(_._1.name))
-        .map(printMetricsComparison)
+        .map(metrics => printMetricsComparison(metrics))
     }.getOrElse {
       Success(Unit)
     }
   }
 
   // TODO: move this to email generator
-  private[this] def printMetricsComparison(benchmarkNames: Iterable[String]): Unit = {
+  def printMetricsComparison(benchmarkNames: Iterable[String]):
+  Unit = {
     benchmarkNames.foreach { benchmarkName =>
       try {
         val comparisonMetrics = Storage.runQuery(
@@ -514,7 +223,7 @@ final case class DatastoreLogger(circleCIEnv: Option[CircleCIEnv]) extends Bench
           ).build())
 
         val metrics = comparisonMetrics.getBatch.getEntityResultsList.asScala
-          .sortBy(_.getEntity.getKey.getPath(0).getName.toInt)
+          .sortBy(_.getEntity.getKey.getPath(0).getName)
           .map(_.getEntity)
         if (metrics.size == 2) {
           val opName = metrics.head.getKey.getPath(0).getKind.substring(Kind.length + 1)
@@ -522,10 +231,10 @@ final case class DatastoreLogger(circleCIEnv: Option[CircleCIEnv]) extends Bench
           PrettyPrint.printSeparator()
           PrettyPrint.print("Benchmark", opName)
 
-          val List(b1, b2) = props.map(_("buildNum").getIntegerValue).toList
-          PrettyPrint.print("BuildNum", "%15d%15d%15s".format(b1, b2, "Delta"))
+          val List(b1, b2) = metrics.map(_.getKey.getPath(0).getName).toList
+          PrettyPrint.print("BuildNum", "%15s%15s%15s".format(b1, b2, "Delta"))
 
-          Metrics.foreach { k =>
+          metricsToCompare.foreach { k: String =>
             val List(prev, curr) = props.map(_(k).getStringValue.toDouble).toList
             val delta = (curr - prev) / curr * 100.0
             val signed = if (delta.isNaN) {
@@ -543,6 +252,8 @@ final case class DatastoreLogger(circleCIEnv: Option[CircleCIEnv]) extends Bench
       }
     }
   }
+
+  def dsKeyId(benchmark: BenchmarkResult, env: CircleCIEnv): String = env.buildNum.toString
 }
 
 final case class ConsoleLogger() extends BenchmarkLogger[Try] {
@@ -551,13 +262,28 @@ final case class ConsoleLogger() extends BenchmarkLogger[Try] {
       PrettyPrint.printSeparator()
       PrettyPrint.print("Benchmark", benchmark.name)
       PrettyPrint.print("Extra arguments", benchmark.extraArgs.mkString(" "))
-      PrettyPrint.print("State", benchmark.scioResult.state.toString)
+      PrettyPrint.print("State", benchmark.state.toString)
       PrettyPrint.print("Create time", benchmark.startTime.toString())
-      PrettyPrint.print("Finish time", benchmark.finishTime.toString())
-      PrettyPrint.print("Elapsed", PeriodFormat.getDefault.print(benchmark.elapsedTime))
+      PrettyPrint.print("Finish time", benchmark.finishTime.map(_.toString()).getOrElse("N/A"))
+      PrettyPrint.print("Elapsed",
+        benchmark.elapsed.map(period => PeriodFormat.getDefault.print(period)).getOrElse("N/A"))
       benchmark.metrics.foreach { kv =>
         PrettyPrint.print(kv._1, kv._2)
       }
     }
+  }
+}
+
+private[this] object PrettyPrint {
+  @inline def printSeparator(numChars: Int = 80): Unit = {
+    // scalastyle:off regex
+    println("=" * numChars)
+    // scalastyle:on regex
+  }
+
+  @inline def print(k: String, v: String): Unit = {
+    // scalastyle:off regex
+    println("%-30s: %s".format(k, v))
+    // scalastyle:on regex
   }
 }

--- a/scio-test/src/it/scala/com/spotify/ScioStreamingBenchmark.scala
+++ b/scio-test/src/it/scala/com/spotify/ScioStreamingBenchmark.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify
+
+import java.util.concurrent.{ScheduledThreadPoolExecutor, TimeUnit}
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.services.dataflow.Dataflow
+import com.google.api.services.dataflow.model.Job
+import com.google.common.reflect.ClassPath
+import com.spotify.scio._
+import com.spotify.scio.runners.dataflow.DataflowResult
+import org.apache.beam.sdk.io.GenerateSequence
+import org.apache.beam.sdk.options.StreamingOptions
+import org.joda.time._
+import org.joda.time.format.DateTimeFormat
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.Duration
+
+
+object ScioStreamingBenchmark {
+
+  object Settings {
+    val defaultProjectId: String = "data-integration-test"
+    val numOfWorkers = 4
+    val commonArgs = Array(
+      "--runner=DataflowRunner",
+      s"--numWorkers=$numOfWorkers",
+      "--workerMachineType=n1-highmem-8",
+      "--autoscalingAlgorithm=NONE")
+
+    val shuffleConf = Map("ShuffleService" -> Array("--experiments=shuffle_mode=service"))
+
+    val dataflow: Dataflow = {
+      val transport = GoogleNetHttpTransport.newTrustedTransport()
+      val jackson = JacksonFactory.getDefaultInstance
+      val credential = GoogleCredential.getApplicationDefault
+      new Dataflow.Builder(transport, jackson, credential).build()
+    }
+  }
+
+  private val executor = new ScheduledThreadPoolExecutor(1)
+
+  private val benchmarks = ClassPath.from(Thread.currentThread().getContextClassLoader)
+    .getAllClasses
+    .asScala
+    .filter(_.getName.matches("com\\.spotify\\.ScioStreamingBenchmark\\$[\\w]+\\$"))
+    .flatMap { ci =>
+      val cls = ci.load()
+      if (classOf[StreamingBenchmark] isAssignableFrom cls) {
+        Some(cls.newInstance().asInstanceOf[StreamingBenchmark])
+      } else {
+        None
+      }
+    }
+
+  def main(args: Array[String]): Unit = {
+    val argz = Args(args)
+    val name = argz("name")
+    val regex = argz.getOrElse("regex", ".*")
+    val projectId = argz.getOrElse("project", Settings.defaultProjectId)
+    val timestamp = DateTimeFormat.forPattern("yyyyMMddHHmmss")
+      .withZone(DateTimeZone.UTC)
+      .print(System.currentTimeMillis())
+    val prefix = s"ScioStreamingBenchmark-$name-$timestamp"
+
+    cancelCurrentJobs(projectId)
+
+    val scioResults = benchmarks
+      .filter(_.name.matches(regex))
+      .map(_.run(projectId, prefix, Settings.commonArgs))
+
+    executor.scheduleAtFixedRate(
+      () => scioResults.foreach { case (jobName, result) => pollMetrics(jobName, result) },
+      1,
+      60,
+      TimeUnit.MINUTES)
+
+    scioResults.foreach(result => result._2.waitUntilFinish(Duration(1, TimeUnit.DAYS)))
+  }
+
+  private val cancelledState = "JOB_STATE_CANCELLED"
+
+  /** Cancel any currently running streaming benchmarks before spawning new ones */
+  private def cancelCurrentJobs(projectId: String): Unit = {
+    val jobs = Settings.dataflow.projects().jobs()
+
+    Option(jobs.list(projectId).setFilter("ACTIVE").execute().getJobs).foreach { activeJobs =>
+      activeJobs.asScala.foreach { job =>
+        if (job.getName.toLowerCase.startsWith("sciostreamingbenchmark")) {
+          PrettyPrint.print("CancelCurrentJobs", s"Stopping job.... ${job.getName}")
+
+          jobs.update(
+            projectId,
+            job.getId,
+            new Job().setProjectId(projectId).setId(job.getId).setRequestedState(cancelledState)
+          ).execute()
+        }
+      }
+    }
+  }
+
+  // @Todo write to DataStore etc
+  private def pollMetrics(benchmark: String, result: ScioResult): Unit = {
+    PrettyPrint.print("PollMetrics", s"polling metrics for " + benchmark)
+
+    try {
+      result.as[DataflowResult]
+        .getJobMetrics.getMetrics.asScala
+        .filter { metric =>
+          val name = metric.getName.getName
+          name.startsWith("Total") || name.startsWith("Current")
+        }.foreach { metric =>
+          PrettyPrint.print(benchmark, s"${metric.getName.getName} -> ${metric.getScalar}")
+        }
+    } catch {
+      case e: Exception =>
+        PrettyPrint.print("PollMetrics", s"caught exception polling for metrics: $e")
+    }
+  }
+
+  // =======================================================================
+  // Benchmarks
+  // =======================================================================
+
+  // @Todo write actual benchmark job
+  object StreamingBenchmarkExample extends StreamingBenchmark {
+    override def run(sc: ScioContext): Unit = {
+      sc.optionsAs[StreamingOptions].setStreaming(true)
+
+      sc
+        .customInput(
+          "testJob",
+          GenerateSequence
+            .from(0)
+            .withRate(1, org.joda.time.Duration.standardSeconds(10))
+        )
+        .withFixedWindows(
+          duration = org.joda.time.Duration.standardSeconds(10),
+          offset = org.joda.time.Duration.ZERO)
+        .map(_ * 10)
+    }
+  }
+}
+
+abstract class StreamingBenchmark {
+  val name: String = this.getClass.getSimpleName.replaceAll("\\$$", "")
+
+  def run(projectId: String,
+          prefix: String,
+          args: Array[String]): (String, ScioResult) = {
+    val username = sys.props("user.name")
+
+    val (sc, _) = ContextAndArgs(Array(s"--project=$projectId") ++ args)
+    sc.setAppName(name)
+    sc.setJobName(s"$prefix-$name-$username".toLowerCase())
+
+    run(sc)
+
+    (name, sc.close())
+  }
+
+  def run(sc: ScioContext): Unit
+}

--- a/scripts/circleci_streaming_bench_metrics.sh
+++ b/scripts/circleci_streaming_bench_metrics.sh
@@ -11,5 +11,4 @@ fi
 
 PROPS="-Dbigquery.project=data-integration-test -Dbigquery.secret=$DIR_OF_SCRIPT/$JSON_KEY"
 
-sbt -v $PROPS ++$SCALA_VERSION "scio-test/it:runMain com.spotify.ScioBatchBenchmark --name=ci"
-sbt -v $PROPS ++$SCALA_VERSION "scio-test/it:runMain com.spotify.ScioStreamingBenchmark --name=ci"
+sbt -v $PROPS ++$SCALA_VERSION "scio-test/it:runMain com.spotify.ScioStreamingBenchmarkMetrics --name=ci"


### PR DESCRIPTION
streaming benchmark would be launched once a day at the same time as existing batch benchmarks, then hourly the job metrics would be logged/written to datastore with the key `Benchmarks_${BenchmarkName}[+${hour offset}]`