### PR TITLE
Add support for reusing SideInputs.

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
@@ -36,8 +36,17 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    */
   def hashJoin[W: Coder](that: SCollection[(K, W)])(implicit koder: Coder[K],
                                                     voder: Coder[V]): SCollection[(K, (V, W))] =
+    hashJoin(SideMap(combineAsMapSideInput(that)))
+
+  /**
+   * Perform an inner join with a SideMap.
+   *
+   * @group join
+   */
+  def hashJoin[W: Coder](that: SideMap[K, W])(implicit koder: Coder[K],
+                                              voder: Coder[V]): SCollection[(K, (V, W))] =
     self.transform { in =>
-      val side = combineAsMapSideInput(that)
+      val side = that.side
       implicit val vwCoder = Coder[(V, W)]
       in.withSideInputs(side)
         .flatMap[(K, (V, W))] { (kv, s) =>
@@ -57,8 +66,18 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    */
   def hashLeftJoin[W: Coder](that: SCollection[(K, W)])(
     implicit koder: Coder[K],
+    voder: Coder[V]): SCollection[(K, (V, Option[W]))] =
+    hashLeftJoin(SideMap(combineAsMapSideInput(that)))
+
+  /**
+   * Perform a left outer join with a SideMap.
+   *
+   * @group join
+   */
+  def hashLeftJoin[W: Coder](that: SideMap[K, W])(
+    implicit koder: Coder[K],
     voder: Coder[V]): SCollection[(K, (V, Option[W]))] = self.transform { in =>
-    val side = combineAsMapSideInput(that)
+    val side = that.side
     implicit val vwCoder = Coder[(V, Option[W])]
     in.withSideInputs(side)
       .flatMap[(K, (V, Option[W]))] { (kv, s) =>
@@ -79,8 +98,18 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   def hashFullOuterJoin[W: Coder](that: SCollection[(K, W)])(
     implicit koder: Coder[K],
     voder: Coder[V]): SCollection[(K, (Option[V], Option[W]))] =
+    hashFullOuterJoin(SideMap(combineAsMapSideInput(that)))
+
+  /**
+   * Perform a full outer join with a SideMap.
+   *
+   * @group join
+   */
+  def hashFullOuterJoin[W: Coder](that: SideMap[K, W])(
+    implicit koder: Coder[K],
+    voder: Coder[V]): SCollection[(K, (Option[V], Option[W]))] =
     self.transform { in =>
-      val side = combineAsMapSideInput(that)
+      val side = that.side
 
       val leftHashed = in
         .withSideInputs(side)
@@ -118,13 +147,24 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * @group per key
    */
   def hashIntersectByKey(that: SCollection[K])(implicit koder: Coder[K],
-                                               voder: Coder[V]): SCollection[(K, V)] = {
-    val side = combineAsMapSideInput(that.map((_, ())))
+                                               voder: Coder[V]): SCollection[(K, V)] =
+    hashIntersectByKey(SideSet(combineAsMapSideInput(that.map((_, ())))))
+
+  /**
+   * Return an SCollection with the pairs from `this` whose keys are in the SideSet `that`.
+   * @group per key
+   */
+  def hashIntersectByKey(that: SideSet[K])(implicit koder: Coder[K],
+                                           voder: Coder[V]): SCollection[(K, V)] = {
+    val side = that.side
     self
       .withSideInputs(side)
       .filter { case ((k, v), s) => s(side).contains(k) }
       .toSCollection
   }
+
+  def toSideMap(implicit koder: Coder[K], voder: Coder[V]): SideMap[K, V] =
+    SideMap[K, V](combineAsMapSideInput(self))
 
   private def combineAsMapSideInput[W: Coder](that: SCollection[(K, W)])(
     implicit koder: Coder[K]): SideInput[MMap[K, ArrayBuffer[W]]] = {

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
@@ -148,7 +148,7 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    */
   def hashIntersectByKey(that: SCollection[K])(implicit koder: Coder[K],
                                                voder: Coder[V]): SCollection[(K, V)] =
-    hashIntersectByKey(SideSet(combineAsMapSideInput(that.map((_, ())))))
+    hashIntersectByKey(that.toSideSet)
 
   /**
    * Return an SCollection with the pairs from `this` whose keys are in the SideSet `that`.

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -956,7 +956,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   def toSideSet(implicit coder: Coder[T]): SideSet[T] = SideSet(combineAsSet(self))
 
   private def combineAsSet[A: Coder](c: SCollection[A]): SideInput[Set[A]] =
-    c.aggregate[Set[A], Set[A]](Aggregator.prepareSemigroup(x => Set(x))).asSingletonSideInput
+    c.aggregate[Set[A], Set[A]](Aggregator.prepareSemigroup(x => Set(x))).asSingletonSideInput(Set[A])
 
   // =======================================================================
   // Read operations

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -953,7 +953,10 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
         .of(Functions.serializableFn(f))
         .withAllowedTimestampSkew(allowedTimestampSkew))
 
-  def toSideSet(implicit coder: Coder[T]): SideSet[T] = SideSet(self.map((_, ())).toSideMap.side)
+  def toSideSet(implicit coder: Coder[T]): SideSet[T] = SideSet(combineAsSet(self))
+
+  private def combineAsSet[A: Coder](c: SCollection[A]): SideInput[Set[A]] =
+    c.aggregate[Set[A], Set[A]](Aggregator.prepareSemigroup(x => Set(x))).asSingletonSideInput
 
   // =======================================================================
   // Read operations

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -957,7 +957,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
 
   private def combineAsSet[A: Coder](c: SCollection[A]): SideInput[Set[A]] =
     c.aggregate[Set[A], Set[A]](Aggregator.prepareSemigroup(x => Set(x)))
-      .asSingletonSideInput(Set[A])
+      .asSingletonSideInput(Set[A]())
 
   // =======================================================================
   // Read operations

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -430,6 +430,14 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     }
 
   /**
+   * Return a new SCollection containing only the elements that also exist in the SideSet.
+   *
+   * @group transform
+   */
+  def hashFilter(that: SideSet[T])(implicit coder: Coder[T]): SCollection[T] =
+    self.map((_, ())).hashIntersectByKey(that).keys
+
+  /**
    * Create tuples of the elements in this SCollection by applying `f`.
    * @group transform
    */
@@ -944,6 +952,8 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
       WithTimestamps
         .of(Functions.serializableFn(f))
         .withAllowedTimestampSkew(allowedTimestampSkew))
+
+  def toSideSet(implicit coder: Coder[T]): SideSet[T] = SideSet(self.map((_, ())).toSideMap.side)
 
   // =======================================================================
   // Read operations

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -956,7 +956,8 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   def toSideSet(implicit coder: Coder[T]): SideSet[T] = SideSet(combineAsSet(self))
 
   private def combineAsSet[A: Coder](c: SCollection[A]): SideInput[Set[A]] =
-    c.aggregate[Set[A], Set[A]](Aggregator.prepareSemigroup(x => Set(x))).asSingletonSideInput(Set[A])
+    c.aggregate[Set[A], Set[A]](Aggregator.prepareSemigroup(x => Set(x)))
+      .asSingletonSideInput(Set[A])
 
   // =======================================================================
   // Read operations

--- a/scio-core/src/main/scala/com/spotify/scio/values/SideMap.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SideMap.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.scio.values
+
+import scala.collection.mutable.{ArrayBuffer, Map => MMap}
+
+case class SideMap[K, V](side: SideInput[MMap[K, ArrayBuffer[V]]])

--- a/scio-core/src/main/scala/com/spotify/scio/values/SideSet.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SideSet.scala
@@ -16,6 +16,4 @@
  */
 package com.spotify.scio.values
 
-import scala.collection.mutable.{ArrayBuffer, Map => MMap}
-
-case class SideSet[K](side: SideInput[MMap[K, ArrayBuffer[Unit]]])
+case class SideSet[T](side: SideInput[Set[T]])

--- a/scio-core/src/main/scala/com/spotify/scio/values/SideSet.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SideSet.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.scio.values
+
+import scala.collection.mutable.{ArrayBuffer, Map => MMap}
+
+case class SideSet[K](side: SideInput[MMap[K, ArrayBuffer[Unit]]])

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairHashSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairHashSCollectionFunctionsTest.scala
@@ -153,4 +153,23 @@ class PairHashSCollectionFunctionsTest extends PipelineSpec {
       p should beEmpty
     }
   }
+
+  it should "support hashIntersectByKey() with SideSet" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3), ("b", 4)))
+      val p2 = sc.parallelize(Seq[String]("a", "b", "d")).toSideSet
+      val p = p1.hashIntersectByKey(p2)
+      p should containInAnyOrder(Seq(("a", 1), ("b", 2), ("b", 4)))
+    }
+  }
+
+  it should "support hashJoin() with with SideMap" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("a", 2), ("b", 3)))
+      val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("b", 13))).toSideMap
+      val p = p1.hashJoin(p2)
+      p should
+        containInAnyOrder(Seq(("a", (1, 11)), ("a", (2, 11)), ("b", (3, 12)), ("b", (3, 13))))
+    }
+  }
 }


### PR DESCRIPTION
This is useful for avoiding recreating side inputs when you want to join multiple things
against the same side input.

Example:
There is a workflow using very big inputs, but you want to filter it to run for a small subset of data.
To avoid big shuffles you could hash-filter all big inputs against the small subset first.

Instead of doing:

    val sarsCollection = sarInput.keyBy(_.getUserId.toString)
    val userdata = userdataInput.keyBy(_.getUserId.toString).hashJoin(sarsCollection)
    val pipelinekeys = keyInput.keyBy(_.getUserId.toString).hashJoin(sarsCollection)

which would create two separate but identical side inputs, you could do this:

    val sarsSide = sarInput.map(_.getUserId.toString).toSideSet
    val userdata = userdataInput.keyBy(_.getUserId.toString).hashIntersectByKey(sarsSide)
    val pipelinekeys = keyInput.keyBy(_.getUserId.toString).hashIntersectByKey(sarsSide)

which only creates a single side input.