### PR TITLE
Standardize implicit ScioContext/SCollection wrapper modifiers

### DIFF
--- a/scio-cassandra2/src/main/scala/com/spotify/scio/cassandra/package.scala
+++ b/scio-cassandra2/src/main/scala/com/spotify/scio/cassandra/package.scala
@@ -44,7 +44,8 @@ package object cassandra {
    * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with Cassandra
    * methods.
    */
-  implicit class CassandraSCollection[T](@transient val self: SCollection[T]) extends Serializable {
+  implicit class CassandraSCollection[T](@transient private val self: SCollection[T])
+      extends AnyVal {
 
     /**
      * Save this SCollection as a Cassandra table.

--- a/scio-cassandra3/src/main/scala/com/spotify/scio/cassandra/package.scala
+++ b/scio-cassandra3/src/main/scala/com/spotify/scio/cassandra/package.scala
@@ -44,7 +44,8 @@ package object cassandra {
    * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with Cassandra
    * methods.
    */
-  implicit class CassandraSCollection[T](@transient val self: SCollection[T]) extends Serializable {
+  implicit class CassandraSCollection[T](@transient private val self: SCollection[T])
+      extends AnyVal {
 
     /**
      * Save this SCollection as a Cassandra table.

--- a/scio-core/src/main/scala/com/spotify/scio/transforms/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/transforms/package.scala
@@ -82,7 +82,8 @@ package object transforms {
    * parallelism, where `parallelism` is the number of concurrent `DoFn` threads per worker
    * (default to number of CPU cores).
    */
-  implicit class CustomParallelismSCollection[T](val self: SCollection[T]) {
+  implicit class CustomParallelismSCollection[T](@transient private val self: SCollection[T])
+      extends AnyVal {
     private def parallelCollectFn[U](parallelism: Int)(pfn: PartialFunction[T, U]): DoFn[T, U] =
       new ParallelLimitedFn[T, U](parallelism) {
         val isDefined = ClosureCleaner(pfn.isDefinedAt(_)) // defeat closure
@@ -160,7 +161,7 @@ package object transforms {
   /**
    * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with pipe methods.
    */
-  implicit class PipeSCollection(private val self: SCollection[String]) extends AnyVal {
+  implicit class PipeSCollection(@transient private val self: SCollection[String]) extends AnyVal {
 
     /**
      * Pipe elements through an external command via StdIn & StdOut.
@@ -206,7 +207,8 @@ package object transforms {
    * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with specialized
    * versions of flatMap.
    */
-  implicit class SpecializedFlatMapSCollection[T](val self: SCollection[T]) {
+  implicit class SpecializedFlatMapSCollection[T](@transient private val self: SCollection[T])
+      extends AnyVal {
 
     /**
      * Latency optimized flavor of

--- a/scio-elasticsearch2/src/main/scala/com/spotify/scio/elasticsearch/package.scala
+++ b/scio-elasticsearch2/src/main/scala/com/spotify/scio/elasticsearch/package.scala
@@ -40,7 +40,8 @@ package object elasticsearch {
 
   final case class ElasticsearchOptions(clusterName: String, servers: Seq[InetSocketAddress])
 
-  implicit class ElasticsearchSCollection[T](private val self: SCollection[T]) extends AnyVal {
+  implicit class ElasticsearchSCollection[T](@transient private val self: SCollection[T])
+      extends AnyVal {
 
     /**
      * Save this SCollection into Elasticsearch.

--- a/scio-elasticsearch5/src/main/scala/com/spotify/scio/elasticsearch/package.scala
+++ b/scio-elasticsearch5/src/main/scala/com/spotify/scio/elasticsearch/package.scala
@@ -40,7 +40,8 @@ package object elasticsearch {
 
   final case class ElasticsearchOptions(clusterName: String, servers: Seq[InetSocketAddress])
 
-  implicit class ElasticsearchSCollection[T](private val self: SCollection[T]) extends AnyVal {
+  implicit class ElasticsearchSCollection[T](@transient private val self: SCollection[T])
+      extends AnyVal {
 
     /**
      * Save this SCollection into Elasticsearch.

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/annoy/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/annoy/package.scala
@@ -157,7 +157,8 @@ package object annoy {
     }
   }
 
-  implicit class AnnoyPairSCollection(val self: SCollection[(Int, Array[Float])]) {
+  implicit class AnnoyPairSCollection(@transient private val self: SCollection[(Int, Array[Float])])
+      extends AnyVal {
 
     /**
      * Write the key-value pairs of this SCollection as an Annoy file to a specific location,
@@ -238,7 +239,8 @@ package object annoy {
   /**
    * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with Annoy methods
    */
-  implicit class AnnoySCollection(private val self: SCollection[AnnoyUri]) extends AnyVal {
+  implicit class AnnoySCollection(@transient private val self: SCollection[AnnoyUri])
+      extends AnyVal {
 
     /**
      * Load Annoy index stored at [[AnnoyUri]] in this

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/json/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/json/package.scala
@@ -56,7 +56,7 @@ package object json extends AutoDerivation {
   final case class DecodeError(error: io.circe.Error, input: String)
 
   /** Enhanced version of [[ScioContext]] with JSON methods. */
-  implicit class JsonScioContext(@transient val self: ScioContext) extends Serializable {
+  implicit class JsonScioContext(@transient private val self: ScioContext) extends AnyVal {
     def jsonFile[T: ClassTag: Encoder: Decoder: Coder](path: String): SCollection[T] =
       self.read(JsonIO[T](path))
   }
@@ -65,7 +65,7 @@ package object json extends AutoDerivation {
    * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with JSON methods.
    */
   implicit class JsonSCollection[T: ClassTag: Encoder: Decoder: Coder](
-    @transient val self: SCollection[T])
+    @transient private val self: SCollection[T])
       extends Serializable {
     def saveAsJsonFile(path: String,
                        suffix: String = ".json",

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/libsvm/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/libsvm/package.scala
@@ -95,7 +95,7 @@ package object libsvm {
       }
   }
 
-  implicit class SVMReader(@transient val self: ScioContext) extends Serializable {
+  implicit class SVMReader(@transient private val self: ScioContext) extends AnyVal {
 
     /**
      * Loads labeled data in the LIBSVM format into an SCollection[(Double, SparseVector)].

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -98,7 +98,7 @@ package object sparkey {
   /**
    * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with Sparkey methods.
    */
-  implicit class SparkeyPairSCollection[K, V](val self: SCollection[(K, V)]) {
+  implicit class SparkeyPairSCollection[K, V](@transient private val self: SCollection[(K, V)]) {
 
     private val logger = LoggerFactory.getLogger(this.getClass)
 

--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/package.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/package.scala
@@ -101,7 +101,7 @@ package object jdbc {
   }
 
   /** Enhanced version of [[ScioContext]] with JDBC methods. */
-  implicit class JdbcScioContext(@transient val self: ScioContext) extends Serializable {
+  implicit class JdbcScioContext(@transient private val self: ScioContext) extends AnyVal {
 
     /** Get an SCollection for a JDBC query. */
     def jdbcSelect[T: ClassTag: Coder](readOptions: JdbcReadOptions[T]): SCollection[T] =
@@ -109,7 +109,7 @@ package object jdbc {
   }
 
   /** Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with JDBC methods. */
-  implicit class JdbcSCollection[T](val self: SCollection[T]) {
+  implicit class JdbcSCollection[T](@transient private val self: SCollection[T]) extends AnyVal {
 
     /** Save this SCollection as a JDBC database. */
     def saveAsJdbc(writeOptions: JdbcWriteOptions[T])(

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/package.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/package.scala
@@ -49,7 +49,7 @@ package object avro {
   val Predicate = me.lyh.parquet.avro.Predicate
 
   /** Enhanced version of [[ScioContext]] with Parquet Avro methods. */
-  implicit class ParquetAvroScioContext(private val self: ScioContext) extends AnyVal {
+  implicit class ParquetAvroScioContext(@transient private val self: ScioContext) extends AnyVal {
 
     /**
      * Get an SCollection for a Parquet file as Avro records. Since Avro records produced by
@@ -122,7 +122,7 @@ package object avro {
    * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with Parquet Avro
    * methods.
    */
-  implicit class ParquetAvroSCollection[T: ClassTag: Coder](val self: SCollection[T]) {
+  implicit class ParquetAvroSCollection[T](private val self: SCollection[T]) extends AnyVal {
 
     /**
      * Save this SCollection of Avro records as a Parquet file.
@@ -134,7 +134,8 @@ package object avro {
       schema: Schema = WriteParam.DefaultSchema,
       numShards: Int = WriteParam.DefaultNumShards,
       suffix: String = WriteParam.DefaultSuffix,
-      compression: CompressionCodecName = WriteParam.DefaultCompression): Future[Tap[T]] = {
+      compression: CompressionCodecName = WriteParam.DefaultCompression
+    )(implicit ct: ClassTag[T], coder: Coder[T]): Future[Tap[T]] = {
       val param = WriteParam(schema, numShards, suffix, compression)
       self.write(ParquetAvroIO[T](path))(param)
     }

--- a/scio-spanner/src/main/scala/com/spotify/scio/spanner/package.scala
+++ b/scio-spanner/src/main/scala/com/spotify/scio/spanner/package.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Future
 
 package object spanner {
 
-  implicit class SpannerScioContext(@transient private val self: ScioContext) extends Serializable {
+  implicit class SpannerScioContext(@transient private val self: ScioContext) extends AnyVal {
     import SpannerRead.ReadParam._
 
     def spannerTable(spannerConfig: SpannerConfig,
@@ -60,7 +60,7 @@ package object spanner {
   }
 
   implicit class SpannerSCollection(@transient private val self: SCollection[Mutation])
-      extends Serializable {
+      extends AnyVal {
     import SpannerWrite.WriteParam._
 
     def saveAsSpanner(spannerConfig: SpannerConfig,


### PR DESCRIPTION
I converted them to value classes when possible, then ran Scalafix's `LeakingImplicitClassVal` to ensure `val self` is private (the scalafix rule [only acts on implicit classes extending AnyVal](https://github.com/scalacenter/scalafix/blob/0fceaad2c158bdc39b361b88f316cbc955c6fef1/scalafix-rules/src/main/scala/scalafix/internal/rule/LeakingImplicitClassVal.scala#L19))