### PR TITLE
add Spanner package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -640,6 +640,22 @@ lazy val scioParquet: Project = Project(
     scioTest % "test->test"
   )
 
+lazy val scioSpanner: Project = Project(
+  "scio-spanner",
+  file("scio-spanner")
+).settings(
+    commonSettings ++ itSettings,
+    description := "Scio add-on for Google Cloud Spanner",
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest" % scalatestVersion % "it"
+    )
+  )
+  .dependsOn(
+    scioCore,
+    scioTest % "test"
+  )
+  .configs(IntegrationTest)
+
 lazy val scioTensorFlow: Project = Project(
   "scio-tensorflow",
   file("scio-tensorflow")
@@ -735,6 +751,7 @@ lazy val scioExamples: Project = Project(
     scioSchemas,
     scioJdbc,
     scioExtra,
+    scioSpanner,
     scioTensorFlow,
     scioTest % "test"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -319,6 +319,7 @@ lazy val root: Project = Project(
     scioParquet,
     scioTensorFlow,
     scioSchemas,
+    scioSpanner,
     scioExamples,
     scioRepl,
     scioJmh,

--- a/build.sbt
+++ b/build.sbt
@@ -644,7 +644,7 @@ lazy val scioSpanner: Project = Project(
   "scio-spanner",
   file("scio-spanner")
 ).settings(
-    commonSettings ++ itSettings,
+    commonSettings ++ itSettings ++ beamRunnerSettings,
     description := "Scio add-on for Google Cloud Spanner",
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % scalatestVersion % "it"

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
@@ -22,6 +22,7 @@ import java.math.{BigDecimal, BigInteger}
 import java.time.Instant
 
 import com.google.api.services.bigquery.model.TableRow
+import com.google.cloud.spanner.{Mutation, Struct}
 import com.spotify.scio.coders.Coder
 import org.apache.beam.sdk.values.Row
 import org.apache.beam.sdk.schemas.Schema
@@ -112,4 +113,10 @@ trait JavaCoders {
   // #1447: Kryo throws a NPE
   implicit def spannerReadOperationCoder: Coder[ReadOperation] =
     Coder.beam(bcoders.SerializableCoder.of(classOf[ReadOperation]))
+
+  implicit def spannerMutationCoder: Coder[Mutation] =
+    Coder.beam(bcoders.SerializableCoder.of(classOf[Mutation]))
+
+  implicit def spannerStructCoder: Coder[Struct] =
+    Coder.beam(bcoders.SerializableCoder.of(classOf[Struct]))
 }

--- a/scio-core/src/test/scala/com/spotify/scio/coders/coders.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/coders/coders.scala
@@ -370,4 +370,13 @@ class CodersTest extends FlatSpec with Matchers {
     check(ro)
   }
 
+  it should "support spanner's Mutation class" in {
+    import com.google.cloud.spanner.Mutation
+    check(Mutation.newInsertBuilder("myTable").set("foo").to("bar").build())
+  }
+
+  it should "support spanner's Struct class" in {
+    import com.google.cloud.spanner.Struct
+    check(Struct.newBuilder().set("foo").to("bar").build())
+  }
 }

--- a/scio-spanner/src/it/scala/com/spotify/scio/spanner/SpannerIOIT.scala
+++ b/scio-spanner/src/it/scala/com/spotify/scio/spanner/SpannerIOIT.scala
@@ -40,7 +40,7 @@ object SpannerIOIT {
   private val adminClient = Spanner.getAdminClient(projectId)
   private val dbClient = Spanner.getDatabaseClient(config)
 
-  private val options = PipelineOptionsFactory.fromArgs(s"--project=$projectId").create()
+  private val options = PipelineOptionsFactory.create()
 }
 
 class SpannerIOIT extends FlatSpec with Matchers with BeforeAndAfterAll {
@@ -107,7 +107,8 @@ class SpannerIOIT extends FlatSpec with Matchers with BeforeAndAfterAll {
       sc,
       SpannerRead.ReadParam(
         readMethod = SpannerRead.FromTable(table, Seq("Key", "Value")),
-        withTransaction = true
+        withTransaction = true,
+        withBatching = true
       )
     )
 
@@ -143,6 +144,7 @@ class SpannerIOIT extends FlatSpec with Matchers with BeforeAndAfterAll {
       sc,
       SpannerRead.ReadParam(
         readMethod = SpannerRead.FromQuery(s"SELECT Key, Value FROM $table"),
+        withTransaction = true,
         withBatching = true
       )
     )

--- a/scio-spanner/src/it/scala/com/spotify/scio/spanner/SpannerIOIT.scala
+++ b/scio-spanner/src/it/scala/com/spotify/scio/spanner/SpannerIOIT.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.spanner
+
+import com.google.cloud.spanner._
+import com.spotify.scio.ScioContext
+import com.spotify.scio.spanner.client.Spanner
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig
+import org.apache.beam.sdk.options.PipelineOptionsFactory
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
+import scala.util.Random
+
+object SpannerIOIT {
+  private val tablePrefix = "test_table"
+  private val projectId = "data-integration-test"
+  private val config: SpannerConfig = SpannerConfig.create()
+    .withProjectId(projectId)
+    .withDatabaseId(s"io_it_${Random.nextInt}")
+    .withInstanceId("spanner-it")
+
+  private val adminClient = Spanner.getAdminClient(projectId)
+  private val dbClient = Spanner.getDatabaseClient(config)
+
+  private val options = PipelineOptionsFactory.fromArgs(s"--project=$projectId").create()
+}
+
+class SpannerIOIT extends FlatSpec with Matchers with BeforeAndAfterAll {
+  import SpannerIOIT._
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  override def beforeAll(): Unit = {
+    val create = adminClient.createDatabase(
+      config.getInstanceId.get(),
+      config.getDatabaseId.get(),
+      List(
+        s"CREATE TABLE ${tablePrefix}_1 (\n Key INT64, \n Value STRING(MAX) \n) PRIMARY KEY (Key)",
+        s"CREATE TABLE ${tablePrefix}_2 (\n Key INT64, \n Value STRING(MAX) \n) PRIMARY KEY (Key)",
+        s"CREATE TABLE ${tablePrefix}_3 (\n Key INT64, \n Value STRING(MAX) \n) PRIMARY KEY (Key)"
+      ).asJava)
+
+    create.waitFor()
+  }
+
+  override def afterAll(): Unit = {
+    adminClient.dropDatabase(config.getInstanceId.get(), config.getDatabaseId.get())
+  }
+
+  "SpannerIO" should "perform writes" in {
+    val table = s"${tablePrefix}_1"
+    val mutations = Seq(
+      Mutation.newInsertBuilder(table).set("Key").to(1L).set("Value").to("foo").build(),
+      Mutation.newInsertBuilder(table).set("Key").to(2L).set("Value").to("bar").build()
+    )
+
+    val sc = ScioContext(options)
+    val data = sc.parallelize(mutations)
+
+    SpannerWrite(config).writeWithContext(data, SpannerWrite.WriteParam())
+    sc.close()
+
+    val txn = dbClient.readOnlyTransaction()
+    val read = txn.read(table, KeySet.all(), Seq("Key", "Value").asJava)
+
+    val results: List[Struct] = List(
+      { read.next(); read.getCurrentRowAsStruct },
+      { read.next(); read.getCurrentRowAsStruct }
+    )
+
+    val expectedOut = List(
+      Struct.newBuilder().set("Key").to(1L).set("Value").to("foo").build(),
+      Struct.newBuilder().set("Key").to(2).set("Value").to("bar").build()
+    )
+
+    results should contain theSameElementsAs expectedOut
+  }
+
+  it should "perform reads from table" in {
+    val table = s"${tablePrefix}_2"
+    val mutations = Seq(
+      Mutation.newInsertBuilder(table).set("Key").to(3L).set("Value").to("foo").build(),
+      Mutation.newInsertBuilder(table).set("Key").to(4L).set("Value").to("bar").build()
+    )
+
+    dbClient.write(mutations.asJava)
+
+    val sc = ScioContext(options)
+    val read = SpannerRead(config).readWithContext(
+      sc,
+      SpannerRead.ReadParam(
+        readMethod = SpannerRead.FromTable(table, Seq("Key", "Value")),
+        withTransaction = true
+      )
+    )
+
+    val result = read.materialize.map(_.value.toList)
+    sc.close()
+
+    val expectedOut = List(
+      Struct.newBuilder()
+        .set("Key").to(3L)
+        .set("Value").to("foo")
+        .build(),
+      Struct.newBuilder()
+        .set("Key").to(4L)
+        .set("Value").to("bar")
+        .build())
+
+    val awaited = Await.result(result, 10.seconds)
+
+    awaited should contain theSameElementsAs expectedOut
+  }
+
+  it should "perform reads from query" in {
+    val table = s"${tablePrefix}_3"
+    val mutations = Seq(
+      Mutation.newInsertBuilder(table).set("Key").to(5L).set("Value").to("foo").build(),
+      Mutation.newInsertBuilder(table).set("Key").to(6L).set("Value").to("bar").build()
+    )
+
+    dbClient.write(mutations.asJava)
+
+    val sc = ScioContext(options)
+    val read = SpannerRead(config).readWithContext(
+      sc,
+      SpannerRead.ReadParam(
+        readMethod = SpannerRead.FromQuery(s"SELECT Key, Value FROM $table"),
+        withBatching = true
+      )
+    )
+
+    val result = read.materialize.map(_.value.toList)
+
+    sc.close()
+
+    val expectedOut = List(
+      Struct.newBuilder()
+        .set("Key").to(5L)
+        .set("Value").to("foo")
+        .build(),
+      Struct.newBuilder()
+        .set("Key").to(6L)
+        .set("Value").to("bar")
+        .build())
+
+    Await.result(result, 10.seconds) should contain theSameElementsAs expectedOut
+  }
+}

--- a/scio-spanner/src/main/scala/com/spotify/scio/spanner/SpannerIO.scala
+++ b/scio-spanner/src/main/scala/com/spotify/scio/spanner/SpannerIO.scala
@@ -43,8 +43,8 @@ object SpannerRead {
   }
 
   sealed trait ReadMethod
-  case class FromTable(tableName: String, columns: Seq[String]) extends ReadMethod
-  case class FromQuery(query: String) extends ReadMethod
+  final case class FromTable(tableName: String, columns: Seq[String]) extends ReadMethod
+  final case class FromQuery(query: String) extends ReadMethod
 
   final case class ReadParam private (
     readMethod: ReadMethod,
@@ -103,10 +103,11 @@ final case class SpannerWrite(config: SpannerConfig) extends SpannerIO[Mutation]
 
   override protected def write(data: SCollection[Mutation],
                                params: WriteP): Future[Tap[Nothing]] = {
-    var transform = BSpannerIO.write().withSpannerConfig(config)
-
-    transform = transform.withBatchSizeBytes(params.batchSizeBytes)
-    transform = transform.withFailureMode(params.failureMode)
+    val transform = BSpannerIO
+      .write()
+      .withSpannerConfig(config)
+      .withBatchSizeBytes(params.batchSizeBytes)
+      .withFailureMode(params.failureMode)
 
     data.applyInternal(transform)
     Future.successful(EmptyTap)

--- a/scio-spanner/src/main/scala/com/spotify/scio/spanner/SpannerIO.scala
+++ b/scio-spanner/src/main/scala/com/spotify/scio/spanner/SpannerIO.scala
@@ -81,8 +81,7 @@ final case class SpannerRead(config: SpannerConfig) extends SpannerIO[Struct] {
   override protected def write(data: SCollection[Struct], params: WriteP): Future[Tap[Nothing]] =
     throw new IllegalStateException("SpannerRead is read-only")
 
-  override def tap(params: ReadP): Tap[Nothing] =
-    throw new NotImplementedError("SpannerRead tap is not implemented")
+  override def tap(params: ReadP): Tap[Nothing] = EmptyTap
 }
 
 object SpannerWrite {

--- a/scio-spanner/src/main/scala/com/spotify/scio/spanner/SpannerIO.scala
+++ b/scio-spanner/src/main/scala/com/spotify/scio/spanner/SpannerIO.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.spanner
+
+import com.google.cloud.spanner._
+import com.spotify.scio.ScioContext
+import com.spotify.scio.io.{EmptyTap, EmptyTapOf, ScioIO, Tap}
+import com.spotify.scio.values.SCollection
+import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.FailureMode
+import org.apache.beam.sdk.io.gcp.spanner.{SpannerConfig, SpannerIO => BSpannerIO}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+sealed trait SpannerIO[T] extends ScioIO[T] {
+  override final val tapT = EmptyTapOf[T]
+  val config: SpannerConfig
+
+  override def testId: String =
+    s"SpannerWrite(${config.getProjectId}, ${config.getInstanceId}, ${config.getDatabaseId})"
+}
+
+object SpannerRead {
+  object ReadParam {
+    private[spanner] val DefaultWithTransaction = false
+    private[spanner] val DefaultWithBatching = false
+
+    @inline def apply(readMethod: ReadMethod,
+                      withTransaction: Boolean = ReadParam.DefaultWithTransaction,
+                      withBatching: Boolean = ReadParam.DefaultWithBatching): ReadParam =
+      new ReadParam(readMethod, withBatching, withBatching)
+  }
+
+  case class ReadParam(readMethod: ReadMethod, withTransaction: Boolean, withBatching: Boolean)
+
+  sealed trait ReadMethod
+  case class FromTable(tableName: String, columns: Seq[String]) extends ReadMethod
+  case class FromQuery(query: String) extends ReadMethod
+}
+
+final case class SpannerRead(config: SpannerConfig) extends SpannerIO[Struct] {
+  import SpannerRead._
+
+  override type ReadP = ReadParam
+  override type WriteP = Nothing
+
+  override protected def read(sc: ScioContext, params: ReadP): SCollection[Struct] = sc.wrap {
+    var transform = BSpannerIO
+      .read()
+      .withSpannerConfig(config)
+      .withBatching(params.withBatching)
+
+    transform = params.readMethod match {
+      case x: FromTable => transform.withTable(x.tableName).withColumns(x.columns.asJava)
+      case y: FromQuery => transform.withQuery(y.query)
+    }
+
+    if (params.withTransaction) {
+      val txn = BSpannerIO.createTransaction().withSpannerConfig(config)
+      transform = transform.withTransaction(sc.applyInternal(txn))
+    }
+
+    sc.applyInternal(transform)
+  }
+
+  override protected def write(data: SCollection[Struct], params: WriteP): Future[Tap[Nothing]] =
+    throw new IllegalStateException("SpannerRead is read-only")
+
+  override def tap(params: ReadP): Tap[Nothing] =
+    throw new NotImplementedError("SpannerRead tap is not implemented")
+}
+
+object SpannerWrite {
+  object WriteParam {
+    private[spanner] val DefaultFailureMode = FailureMode.FAIL_FAST
+    private[spanner] val DefaultBatchSizeBytes = 1024L * 1024L
+
+    @inline def apply(failureMode: FailureMode = WriteParam.DefaultFailureMode,
+                      batchSizeBytes: Long = WriteParam.DefaultBatchSizeBytes): WriteParam =
+      new WriteParam(failureMode, batchSizeBytes)
+  }
+
+  final case class WriteParam(failureMode: FailureMode, batchSizeBytes: Long)
+}
+
+final case class SpannerWrite(config: SpannerConfig) extends SpannerIO[Mutation] {
+  import SpannerWrite._
+
+  override type ReadP = Nothing
+  override type WriteP = WriteParam
+
+  override protected def read(sc: ScioContext, params: ReadP): SCollection[Mutation] = sc.wrap {
+    throw new IllegalStateException("SpannerWrite is WO")
+  }
+
+  override protected def write(data: SCollection[Mutation],
+                               params: WriteP): Future[Tap[Nothing]] = {
+    var transform = BSpannerIO.write().withSpannerConfig(config)
+
+    transform = transform.withBatchSizeBytes(params.batchSizeBytes)
+    transform = transform.withFailureMode(params.failureMode)
+
+    data.applyInternal(transform)
+    Future.successful(EmptyTap)
+  }
+
+  override def tap(params: ReadP): Tap[Nothing] = EmptyTap
+}

--- a/scio-spanner/src/main/scala/com/spotify/scio/spanner/client/Spanner.scala
+++ b/scio-spanner/src/main/scala/com/spotify/scio/spanner/client/Spanner.scala
@@ -21,12 +21,11 @@ import com.google.cloud.spanner._
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig
 
 object Spanner {
-  lazy val defaultInstance: Spanner = {
+  private lazy val defaultInstance: Spanner = {
     SpannerOptions.newBuilder().build().getService
   }
 
-  def getDatabaseClient(config: SpannerConfig,
-                        instance: Spanner = defaultInstance): DatabaseClient = {
+  def databaseClient(config: SpannerConfig, instance: Spanner = defaultInstance): DatabaseClient = {
     instance.getDatabaseClient(
       DatabaseId.of(
         config.getProjectId.get(),
@@ -35,6 +34,6 @@ object Spanner {
       ))
   }
 
-  def getAdminClient(project: String, instance: Spanner = defaultInstance): DatabaseAdminClient =
+  def adminClient(project: String, instance: Spanner = defaultInstance): DatabaseAdminClient =
     instance.getDatabaseAdminClient
 }

--- a/scio-spanner/src/main/scala/com/spotify/scio/spanner/client/Spanner.scala
+++ b/scio-spanner/src/main/scala/com/spotify/scio/spanner/client/Spanner.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.spanner.client
+
+import com.google.cloud.spanner._
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig
+
+object Spanner {
+  lazy val defaultInstance: Spanner = {
+    SpannerOptions.newBuilder().build().getService
+  }
+
+  def getDatabaseClient(config: SpannerConfig,
+                        instance: Spanner = defaultInstance): DatabaseClient = {
+    instance.getDatabaseClient(
+      DatabaseId.of(
+        config.getProjectId.get(),
+        config.getInstanceId.get(),
+        config.getDatabaseId.get()
+      ))
+  }
+
+  def getAdminClient(project: String, instance: Spanner = defaultInstance): DatabaseAdminClient =
+    instance.getDatabaseAdminClient
+}

--- a/scio-spanner/src/main/scala/com/spotify/scio/spanner/package.scala
+++ b/scio-spanner/src/main/scala/com/spotify/scio/spanner/package.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio
+
+import com.google.cloud.spanner.{Mutation, Struct}
+import com.spotify.scio.coders.Coder
+import com.spotify.scio.io.Tap
+import com.spotify.scio.values.SCollection
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig
+import org.apache.beam.sdk.io.gcp.spanner.SpannerIO.FailureMode
+
+import scala.concurrent.Future
+
+package object spanner {
+
+  implicit class SpannerScioContext(@transient val self: ScioContext) extends Serializable {
+    import SpannerRead.ReadParam._
+
+    def spannerTable(spannerConfig: SpannerConfig,
+                     table: String,
+                     columns: Seq[String]): SCollection[Struct] = {
+      val params = SpannerRead.ReadParam(SpannerRead.FromTable(table, columns))
+      self.read(SpannerRead(spannerConfig))(params)
+    }
+
+    def spannerTable(spannerConfig: SpannerConfig,
+                     table: String,
+                     columns: Seq[String],
+                     withBatching: Boolean = DefaultWithBatching,
+                     withTransaction: Boolean = DefaultWithTransaction): SCollection[Struct] = {
+      val params = SpannerRead.ReadParam(
+        SpannerRead.FromTable(table, columns),
+        withTransaction,
+        withBatching
+      )
+
+      self.read(SpannerRead(spannerConfig))(params)
+    }
+
+    def spannerQuery(spannerConfig: SpannerConfig, query: String): SCollection[Struct] = {
+      val params = SpannerRead.ReadParam(SpannerRead.FromQuery(query))
+      self.read(SpannerRead(spannerConfig))(params)
+    }
+
+    def spannerQuery(spannerConfig: SpannerConfig,
+                     query: String,
+                     withBatching: Boolean = DefaultWithBatching,
+                     withTransaction: Boolean = DefaultWithTransaction): SCollection[Struct] = {
+      val params = SpannerRead.ReadParam(
+        SpannerRead.FromQuery(query),
+        withTransaction,
+        withBatching
+      )
+
+      self.read(SpannerRead(spannerConfig))(params)
+    }
+  }
+
+  implicit class SpannerSCollection(@transient val self: SCollection[Mutation])
+      extends Serializable {
+    import SpannerWrite.WriteParam._
+
+    def saveAsSpanner(spannerConfig: SpannerConfig)(
+      implicit coder: Coder[Mutation]): Future[Tap[Nothing]] = {
+      self
+        .asInstanceOf[SCollection[Mutation]]
+        .write(SpannerWrite(spannerConfig))(SpannerWrite.WriteParam())
+    }
+
+    def saveAsSpanner(spannerConfig: SpannerConfig,
+                      failureMode: FailureMode = DefaultFailureMode,
+                      batchSizeBytes: Long = DefaultBatchSizeBytes)(
+      implicit coder: Coder[Mutation]): Future[Tap[Nothing]] = {
+      val params = SpannerWrite.WriteParam(failureMode, batchSizeBytes)
+
+      self
+        .asInstanceOf[SCollection[Mutation]]
+        .write(SpannerWrite(spannerConfig))(params)
+    }
+  }
+
+}

--- a/scio-spanner/src/main/scala/com/spotify/scio/spanner/package.scala
+++ b/scio-spanner/src/main/scala/com/spotify/scio/spanner/package.scala
@@ -33,13 +33,6 @@ package object spanner {
 
     def spannerTable(spannerConfig: SpannerConfig,
                      table: String,
-                     columns: Seq[String]): SCollection[Struct] = {
-      val params = SpannerRead.ReadParam(SpannerRead.FromTable(table, columns))
-      self.read(SpannerRead(spannerConfig))(params)
-    }
-
-    def spannerTable(spannerConfig: SpannerConfig,
-                     table: String,
                      columns: Seq[String],
                      withBatching: Boolean = DefaultWithBatching,
                      withTransaction: Boolean = DefaultWithTransaction): SCollection[Struct] = {
@@ -49,11 +42,6 @@ package object spanner {
         withBatching
       )
 
-      self.read(SpannerRead(spannerConfig))(params)
-    }
-
-    def spannerQuery(spannerConfig: SpannerConfig, query: String): SCollection[Struct] = {
-      val params = SpannerRead.ReadParam(SpannerRead.FromQuery(query))
       self.read(SpannerRead(spannerConfig))(params)
     }
 
@@ -74,13 +62,6 @@ package object spanner {
   implicit class SpannerSCollection(@transient val self: SCollection[Mutation])
       extends Serializable {
     import SpannerWrite.WriteParam._
-
-    def saveAsSpanner(spannerConfig: SpannerConfig)(
-      implicit coder: Coder[Mutation]): Future[Tap[Nothing]] = {
-      self
-        .asInstanceOf[SCollection[Mutation]]
-        .write(SpannerWrite(spannerConfig))(SpannerWrite.WriteParam())
-    }
 
     def saveAsSpanner(spannerConfig: SpannerConfig,
                       failureMode: FailureMode = DefaultFailureMode,

--- a/scio-spanner/src/main/scala/com/spotify/scio/spanner/package.scala
+++ b/scio-spanner/src/main/scala/com/spotify/scio/spanner/package.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Future
 
 package object spanner {
 
-  implicit class SpannerScioContext(@transient val self: ScioContext) extends Serializable {
+  implicit class SpannerScioContext(@transient private val self: ScioContext) extends Serializable {
     import SpannerRead.ReadParam._
 
     def spannerTable(spannerConfig: SpannerConfig,
@@ -59,7 +59,7 @@ package object spanner {
     }
   }
 
-  implicit class SpannerSCollection(@transient val self: SCollection[Mutation])
+  implicit class SpannerSCollection(@transient private val self: SCollection[Mutation])
       extends Serializable {
     import SpannerWrite.WriteParam._
 

--- a/scio-spanner/src/test/scala/com/spotify/scio/spanner/SpannerIOTest.scala
+++ b/scio-spanner/src/test/scala/com/spotify/scio/spanner/SpannerIOTest.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.spanner
+
+import com.google.cloud.spanner.{Mutation, Struct}
+import com.spotify.scio.ContextAndArgs
+import com.spotify.scio.io.TextIO
+import com.spotify.scio.testing.PipelineSpec
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig
+import org.scalatest.Matchers
+
+object QueryReadJob {
+  def main(cmdlineArgs: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(cmdlineArgs)
+    val out = args("out")
+
+    sc.spannerQuery(SpannerIOTest.spannerConfig, s"Select * From someTable")
+      .saveAsTextFile(out)
+
+    sc.close()
+  }
+}
+
+object TableReadJob {
+  def main(cmdlineArgs: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(cmdlineArgs)
+    val out = args("out")
+
+    sc.spannerTable(SpannerIOTest.spannerConfig, "someTable", Seq("someColumn"))
+      .saveAsTextFile(out)
+
+    sc.close()
+  }
+}
+
+object SpannerWriteJob {
+  def main(cmdlineArgs: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(cmdlineArgs)
+
+    sc.parallelize(
+        Seq(
+          Mutation.newInsertBuilder("someTable").set("foo").to("bar").build()
+        ))
+      .saveAsSpanner(SpannerIOTest.spannerConfig)
+
+    sc.close()
+  }
+}
+
+object SpannerIOTest {
+  val spannerConfig: SpannerConfig = SpannerConfig
+    .create()
+    .withProjectId("someProject")
+    .withDatabaseId("someDatabase")
+    .withInstanceId("someInstance")
+}
+
+class SpannerIOTest extends PipelineSpec with Matchers {
+  import SpannerIOTest.spannerConfig
+
+  "SpannerScioContext" should "support reading from query" in {
+    val out = "someOutput"
+    val spannerRows = Seq(Struct.newBuilder().set("foo").to("bar").build())
+
+    JobTest[QueryReadJob.type]
+      .args(s"--out=$out")
+      .input[Struct](SpannerRead(spannerConfig), spannerRows)
+      .output[String](TextIO(out))(_ should containInAnyOrder(spannerRows.map(_.toString)))
+      .run()
+  }
+
+  it should "support reading from table" in {
+    val out = "someOutput"
+    val spannerRows = Seq(Struct.newBuilder().set("foo").to("bar").build())
+
+    JobTest[TableReadJob.type]
+      .args(s"--out=$out")
+      .input[Struct](SpannerRead(spannerConfig), spannerRows)
+      .output[String](TextIO(out))(_ should containInAnyOrder(spannerRows.map(_.toString)))
+      .run()
+  }
+
+  "SpannerSCollection" should "support writes" in {
+    val spannerRows = Seq(Mutation.newInsertBuilder("someTable").set("foo").to("bar").build())
+
+    JobTest[SpannerWriteJob.type]
+      .output[Mutation](SpannerWrite(SpannerIOTest.spannerConfig))(_ should
+        containInAnyOrder(spannerRows))
+      .run()
+  }
+}

--- a/scio-spanner/src/test/scala/com/spotify/scio/spanner/SpannerIOTest.scala
+++ b/scio-spanner/src/test/scala/com/spotify/scio/spanner/SpannerIOTest.scala
@@ -18,87 +18,32 @@
 package com.spotify.scio.spanner
 
 import com.google.cloud.spanner.{Mutation, Struct}
-import com.spotify.scio.ContextAndArgs
-import com.spotify.scio.io.TextIO
-import com.spotify.scio.testing.PipelineSpec
+import com.spotify.scio.testing.ScioIOSpec
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig
 import org.scalatest.Matchers
 
-object QueryReadJob {
-  def main(cmdlineArgs: Array[String]): Unit = {
-    val (sc, args) = ContextAndArgs(cmdlineArgs)
-    val out = args("out")
-
-    sc.spannerQuery(SpannerIOTest.spannerConfig, s"Select * From someTable")
-      .saveAsTextFile(out)
-
-    sc.close()
-  }
-}
-
-object TableReadJob {
-  def main(cmdlineArgs: Array[String]): Unit = {
-    val (sc, args) = ContextAndArgs(cmdlineArgs)
-    val out = args("out")
-
-    sc.spannerTable(SpannerIOTest.spannerConfig, "someTable", Seq("someColumn"))
-      .saveAsTextFile(out)
-
-    sc.close()
-  }
-}
-
-object SpannerWriteJob {
-  def main(cmdlineArgs: Array[String]): Unit = {
-    val (sc, args) = ContextAndArgs(cmdlineArgs)
-
-    sc.parallelize(
-        Seq(
-          Mutation.newInsertBuilder("someTable").set("foo").to("bar").build()
-        ))
-      .saveAsSpanner(SpannerIOTest.spannerConfig)
-
-    sc.close()
-  }
-}
-
-object SpannerIOTest {
-  val spannerConfig: SpannerConfig = SpannerConfig
+class SpannerIOTest extends ScioIOSpec with Matchers {
+  private val config: SpannerConfig = SpannerConfig
     .create()
     .withProjectId("someProject")
     .withDatabaseId("someDatabase")
     .withInstanceId("someInstance")
-}
-
-class SpannerIOTest extends PipelineSpec with Matchers {
-  import SpannerIOTest.spannerConfig
 
   private val readData = Seq(Struct.newBuilder().set("foo").to("bar").build())
   private val writeData = Seq(
     Mutation.newInsertBuilder("someTable").set("foo").to("bar").build()
   )
-  private val outIO = TextIO("someOutput")
 
-  "SpannerScioContext" should "support reading from query" in {
-    JobTest[QueryReadJob.type]
-      .args(s"--out=${outIO.path}")
-      .input[Struct](SpannerRead(spannerConfig), readData)
-      .output[String](outIO)(_ should containInAnyOrder(readData.map(_.toString)))
-      .run()
+  "SpannerScioContext" should "support table input" in {
+    testJobTestInput(readData)(_ => SpannerRead(config))(
+      _.spannerTable(config, _, Seq("someColumn")))
   }
 
-  it should "support reading from table" in {
-    JobTest[TableReadJob.type]
-      .args(s"--out=${outIO.path}")
-      .input[Struct](SpannerRead(spannerConfig), readData)
-      .output[String](outIO)(_ should containInAnyOrder(readData.map(_.toString)))
-      .run()
+  it should "support query input" in {
+    testJobTestInput(readData)(_ => SpannerRead(config))(_.spannerQuery(config, _))
   }
 
   "SpannerSCollection" should "support writes" in {
-    JobTest[SpannerWriteJob.type]
-      .output[Mutation](SpannerWrite(SpannerIOTest.spannerConfig))(_ should
-        containInAnyOrder(writeData))
-      .run()
+    testJobTestOutput(writeData)(_ => SpannerWrite(config))((data, _) => data.saveAsSpanner(config))
   }
 }


### PR DESCRIPTION
Currently supports writes from `Mutation`s and reads into `Struct`s. I have the spanner type macros saved for sometime further down the line.

notes:
- Spanner integration test is kind of slow, takes 37 seconds
- SpannerIO's `testId` doesn't support a unit having 2 spanner reads/writes to the same DB since it's just keyed by the `SpannerConfig` params, which don't include table name. For writes the table name is keyed into each `Mutation` object and reads give you a choice of specifying a table name or a literal query
- Haven't implemented Taps yet