### PR TITLE
Add HashPartitioning and fix negative hashCode

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
@@ -96,14 +96,4 @@ private[scio] object ScioUtil {
     }
   }
 
-  /**
-   * Modulo operation, This always return a non negative value in the range [0, mod)
-   * Returns incorrect value for `mod(Int.MinValue, Int.MaxValue)` as Int.MaxValue - 1
-   * but remainder of Int.MinValue % Int.MaxValue is -1
-   */
-  @inline def mod(value: Int, mod: Int): Int = {
-    val rawMod = value % mod
-    rawMod + (if (rawMod < 0) mod else 0)
-  }
-
 }

--- a/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
@@ -96,4 +96,14 @@ private[scio] object ScioUtil {
     }
   }
 
+  /**
+   * Modulo operation, This always return a non negative value in the range [0, mod)
+   * Returns incorrect value for `mod(Int.MinValue, Int.MaxValue)` as Int.MaxValue - 1
+   * but remainder of Int.MinValue % Int.MaxValue is -1
+   */
+  @inline def mod(value: Int, mod: Int): Int = {
+    val rawMod = value % mod
+    rawMod + (if (rawMod < 0) mod else 0)
+  }
+
 }

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -211,6 +211,19 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     voder: Coder[V]): SCollection[(K, (Iterable[V], Iterable[W1], Iterable[W2], Iterable[W3]))] =
     this.cogroup(that1, that2, that3)
 
+  /**
+   * Partition this SCollection using K.hashCode() into `n` partitions
+   *
+   * @param numPartitions number of output partitions
+   * @return partitioned SCollections in a `Seq`
+   * @group collection
+   */
+  def hashPartitionByKey(numPartitions: Int): Seq[SCollection[(K, V)]] =
+    self.partition(numPartitions, {
+      case (key, _) =>
+        ScioUtil.mod(key.hashCode(), numPartitions)
+    })
+
   // =======================================================================
   // Joins
   // =======================================================================
@@ -345,8 +358,8 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val thatBfSIs = that.optimalKeysBloomFiltersAsSideInputs(thatNumKeys, fpProb)
     val n = thatBfSIs.size
 
-    val thisParts = self.partition(n, { case (key, _) => key.hashCode() % n })
-    val thatParts = that.partition(n, { case (key, _) => key.hashCode() % n })
+    val thisParts = self.hashPartitionByKey(n)
+    val thatParts = that.hashPartitionByKey(n)
 
     thisParts.zip(thatParts).zip(thatBfSIs).map {
       case ((lhs, rhs), bfsi) =>
@@ -381,8 +394,8 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val selfBfSideInputs = sColl.optimalKeysBloomFiltersAsSideInputs(thisNumKeys, fpProb)
     val n = selfBfSideInputs.size
 
-    val thisParts = sColl.partition(n, { case (key, _) => key.hashCode() % n })
-    val thatParts = that.partition(n, { case (key, _)  => key.hashCode() % n })
+    val thisParts = sColl.hashPartitionByKey(n)
+    val thatParts = that.hashPartitionByKey(n)
 
     SCollection.unionAll(
       thisParts
@@ -436,9 +449,9 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val selfBfSideInputs = sColl.optimalKeysBloomFiltersAsSideInputs(thisNumKeys, fpProb)
     val n = selfBfSideInputs.size
 
-    val thisParts = sColl.partition(n, { case (key, _)  => key.hashCode() % n })
-    val that1Parts = that1.partition(n, { case (key, _) => key.hashCode() % n })
-    val that2Parts = that2.partition(n, { case (key, _) => key.hashCode() % n })
+    val thisParts = sColl.hashPartitionByKey(n)
+    val that1Parts = that1.hashPartitionByKey(n)
+    val that2Parts = that2.hashPartitionByKey(n)
 
     SCollection.unionAll(
       thisParts.zip(selfBfSideInputs).zip(that1Parts).zip(that2Parts).map {
@@ -490,11 +503,10 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     val width = BloomFilter.optimalWidth(numKeysPerPartition, fpProb).get
     val numHashes = BloomFilter.optimalNumHashes(numKeysPerPartition, width)
     val bfAggregator = BloomFilterAggregator[K](numHashes, width)
-    self
-      .partition(n, { case (key, _) => key.hashCode() % n })
+    self.keys
+      .hashPartition(n)
       .map { me =>
-        me.keys
-          .aggregate(bfAggregator.monoid.zero)(_ + _, _ ++ _)
+        me.aggregate(bfAggregator.monoid.zero)(_ + _, _ ++ _)
           .asSingletonSideInput(bfAggregator.monoid.zero)
       }
   }
@@ -687,8 +699,8 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
       sparseIntersectByKeyImpl(that, thatNumKeys.toInt, computeExact, fpProb)
     } else {
       val n = bfSettings.numBFs
-      val thisParts = self.partition(n, { case (key, _) => key.hashCode() % n })
-      val thatParts = that.partition(n, _.hashCode() % n)
+      val thisParts = self.hashPartitionByKey(n)
+      val thatParts = that.hashPartition(n)
       val joined = thisParts.zip(thatParts).map {
         case (lhs, rhs) =>
           lhs.sparseIntersectByKeyImpl(rhs, bfSettings.capacity, computeExact, fpProb)

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -221,7 +221,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   def hashPartitionByKey(numPartitions: Int): Seq[SCollection[(K, V)]] =
     self.partition(numPartitions, {
       case (key, _) =>
-        ScioUtil.mod(key.hashCode(), numPartitions)
+        Math.floorMod(key.hashCode(), numPartitions)
     })
 
   // =======================================================================

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -266,7 +266,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   def hashPartition(numPartitions: Int): Seq[SCollection[T]] =
     self.partition(
       numPartitions, { t =>
-        ScioUtil.mod(t.hashCode(), numPartitions)
+        Math.floorMod(t.hashCode(), numPartitions)
       }
     )
 

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -256,6 +256,20 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     (left, right)
   }
 
+  /**
+   * Partition this SCollection using Object.hashCode() into `n` partitions
+   *
+   * @param numPartitions number of output partitions
+   * @return partitioned SCollections in a `Seq`
+   * @group collection
+   */
+  def hashPartition(numPartitions: Int): Seq[SCollection[T]] =
+    self.partition(
+      numPartitions, { t =>
+        ScioUtil.mod(t.hashCode(), numPartitions)
+      }
+    )
+
   // =======================================================================
   // Transformations
   // =======================================================================

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -164,6 +164,15 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
+  it should "support hashPartition() based on Object.hashCode()" in {
+    runWithContext { sc =>
+      val p = sc.parallelize(Seq(-1, 2, -3, 4, -5, 6)).hashPartition(3)
+      p(0) should containInAnyOrder(Seq(-3, 6))
+      p(1) should containInAnyOrder(Seq(4, -5))
+      p(2) should containInAnyOrder(Seq(-1, 2))
+    }
+  }
+
   it should "support aggregate()" in {
     runWithContext { sc =>
       val p = sc.parallelize(1 to 100)


### PR DESCRIPTION
For large SCollections, we create multiple Bloom Filters for some operations. This means partitioning SCollections into multiple smaller ones. This is achieved using keys.hashCode % n, which is a 💣. It blows up because hashCode can be negative, and the partitioning function expects something in the range [0, n) . This is fixed using a `nonNegativeMod` much like Spark. 

Also added APIs for Hash Partitioning a SCollection because that helped remove some of the duplicate code.