### PR TITLE
#1551: Fix flatten type inference changing the coder context bound to an implicit parameter

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -388,7 +388,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * Return a new `SCollection[U]` by flattening each element of an `SCollection[Traversable[U]]`.
    * @group transform
    */
-  def flatten[U: Coder](implicit ev: T => TraversableOnce[U]): SCollection[U] =
+  def flatten[U](implicit ev: T => TraversableOnce[U], coder: Coder[U]): SCollection[U] =
     flatMap(ev)
 
   /**

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -252,10 +252,10 @@ class SCollectionTest extends PipelineSpec {
     runWithContext { sc =>
       val p1 = sc
         .parallelize(Seq(Seq("a b", "c d"), Seq("e f", "g h")))
-        .flatten[String]
+        .flatten
       p1 should containInAnyOrder(Seq("a b", "c d", "e f", "g h"))
 
-      val p2 = sc.parallelize(Seq(Some(1), None)).flatten[Int]
+      val p2 = sc.parallelize(Seq(Some(1), None)).flatten
       p2 should containInAnyOrder(Seq(1))
     }
   }


### PR DESCRIPTION
This PR discusses a possible workaround for #1551

The original problematic code:

```scala
sc.parallelize(Seq(1,2,3,4,5)).top(3).flatten
```

It fails to find a correct implicit in this line:

```scala
def flatten[U: Coder](implicit ev: T => TraversableOnce[U]): SCollection[U]
```

Using a context bound for the coder, the Scala compiler tries to use a `jBitSetCoder` or a `jShortCoder`, which is ambiguous. If we move the context bound to a regular implicit parameter, `flatten` works as expected.

```scala
def flatten[U](implicit ev: T => TraversableOnce[U], coder: Coder[U]): SCollection[U]
```

I'm not 100% about why it works. Using an implicit parameter works whatever the order is. Maybe someone with better knowledge of the compiler can give us a hint.

I haven't included new tests in the PR, but this executes correctly.

```scala
"SCollection" should "support flatten() of iterables" in {
    runWithContext { sc =>
      val p1 = sc.parallelize(Seq(1, 2, 3, 4, 5)).top(3).flatten
      p1 should containInAnyOrder(Seq(3, 4, 5))
    }
}
```
  