### PR TITLE
Use list side input on cross product

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -660,8 +660,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    */
   def cross[U: Coder](that: SCollection[U])(implicit tcoder: Coder[T]): SCollection[(T, U)] =
     this.transform { in =>
-      // TODO: switch to ListSideInput when https://github.com/spotify/scio/issues/1152 is resolved
-      val side = that.aggregate(Aggregator.toList[U]).asSingletonSideInput
+      val side = that.asListSideInput
       in.withSideInputs(side)
         .flatMap((t, s) => s(side).map((t, _)))
         .toSCollection


### PR DESCRIPTION
this is related to #1152. A lot as changed since then:

* we can now detect the serialization of `null` values
* and beam is now `2.10`.

Given this and the fact we are still not able to replicate I think we should restore the usage of `ListSideInput`.