### PR TITLE
Fix materialize and FileStorage.avroFile

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
@@ -54,6 +54,7 @@ private[scio] final class FileStorage(protected[scio] val path: String) {
       require(meta.isReadSeekEfficient)
       private val in =
         FileSystems.open(meta.resourceId()).asInstanceOf[SeekableByteChannel]
+      in.read(ByteBuffer.allocate(1))  // read a single byte to initialize the channel
       override def read(b: Array[Byte], off: Int, len: Int): Int =
         in.read(ByteBuffer.wrap(b, off, len))
       override def tell(): Long = in.position()


### PR DESCRIPTION
On scio 0.7.2, `SCollection.materialize()` appears to be broken (when using GCS path as tempDir). When calling `myScollection.materialize.waitForResult().value` I get following exception:

```
Exception in thread "main" java.io.IOException: Not an Avro data file
	at org.apache.avro.file.DataFileReader.openReader(DataFileReader.java:50)
	at com.spotify.scio.io.FileStorage$$anonfun$avroFile$1.apply(FileStorage.scala:74)
	at com.spotify.scio.io.FileStorage$$anonfun$avroFile$1.apply(FileStorage.scala:74)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:237)
	at scala.collection.Iterator.foreach(Iterator.scala:941)
	at scala.collection.Iterator.foreach$(Iterator.scala:941)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at scala.collection.TraversableLike.map(TraversableLike.scala:237)
	at scala.collection.TraversableLike.map$(TraversableLike.scala:230)
	at scala.collection.AbstractTraversable.map(Traversable.scala:108)
	at com.spotify.scio.io.FileStorage.avroFile(FileStorage.scala:74)
	at com.spotify.scio.io.MaterializeTap.value(Tap.scala:88)
	at com.spotify.data.common.SmokeScioJob$.main(SmokeScioJob.scala:83)
	at com.spotify.data.common.SmokeScioJob.main(SmokeScioJob.scala)
```

It looks like the behavior of com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadChannel has changed in newer versions. `org.apache.avro.file.DataFileReader#openReader(org.apache.avro.file.SeekableInput, org.apache.avro.io.DatumReader<D>)` uses `GoogleCloudStorageReadChannel.size()` which returns `-1` and creates this exception.

The workaround is to call `GoogleCloudStorageReadChannel.read()` to properly initialize the channel. It should not cause any other size effect, since `DataFileReader.openReader()` is calling `in.seek(0)` just after the assertion.

Beam SDK 2.10.0 / scio 0.7.4 seem to be using `GoogleCloudStorageReadChannel` from https://github.com/GoogleCloudPlatform/bigdata-interop/releases/tag/v1.9.13 . I found interesting that release notes say:

> This version has a [bug](https://github.com/GoogleCloudPlatform/bigdata-interop/issues/151) that leads to GCS list requests spike, please use [1.9.15 version](https://github.com/GoogleCloudPlatform/bigdata-interop/releases/tag/v1.9.15) instead. 