### PR TITLE
register default file systems in Scio test context (fix #1455)

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -565,7 +565,7 @@ class ScioContext private[scio] (val options: PipelineOptions, private var artif
   // =======================================================================
 
   /**  Whether this is a test context. */
-  lazy val isTest: Boolean = testId.isDefined
+  def isTest: Boolean = testId.isDefined
 
   // =======================================================================
   // Read operations

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -36,6 +36,7 @@ import com.spotify.scio.values._
 import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import org.apache.beam.sdk.PipelineResult.State
 import org.apache.beam.sdk.extensions.gcp.options.GcsOptions
+import org.apache.beam.sdk.io.FileSystems
 import org.apache.beam.sdk.metrics.Counter
 import org.apache.beam.sdk.options._
 import org.apache.beam.sdk.transforms._
@@ -379,6 +380,10 @@ class ScioContext private[scio] (val options: PipelineOptions, private var artif
     options.setTempLocation(tmpDir.toString)
   }
 
+  if (isTest) {
+    FileSystems.setDefaultPipelineOptions(PipelineOptionsFactory.create)
+  }
+
   /** Underlying pipeline. */
   def pipeline: Pipeline = {
     if (_pipeline == null) {
@@ -560,7 +565,7 @@ class ScioContext private[scio] (val options: PipelineOptions, private var artif
   // =======================================================================
 
   /**  Whether this is a test context. */
-  def isTest: Boolean = testId.isDefined
+  lazy val isTest: Boolean = testId.isDefined
 
   // =======================================================================
   // Read operations

--- a/scio-test/src/it/scala/com/spotify/scio/ScioContextIT.scala
+++ b/scio-test/src/it/scala/com/spotify/scio/ScioContextIT.scala
@@ -23,6 +23,7 @@ import com.spotify.scio.testing.util.ItUtils
 import com.spotify.scio.util.ScioUtil
 import org.apache.beam.runners.dataflow.DataflowRunner
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions
+import org.apache.beam.sdk.io.FileSystems
 import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
 import org.scalatest._
 
@@ -67,4 +68,11 @@ class ScioContextIT extends FlatSpec with Matchers {
     noException shouldBe thrownBy { sc.close() }
   }
 
+  it should "register remote file systems in the test context" in {
+    val sc = ScioContext.forTest()
+    noException shouldBe thrownBy {
+      FileSystems.matchSingleFileSpec("gs://data-integration-test-eu/shakespeare.json")
+    }
+    sc.close()
+  }
 }


### PR DESCRIPTION
doc for `FileSystems.setDefaultPipelineOptions` says:
```
This is expected only to be used by runners after {@code Pipeline.run}, or in tests.
```

Beam manually registers these in their unit testing framework: [TestPipeline.java](https://github.com/apache/beam/blob/4a92d28967a1c3fbe4719d8599bdde7b9ff2e31f/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java#L463) so it seems reasonable to also register it in ours?
