### PR TITLE
Fix mixed content on examples page by serving js from https

### DIFF
--- a/project/SoccoIndex.scala
+++ b/project/SoccoIndex.scala
@@ -33,7 +33,7 @@ object SoccoIndex {
     """.stripMargin
   val footer =
     """  </xmp>
-      |  <script src="http://strapdownjs.com/v/0.2/strapdown.js"></script>
+      |  <script src="https://strapdownjs.com/v/0.2/strapdown.js"></script>
       |</html>
     """.stripMargin
 


### PR DESCRIPTION
before: 
<img width="1552" alt="screenshot 2018-10-24 at 17 47 16" src="https://user-images.githubusercontent.com/235297/47439386-f340de80-d7b4-11e8-8e83-bc070e1476ec.png">
after:
<img width="1552" alt="screenshot 2018-10-24 at 17 47 40" src="https://user-images.githubusercontent.com/235297/47439406-fb008300-d7b4-11e8-860e-d08120ac766d.png">

With that said, I've only tested on Chrome (69.0.3497.100) and Safari (v12 14606.1.36.1.9)