### PR TITLE
pass in region to DataflowResult.apply() (alt 2)

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowResult.scala
@@ -84,10 +84,10 @@ class DataflowResult(val internal: DataflowPipelineJob) extends RunnerResult {
 object DataflowResult {
 
   /** Create a new [[DataflowResult]] instance. */
-  def apply(projectId: String, jobId: String): DataflowResult = {
+  def apply(projectId: String, region: String, jobId: String): DataflowResult = {
     val options = getOptions(projectId)
 
-    val job = getJob(options.getDataflowClient, options.getProject, options.getRegion, jobId)
+    val job = getJob(options.getDataflowClient, options.getProject, region, jobId)
     // DataflowPipelineJob require a mapping of human-readable transform names via
     // AppliedPTransform#getUserName, e.g. flatMap@MyJob.scala:12, to Dataflow service generated
     // transform names, e.g. s12


### PR DESCRIPTION
Unless the region is explicitly set, we get the default region from the pipeline options when looking up the dataflow job and will get a 404 unless the job was running in that region.

Alternative to https://github.com/spotify/scio/pull/1479

**Note**: Calling `getJob` on the returned `DataflowResult` will not work as it uses the region of the  `DataflowPipelineOptions` when querying the dataflow api for the job.