### PR TITLE
Method to parse only expected options

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -229,6 +229,16 @@ object ScioContext {
     }
   }
 
+  def parseOptions[T <: PipelineOptions: ClassTag](args: Array[String],
+                                                   withValidation: Boolean = false): T = {
+    val (opts, extra) = parseArguments[T](args)
+    val extraArgs = extra.asMap.keys
+    if (extraArgs.nonEmpty) {
+      throw new IllegalArgumentException("Unsupported arguments: " + extraArgs.mkString(", "))
+    }
+    opts
+  }
+
   import scala.language.implicitConversions
 
   /** Implicit conversion from ScioContext to DistCacheScioContext. */

--- a/scio-core/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio
+
+import org.apache.beam.sdk.options.PipelineOptions
+import org.scalatest.{FlatSpec, Matchers}
+
+trait Opts extends PipelineOptions {
+  def getFoo: String
+
+  def setFoo(s: String)
+}
+
+class ScioContextTest extends FlatSpec with Matchers {
+
+  "ScioContext.parseOptions" should "parse known options" in {
+    val args = Array("--jobName=name", "--foo=bar")
+    val opts = ScioContext.parseOptions[Opts](args)
+    opts.getFoo shouldBe "bar"
+    opts.getJobName shouldBe "name"
+  }
+
+  it should "throw if given unknown option" in {
+    val args = Array("--jobName=name", "--foo=bar", "--unknown=value")
+    an[IllegalArgumentException] should be thrownBy ScioContext.parseOptions[Opts](args)
+  }
+}


### PR DESCRIPTION
I've found something like this useful when fixing a bug in
a project using scio. Basically, it protects you from issues
resulting from typos in options, or accidentally running an
older version that silently ignores an option.

When that came up, we solved it with a wrapper, but it would have
been nice if support for failing on unknown arguments was built
into scio.