### PR TITLE
pass in region to DataflowResult.apply()

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowResult.scala
@@ -91,7 +91,7 @@ object DataflowResult {
   }
 
   def apply(job: Job): DataflowResult = {
-    val options = getOptions(job.getProjectId)
+    val options = getOptions(job.getProjectId, job.getLocation)
     apply(options, job)
   }
 

--- a/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowResult.scala
@@ -41,7 +41,7 @@ class DataflowResult(val internal: DataflowPipelineJob) extends RunnerResult {
     this(internal.asInstanceOf[DataflowPipelineJob])
 
   private val client =
-    DataflowResult.getOptions(internal.getProjectId).getDataflowClient
+    DataflowResult.getOptions(internal.getProjectId, internal.getRegion).getDataflowClient
 
   /** Get Dataflow [[com.google.api.services.dataflow.model.Job Job]]. */
   def getJob: Job =
@@ -84,8 +84,8 @@ class DataflowResult(val internal: DataflowPipelineJob) extends RunnerResult {
 object DataflowResult {
 
   /** Create a new [[DataflowResult]] instance. */
-  def apply(projectId: String, jobId: String): DataflowResult = {
-    val options = getOptions(projectId)
+  def apply(projectId: String, region: String, jobId: String): DataflowResult = {
+    val options = getOptions(projectId, region)
 
     val job = getJob(options.getDataflowClient, options.getProject, options.getRegion, jobId)
     // DataflowPipelineJob require a mapping of human-readable transform names via
@@ -109,10 +109,10 @@ object DataflowResult {
     new DataflowResult(internal)
   }
 
-  private def getOptions(projectId: String): DataflowPipelineOptions = {
-    val options =
-      PipelineOptionsFactory.create().as(classOf[DataflowPipelineOptions])
+  private def getOptions(projectId: String, region: String): DataflowPipelineOptions = {
+    val options = PipelineOptionsFactory.create().as(classOf[DataflowPipelineOptions])
     options.setProject(projectId)
+    options.setRegion(region)
     options
   }
 

--- a/scio-test/src/it/scala/com/spotify/DataflowIT.scala
+++ b/scio-test/src/it/scala/com/spotify/DataflowIT.scala
@@ -62,7 +62,9 @@ class DataflowIT extends FlatSpec with Matchers {
   }
 
   it should "work independently" taggedAs Slow in {
-    val r = DataflowResult(dfResult.internal.getProjectId, dfResult.internal.getJobId)
+    val r = DataflowResult(dfResult.internal.getProjectId,
+                           dfResult.internal.getRegion,
+                           dfResult.internal.getJobId)
     r.getJob.getProjectId shouldBe dfResult.internal.getProjectId
     r.getJobMetrics.getMetrics.asScala should not be empty
     r.asScioResult.state shouldBe scioResult.state


### PR DESCRIPTION
Unless the region is explicitly set, we get the default region from the pipeline options when looking up the dataflow job and will get a 404 unless the job was running in that region.