### PR TITLE
Fix verifyNondeterministic exception in coders

### DIFF
--- a/scio-coders/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-coders/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -198,7 +198,7 @@ private class RecordCoder[T](typeName: String,
 
     problems match {
       case (_, e) :: _ =>
-        val reasons = problems.map { case (reason, e) => reason }
+        val reasons = problems.map { case (reason, _) => reason }
         throw new NonDeterministicException(this, reasons.asJava, e)
       case Nil =>
     }

--- a/scio-coders/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-coders/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -19,11 +19,13 @@ package com.spotify.scio.coders
 
 import java.io.{InputStream, OutputStream}
 
+import org.apache.beam.sdk.coders.Coder.NonDeterministicException
 import org.apache.beam.sdk.coders.{AtomicCoder, Coder => BCoder}
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver
 import org.apache.beam.sdk.values.KV
 
 import scala.annotation.implicitNotFound
+import scala.collection.JavaConverters
 import scala.reflect.ClassTag
 
 @implicitNotFound(
@@ -45,15 +47,23 @@ sealed trait Coder[T] extends Serializable
 final case class Beam[T] private (beam: BCoder[T]) extends Coder[T]
 final case class Fallback[T] private (ct: ClassTag[T]) extends Coder[T]
 final case class Transform[A, B] private (c: Coder[A], f: BCoder[A] => Coder[B]) extends Coder[B]
-final case class Disjunction[T, Id] private (idCoder: Coder[Id],
+final case class Disjunction[T, Id] private (typeName: String,
+                                             idCoder: Coder[Id],
                                              id: T => Id,
                                              coder: Map[Id, Coder[T]])
     extends Coder[T]
-final case class Record[T] private (cs: Array[(String, Coder[T])]) extends Coder[Array[T]]
+
+final case class Record[T] private (typeName: String,
+                                    cs: Array[(String, Coder[Any])],
+                                    construct: Seq[Any] => T,
+                                    destruct: T => Array[Any])
+    extends Coder[T]
+
 // KV are special in beam and need to be serialized using an instance of KvCoder.
 final case class KVCoder[K, V] private (koder: Coder[K], voder: Coder[V]) extends Coder[KV[K, V]]
 
-private final case class DisjunctionCoder[T, Id](idCoder: BCoder[Id],
+private final case class DisjunctionCoder[T, Id](typeName: String,
+                                                 idCoder: BCoder[Id],
                                                  id: T => Id,
                                                  coders: Map[Id, BCoder[T]])
     extends AtomicCoder[T] {
@@ -100,19 +110,23 @@ private object WrappedBCoder {
 // Coder used internally specifically for Magnolia derived coders.
 // It's technically possible to define Product coders only in terms of `Coder.transform`
 // This is just faster
-private class RecordCoder[T: ClassTag](cs: Array[(String, BCoder[T])])
-    extends AtomicCoder[Array[T]] {
+private class RecordCoder[T](typeName: String,
+                             cs: Array[(String, BCoder[Any])],
+                             construct: Seq[Any] => T,
+                             destruct: T => Array[Any])
+    extends AtomicCoder[T] {
   @inline def onErrorMsg[A](msg: => String)(f: => A): A =
     try { f } catch {
       case e: Exception =>
         throw new RuntimeException(msg, e)
     }
 
-  override def encode(value: Array[T], os: OutputStream): Unit = {
+  override def encode(value: T, os: OutputStream): Unit = {
     var i = 0
-    while (i < value.length) {
+    val array = destruct(value)
+    while (i < array.length) {
       val (label, c) = cs(i)
-      val v = value(i)
+      val v = array(i)
       onErrorMsg(s"Exception while trying to `encode` field $label with value $v") {
         c.encode(v, os)
       }
@@ -120,8 +134,8 @@ private class RecordCoder[T: ClassTag](cs: Array[(String, BCoder[T])])
     }
   }
 
-  override def decode(is: InputStream): Array[T] = {
-    val vs = new Array[T](cs.length)
+  override def decode(is: InputStream): T = {
+    val vs = new Array[Any](cs.length)
     var i = 0
     while (i < cs.length) {
       val (label, c) = cs(i)
@@ -130,18 +144,42 @@ private class RecordCoder[T: ClassTag](cs: Array[(String, BCoder[T])])
       }
       i += 1
     }
-    vs
+    construct(vs.toSeq)
   }
 
   // delegate methods for determinism and equality checks
-  override def verifyDeterministic(): Unit = cs.foreach(_._2.verifyDeterministic())
+
+  override def verifyDeterministic(): Unit = {
+    val problems = cs.toList.flatMap {
+      case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+    }
+
+    problems match {
+      case (_, e) :: _ =>
+        val reasons = problems.map { case (reason, e) => reason }
+        throw new NonDeterministicException(this, JavaConverters.seqAsJavaList(reasons), e)
+      case Nil =>
+    }
+  }
+
+  override def toString: String = s"RecordCoder[$typeName]"
+
   override def consistentWithEquals(): Boolean = cs.forall(_._2.consistentWithEquals())
-  override def structuralValue(value: Array[T]): AnyRef = {
+  override def structuralValue(value: T): AnyRef = {
     val b = Seq.newBuilder[AnyRef]
     var i = 0
+    val array = destruct(value)
     while (i < cs.length) {
       val (label, c) = cs(i)
-      val v = value(i)
+      val v = array(i)
       onErrorMsg(s"Exception while trying to `encode` field $label with value $v") {
         b += c.structuralValue(v)
       }
@@ -151,21 +189,22 @@ private class RecordCoder[T: ClassTag](cs: Array[(String, BCoder[T])])
   }
 
   // delegate methods for byte size estimation
-  override def isRegisterByteSizeObserverCheap(value: Array[T]): Boolean = {
+  override def isRegisterByteSizeObserverCheap(value: T): Boolean = {
     var res = true
     var i = 0
+    val array = destruct(value)
     while (res && i < cs.length) {
-      res = cs(i)._2.isRegisterByteSizeObserverCheap(value(i))
+      res = cs(i)._2.isRegisterByteSizeObserverCheap(array(i))
       i += 1
     }
     res
   }
-  override def registerByteSizeObserver(value: Array[T],
-                                        observer: ElementByteSizeObserver): Unit = {
+  override def registerByteSizeObserver(value: T, observer: ElementByteSizeObserver): Unit = {
     var i = 0
+    val array = destruct(value)
     while (i < cs.length) {
       val (_, c) = cs(i)
-      val v = value(i)
+      val v = array(i)
       c.registerByteSizeObserver(v, observer)
       i += 1
     }
@@ -181,8 +220,8 @@ sealed trait CoderGrammar {
     Fallback[T](ct)
   def transform[A, B](c: Coder[A])(f: BCoder[A] => Coder[B]): Coder[B] =
     Transform(c, f)
-  def disjunction[T, Id: Coder](coder: Map[Id, Coder[T]])(id: T => Id): Coder[T] =
-    Disjunction(Coder[Id], id, coder)
+  def disjunction[T, Id: Coder](typeName: String, coder: Map[Id, Coder[T]])(id: T => Id): Coder[T] =
+    Disjunction(typeName, Coder[Id], id, coder)
   def xmap[A, B](c: Coder[A])(f: A => B, t: B => A): Coder[B] = {
     @inline def toB(bc: BCoder[A]) = new AtomicCoder[B] {
       override def encode(value: B, os: OutputStream): Unit =
@@ -203,8 +242,12 @@ sealed trait CoderGrammar {
     }
     Transform[A, B](c, bc => Coder.beam(toB(bc)))
   }
-  private[scio] def sequence[T](cs: Array[(String, Coder[T])]): Coder[Array[T]] =
-    Record(cs)
+
+  private[scio] def record[T](typeName: String,
+                              cs: Array[(String, Coder[Any])],
+                              construct: Seq[Any] => T,
+                              destruct: T => Array[Any]): Coder[T] =
+    Record[T](typeName, cs, construct, destruct)
 }
 
 object Coder extends CoderGrammar with Implicits {

--- a/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
@@ -44,11 +44,12 @@ final object CoderMaterializer {
       case Transform(c, f) =>
         val u = f(beam(r, o, c))
         WrappedBCoder.create(beam(r, o, u))
-      case Record(coders) =>
-        new RecordCoder(coders.map(c => c._1 -> beam(r, o, c._2)))
-      case Disjunction(idCoder, id, coders) =>
+      case Record(typeName, coders, construct, destruct) =>
+        new RecordCoder(typeName, coders.map(c => c._1 -> beam(r, o, c._2)), construct, destruct)
+      case Disjunction(typeName, idCoder, id, coders) =>
         WrappedBCoder.create(
-          DisjunctionCoder(beam(r, o, idCoder),
+          DisjunctionCoder(typeName,
+                           beam(r, o, idCoder),
                            id,
                            coders.mapValues(u => beam(r, o, u)).map(identity)))
       case KVCoder(koder, voder) =>

--- a/scio-core/src/test/scala/com/spotify/scio/coders/coders.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/coders/coders.scala
@@ -271,8 +271,9 @@ class CodersTest extends FlatSpec with Matchers {
         materialize(coder).verifyDeterministic()
       }
 
-    val leftCoder = "RecordCoder[scala.util.Left](value -> DoubleCoder)"
-    val rightCoder = "RecordCoder[scala.util.Right](value -> VarIntCoder)"
+    // field names vary between Scala 2.11 and 2.12
+    val leftCoder = materialize(Coder[scala.util.Left[Double, Int]]).toString
+    val rightCoder = materialize(Coder[scala.util.Right[Double, Int]]).toString
 
     val expectedMsg = s"DisjunctionCoder[scala.util.Either](" +
       s"id -> VarIntCoder, 0 -> $leftCoder, 1 -> $rightCoder) is not deterministic"


### PR DESCRIPTION
Now exception message includes offending fields and their coders.
Otherwise, it isn't clear what is the root cause.

Change RecordCoder to encode records instead of sequences

# TODO
- [x] fix scala 2.11
- [x] implement disjunction checks