### PR TITLE
Add BinaryIO output.

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/io/BinaryIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/BinaryIO.scala
@@ -40,7 +40,7 @@ final case class BinaryIO(path: String) extends ScioIO[Array[Byte]] {
   override def testId: String = s"BinaryIO($path)"
 
   override def read(sc: ScioContext, params: ReadP): SCollection[Array[Byte]] =
-    throw new IllegalStateException("BinaryIO is read-only")
+    throw new IllegalStateException("BinaryIO is write-only")
 
   override def write(data: SCollection[Array[Byte]], params: WriteP): Future[Tap[Nothing]] = {
     data.applyInternal(

--- a/scio-core/src/main/scala/com/spotify/scio/io/BinaryIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/BinaryIO.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.io
+
+import java.io.OutputStream
+import java.nio.channels.{Channels, WritableByteChannel}
+
+import com.spotify.scio.ScioContext
+import com.spotify.scio.io.BinaryIO.BytesSink
+import com.spotify.scio.values.SCollection
+import org.apache.beam.sdk.io._
+
+import scala.concurrent.Future
+
+/**
+ * A ScioIO class for writing raw bytes to files.
+ * Like TextIO, but without newline delimiters and operating over Array[Byte] instead of String.
+ * @param path a path to write to.
+ */
+final case class BinaryIO(path: String) extends ScioIO[Array[Byte]] {
+  override type ReadP = Nothing
+  override type WriteP = BinaryIO.WriteParam
+  override final val tapT = EmptyTapOf[Array[Byte]]
+
+  override def testId: String = s"BinaryIO($path)"
+
+  override def read(sc: ScioContext, params: ReadP): SCollection[Array[Byte]] =
+    throw new IllegalStateException("BinaryIO is read-only")
+
+  override def write(data: SCollection[Array[Byte]], params: WriteP): Future[Tap[Nothing]] = {
+    data.applyInternal(
+      FileIO
+        .write[Array[Byte]]
+        .via(new BytesSink())
+        .withCompression(params.compression)
+        .withNumShards(params.numShards)
+        .withSuffix(params.suffix)
+        .to(pathWithShards(path)))
+    Future.successful(EmptyTap)
+  }
+
+  override def tap(params: Nothing): Tap[Nothing] = EmptyTap
+
+  private[scio] def pathWithShards(path: String) =
+    path.replaceAll("\\/+$", "") + "/part"
+}
+
+object BinaryIO {
+  final case class WriteParam(suffix: String = ".bin",
+                              numShards: Int = 0,
+                              compression: Compression = Compression.UNCOMPRESSED)
+
+  private final class BytesSink extends FileIO.Sink[Array[Byte]] {
+    @transient private var channel: OutputStream = _
+
+    override def open(channel: WritableByteChannel): Unit =
+      this.channel = Channels.newOutputStream(channel)
+
+    override def flush(): Unit = {
+      if (this.channel == null) {
+        throw new IllegalStateException("Trying to flush a BytesSink that has not been opened")
+      }
+
+      this.channel.flush()
+    }
+
+    override def write(datum: Array[Byte]): Unit = {
+      if (this.channel == null) {
+        throw new IllegalStateException("Trying to write to a BytesSink that has not been opened")
+      }
+
+      this.channel.write(datum)
+    }
+  }
+}

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1124,6 +1124,19 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   }
 
   /**
+   * Save this SCollection as raw bytes. Note that elements must be of type `Array[Byte]`.
+   * @group output
+   */
+  def saveAsBinaryFile(path: String,
+                       numShards: Int = 0,
+                       suffix: String = ".bin",
+                       compression: Compression = Compression.UNCOMPRESSED)(
+    implicit ev: T <:< Array[Byte]): Future[Tap[Nothing]] =
+    this
+      .asInstanceOf[SCollection[Array[Byte]]]
+      .write(BinaryIO(path))(BinaryIO.WriteParam(suffix, numShards, compression))
+
+  /**
    * Save this SCollection with a custom output transform. The transform should have a unique name.
    * @group output
    */

--- a/scio-test/src/test/scala/com/spotify/scio/io/ScioIOTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/ScioIOTest.scala
@@ -17,6 +17,8 @@
 
 package com.spotify.scio.io
 
+import java.nio.ByteBuffer
+
 import com.google.datastore.v1.Entity
 import com.google.datastore.v1.client.DatastoreHelper
 import com.spotify.scio.avro._
@@ -93,6 +95,11 @@ class ScioIOTest extends ScioIOSpec {
     val xs = (1 to 100).map(_.toString)
     testTap(xs)(_.saveAsTextFile(_))(".txt")
     testJobTest(xs)(TextIO(_))(_.textFile(_))(_.saveAsTextFile(_))
+  }
+
+  "BinaryIO" should "work" in {
+    val xs = (1 to 100).map(i => ByteBuffer.allocate(4).putInt(i).array)
+    testJobTestOutput(xs)(BinaryIO(_))(_.saveAsBinaryFile(_))
   }
 
   "DatastoreIO" should "work" in {


### PR DESCRIPTION
(cc @regadas)

This PR adds `BinaryIO` (name up for debate) which allows us to write `SCollection[Array[Byte]]` to files. Think of this as `TextIO`, but with no delimiters, any arbitrary bytes rather than strings, and write-only (for now).

More tests to be added once I confirm that this might be something we want to move forward with. My team has found that certain Dataflow jobs produce output that's ~60% smaller than flat text files with this change, and while this might not be widely useful, it seems like something that could be used by other Scio users.