### PR TITLE
Add registered sys props to --help

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -133,10 +133,15 @@ object ContextAndArgs {
         Console.out.println(Help[T].help)
         sys.exit(0)
       case Right((_, usage, help, _)) if usage =>
+        SysProps.properties
+          .map(_.show)
+          .foreach(Console.out.println)
+
         Console.out.println(Help[T].help)
         for {
           i <- PipelineOptionsFactory.getRegisteredOptions.asScala
         } PipelineOptionsFactory.printHelp(Console.out, i)
+
         sys.exit(0)
       case Right((Right(t), usage, help, _)) =>
         val (ctx, _) = ContextAndArgs(remainingArgs)

--- a/scio-core/src/main/scala/com/spotify/scio/SysProps.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/SysProps.scala
@@ -30,10 +30,19 @@ final case class SysProp(flag: String, description: String) {
   def value_=(str: String): Unit =
     sys.props(flag) = str
   // scalastyle:on method.name
+
+  def show: String =
+    s"-D$flag=<String>\n\t$description"
 }
 
 trait SysProps {
   def properties: List[SysProp]
+
+  def show: String = {
+    val props = properties.map(p => s"  ${p.show}").mkString("\n")
+    val name = this.getClass.getName.replace("$", "")
+    s"$name:\n$props\n"
+  }
 }
 
 object SysProps {


### PR DESCRIPTION
Fixes #950

Example output running:

`runMain com.spotify.scio.examples.MinimalWordCountTypedArguments  --help`

```
com.spotify.scio.io.TapsSysProps:
  -Dtaps.algorithm=<String>
        System property key for taps algorithm
  -Dtaps.polling.maximum_interval=<String>
        System property key for polling taps maximum interval in milliseconds
  -Dtaps.polling.initial_interval=<String>
        System property key for polling taps initial interval in milliseconds
  -Dtaps.polling.maximum_attempts=<String>
        System property key for polling taps maximum number of attempts, unlimited if <= 0. Default is 0

com.spotify.scio.CoreSysProps:
  -Djava.io.tmpdir=<String>
        java temporary directory

com.spotify.scio.avro.AvroSysProps:
  -Davro.types.debug=<String>
        debug
  -Davro.plugin.disable.dump=<String>
        disable class dump
  -Davro.class.cache.directory=<String>
        class cache directory

com.spotify.scio.bigquery.BigQuerySysProps:
  -Dbigquery.types.debug=<String>
        debug
  -Dbigquery.plugin.disable.dump=<String>
        disable class dump
  -Dbigquery.class.cache.directory=<String>
        class cache directory
  -Dbigquery.cache.directory=<String>
        System property key for local schema cache directory
  -Dbigquery.cache.enabled=<String>
        System property key for enabling or disabling scio bigquery caching
  -Dbigquery.project=<String>
        System property key for billing project.
  -Dbigquery.secret=<String>

  -Dbigquery.priority=<String>
        "BATCH" or "INTERACTIVE"
  -Dbigquery.connect_timeout=<String>
        Timeout in milliseconds to establish a connection. Default is 20000 (20 seconds). 0 for an infinite timeout.
  -Dbigquery.read_timeout=<String>
        Timeout in milliseconds to read data from an established connection. Default is 20000 (20 seconds). 0 for an infinite timeout.
```