### PR TITLE
refactor ScioIO to allow implementations to override pipeline test behavior

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -569,13 +569,7 @@ class ScioContext private[scio] (val options: PipelineOptions, private var artif
     idAttribute: String,
     timestampAttribute: String): SCollection[(T, Map[String, String])] = {
     val io = PubsubIO.withAttributes[T](name, idAttribute, timestampAttribute)
-    val read = this.read(io)(PubsubIO.ReadParam(isSubscription))
-
-    if (this.isTest && timestampAttribute != null) {
-      read.timestampBy(kv => new Instant(kv._2(timestampAttribute)))
-    } else {
-      read
-    }
+    this.read(io)(PubsubIO.ReadParam(isSubscription))
   }
 
   /**

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -618,10 +618,9 @@ class ScioContext private[scio] (val options: PipelineOptions, private var artif
     }
 
   /**
-   * Generic read method for all `ScioIO[T]` implementations, if it is test pipeline this will
-   * feed value of pre-registered input IO implementation which match for the passing `ScioIO[T]`
-   * implementation. if not this will invoke [[com.spotify.scio.io.ScioIO[T]#read]] method along
-   * with read configurations passed by.
+   * Generic read method for all `ScioIO[T]` implementations, which will invoke the provided IO's
+   * [[com.spotify.scio.io.ScioIO[T]#readWithContext]] method along with read configurations
+   * passed in. The IO class can delegate test-specific behavior if necessary.
    *
    * @param io     an implementation of `ScioIO[T]` trait
    * @param params configurations need to pass to perform underline read implementation

--- a/scio-core/src/main/scala/com/spotify/scio/io/ScioIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/ScioIO.scala
@@ -28,7 +28,8 @@ import scala.concurrent.Future
  * Base trait for all Read/Write IO classes. Every IO connector must implement this.
  * This trait has two abstract implicit methods #read, #write that need to be implemented
  * in every subtype. Look at the [[com.spotify.scio.io.TextIO]] subclass for a reference
- * implementation.
+ * implementation. IO connectors can choose to override #readTest and #writeTest if custom
+ * test logic is necessary.
  */
 trait ScioIO[T] {
   // abstract types for read/write params.
@@ -58,14 +59,14 @@ trait ScioIO[T] {
 
   protected def read(sc: ScioContext, params: ReadP): SCollection[T]
 
+  protected def write(data: SCollection[T], params: WriteP): Future[Tap[T]]
+
   protected def readTest(sc: ScioContext, params: ReadP)(
     implicit coder: Coder[T]): SCollection[T] = {
     sc.parallelize(
       TestDataManager.getInput(sc.testId.get)(this).asInstanceOf[Seq[T]]
     )
   }
-
-  protected def write(data: SCollection[T], params: WriteP): Future[Tap[T]]
 
   protected def writeTest(data: SCollection[T], params: WriteP)(
     implicit coder: Coder[T]): Future[Tap[T]] = {

--- a/scio-core/src/main/scala/com/spotify/scio/io/ScioIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/ScioIO.scala
@@ -39,7 +39,8 @@ trait ScioIO[T] {
   // identifier for JobTest IO matching
   def testId: String = this.toString
 
-  def readWithContext(sc: ScioContext, params: ReadP)(implicit coder: Coder[T]): SCollection[T] =
+  protected[scio] def readWithContext(sc: ScioContext, params: ReadP)(
+    implicit coder: Coder[T]): SCollection[T] =
     sc.requireNotClosed {
       if (sc.isTest) {
         readTest(sc, params)
@@ -48,14 +49,13 @@ trait ScioIO[T] {
       }
     }
 
-  def writeWithContext(data: SCollection[T], params: WriteP)(
-    implicit coder: Coder[T]): Future[Tap[T]] = {
+  protected[scio] def writeWithContext(data: SCollection[T], params: WriteP)(
+    implicit coder: Coder[T]): Future[Tap[T]] =
     if (data.context.isTest) {
       writeTest(data, params)
     } else {
       write(data, params)
     }
-  }
 
   protected def read(sc: ScioContext, params: ReadP): SCollection[T]
 

--- a/scio-core/src/main/scala/com/spotify/scio/io/ScioIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/ScioIO.scala
@@ -39,7 +39,7 @@ trait ScioIO[T] {
   // identifier for JobTest IO matching
   def testId: String = this.toString
 
-  protected[scio] def readWithContext(sc: ScioContext, params: ReadP)(
+  private[scio] def readWithContext(sc: ScioContext, params: ReadP)(
     implicit coder: Coder[T]): SCollection[T] =
     sc.requireNotClosed {
       if (sc.isTest) {
@@ -49,7 +49,7 @@ trait ScioIO[T] {
       }
     }
 
-  protected[scio] def writeWithContext(data: SCollection[T], params: WriteP)(
+  private[scio] def writeWithContext(data: SCollection[T], params: WriteP)(
     implicit coder: Coder[T]): Future[Tap[T]] =
     if (data.context.isTest) {
       writeTest(data, params)

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/checkpoint/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/checkpoint/package.scala
@@ -21,6 +21,7 @@ import com.spotify.scio.ScioContext
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.avro._
 import com.spotify.scio.io.{FileStorage, ObjectFileIO}
+import com.spotify.scio.testing.TestDataManager
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
 import org.apache.beam.sdk.io.FileSystems
@@ -71,7 +72,8 @@ package object checkpoint {
     }
 
     private def isCheckpointAvailable(path: String): Boolean = {
-      if (self.isTest && self.testInput.m.contains(CheckpointIO[Unit](path).testId)) {
+      if (self.isTest &&
+          TestDataManager.getInput(self.testId.get).m.contains(CheckpointIO[Unit](path).testId)) {
         // if it's test and checkpoint was registered in test
         true
       } else {


### PR DESCRIPTION
follow up to https://github.com/spotify/scio/pull/1417 -  we wanted to move custom test logic outside of `ScioContext` and allow specific IO's to override test behavior.

one downside is having to move `Coder` implicits into the `ScioIO` trait itself in order to invoke `sc.parallelize` and `data.saveAsInMemoryTap`. however, the interface IO's have to implement is unchanged.
