### PR TITLE
Clarify error message when a job uses an input multiple times.

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -32,7 +32,7 @@ private[scio] class TestInput(val m: Map[String, Iterable[_]]) {
     val key = io.testId
     require(m.contains(key),
             s"Missing test input: $key, available: ${m.keys.mkString("[", ", ", "]")}")
-    require(!s.contains(key), s"Test input $key has already been used once.")
+    require(!s.contains(key), s"Test input $key has already been read from once.")
     s.add(key)
     m(key).asInstanceOf[Iterable[T]]
   }
@@ -52,9 +52,7 @@ private[scio] class TestOutput(val m: Map[String, SCollection[_] => Unit]) {
     val key = io.testId
     require(m.contains(key),
             s"Missing test output: $key, available: ${m.keys.mkString("[", ", ", "]")}")
-    require(!s.contains(key),
-            s"There already exists test output for $key, currently " +
-              s"registered outputs: ${s.mkString("[", ", ", "]")}")
+    require(!s.contains(key), s"Test output $key has already been written to once.")
     s.add(key)
     m(key)
   }

--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -32,9 +32,7 @@ private[scio] class TestInput(val m: Map[String, Iterable[_]]) {
     val key = io.testId
     require(m.contains(key),
             s"Missing test input: $key, available: ${m.keys.mkString("[", ", ", "]")}")
-    require(!s.contains(key),
-            s"There already exists test input for $key, currently " +
-              s"registered inputs: ${s.mkString("[", ", ", "]")}")
+    require(!s.contains(key), s"Test input $key has already been used once.")
     s.add(key)
     m(key).asInstanceOf[Iterable[T]]
   }

--- a/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
@@ -843,7 +843,7 @@ class JobTestTest extends PipelineSpec {
   }
 
   it should "fail on duplicate usages of inputs in the job itself" in {
-    val msg = "requirement failed: Test input TextIO(input) has already been used once."
+    val msg = "requirement failed: Test input TextIO(input) has already been read from once."
     the[IllegalArgumentException] thrownBy {
       JobTest[JobWithDuplicateInput.type]
         .args("--input=input")
@@ -853,8 +853,7 @@ class JobTestTest extends PipelineSpec {
   }
 
   it should "fail on duplicate outputs in the job itself" in {
-    val msg = "requirement failed: There already exists test output for TextIO(output), " +
-      "currently registered outputs: [TextIO(output)]"
+    val msg = "requirement failed: Test output TextIO(output) has already been written to once."
     the[IllegalArgumentException] thrownBy {
       JobTest[JobWithDuplicateOutput.type]
         .args("--output=output")

--- a/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
@@ -196,7 +196,7 @@ object JobWithoutClose {
   }
 }
 
-object JobWitDuplicateInput {
+object JobWithDuplicateInput {
   def main(cmdlineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdlineArgs)
     sc.textFile(args("input"))
@@ -205,7 +205,7 @@ object JobWitDuplicateInput {
   }
 }
 
-object JobWitDuplicateOutput {
+object JobWithDuplicateOutput {
   def main(cmdlineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdlineArgs)
     sc.parallelize(1 to 10)
@@ -842,11 +842,10 @@ class JobTestTest extends PipelineSpec {
     } should have message msg
   }
 
-  it should "fail on duplicate inputs in the job itself" in {
-    val msg = "requirement failed: There already exists test input for TextIO(input), " +
-      "currently registered inputs: [TextIO(input)]"
+  it should "fail on duplicate usages of inputs in the job itself" in {
+    val msg = "requirement failed: Test input TextIO(input) has already been used once."
     the[IllegalArgumentException] thrownBy {
-      JobTest[JobWitDuplicateInput.type]
+      JobTest[JobWithDuplicateInput.type]
         .args("--input=input")
         .input(TextIO("input"), Seq("does", "not", "matter"))
         .run()
@@ -857,7 +856,7 @@ class JobTestTest extends PipelineSpec {
     val msg = "requirement failed: There already exists test output for TextIO(output), " +
       "currently registered outputs: [TextIO(output)]"
     the[IllegalArgumentException] thrownBy {
-      JobTest[JobWitDuplicateOutput.type]
+      JobTest[JobWithDuplicateOutput.type]
         .args("--output=output")
         .output(TextIO("output"))(_ should containSingleValue("does not matter"))
         .run()


### PR DESCRIPTION
Given a Scio job that uses the same input multiple times:

```scala
object JobWithDuplicateInput {
  def main(cmdlineArgs: Array[String]): Unit = {
    val (sc, args) = ContextAndArgs(cmdlineArgs)
    sc.textFile(args("input"))
    sc.textFile(args("input"))
    sc.close()
  }
}
```

...Scio's `TestDataManager` currently throws an error in test that reads: `There already exists test input for...`, which implies that the test itself has multiples of the same test input. This is unclear as the issue is actually with the job itself, not the test.

This PR clarifies this error message by changing it to `s"Test input $key has already been used once."`, which is hopefully clearer for users that encounter this error.

(cc @ClaireMcGinty, @regadas)