### PR TITLE
Improve Bloom Filter aggregations in Sparse Joins

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -345,8 +345,8 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val thatBfSIs = that.optimalKeysBloomFiltersAsSideInputs(thatNumKeys, fpProb)
     val n = thatBfSIs.size
 
-    val thisParts = self.partition(n, { case ( key, _ ) => key.hashCode() % n })
-    val thatParts = that.partition(n, { case ( key, _ ) => key.hashCode() % n })
+    val thisParts = self.partition(n, { case (key, _) => key.hashCode() % n })
+    val thatParts = that.partition(n, { case (key, _) => key.hashCode() % n })
 
     thisParts.zip(thatParts).zip(thatBfSIs).map {
       case ((lhs, rhs), bfsi) =>
@@ -381,8 +381,8 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val selfBfSideInputs = sColl.optimalKeysBloomFiltersAsSideInputs(thisNumKeys, fpProb)
     val n = selfBfSideInputs.size
 
-    val thisParts = sColl.partition(n, { case ( key, _ ) => key.hashCode() % n })
-    val thatParts = that.partition(n, { case ( key, _ ) => key.hashCode() % n })
+    val thisParts = sColl.partition(n, { case (key, _) => key.hashCode() % n })
+    val thatParts = that.partition(n, { case (key, _)  => key.hashCode() % n })
 
     SCollection.unionAll(
       thisParts
@@ -436,9 +436,9 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val selfBfSideInputs = sColl.optimalKeysBloomFiltersAsSideInputs(thisNumKeys, fpProb)
     val n = selfBfSideInputs.size
 
-    val thisParts = sColl.partition(n, { case ( key, _ ) => key.hashCode() % n })
-    val that1Parts = that1.partition(n, { case ( key, _ ) => key.hashCode() % n })
-    val that2Parts = that2.partition(n,{ case ( key, _ ) => key.hashCode() % n })
+    val thisParts = sColl.partition(n, { case (key, _)  => key.hashCode() % n })
+    val that1Parts = that1.partition(n, { case (key, _) => key.hashCode() % n })
+    val that2Parts = that2.partition(n, { case (key, _) => key.hashCode() % n })
 
     SCollection.unionAll(
       thisParts.zip(selfBfSideInputs).zip(that1Parts).zip(that2Parts).map {
@@ -491,7 +491,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val numHashes = BloomFilter.optimalNumHashes(numKeysPerPartition, width)
     val bfAggregator = BloomFilterAggregator[K](numHashes, width)
     self
-      .partition(n, { case ( key, _ ) => key.hashCode() % n })
+      .partition(n, { case (key, _) => key.hashCode() % n })
       .map { me =>
         me.keys
           .aggregate(bfAggregator.monoid.zero)(_ + _, _ ++ _)
@@ -687,7 +687,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
       sparseIntersectByKeyImpl(that, thatNumKeys.toInt, computeExact, fpProb)
     } else {
       val n = bfSettings.numBFs
-      val thisParts = self.partition(n, { case ( key, _ ) => key.hashCode() % n })
+      val thisParts = self.partition(n, { case (key, _) => key.hashCode() % n })
       val thatParts = that.partition(n, _.hashCode() % n)
       val joined = thisParts.zip(thatParts).map {
         case (lhs, rhs) =>

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -17,12 +17,11 @@
 
 package com.spotify.scio.values
 
-import com.spotify.scio.coders.{Coder, CoderMaterializer}
-
 import java.lang.{Iterable => JIterable}
 import java.util.{Map => JMap}
 
 import com.spotify.scio.ScioContext
+import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.util._
 import com.spotify.scio.util.random.{BernoulliValueSampler, PoissonValueSampler}
 import com.twitter.algebird._
@@ -346,8 +345,8 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val thatBfSIs = that.optimalKeysBloomFiltersAsSideInputs(thatNumKeys, fpProb)
     val n = thatBfSIs.size
 
-    val thisParts = self.partition(n, _._1.hashCode() % n)
-    val thatParts = that.partition(n, _._1.hashCode() % n)
+    val thisParts = self.partition(n, { case ( key, _ ) => key.hashCode() % n })
+    val thatParts = that.partition(n, { case ( key, _ ) => key.hashCode() % n })
 
     thisParts.zip(thatParts).zip(thatBfSIs).map {
       case ((lhs, rhs), bfsi) =>
@@ -382,8 +381,8 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val selfBfSideInputs = sColl.optimalKeysBloomFiltersAsSideInputs(thisNumKeys, fpProb)
     val n = selfBfSideInputs.size
 
-    val thisParts = sColl.partition(n, _._1.hashCode() % n)
-    val thatParts = that.partition(n, _._1.hashCode() % n)
+    val thisParts = sColl.partition(n, { case ( key, _ ) => key.hashCode() % n })
+    val thatParts = that.partition(n, { case ( key, _ ) => key.hashCode() % n })
 
     SCollection.unionAll(
       thisParts
@@ -437,9 +436,9 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val selfBfSideInputs = sColl.optimalKeysBloomFiltersAsSideInputs(thisNumKeys, fpProb)
     val n = selfBfSideInputs.size
 
-    val thisParts = sColl.partition(n, _._1.hashCode() % n)
-    val that1Parts = that1.partition(n, _._1.hashCode() % n)
-    val that2Parts = that2.partition(n, _._1.hashCode() % n)
+    val thisParts = sColl.partition(n, { case ( key, _ ) => key.hashCode() % n })
+    val that1Parts = that1.partition(n, { case ( key, _ ) => key.hashCode() % n })
+    val that2Parts = that2.partition(n,{ case ( key, _ ) => key.hashCode() % n })
 
     SCollection.unionAll(
       thisParts.zip(selfBfSideInputs).zip(that1Parts).zip(that2Parts).map {
@@ -492,7 +491,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val numHashes = BloomFilter.optimalNumHashes(numKeysPerPartition, width)
     val bfAggregator = BloomFilterAggregator[K](numHashes, width)
     self
-      .partition(n, _._1.hashCode() % n)
+      .partition(n, { case ( key, _ ) => key.hashCode() % n })
       .map { me =>
         me.keys
           .aggregate(bfAggregator.monoid.zero)(_ + _, _ ++ _)
@@ -688,7 +687,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
       sparseIntersectByKeyImpl(that, thatNumKeys.toInt, computeExact, fpProb)
     } else {
       val n = bfSettings.numBFs
-      val thisParts = self.partition(n, _._1.hashCode() % n)
+      val thisParts = self.partition(n, { case ( key, _ ) => key.hashCode() % n })
       val thatParts = that.partition(n, _.hashCode() % n)
       val joined = thisParts.zip(thatParts).map {
         case (lhs, rhs) =>


### PR DESCRIPTION
BloomFilters used in Sparse Join implementations use Algebird aggregators. This step incurs a good cost in terms of memory and cpu when using `.aggregate(com.twitter.algebird.Aggregator)` because of the way BloomFilters are modelled in Algebird. The aggregate goes as prepare -> sum -> present. For BloomFilterAggregator, the prepare step creates a BFMonoid for each element, and then the sum adds up the monoids. This means that all the keys becomes its own monoid, which takes up a lot of intermediate space. (Around 8 times more space than the keys itself). This can be seen when we expand the transforms in Dataflow.

<img width="1112" alt="screenshot 2019-01-31 at 19 48 32" src="https://user-images.githubusercontent.com/15274312/52078580-d0804c00-2593-11e9-97f8-6614eb0acea2.png">
Prepare step of aggregation

<img width="1123" alt="screenshot 2019-01-31 at 19 50 24" src="https://user-images.githubusercontent.com/15274312/52078583-d37b3c80-2593-11e9-8240-020d30832336.png">
Sum operation of aggregation

The vCPU time for the sum operation is around 14 hrs, which is quite high.

Changing this to use our own combine functions, provides significant performance improvements.
`.aggregate(bfAggregator.monoid.zero)(_ + _, _ ++ _)`
<img width="1137" alt="screenshot 2019-01-31 at 19 54 09" src="https://user-images.githubusercontent.com/15274312/52078892-9f544b80-2594-11e9-9b04-ac1f2b4c564f.png">

By removing prepare, the intermediate step which was having an output more than 8 times the size of the keys is now removed. The vCPU time has also come down to 5 hrs. (35% of what it was previously)


We noticed up 20% less overall CPU usage on one of our jobs with this change.


Also in this PR.

Added the sparse lookups in a transform to make it look pretty in DataFlow UI.