### PR TITLE
Allow custom transform names for union all

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -690,7 +690,11 @@ class ScioContext private[scio] (val options: PipelineOptions, private var artif
   def unionAll[T: Coder](scs: Iterable[SCollection[T]]): SCollection[T] =
     scs match {
       case Nil      => empty()
-      case contents => SCollection.unionAll(contents)
+      case contents =>
+        val o = PCollectionList
+          .of(contents.map(_.internal).asJava)
+          .apply(this.tfName, Flatten.pCollections())
+        context.wrap(o)
     }
 
   /** Form an empty SCollection. */

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -689,12 +689,13 @@ class ScioContext private[scio] (val options: PipelineOptions, private var artif
   /** Create a union of multiple SCollections. Supports empty lists. */
   def unionAll[T: Coder](scs: Iterable[SCollection[T]]): SCollection[T] =
     scs match {
-      case Nil      => empty()
+      case Nil => empty()
       case contents =>
-        val o = PCollectionList
-          .of(contents.map(_.internal).asJava)
-          .apply(this.tfName, Flatten.pCollections())
-        context.wrap(o)
+        context.wrap(
+          PCollectionList
+            .of(contents.map(_.internal).asJava)
+            .apply(this.tfName, Flatten.pCollections())
+        )
     }
 
   /** Form an empty SCollection. */

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -56,12 +56,8 @@ object SCollection {
    * Will throw an exception if the provided iterable is empty.
    * For a version that accepts empty iterables, see [[ScioContext#unionAll]].
    */
-  def unionAll[T](scs: Iterable[SCollection[T]]): SCollection[T] = {
-    val o = PCollectionList
-      .of(scs.map(_.internal).asJava)
-      .apply("UnionAll", Flatten.pCollections())
-    scs.head.context.wrap(o)
-  }
+  def unionAll[T](scs: Iterable[SCollection[T]]): SCollection[T] =
+    scs.head.context.unionAll(scs)
 
   import scala.language.implicitConversions
 

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -56,7 +56,7 @@ object SCollection {
    * Will throw an exception if the provided iterable is empty.
    * For a version that accepts empty iterables, see [[ScioContext#unionAll]].
    */
-  def unionAll[T](scs: Iterable[SCollection[T]]): SCollection[T] =
+  def unionAll[T: Coder](scs: Iterable[SCollection[T]]): SCollection[T] =
     scs.head.context.unionAll(scs)
 
   import scala.language.implicitConversions


### PR DESCRIPTION
The transform name was hard coded to `UnionAll` for the union all transform, and doesn't pick up the call site name as the transform name. Adding unique names / user defined custom names, helps in easy tracking in the DataFlow UI.