### PR TITLE
Use Combine By Key for DistinctBy

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -382,7 +382,9 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    */
   // This is simplier than Distinct.withRepresentativeValueFn, and allows us to set Coders
   def distinctBy[U](f: T => U)(implicit toder: Coder[T], uoder: Coder[U]): SCollection[T] =
-    this.transform(me => me.groupBy(f).values.map(_.head))
+    this.transform { me =>
+      me.keyBy(f).groupBy(identity) { case (c, _) => c } { case (c, _) => c }.values
+    }
 
   /**
    * Return a new SCollection containing only the elements that satisfy a predicate.

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -383,7 +383,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   // This is simplier than Distinct.withRepresentativeValueFn, and allows us to set Coders
   def distinctBy[U](f: T => U)(implicit toder: Coder[T], uoder: Coder[U]): SCollection[T] =
     this.transform { me =>
-      me.keyBy(f).groupBy(identity) { case (c, _) => c } { case (c, _) => c }.values
+      me.keyBy(f).combineByKey(identity) { case (c, _) => c } { case (c, _) => c }.values
     }
 
   /**

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -250,15 +250,6 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
-  it should "support distinctBy() on Java types as representative values" in {
-    runWithContext { sc =>
-      val p = sc
-        .parallelize(Seq(1 -> "vA1", 2 -> "vB", 1 -> "vA2"))
-        .distinctBy(a => java.lang.Long.valueOf(a._1))
-      p.keys should containInAnyOrder(Seq(1, 2))
-    }
-  }
-
   it should "support filter()" in {
     runWithContext { sc =>
       val p = sc.parallelize(Seq(1, 2, 3, 4, 5)).filter(_ % 2 == 0)


### PR DESCRIPTION
Follows #1710 and addresses review comments.
`groupBy` is not necessary as the results are being ignored, and hence we can use `combineByKey`