### PR TITLE
Fix DistinctBy for Scala Classes

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -30,8 +30,6 @@ import org.apache.beam.sdk.transforms._
 import org.apache.beam.sdk.values.{KV, PCollection, PCollectionView}
 import org.slf4j.LoggerFactory
 
-import scala.reflect.ClassTag
-
 private object PairSCollectionFunctions {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -618,7 +616,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * @return a new SCollection of (key, value) pairs
    * @group per_key
    */
-  def distinctByKey(implicit ct: ClassTag[K]): SCollection[(K, V)] =
+  def distinctByKey(implicit koder: Coder[K], voder: Coder[V]): SCollection[(K, V)] =
     self.distinctBy(_._1)
 
   /**

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -380,10 +380,9 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @tparam U The type of representative values used to dedup.
    * @group transform
    */
-  def distinctBy[U](f: T => U)(implicit ctu: ClassTag[U]): SCollection[T] =
-    this.pApply(Distinct
-      .withRepresentativeValueFn(Functions.serializableFn(f))
-      .withRepresentativeType(TypeDescriptor.of(ctu.runtimeClass).asInstanceOf[TypeDescriptor[U]]))
+  // This is simplier than Distinct.withRepresentativeValueFn, and allows us to set Coders
+  def distinctBy[U](f: T => U)(implicit toder: Coder[T], uoder: Coder[U]): SCollection[T] =
+    this.transform(me => me.groupBy(f).values.map(_.head))
 
   /**
    * Return a new SCollection containing only the elements that satisfy a predicate.

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -234,12 +234,30 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support distinctByKey()" in {
+  it should "support distinctByKey() on Strings" in {
     runWithContext { sc =>
       val p = sc
         .parallelize(Seq(("a", 11), ("a", 11), ("b", 22), ("b", 22), ("b", 22)))
         .distinctByKey
       p should containInAnyOrder(Seq(("a", 11), ("b", 22)))
+    }
+  }
+
+  it should "support distinctByKey() on scala Long" in {
+    runWithContext { sc =>
+      val p = sc
+        .parallelize(Seq((1L, 11), (1L, 11), (2L, 22), (2L, 22), (2L, 22)))
+        .distinctByKey
+      p should containInAnyOrder(Seq((1L, 11), (2L, 22)))
+    }
+  }
+
+  it should "support distinctByKey() on scala Int" in {
+    runWithContext { sc =>
+      val p = sc
+        .parallelize(Seq((1, 11), (1, 11), (2, 22), (2, 22), (2, 22)))
+        .distinctByKey
+      p should containInAnyOrder(Seq((1, 11), (2, 22)))
     }
   }
 

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -234,7 +234,7 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support distinctByKey() on Strings" in {
+  it should "support distinctByKey() on String keys" in {
     runWithContext { sc =>
       val p = sc
         .parallelize(Seq(("a", 11), ("a", 11), ("b", 22), ("b", 22), ("b", 22)))
@@ -243,7 +243,7 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support distinctByKey() on scala Long" in {
+  it should "support distinctByKey() on Scala Long keys" in {
     runWithContext { sc =>
       val p = sc
         .parallelize(Seq((1L, 11), (1L, 11), (2L, 22), (2L, 22), (2L, 22)))
@@ -252,7 +252,7 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support distinctByKey() on scala Int" in {
+  it should "support distinctByKey() on Scala Int keys" in {
     runWithContext { sc =>
       val p = sc
         .parallelize(Seq((1, 11), (1, 11), (2, 22), (2, 22), (2, 22)))

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -227,19 +227,28 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
-  it should "support distinct" in {
+  it should "support distinct on String" in {
     runWithContext { sc =>
       val p = sc.parallelize(Seq("a", "b", "b", "c", "c", "c")).distinct
       p should containInAnyOrder(Seq("a", "b", "c"))
     }
   }
 
-  it should "support distinctBy()" in {
+  it should "support distinctBy() with scala primitive types" in {
     runWithContext { sc =>
       val p = sc
-        .parallelize(Seq("kA" -> "vA1", "kB" -> "vB", "kA" -> "vA2"))
+        .parallelize(Seq(1 -> "vA1", 2 -> "vB", 1 -> "vA2"))
         .distinctBy(_._1)
-      p.keys should containInAnyOrder(Seq("kA", "kB"))
+      p.keys should containInAnyOrder(Seq(1, 2))
+    }
+  }
+
+  it should "support distinctBy() on java types" in {
+    runWithContext { sc =>
+      val p = sc
+        .parallelize(Seq(11, 12, 11, 21))
+        .distinctBy(a => java.lang.Long.valueOf(a % 10))
+      p should containInAnyOrder(Seq(21, 12))
     }
   }
 

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -234,7 +234,14 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
-  it should "support distinctBy() with scala primitive types" in {
+  it should "support distinct on Int" in {
+    runWithContext { sc =>
+      val p = sc.parallelize(Seq(1, 3, 4, 2, 2, 5, 4, 2, 1, 1)).distinct
+      p should containInAnyOrder(Seq(1, 2, 3, 4, 5))
+    }
+  }
+
+  it should "support distinctBy() with Scala primitive as representative values" in {
     runWithContext { sc =>
       val p = sc
         .parallelize(Seq(1 -> "vA1", 2 -> "vB", 1 -> "vA2"))
@@ -243,12 +250,12 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
-  it should "support distinctBy() on java types" in {
+  it should "support distinctBy() on Java types as representative values" in {
     runWithContext { sc =>
       val p = sc
-        .parallelize(Seq(11, 12, 11, 21))
-        .distinctBy(a => java.lang.Long.valueOf(a % 10))
-      p should containInAnyOrder(Seq(21, 12))
+        .parallelize(Seq(1 -> "vA1", 2 -> "vB", 1 -> "vA2"))
+        .distinctBy(a => java.lang.Long.valueOf(a._1))
+      p.keys should containInAnyOrder(Seq(1, 2))
     }
   }
 


### PR DESCRIPTION
The bug appears as a runtime exception when the output type of the distinctBy function is a Scala primitive type (or potentially a case class - I haven't checked)

```
Unable to return a default Coder for distinctByKey@{SecretCodeToMakePeace.scala:60}2/KeyByRepresentativeValue/AddKeys/Map/ParMultiDo(Anonymous).output [PCollection]. Correct one of the following root causes:   No Coder has been manually specified;  you may do so using .setCoder().   Inferring a Coder from the CoderRegistry failed: Cannot provide coder for parameterized type org.apache.beam.sdk.values.KV<K, V>: Unable to provide a Coder for K.   Building a Coder using a registered CoderProvider failed.   See suppressed exceptions for detailed failures.   Using the default output Coder from the producing PTransform failed: PTransform.getOutputCoder called.
Stacktrace
java.lang.IllegalStateException: Unable to return a default Coder for distinctByKey@{SecretCodeToMakePeace.scala:60}2/KeyByRepresentativeValue/AddKeys/Map/ParMultiDo(Anonymous).output [PCollection]. Correct one of the following root causes:
  No Coder has been manually specified;  you may do so using .setCoder().
  Inferring a Coder from the CoderRegistry failed: Cannot provide coder for parameterized type org.apache.beam.sdk.values.KV<K, V>: Unable to provide a Coder for K.
  Building a Coder using a registered CoderProvider failed.
  See suppressed exceptions for detailed failures.
  Using the default output Coder from the producing PTransform failed: PTransform.getOutputCoder called.
	at org.apache.beam.repackaged.beam_sdks_java_core.com.google.common.base.Preconditions.checkState(Preconditions.java:444)
	at org.apache.beam.sdk.values.PCollection.getCoder(PCollection.java:278)
...
com.spotify.scio.values.PairSCollectionFunctions.distinctByKey(PairSCollectionFunctions.scala:622)
```

The distinctBy uses Beam's `Distinct.withRepresentativeValueFn`. This function internally does a GroupByKey, and hence needs a coder for the representative value. This transform in Beam doesn't have an api to provide coders, and [it is getting the coder](https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Distinct.java#L166) from the CoderRegistry. 
This means that we would need to use the coder registry and register the coders there for it to infer it correctly. And if we want to have an option to use different coders for the same type in different steps of the pipeline, this might get complicated.

Earlier we were registering the coders for Scala types, which has not been removed https://github.com/spotify/scio/pull/1670


The bug can be reproduced with this test on SCollection:
```
  it should "support distinctBy() with scala primitive types" in {
    runWithContext { sc =>
      val p = sc
        .parallelize(Seq(1 -> "vA1", 2 -> "vB", 1 -> "vA2"))
        .distinctBy(_._1)
      p.keys should containInAnyOrder(Seq(1, 2))
    }
  }
```

the following works:
```
  it should "support distinctBy() on java types" in {
    runWithContext { sc =>
      val p = sc
        .parallelize(Seq(11, 12, 11, 21))
        .distinctBy(a => java.lang.Long.valueOf(a % 10))
      p should containInAnyOrder(Seq(21, 12))
    }
  }
```