### PR TITLE
fix broken code formatting in Scio-Unit-Tests.md

### DIFF
--- a/site/src/paradox/Scio-Unit-Tests.md
+++ b/site/src/paradox/Scio-Unit-Tests.md
@@ -98,7 +98,7 @@ runWithContext { sc =>
  r should haveSize(1)
  r should containSingleValue(("94", 29))
 }
-````
+```
 
 ### Test for pipeline with windowing
 We will use the LeaderBoardTest to explain how to test Windowing in Scio. The full example code is found [here](https://github.com/spotify/scio/blob/master/scio-examples/src/test/scala/com/spotify/scio/examples/complete/game/LeaderBoardTest.scala). LeaderBoardTest also extends `PipelineSpec`. The function under test is the [LeaderBoard.calculateTeamScores](https://github.com/spotify/scio/blob/master/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/LeaderBoard.scala#L131).  This function calculates teams scores within a fixed window with the following the window options: 


### PR DESCRIPTION
I noticed that the code formatting on
https://spotify.github.io/scio/Scio-Unit-Tests.html is broken past a
certain point in the page, and the code examples are rendered as regular
text but the regular text is rendered as code examples.

I'm not 100% sure this is the only problem on the page, as I'm not sure how to render the markdown into the html/website locally.

![image](https://user-images.githubusercontent.com/113840/51917909-8e49e580-23ae-11e9-9c44-b6b603d999db.png)
