### PR TITLE
add Joda coders

### DIFF
--- a/scio-coders/src/main/scala/com/spotify/scio/coders/Implicits.scala
+++ b/scio-coders/src/main/scala/com/spotify/scio/coders/Implicits.scala
@@ -25,6 +25,7 @@ trait Implicits
     with ProtobufCoders
     with JavaCoders
     with AlgebirdCoders
+    with JodaCoders
     with Serializable
 
 final object Implicits extends Implicits

--- a/scio-coders/src/main/scala/com/spotify/scio/coders/JodaCoders.scala
+++ b/scio-coders/src/main/scala/com/spotify/scio/coders/JodaCoders.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.coders
+
+import java.io.{DataInputStream, DataOutputStream, InputStream, OutputStream}
+
+import org.apache.beam.sdk.coders.AtomicCoder
+import org.joda.time.chrono.ISOChronology
+import org.joda.time.{Chronology, LocalDate, LocalDateTime, LocalTime}
+
+trait JodaCoders {
+  implicit def jodaLocalDateTimeCoder: Coder[LocalDateTime] = Coder.beam(new JodaLocalDateTimeCoder)
+  implicit def jodaLocalDateCoder: Coder[LocalDate] = Coder.beam(new JodaLocalDateCoder)
+  implicit def jodaLocalTimeCoder: Coder[LocalTime] = Coder.beam(new JodaLocalTimeCoder)
+}
+
+object JodaCoders {
+  def checkChronology(chronology: Chronology): Unit = {
+    if (chronology != null && chronology != ISOChronology.getInstanceUTC) {
+      throw new IllegalArgumentException(s"Unsupported chronology: $chronology")
+    }
+  }
+}
+
+private final class JodaLocalDateTimeCoder extends AtomicCoder[LocalDateTime] {
+  import JodaCoders.checkChronology
+
+  def encode(value: LocalDateTime, os: OutputStream): Unit = {
+    checkChronology(value.getChronology)
+    val dos = new DataOutputStream(os)
+
+    dos.writeShort(value.getYear)
+    dos.writeShort(value.getMonthOfYear)
+    dos.writeShort(value.getDayOfMonth)
+    dos.writeShort(value.getHourOfDay)
+    dos.writeShort(value.getMinuteOfHour)
+    dos.writeShort(value.getSecondOfMinute)
+    dos.writeShort(value.getMillisOfSecond)
+  }
+
+  def decode(is: InputStream): LocalDateTime = {
+    val dis = new DataInputStream(is)
+
+    val year = dis.readShort()
+    val month = dis.readShort()
+    val day = dis.readShort()
+    val hour = dis.readShort()
+    val minute = dis.readShort()
+    val second = dis.readShort()
+    val ms = dis.readShort()
+
+    new LocalDateTime(year, month, day, hour, minute, second, ms)
+  }
+}
+
+private final class JodaLocalDateCoder extends AtomicCoder[LocalDate] {
+  import JodaCoders.checkChronology
+
+  def encode(value: LocalDate, os: OutputStream): Unit = {
+    checkChronology(value.getChronology)
+    val dos = new DataOutputStream(os)
+
+    dos.writeShort(value.getYear)
+    dos.writeShort(value.getMonthOfYear)
+    dos.writeShort(value.getDayOfMonth)
+  }
+
+  def decode(is: InputStream): LocalDate = {
+    val dis = new DataInputStream(is)
+
+    val year = dis.readShort()
+    val month = dis.readShort()
+    val day = dis.readShort()
+
+    new LocalDate(year, month, day)
+  }
+}
+
+private final class JodaLocalTimeCoder extends AtomicCoder[LocalTime] {
+  import JodaCoders.checkChronology
+
+  def encode(value: LocalTime, os: OutputStream): Unit = {
+    checkChronology(value.getChronology)
+    val dos = new DataOutputStream(os)
+
+    dos.writeShort(value.getHourOfDay)
+    dos.writeShort(value.getMinuteOfHour)
+    dos.writeShort(value.getSecondOfMinute)
+    dos.writeShort(value.getMillisOfSecond)
+  }
+
+  def decode(is: InputStream): LocalTime = {
+    val dis = new DataInputStream(is)
+
+    val hour = dis.readShort()
+    val minute = dis.readShort()
+    val second = dis.readShort()
+    val ms = dis.readShort()
+
+    new LocalTime(hour, minute, second, ms)
+  }
+}

--- a/scio-coders/src/test/scala/com/spotify/scio/coders/JodaCodersTest.scala
+++ b/scio-coders/src/test/scala/com/spotify/scio/coders/JodaCodersTest.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.coders
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+
+import org.joda.time.{LocalDate, LocalDateTime, LocalTime}
+import org.scalatest.{FlatSpec, Matchers}
+
+class JodaCodersTest extends FlatSpec with Matchers {
+  "JodaLocalDateTimeCoder" should "work" in {
+    val coder = new JodaLocalDateTimeCoder()
+    val value = new LocalDateTime(2018, 3, 12, 7, 15, 5, 900)
+    val bytesOut = new ByteArrayOutputStream()
+    coder.encode(value, bytesOut)
+
+    val bytesIn = new ByteArrayInputStream(bytesOut.toByteArray)
+    val decoded = coder.decode(bytesIn)
+    decoded shouldEqual value
+  }
+
+  "JodaLocalDateCoder" should "work" in {
+    val coder = new JodaLocalDateCoder()
+    val value = new LocalDate(2018, 5, 12)
+    val bytesOut = new ByteArrayOutputStream()
+    coder.encode(value, bytesOut)
+
+    val bytesIn = new ByteArrayInputStream(bytesOut.toByteArray)
+    val decoded = coder.decode(bytesIn)
+    decoded shouldEqual value
+  }
+
+  "JodaLocalTimeCoder" should "work" in {
+    val coder = new JodaLocalTimeCoder()
+    val value = new LocalTime(7, 30, 45, 100)
+    val bytesOut = new ByteArrayOutputStream()
+    coder.encode(value, bytesOut)
+
+    val bytesIn = new ByteArrayInputStream(bytesOut.toByteArray)
+    val decoded = coder.decode(bytesIn)
+    decoded shouldEqual value
+  }
+}


### PR DESCRIPTION
I copied the chronology checks from the preexisting [JodaSerializer](https://github.com/spotify/scio/blob/46683321cafe3959d516d2deaa933a0e209a56a7/scio-core/src/main/scala/com/spotify/scio/coders/serializers/JodaSerializer.scala) assuming the logic is still the same