### PR TITLE
Map big decimals to BQ numeric data type

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -59,12 +59,13 @@ private[types] object SchemaProvider {
     tpe match {
       case t if provider.shouldOverrideType(t) =>
         (provider.getBigQueryType(t), Iterable.empty)
-      case t if t =:= typeOf[Boolean] => ("BOOLEAN", Iterable.empty)
-      case t if t =:= typeOf[Int]     => ("INTEGER", Iterable.empty)
-      case t if t =:= typeOf[Long]    => ("INTEGER", Iterable.empty)
-      case t if t =:= typeOf[Float]   => ("FLOAT", Iterable.empty)
-      case t if t =:= typeOf[Double]  => ("FLOAT", Iterable.empty)
-      case t if t =:= typeOf[String]  => ("STRING", Iterable.empty)
+      case t if t =:= typeOf[Boolean]    => ("BOOLEAN", Iterable.empty)
+      case t if t =:= typeOf[Int]        => ("INTEGER", Iterable.empty)
+      case t if t =:= typeOf[Long]       => ("INTEGER", Iterable.empty)
+      case t if t =:= typeOf[Float]      => ("FLOAT", Iterable.empty)
+      case t if t =:= typeOf[Double]     => ("FLOAT", Iterable.empty)
+      case t if t =:= typeOf[String]     => ("STRING", Iterable.empty)
+      case t if t =:= typeOf[BigDecimal] => ("NUMERIC", Iterable.empty)
 
       case t if t =:= typeOf[ByteString]  => ("BYTES", Iterable.empty)
       case t if t =:= typeOf[Array[Byte]] => ("BYTES", Iterable.empty)

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/BigDecimalConversionTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/BigDecimalConversionTest.scala
@@ -1,0 +1,52 @@
+package com.spotify.scio.bigquery.types
+
+import java.math.MathContext
+
+import com.spotify.scio.bigquery.BigQueryUtil
+import org.scalatest.{FlatSpec, Matchers}
+
+class BigDecimalConversionTest extends FlatSpec with Matchers {
+  case class BigBoy(x: BigDecimal)
+
+  "big decimal values" should "roundtrip if they fit NUMERIC" in {
+    val before = BigBoy(BigDecimal("459592.59696"))
+    val after = BigQueryType.fromTableRow[BigBoy](BigQueryType.toTableRow[BigBoy](before))
+
+    after should equal(before)
+  }
+
+  "big decimal values" should "be rounded to BQ precision on write" in {
+    // if type does not fit bq NUMERIC type, insertion query will fail
+    // at least that's what I see with `bq load` for json data
+    val original = "4288.1111111119"
+    val rounded = "4288.111111112"
+    val before = BigBoy(BigDecimal(original))
+    val after = BigQueryType.fromTableRow[BigBoy](BigQueryType.toTableRow[BigBoy](before))
+
+    after should equal(BigBoy(BigDecimal(rounded)))
+  }
+
+  "math context" should "be identical to BQ settings" in {
+    // math context is a set of rules on how to do the rounding of bigdecimal value
+    // it can't be encoded in NUMERIC, so it will be lost during conversion
+    // the most sensible return value for math context is to mimic BQ behaviour
+    // see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric-type
+    // and https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators
+    val before = BigBoy(BigDecimal("4288.29392", MathContext.UNLIMITED))
+    val bqRow = BigQueryType.toTableRow[BigBoy](before)
+    val after = BigQueryType.fromTableRow[BigBoy](bqRow)
+    val bqMath = new MathContext(38)
+    after.x.mc should equal(bqMath)
+  }
+
+  "bigdecimal" should "be represented as NUMERIC in schema" in {
+    val expectedRawSchema =
+      """
+        |{"mode": "REQUIRED", "name": "x", "type": "NUMERIC"}
+        |""".stripMargin
+    val expectedParsedSchema = BigQueryUtil.parseSchema(expectedRawSchema)
+    val actualFields = BigQueryType.schemaOf[BigBoy].getFields
+    actualFields.get(0) shouldBe (expectedParsedSchema)
+  }
+
+}

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/BigDecimalConversionTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/BigDecimalConversionTest.scala
@@ -1,14 +1,12 @@
 package com.spotify.scio.bigquery.types
 
-import java.math.MathContext
-
 import com.spotify.scio.bigquery.BigQueryUtil
 import org.scalatest.{FlatSpec, Matchers}
 
 class BigDecimalConversionTest extends FlatSpec with Matchers {
   case class BigBoy(x: BigDecimal)
 
-  "big decimal values" should "roundtrip if they fit NUMERIC" in {
+  "big decimal values" should "roundtrip if they fit NUMERIC scale" in {
     val before = BigBoy(BigDecimal("459592.59696"))
     val after = BigQueryType.fromTableRow[BigBoy](BigQueryType.toTableRow[BigBoy](before))
 
@@ -17,26 +15,13 @@ class BigDecimalConversionTest extends FlatSpec with Matchers {
 
   "big decimal values" should "be rounded to BQ precision on write" in {
     // if type does not fit bq NUMERIC type, insertion query will fail
-    // at least that's what I see with `bq load` for json data
+    // at least that's what seen with `bq load` for json data
     val original = "4288.1111111119"
     val rounded = "4288.111111112"
     val before = BigBoy(BigDecimal(original))
     val after = BigQueryType.fromTableRow[BigBoy](BigQueryType.toTableRow[BigBoy](before))
 
     after should equal(BigBoy(BigDecimal(rounded)))
-  }
-
-  "math context" should "be identical to BQ settings" in {
-    // math context is a set of rules on how to do the rounding of bigdecimal value
-    // it can't be encoded in NUMERIC, so it will be lost during conversion
-    // the most sensible return value for math context is to mimic BQ behaviour
-    // see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric-type
-    // and https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators
-    val before = BigBoy(BigDecimal("4288.29392", MathContext.UNLIMITED))
-    val bqRow = BigQueryType.toTableRow[BigBoy](before)
-    val after = BigQueryType.fromTableRow[BigBoy](bqRow)
-    val bqMath = new MathContext(38)
-    after.x.mc should equal(bqMath)
   }
 
   "bigdecimal" should "be represented as NUMERIC in schema" in {


### PR DESCRIPTION
Few important points:
- unlike the other types, BD <=> NUMERIC is lossy conversion. Scale is a number of digits after the dot. [NUMERIC has scale =9, precision=38](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric-type), so there is no way to fit BigDecimal with higher scale to NUMERIC data type;
- Scala's BigDecimal is not equal to java one, so for java you would have to access underlying value
- Scala's BigDecimal keeps MathContext as a field.  There is no way to store this in NUMERIC, so math context is also lost and might be different after conversion.