### PR TITLE
Remove unused dependences from scio-parquet

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,6 @@ val annoy4sVersion = "0.7.0"
 val annoyVersion = "0.2.5"
 val asmVersion = "4.9"
 val autoServiceVersion = "1.0-rc4"
-val autoValueVersion = "1.6.2"
 val avroVersion = "1.8.2"
 val breezeVersion = "1.0-RC2"
 val chillVersion = "0.9.3"
@@ -624,7 +623,6 @@ lazy val scioParquet: Project = Project(
     description := "Scio add-on for Parquet",
     libraryDependencies ++= Seq(
       "me.lyh" %% "parquet-avro-extra" % parquetAvroExtraVersion,
-      "com.google.auto.value" % "auto-value" % autoValueVersion % "provided",
       "com.google.cloud.bigdataoss" % "gcs-connector" % gcsConnectorVersion,
       "org.apache.beam" % "beam-sdks-java-io-hadoop-input-format" % beamVersion,
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion,


### PR DESCRIPTION
Scala steward put up a PR for autovalue, but it seems we aren't actually using that anywhere in scio-parquet. Likewise with `com.google.cloud.bigdataoss.gcs-connector`. 