### PR TITLE
Sparse left and right outer joins

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
@@ -71,7 +71,7 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   }
 
   /**
-   * Perform a gull outer join by replicating `that` to all workers. The right side should be tiny
+   * Perform a full outer join by replicating `that` to all workers. The right side should be tiny
    * and fit in memory.
    *
    * @group join

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -325,8 +325,8 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * @param fpProb false positive probability when computing the overlap
    */
   def sparseRightOuterJoin[W: Coder](that: SCollection[(K, W)],
-                                    thatNumKeys: Long,
-                                    fpProb: Double = 0.01)(
+                                     thatNumKeys: Long,
+                                     fpProb: Double = 0.01)(
     implicit hash: Hash128[K],
     koder: Coder[K],
     voder: Coder[V]): SCollection[(K, (Option[V], W))] =

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -232,12 +232,18 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @return partitioned SCollections in a `Seq`
    * @group collection
    */
-  def partition(numPartitions: Int, f: T => Int): Seq[SCollection[T]] =
-    this
-      .applyInternal(Partition.of[T](numPartitions, Functions.partitionFn[T](numPartitions, f)))
-      .getAll
-      .asScala
-      .map(p => context.wrap(p))
+  def partition(numPartitions: Int, f: T => Int): Seq[SCollection[T]] = {
+    require(numPartitions > 0, "Number of partitions should be positive")
+    if (numPartitions == 1) {
+      Seq(this)
+    } else {
+      this
+        .applyInternal(Partition.of[T](numPartitions, Functions.partitionFn[T](numPartitions, f)))
+        .getAll
+        .asScala
+        .map(p => context.wrap(p))
+    }
+  }
 
   /**
    * Partition this SCollection into a pair of SCollections according to a predicate.

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -465,18 +465,25 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
 
   val sparseLhs = Seq(("a", 1), ("a", 2), ("b", 3), ("c", 4))
   val sparseRhs = Seq(("a", 11), ("d", 5))
-  val sparseExpected = Seq(("a", (Some(1), Some(11))),
-                           ("a", (Some(2), Some(11))),
-                           ("b", (Some(3), None)),
-                           ("c", (Some(4), None)),
-                           ("d", (None, Some(5))))
+  val sparseOuterJoinExpected = Seq(("a", (Some(1), Some(11))),
+                                    ("a", (Some(2), Some(11))),
+                                    ("b", (Some(3), None)),
+                                    ("c", (Some(4), None)),
+                                    ("d", (None, Some(5))))
+  val sparseRightOuterJoinExpected = Seq(("a", (Some(1), 11)),
+                                         ("a", (Some(2), 11)),
+                                         ("d", (None, 5)))
+  val sparseLeftOuterJoinExpected = Seq(("a", (1, Some(11))),
+                                        ("a", (2, Some(11))),
+                                        ("b", (3, None)),
+                                        ("c", (4, None)))
 
   it should "support sparseOuterJoin()" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(sparseLhs)
       val p2 = sc.parallelize(sparseRhs)
       val p = p1.sparseOuterJoin(p2, 10)
-      p should containInAnyOrder(sparseExpected)
+      p should containInAnyOrder(sparseOuterJoinExpected)
     }
   }
 
@@ -485,7 +492,43 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
       val p1 = sc.parallelize(sparseLhs)
       val p2 = sc.parallelize(sparseRhs)
       val p = p1.sparseOuterJoin(p2, 1000000000L)
-      p should containInAnyOrder(sparseExpected)
+      p should containInAnyOrder(sparseOuterJoinExpected)
+    }
+  }
+
+  it should "support sparseLeftOuterJoin()" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(sparseLhs)
+      val p2 = sc.parallelize(sparseRhs)
+      val p = p1.sparseLeftOuterJoin(p2, 10)
+      p should containInAnyOrder(sparseLeftOuterJoinExpected)
+    }
+  }
+
+  it should "support sparseLeftOuterJoin() with partitions" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(sparseLhs)
+      val p2 = sc.parallelize(sparseRhs)
+      val p = p1.sparseLeftOuterJoin(p2, 1000000000L)
+      p should containInAnyOrder(sparseLeftOuterJoinExpected)
+    }
+  }
+
+  it should "support sparseRightOuterJoin()" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(sparseLhs)
+      val p2 = sc.parallelize(sparseRhs)
+      val p = p1.sparseRightOuterJoin(p2, 10)
+      p should containInAnyOrder(sparseRightOuterJoinExpected)
+    }
+  }
+
+  it should "support sparseRightOuterJoin() with partitions" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(sparseLhs)
+      val p2 = sc.parallelize(sparseRhs)
+      val p = p1.sparseRightOuterJoin(p2, 1000000000L)
+      p should containInAnyOrder(sparseRightOuterJoinExpected)
     }
   }
 


### PR DESCRIPTION
A version of sparse left and right outer joins, taken from the original sparse outer join implementation

In some of our pipeline we have a bunch of right outer joins where the RHS of the join is around 5% of the LHS, and but the RHS still doesn't fit in memory. As of now we extract the keys as a Side Input out of RHS which barely fits in memory and then we filter LHS using the keys, before doing the right outer join. Using a BF and sparse joins would help us scale well, which we would need to very soon, but we would need a right outer join variant. So I thought of adding the right and left versions.

 Also,
Can we have sparse multi joins?
The use case is like a small but not tiny dataset to be left joined with multiple very large right sides.