### PR TITLE
Sparse lookups

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -343,7 +343,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     koder: Coder[K],
     voder: Coder[V]): Seq[(SCollection[(K, V)], SCollection[(K, V)], SCollection[(K, W)])] = {
 
-    val thatBfSIs = that.getOptimalKeysBloomFiltersAsSideInputs(thatNumKeys, fpProb)
+    val thatBfSIs = that.optimalKeysBloomFiltersAsSideInputs(thatNumKeys, fpProb)
     val n = thatBfSIs.size
 
     val thisParts = self.partition(n, _._1.hashCode() % n)
@@ -379,7 +379,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     implicit hash: Hash128[K],
     koder: Coder[K],
     voder: Coder[V]): SCollection[(K, (V, Iterable[A]))] = {
-    val selfBfSideInputs = self.getOptimalKeysBloomFiltersAsSideInputs(thisNumKeys, fpProb)
+    val selfBfSideInputs = self.optimalKeysBloomFiltersAsSideInputs(thisNumKeys, fpProb)
     val n = selfBfSideInputs.size
 
     val thisParts = self.partition(n, _._1.hashCode() % n)
@@ -431,7 +431,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     implicit hash: Hash128[K],
     koder: Coder[K],
     voder: Coder[V]): SCollection[(K, (V, Iterable[A], Iterable[B]))] = {
-    val selfBfSideInputs = self.getOptimalKeysBloomFiltersAsSideInputs(thisNumKeys, fpProb)
+    val selfBfSideInputs = self.optimalKeysBloomFiltersAsSideInputs(thisNumKeys, fpProb)
     val n = selfBfSideInputs.size
 
     val thisParts = self.partition(n, _._1.hashCode() % n)
@@ -477,7 +477,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     voder: Coder[V]): SCollection[(K, (V, Iterable[A], Iterable[B]))] =
     sparseLookup(that1, that2, thisNumKeys, 0.01)
 
-  private[values] def getOptimalKeysBloomFiltersAsSideInputs(thisNumKeys: Long, fpProb: Double)(
+  private[values] def optimalKeysBloomFiltersAsSideInputs(thisNumKeys: Long, fpProb: Double)(
     implicit hash: Hash128[K],
     koder: Coder[K],
     voder: Coder[V]): Seq[SideInput[BF[K]]] = {

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -477,7 +477,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     voder: Coder[V]): SCollection[(K, (V, Iterable[A], Iterable[B]))] =
     sparseLookup(that1, that2, thisNumKeys, 0.01)
 
-  protected def getOptimalKeysBloomFiltersAsSideInputs(thisNumKeys: Long, fpProb: Double)(
+  private[values] def getOptimalKeysBloomFiltersAsSideInputs(thisNumKeys: Long, fpProb: Double)(
     implicit hash: Hash128[K],
     koder: Coder[K],
     voder: Coder[V]): Seq[SideInput[BF[K]]] = {

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -695,6 +695,7 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
       val p3 = sc.parallelize(sparseLookup2)
       val p = p1.sparseLookup(p2, p3, 10)
 
+      p should beEmpty
     }
   }
 


### PR DESCRIPTION
Tried to add some more sparse join functions which we wanted to use.
I mentioned this in #1397 

The idea here is this being opposite of hashLookUp. `that` would be considerably larger and `this` is also large enough to not fit in memory.

The left side here ends up being smaller than the right side. Is this way of naming a good idea?

Our use case is mostly joining smaller feature specific datasets keyed on some id with larger company wide datasets which are also keyed on the same id. Also we mostly end up joining with at least 2 company wide datasets in our pipelines.