### PR TITLE
Add a blacklist for coders fallback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -734,7 +734,8 @@ lazy val scioExamples: Project = Project(
       "mysql" % "mysql-connector-java" % "5.1.+",
       "com.google.cloud.sql" % "mysql-socket-factory" % "1.0.2",
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
-      "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test"
+      "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
+      "org.apache.beam" % "beam-sdks-java-extensions-sql" % beamVersion
     ),
     addCompilerPlugin(paradiseDependency),
     // exclude problematic sources if we don't have GCP credentials

--- a/scio-coders-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
+++ b/scio-coders-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
@@ -29,6 +29,8 @@ private[coders] object CoderMacros {
   private[this] val DEFAULT_SHOW_WARN = true
   private[this] val KVS = "show-coder-fallback=(true|false)".r
 
+  val blacklistedTypes = List("org.apache.beam.sdk.values.Row")
+
   /**
    * Makes it possible to configure fallback warnings by passing
    * "-Xmacro-settings:show-coder-fallback=true" as a Scalac option.
@@ -99,6 +101,10 @@ private[coders] object CoderMacros {
     val fallback = q"""_root_.com.spotify.scio.coders.Coder.kryo[$wtt]"""
 
     (verbose, alreadyReported) match {
+      case _ if blacklistedTypes.contains(wtt.toString) =>
+        val msg =
+          s"Can't use a Kryo coder for ${wtt}. You need to explicitly set the Coder for this type"
+        c.abort(c.enclosingPosition, msg)
       case (false, false) =>
         if (show) c.echo(c.enclosingPosition, shortMessage.stripMargin)
         fallback

--- a/scio-coders/src/main/scala/com/spotify/scio/coders/JavaCoders.scala
+++ b/scio-coders/src/main/scala/com/spotify/scio/coders/JavaCoders.scala
@@ -22,6 +22,8 @@ import java.math.{BigDecimal, BigInteger}
 import java.time.Instant
 
 import com.google.api.services.bigquery.model.TableRow
+import org.apache.beam.sdk.values.Row
+import org.apache.beam.sdk.schemas.Schema
 import org.apache.beam.sdk.{coders => bcoders}
 import org.apache.beam.sdk.values.KV
 import org.apache.beam.sdk.io.gcp.pubsub.{PubsubMessage, PubsubMessageWithAttributesCoder}
@@ -91,6 +93,8 @@ trait JavaCoders {
   implicit def paneInfoCoder: Coder[PaneInfo] = Coder.beam(PaneInfo.PaneInfoCoder.of())
 
   implicit def tableRowCoder: Coder[TableRow] = Coder.beam(TableRowJsonCoder.of())
+
+  def row(schema: Schema): Coder[Row] = Coder.beam(RowCoder.of(schema))
 
   implicit def messageCoder: Coder[PubsubMessage] =
     Coder.beam(PubsubMessageWithAttributesCoder.of())

--- a/scio-core/src/test/scala/com/spotify/scio/coders/coders.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/coders/coders.scala
@@ -228,4 +228,10 @@ class CodersTest extends FlatSpec with Matchers {
     checkFallback(PrivateClass(42L))
   }
 
+  it should "not derive Coders for org.apache.beam.sdk.values.Row" in {
+    import org.apache.beam.sdk.values.Row
+    "Coder[Row]" shouldNot compile
+    "Coder.gen[Row]" shouldNot compile
+  }
+
 }

--- a/scio-examples/src/main/java/org/apache/beam/examples/BeamSqlExample.java
+++ b/scio-examples/src/main/java/org/apache/beam/examples/BeamSqlExample.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.examples;
+
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.extensions.sql.SqlTransform;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.SerializableFunctions;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TupleTag;
+
+/**
+ * This is a quick example, which uses Beam SQL DSL to create a data pipeline.
+ *
+ * <p>
+ * Run the example from the Beam source root with
+ *
+ * <pre>
+ *   ./gradlew :beam-sdks-java-extensions-sql:runBasicExample
+ * </pre>
+ *
+ * <p>
+ * The above command executes the example locally using direct runner. Running
+ * the pipeline in other runners require additional setup and are out of scope
+ * of the SQL examples. Please consult Beam documentation on how to run
+ * pipelines.
+ */
+class BeamSqlExample {
+  public static void main(String[] args) {
+    PipelineOptions options = PipelineOptionsFactory.fromArgs(args).as(PipelineOptions.class);
+    Pipeline p = Pipeline.create(options);
+
+    // define the input row format
+    Schema type = Schema.builder().addInt32Field("c1").addStringField("c2").addDoubleField("c3").build();
+
+    Row row1 = Row.withSchema(type).addValues(1, "row", 1.0).build();
+    Row row2 = Row.withSchema(type).addValues(2, "row", 2.0).build();
+    Row row3 = Row.withSchema(type).addValues(3, "row", 3.0).build();
+
+    // create a source PCollection with Create.of();
+    PCollection<Row> inputTable = PBegin.in(p).apply(Create.of(row1, row2, row3).withSchema(type,
+        SerializableFunctions.identity(), SerializableFunctions.identity()));
+
+    // Case 1. run a simple SQL query over input PCollection with
+    // BeamSql.simpleQuery;
+    PCollection<Row> outputStream = inputTable
+        .apply(SqlTransform.query("select c1, c2, c3 from PCOLLECTION where c1 > 1"));
+
+    // print the output record of case 1;
+    outputStream.apply("log_result", MapElements.via(new SimpleFunction<Row, Void>() {
+      @Override
+      public @Nullable Void apply(Row input) {
+        // expect output:
+        // PCOLLECTION: [3, row, 3.0]
+        // PCOLLECTION: [2, row, 2.0]
+        System.out.println("PCOLLECTION: " + input.getValues());
+        return null;
+      }
+    }));
+
+    // Case 2. run the query with SqlTransform.query over result PCollection of case
+    // 1.
+    PCollection<Row> outputStream2 = PCollectionTuple.of(new TupleTag<>("CASE1_RESULT"), outputStream)
+        .apply(SqlTransform.query("select c2, sum(c3) from CASE1_RESULT group by c2"));
+
+    // print the output record of case 2;
+    outputStream2.apply("log_result", MapElements.via(new SimpleFunction<Row, Void>() {
+      @Override
+      public @Nullable Void apply(Row input) {
+        // expect output:
+        // CASE1_RESULT: [row, 5.0]
+        System.out.println("CASE1_RESULT: " + input.getValues());
+        return null;
+      }
+    }));
+
+    p.run().waitUntilFinish();
+  }
+}

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/BeamSqlExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/BeamSqlExample.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Example: Minimal BeamSQL Example
+// Usage:
+
+// `sbt runMain "com.spotify.scio.examples.BeamSqlExample"
+package com.spotify.scio.examples
+
+import com.spotify.scio._
+
+import org.apache.beam.sdk.extensions.sql.SqlTransform
+import org.apache.beam.sdk.schemas.Schema
+import org.apache.beam.sdk.values.Row
+import com.spotify.scio.coders.Coder
+import org.slf4j.LoggerFactory
+import java.lang.{Integer => jInt, String => jString, Double => jDouble}
+
+object BeamSqlExample {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  private def log(name: String): Row => Row = { input =>
+    logger.debug(s"$name: ${input.getValues()}")
+    input
+  }
+
+  def main(cmdlineArgs: Array[String]): Unit = {
+
+    val (sc, _) = ContextAndArgs(cmdlineArgs)
+
+    //define the input row format
+    val schema =
+      Schema.builder().addInt32Field("c1").addStringField("c2").addDoubleField("c3").build()
+    def coderRow1 = Coder.row(schema)
+
+    val schemaAggr = Schema.builder().addStringField("c2").addDoubleField("sum(c3)").build()
+    def coderRowAggr = Coder.row(schemaAggr)
+
+    val rows =
+      List[(jInt, jString, jDouble)]((1, "row", 1.0), (2, "row", 2.0), (3, "row", 3.0)).map {
+        case (a, b, c) =>
+          Row.withSchema(schema).addValues(a, b, c).build()
+      }
+
+    //Case 1. run a simple SQL query over input PCollection with BeamSql.simpleQuery;
+    sc.parallelize(rows)(coderRow1)
+      .map(log("PCOLLECTION"))(coderRow1)
+      .applyTransform(SqlTransform.query("select c1, c2, c3 from PCOLLECTION where c1 > 1"))(
+        coderRow1)
+      .applyTransform(SqlTransform.query("select c2, sum(c3) from PCOLLECTION group by c2"))(
+        coderRowAggr)
+      .map(log("CASE1_RESULT"))(coderRowAggr)
+
+    // Close the context and execute the pipeline
+    sc.close()
+  }
+}


### PR DESCRIPTION
This PR prevent Scio from using Kryo coders when it's known to fail.
See https://github.com/spotify/scio/issues/1344 for background.

Kryo can't serialize `Row` properly and we can't automatically derive a Coder because the schema needs to be explicitly provided.

In future work to support BeamSQL, we'll probably change the way we derive coders instance to use [`SchemaCoder`](https://beam.apache.org/documentation/sdks/javadoc/2.6.0/org/apache/beam/sdk/schemas/SchemaCoder.html) everywhere.

This would give Scio out of the box support for BeamSQL and one could do:

```scala
case class Foo(s: String, i: Int, d: Double)
//...

val scoll: SCollection[Foo] = // some impl ...
scoll.applyTransform(SqlTransform.query("select s, i from PCOLLECTION where i > 1")) // Schema based Coder[Foo] automatically derived there
```
The schema would be statically known which would allow users to use fields names in their BeamSQL query without relying on runtime black magic like Beam does.

While it's not strictly related, I added a BeamSQL example because it helped me validate that the compiler would indeed not derive `Coder[Row]` and that Scio works with beamSQL **IF** you provide proper coders explicitly.
