### PR TITLE
add Dataflow scopes to credential for StreamingBenchmark

### DIFF
--- a/scio-test/src/it/scala/com/spotify/ScioBenchmark.scala
+++ b/scio-test/src/it/scala/com/spotify/ScioBenchmark.scala
@@ -20,7 +20,7 @@ package com.spotify
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.api.services.dataflow.Dataflow
+import com.google.api.services.dataflow.{Dataflow, DataflowScopes}
 import com.google.api.services.dataflow.model.{Job, JobMetrics}
 import com.google.datastore.v1._
 import com.google.datastore.v1.client.{Datastore, DatastoreHelper}
@@ -85,6 +85,7 @@ object DataflowProvider {
     val transport = GoogleNetHttpTransport.newTrustedTransport()
     val jackson = JacksonFactory.getDefaultInstance
     val credential = GoogleCredential.getApplicationDefault
+      .createScoped(DataflowScopes.all())
     new Dataflow.Builder(transport, jackson, credential).build()
   }
 }


### PR DESCRIPTION
in light of CircleCI failing to setup a Dataflow client in the new streaming metrics:

```
[error] (run-main-0) com.google.api.client.auth.oauth2.TokenResponseException: 400 Bad Request
[error] {
[error]   "error" : "invalid_scope",
[error]   "error_description" : "Empty or missing scope not allowed."
[error] }
[error] com.google.api.client.auth.oauth2.TokenResponseException: 400 Bad Request
[error] {
[error]   "error" : "invalid_scope",
[error]   "error_description" : "Empty or missing scope not allowed."
[error] }
[error] 	at com.google.api.client.auth.oauth2.TokenResponseException.from(TokenResponseException.java:105)
[error] 	at com.google.api.client.auth.oauth2.TokenRequest.executeUnparsed(TokenRequest.java:287)
[error] 	at com.google.api.client.auth.oauth2.TokenRequest.execute(TokenRequest.java:307)
[error] 	at com.google.api.client.googleapis.auth.oauth2.GoogleCredential.executeRefreshToken(GoogleCredential.java:394)
[error] 	at com.google.api.client.auth.oauth2.Credential.refreshToken(Credential.java:489)
[error] 	at com.google.api.client.auth.oauth2.Credential.intercept(Credential.java:217)
[error] 	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:868)
[error] 	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:419)
[error] 	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:352)
[error] 	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:469)
[error] 	at com.spotify.ScioStreamingBenchmarkMetrics$.main(ScioStreamingBenchmark.scala:129)
[error] 	at com.spotify.ScioStreamingBenchmarkMetrics.main(ScioStreamingBenchmark.scala)
[error] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[error] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[error] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[error] 	at java.lang.reflect.Method.invoke(Method.java:498)
```