### PR TITLE
Increase scala.repl.maxprintstring flag for scio-repl shell

### DIFF
--- a/scio-repl/src/main/scala/com/spotify/scio/repl/ScioReplSysProps.scala
+++ b/scio-repl/src/main/scala/com/spotify/scio/repl/ScioReplSysProps.scala
@@ -22,4 +22,7 @@ import com.spotify.scio.{registerSysProps, SysProp}
 @registerSysProps
 object ScioReplSysProps {
   val Key = SysProp("key", "")
+
+  val MaxPrintString =
+    SysProp("scala.repl.maxprintstring", "Max characters to display in REPL before truncation")
 }

--- a/scio-repl/src/main/scala/com/spotify/scio/repl/ScioShell.scala
+++ b/scio-repl/src/main/scala/com/spotify/scio/repl/ScioShell.scala
@@ -109,6 +109,8 @@ trait BaseScioShell extends MainGenericRunner {
   /** Runs an instance of the shell. */
   def main(args: Array[String]): Unit = {
     sys.props(BigQuerySysProps.DisableDump.flag) = "true"
+    sys.props(ScioReplSysProps.MaxPrintString.flag) = "1500"
+
     val retVal = process(args)
     if (!retVal) {
       sys.exit(1)


### PR DESCRIPTION
When testing out the 0.7.0 docs I noticed that [CoderMacros.longMessage](https://github.com/spotify/scio/blob/cb40f84b88f70c50da943c48fdd55996190ceaab/scio-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala#L76) is long enough that it gets truncated when executed in scio-repl:

```
scio> Coder[java.util.Locale]
<console>:36: 
 Warning: No implicit Coder found for the following type:

   >> java.util.Locale

 using Kryo fallback instead.


  Scio will use a fallback Kryo coder instead.

  If a type is not supported, consider implementing your own implicit Coder for this type.
  It is recommended to declare this Coder in your class companion object:

       object Locale {
         import com.spotify.scio.coders.Coder
         import org.apache.beam.sdk.coders.AtomicCoder

         implicit def coderLocale: Coder[Locale] =
           Coder.beam(new AtomicCoder[Locale] {
             def decode(in: InputStream): Locale = ???
             def encode(ts: Locale, out: OutputStream): Unit = ???
           })
       }

  If you do want to use a Kryo coder, be explicit about it:

       implici...
```

Overriding the compiler flag `scala.repl.maxprintstring` resolves the issue. Since it's such a common error message I think we should add the flag to scio-repl shell manually rather than leaving it up to the end user to include it. I added it to `ScioReplSysProp`, lmk if there's a more optimal way to do it..