### PR TITLE
Optimize CombineFn's

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
@@ -23,7 +23,7 @@ import java.util.{ArrayList => JArrayList, List => JList}
 import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.twitter.algebird.{Monoid, Semigroup}
 import org.apache.beam.sdk.coders.{CoderRegistry, Coder => BCoder}
-import org.apache.beam.sdk.transforms.Combine.CombineFn
+import org.apache.beam.sdk.transforms.Combine.{CombineFn => BCombineFn}
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.transforms.Partition.PartitionFn
 import org.apache.beam.sdk.transforms.{DoFn, SerializableFunction}
@@ -34,9 +34,18 @@ private[scio] object Functions {
 
   private[this] val BufferSize = 20
 
-  // TODO: rename
-  private abstract class KryoCombineFn[VI, VA, VO] extends CombineFn[VI, VA, VO] with NamedFn {
-    // TODO: should those coder be transient ?
+  private object CombineFn {
+    def fold[A, B](accumulator: A, list: JList[B])(f: (A, B) => A): A = {
+      val iter = list.iterator()
+      var acc: A = accumulator
+      while (iter.hasNext) {
+        acc = f(acc, iter.next())
+      }
+      acc
+    }
+  }
+
+  private abstract class CombineFn[VI, VA, VO] extends BCombineFn[VI, VA, VO] with NamedFn {
     val vacoder: Coder[VA]
     val vocoder: Coder[VO]
 
@@ -49,19 +58,19 @@ private[scio] object Functions {
   }
 
   def aggregateFn[T: Coder, U: Coder](
-    zeroValue: U)(seqOp: (U, T) => U, combOp: (U, U) => U): CombineFn[T, (U, JList[T]), U] =
-    new KryoCombineFn[T, (U, JList[T]), U] {
+    zeroValue: U)(seqOp: (U, T) => U, combOp: (U, U) => U): BCombineFn[T, (U, JList[T]), U] =
+    new CombineFn[T, (U, JList[T]), U] {
 
       val vacoder = Coder[(U, JList[T])]
       val vocoder = Coder[U]
 
       // defeat closure
-      val s = ClosureCleaner(seqOp)
-      val c = ClosureCleaner(combOp)
+      private[this] val s = ClosureCleaner(seqOp)
+      private[this] val c = ClosureCleaner(combOp)
 
       private def fold(accumulator: (U, JList[T])): U = {
         val (a, l) = accumulator
-        l.asScala.foldLeft(a)(s)
+        CombineFn.fold(a, l)(s)
       }
 
       override def createAccumulator(): (U, JList[T]) =
@@ -77,12 +86,15 @@ private[scio] object Functions {
         }
       }
 
-      override def extractOutput(accumulator: (U, JList[T])): U =
-        accumulator._2.asScala.foldLeft(accumulator._1)(s)
+      override def extractOutput(accumulator: (U, JList[T])): U = fold(accumulator)
 
       override def mergeAccumulators(accumulators: JIterable[(U, JList[T])]): (U, JList[T]) = {
-        val combined = accumulators.iterator.asScala.map(fold).reduce(c)
-        (combined, new JArrayList[T]())
+        val iter = accumulators.iterator()
+        var acc: U = fold(iter.next())
+        while (iter.hasNext) {
+          acc = c(acc, fold(iter.next()))
+        }
+        (acc, new JArrayList[T]())
       }
 
     }
@@ -90,22 +102,25 @@ private[scio] object Functions {
   def combineFn[T: Coder, C: Coder](
     createCombiner: T => C,
     mergeValue: (C, T) => C,
-    mergeCombiners: (C, C) => C): CombineFn[T, (Option[C], JList[T]), C] =
-    new KryoCombineFn[T, (Option[C], JList[T]), C] {
+    mergeCombiners: (C, C) => C): BCombineFn[T, (Option[C], JList[T]), C] =
+    new CombineFn[T, (Option[C], JList[T]), C] {
 
       val vacoder = Coder[(Option[C], JList[T])]
       val vocoder = Coder[C]
 
       // defeat closure
-      val cc = ClosureCleaner(createCombiner)
-      val mv = ClosureCleaner(mergeValue)
-      val mc = ClosureCleaner(mergeCombiners)
+      private[this] val cc = ClosureCleaner(createCombiner)
+      private[this] val mv = ClosureCleaner(mergeValue)
+      private[this] val mc = ClosureCleaner(mergeCombiners)
 
-      private def foldOption(accumulator: (Option[C], JList[T])): Option[C] =
-        accumulator match {
-          case (Some(a), l)           => Some(l.asScala.foldLeft(a)(mv))
-          case (None, l) if l.isEmpty => None
-          case (None, l) =>
+      private def foldOption(accumulator: (Option[C], JList[T])): Option[C] = {
+        val (opt, l) = accumulator
+        if (opt.isDefined) {
+          Some(CombineFn.fold(opt.get, l)(mv))
+        } else {
+          if (opt.isEmpty && l.isEmpty) {
+            None
+          } else {
             var c = cc(l.get(0))
             var i = 1
             while (i < l.size) {
@@ -113,13 +128,15 @@ private[scio] object Functions {
               i += 1
             }
             Some(c)
+          }
         }
+      }
 
       override def createAccumulator(): (Option[C], JList[T]) =
         (None, new JArrayList[T]())
 
       override def addInput(accumulator: (Option[C], JList[T]), input: T): (Option[C], JList[T]) = {
-        val (a, l) = accumulator
+        val (_, l) = accumulator
         l.add(input)
         if (l.size() >= BufferSize) {
           (foldOption(accumulator), new JArrayList[T]())
@@ -133,15 +150,26 @@ private[scio] object Functions {
 
       override def mergeAccumulators(
         accumulators: JIterable[(Option[C], JList[T])]): (Option[C], JList[T]) = {
-        val flattened: Iterator[C] = accumulators.iterator.asScala.flatMap(foldOption)
-        // make sure not to fail when flattened is empty
-        // see: https://github.com/spotify/scio/issues/1425
-        val combined =
-          if (flattened.hasNext) {
-            Option(flattened.reduce(mc))
-          } else {
-            None
+        val iter = accumulators.iterator()
+        val combined = if (!iter.hasNext) {
+          None
+        } else {
+          var acc: Option[C] = foldOption(iter.next())
+          while (iter.hasNext) {
+            val elem: Option[C] = foldOption(iter.next())
+            acc = if (acc.isDefined && elem.isDefined) {
+              Some(mc(acc.get, elem.get))
+            } else {
+              if (acc.isDefined || elem.isDefined) {
+                acc.orElse(elem)
+              } else {
+                None
+              }
+            }
           }
+          acc
+        }
+
         (combined, new JArrayList[T]())
       }
 
@@ -149,7 +177,7 @@ private[scio] object Functions {
 
   def flatMapFn[T, U](f: T => TraversableOnce[U]): DoFn[T, U] =
     new NamedDoFn[T, U] {
-      val g = ClosureCleaner(f) // defeat closure
+      private[this] val g = ClosureCleaner(f) // defeat closure
       @ProcessElement
       private[scio] def processElement(c: DoFn[T, U]#ProcessContext): Unit = {
         val i = g(c.element()).toIterator
@@ -159,12 +187,12 @@ private[scio] object Functions {
 
   def serializableFn[T, U](f: T => U): SerializableFunction[T, U] =
     new NamedSerializableFn[T, U] {
-      val g = ClosureCleaner(f) // defeat closure
+      private[this] val g = ClosureCleaner(f) // defeat closure
       override def apply(input: T): U = g(input)
     }
 
   def mapFn[T, U](f: T => U): DoFn[T, U] = new NamedDoFn[T, U] {
-    val g = ClosureCleaner(f) // defeat closure
+    private[this] val g = ClosureCleaner(f) // defeat closure
     @ProcessElement
     private[scio] def processElement(c: DoFn[T, U]#ProcessContext): Unit =
       c.output(g(c.element()))
@@ -172,18 +200,18 @@ private[scio] object Functions {
 
   def partitionFn[T](numPartitions: Int, f: T => Int): PartitionFn[T] =
     new NamedPartitionFn[T] {
-      val g = ClosureCleaner(f) // defeat closure
+      private[this] val g = ClosureCleaner(f) // defeat closure
       override def partitionFor(elem: T, numPartitions: Int): Int = g(elem)
     }
 
-  private abstract class ReduceFn[T: Coder] extends KryoCombineFn[T, JList[T], T] {
+  private abstract class ReduceFn[T: Coder] extends CombineFn[T, JList[T], T] {
 
     override def createAccumulator(): JList[T] = new JArrayList[T]()
 
     override def addInput(accumulator: JList[T], input: T): JList[T] = {
       accumulator.add(input)
       if (accumulator.size > BufferSize) {
-        val v = reduceOption(accumulator.asScala).get
+        val v = reduceOption(accumulator).get
         accumulator.clear()
         accumulator.add(v)
       }
@@ -191,53 +219,74 @@ private[scio] object Functions {
     }
 
     override def extractOutput(accumulator: JList[T]): T =
-      reduceOption(accumulator.asScala).get
+      reduceOption(accumulator).get
 
     override def mergeAccumulators(accumulators: JIterable[JList[T]]): JList[T] = {
-      val partial: Iterable[T] =
-        accumulators.asScala.flatMap(a => reduceOption(a.asScala))
+      val iter = accumulators.iterator()
+      val partial: JArrayList[T] = new JArrayList[T]()
+      while (iter.hasNext) {
+        reduceOption(iter.next()).foreach(partial.add(_))
+      }
       val r = new JArrayList[T]()
       reduceOption(partial).foreach(r.add)
       r
     }
 
-    def reduceOption(accumulator: Iterable[T]): Option[T]
+    def reduceOption(accumulator: JIterable[T]): Option[T]
 
   }
 
-  def reduceFn[T: Coder](f: (T, T) => T): CombineFn[T, JList[T], T] =
+  def reduceFn[T: Coder](f: (T, T) => T): BCombineFn[T, JList[T], T] =
     new ReduceFn[T] {
       val vacoder = Coder[JList[T]]
       val vocoder = Coder[T]
-      val g = ClosureCleaner(f) // defeat closure
-      override def reduceOption(accumulator: Iterable[T]): Option[T] =
-        accumulator.reduceOption(g)
+      private[this] val g = ClosureCleaner(f) // defeat closure
+
+      override def reduceOption(accumulator: JIterable[T]): Option[T] = {
+        val iter = accumulator.iterator()
+        if (iter.hasNext) {
+          var acc = iter.next()
+          while (iter.hasNext) {
+            acc = g(acc, iter.next())
+          }
+          Some(acc)
+        } else {
+          None
+        }
+      }
     }
 
-  def reduceFn[T: Coder](sg: Semigroup[T]): CombineFn[T, JList[T], T] =
+  def reduceFn[T: Coder](sg: Semigroup[T]): BCombineFn[T, JList[T], T] =
     new ReduceFn[T] {
       val vacoder = Coder[JList[T]]
       val vocoder = Coder[T]
-      val _sg = ClosureCleaner(sg) // defeat closure
+      private[this] val _sg = ClosureCleaner(sg) // defeat closure
+
       override def mergeAccumulators(accumulators: JIterable[JList[T]]): JList[T] = {
-        val partial =
-          accumulators.asScala.flatMap(a => _sg.sumOption(a.asScala))
-        val combined: T = _sg.sumOption(partial).get
+        val iter = accumulators.iterator()
+        val acc: JArrayList[T] = new JArrayList[T]()
+        while (iter.hasNext) {
+          _sg.sumOption(iter.next().asScala).foreach(acc.add(_))
+        }
+
+        val combined: T = _sg.sumOption(acc.asScala).get
         val list = new JArrayList[T]()
         list.add(combined)
         list
       }
-      override def reduceOption(accumulator: Iterable[T]): Option[T] =
-        _sg.sumOption(accumulator)
+
+      override def reduceOption(accumulator: JIterable[T]): Option[T] =
+        _sg.sumOption(accumulator.asScala)
     }
 
-  def reduceFn[T: Coder](mon: Monoid[T]): CombineFn[T, JList[T], T] =
+  def reduceFn[T: Coder](mon: Monoid[T]): BCombineFn[T, JList[T], T] =
     new ReduceFn[T] {
       val vacoder = Coder[JList[T]]
       val vocoder = Coder[T]
-      val _mon = ClosureCleaner(mon) // defeat closure
-      override def reduceOption(accumulator: Iterable[T]): Option[T] =
-        _mon.sumOption(accumulator).orElse(Some(_mon.zero))
+      private[this] val _mon = ClosureCleaner(mon) // defeat closure
+
+      override def reduceOption(accumulator: JIterable[T]): Option[T] =
+        _mon.sumOption(accumulator.asScala).orElse(Some(_mon.zero))
     }
 
 }


### PR DESCRIPTION
### Before
```
[info] Benchmark                          Mode  Cnt        Score       Error  Units
[info] FunctionsBenchmark.benchAggregate  avgt   20  2646845.608 ± 15481.001  ns/op
[info] FunctionsBenchmark.benchCombine    avgt   20  2244241.371 ±  8921.944  ns/op
[info] FunctionsBenchmark.benchMonoid     avgt   20  7115897.251 ± 51600.308  ns/op
[info] FunctionsBenchmark.benchReduce     avgt   20  2628645.814 ± 46589.656  ns/op
[info] FunctionsBenchmark.benchSemigroup  avgt   20  7237729.044 ± 31415.158  ns/op
```

### After
```
[info] Benchmark                          Mode  Cnt        Score       Error  Units
[info] FunctionsBenchmark.benchAggregate  avgt   20  2486561.601 ± 15809.799  ns/op
[info] FunctionsBenchmark.benchCombine    avgt   20  2164058.998 ± 15960.153  ns/op
[info] FunctionsBenchmark.benchMonoid     avgt   20  2419176.004 ± 35601.634  ns/op
[info] FunctionsBenchmark.benchReduce     avgt   20  2324575.817 ± 76884.608  ns/op
[info] FunctionsBenchmark.benchSemigroup  avgt   20  3211684.503 ± 19937.007  ns/op
```