### PR TITLE
Repackage Spanner coders (fix #1629)

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
@@ -22,17 +22,14 @@ import java.math.{BigDecimal, BigInteger}
 import java.time.Instant
 
 import com.google.api.services.bigquery.model.TableRow
-import com.google.cloud.spanner.{Mutation, Struct}
 import com.spotify.scio.coders.Coder
-import org.apache.beam.sdk.values.Row
-import org.apache.beam.sdk.schemas.Schema
-import org.apache.beam.sdk.{coders => bcoders}
-import org.apache.beam.sdk.values.KV
-import org.apache.beam.sdk.io.gcp.pubsub.{PubsubMessage, PubsubMessageWithAttributesCoder}
-import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder
-import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, IntervalWindow, PaneInfo}
 import org.apache.beam.sdk.coders.{Coder => _, _}
-import org.apache.beam.sdk.io.gcp.spanner.ReadOperation
+import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder
+import org.apache.beam.sdk.io.gcp.pubsub.{PubsubMessage, PubsubMessageWithAttributesCoder}
+import org.apache.beam.sdk.schemas.Schema
+import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, IntervalWindow, PaneInfo}
+import org.apache.beam.sdk.values.{KV, Row}
+import org.apache.beam.sdk.{coders => bcoders}
 
 private object VoidCoder extends AtomicCoder[Void] {
   override def encode(value: Void, outStream: OutputStream): Unit = ()
@@ -111,14 +108,4 @@ trait JavaCoders {
 
   implicit def coderJEnum[E <: java.lang.Enum[_]: scala.reflect.ClassTag]: Coder[E] =
     Coder.kryo[E]
-
-  // #1447: Kryo throws a NPE
-  implicit def spannerReadOperationCoder: Coder[ReadOperation] =
-    Coder.beam(bcoders.SerializableCoder.of(classOf[ReadOperation]))
-
-  implicit def spannerMutationCoder: Coder[Mutation] =
-    Coder.beam(bcoders.SerializableCoder.of(classOf[Mutation]))
-
-  implicit def spannerStructCoder: Coder[Struct] =
-    Coder.beam(bcoders.SerializableCoder.of(classOf[Struct]))
 }

--- a/scio-core/src/test/scala/com/spotify/scio/coders/coders.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/coders/coders.scala
@@ -365,22 +365,6 @@ class CodersTest extends FlatSpec with Matchers {
     check(new FixedSpefificDataExample(bytes))
   }
 
-  it should "#1447: Properly serde spanner's ReadOperation" in {
-    import org.apache.beam.sdk.io.gcp.spanner.ReadOperation
-    val ro = ReadOperation.create().withQuery("SELECT 1")
-    check(ro)
-  }
-
-  it should "support spanner's Mutation class" in {
-    import com.google.cloud.spanner.Mutation
-    check(Mutation.newInsertBuilder("myTable").set("foo").to("bar").build())
-  }
-
-  it should "support spanner's Struct class" in {
-    import com.google.cloud.spanner.Struct
-    check(Struct.newBuilder().set("foo").to("bar").build())
-  }
-
   it should "#1604: not throw on null" in {
     import java.lang.{
       Integer => jInt,

--- a/scio-spanner/src/test/scala/com/spotify/scio/spanner/SpannerIOTest.scala
+++ b/scio-spanner/src/test/scala/com/spotify/scio/spanner/SpannerIOTest.scala
@@ -18,9 +18,13 @@
 package com.spotify.scio.spanner
 
 import com.google.cloud.spanner.{Mutation, Struct}
+import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.testing.ScioIOSpec
-import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig
-import org.scalatest.Matchers
+import org.apache.beam.sdk.io.gcp.spanner.{ReadOperation, SpannerConfig}
+import org.apache.beam.sdk.options.PipelineOptionsFactory
+import org.apache.beam.sdk.util.{CoderUtils, SerializableUtils}
+import org.scalactic.Equality
+import org.scalatest.{Assertion, Matchers}
 
 class SpannerIOTest extends ScioIOSpec with Matchers {
   private val config: SpannerConfig = SpannerConfig
@@ -34,6 +38,15 @@ class SpannerIOTest extends ScioIOSpec with Matchers {
     Mutation.newInsertBuilder("someTable").set("foo").to("bar").build()
   )
 
+  private def checkCoder[T](t: T)(implicit C: Coder[T], eq: Equality[T]): Assertion = {
+    val options = PipelineOptionsFactory.create()
+    val beamCoder = CoderMaterializer.beamWithDefault(C, o = options)
+    SerializableUtils.ensureSerializable(beamCoder)
+    val enc = CoderUtils.encodeToByteArray(beamCoder, t)
+    val dec = CoderUtils.decodeFromByteArray(beamCoder, enc)
+    dec should ===(t)
+  }
+
   "SpannerScioContext" should "support table input" in {
     testJobTestInput(readData)(_ => SpannerRead(config))(
       _.spannerTable(config, _, Seq("someColumn")))
@@ -45,5 +58,18 @@ class SpannerIOTest extends ScioIOSpec with Matchers {
 
   "SpannerSCollection" should "support writes" in {
     testJobTestOutput(writeData)(_ => SpannerWrite(config))((data, _) => data.saveAsSpanner(config))
+  }
+
+  "Spanner coders" should "#1447: Properly serde spanner's ReadOperation" in {
+    val ro = ReadOperation.create().withQuery("SELECT 1")
+    checkCoder(ro)
+  }
+
+  it should "support spanner's Mutation class" in {
+    checkCoder(Mutation.newInsertBuilder("myTable").set("foo").to("bar").build())
+  }
+
+  it should "support spanner's Struct class" in {
+    checkCoder(Struct.newBuilder().set("foo").to("bar").build())
   }
 }

--- a/scio-spanner/src/test/scala/com/spotify/scio/spanner/SpannerIOTest.scala
+++ b/scio-spanner/src/test/scala/com/spotify/scio/spanner/SpannerIOTest.scala
@@ -38,9 +38,9 @@ class SpannerIOTest extends ScioIOSpec with Matchers {
     Mutation.newInsertBuilder("someTable").set("foo").to("bar").build()
   )
 
-  private def checkCoder[T](t: T)(implicit C: Coder[T], eq: Equality[T]): Assertion = {
+  private def checkCoder[T](t: T)(implicit c: Coder[T], eq: Equality[T]): Assertion = {
     val options = PipelineOptionsFactory.create()
-    val beamCoder = CoderMaterializer.beamWithDefault(C, o = options)
+    val beamCoder = CoderMaterializer.beamWithDefault(c, o = options)
     SerializableUtils.ensureSerializable(beamCoder)
     val enc = CoderUtils.encodeToByteArray(beamCoder, t)
     val dec = CoderUtils.decodeFromByteArray(beamCoder, enc)


### PR DESCRIPTION
fix #1629 

possible followup PR is to extract the `checkCoder`, `checkSer` etc methods from [coders.scala](https://github.com/spotify/scio/blob/master/scio-core/src/test/scala/com/spotify/scio/coders/coders.scala) into a utility in `scio-test` (maybe `CoderAssertions` or something?) so they can be shared externally.