### PR TITLE
make BigQuery priority sysprop case-insensitive

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/BigQueryConfig.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/BigQueryConfig.scala
@@ -57,7 +57,7 @@ object BigQueryConfig {
     BigQuerySysProps.ReadTimeoutMs.valueOption.map(_.toInt)
 
   def priority: QueryPriority = {
-    val isCompilingOrTesting = Thread
+    lazy val isCompilingOrTesting = Thread
       .currentThread()
       .getStackTrace
       .exists { e =>

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/BigQueryConfig.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/BigQueryConfig.scala
@@ -52,6 +52,6 @@ object BigQueryConfig {
   def readTimeoutMs: Option[Int] =
     BigQuerySysProps.ReadTimeoutMs.valueOption.map(_.toInt)
 
-  def priority: Option[String] = BigQuerySysProps.Priority.valueOption
+  def priority: Option[String] = BigQuerySysProps.Priority.valueOption.map(_.toUpperCase)
 
 }

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
@@ -34,10 +34,7 @@ import scala.util.{Failure, Success, Try}
 private[client] object QueryOps {
   private val Logger = LoggerFactory.getLogger(this.getClass)
 
-  private def isInteractive: Boolean = BigQueryConfig.priority match {
-    case QueryPriority.INTERACTIVE => true
-    case QueryPriority.BATCH       => false
-  }
+  private def isInteractive: Boolean = BigQueryConfig.priority.equals(QueryPriority.INTERACTIVE)
 
   private val Priority = if (isInteractive) "INTERACTIVE" else "BATCH"
 

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
@@ -240,9 +240,9 @@ private[client] final class QueryOps(client: Client, tableService: TableOps, job
       client.underlying.jobs().insert(client.project, job).execute()
     }
     if (config.useLegacySql) {
-      Logger.info(s"Executing legacy query: `${config.sql}`")
+      Logger.info(s"Executing legacy query (${Priority}): `${config.sql}`")
     } else {
-      Logger.info(s"Executing standard SQL query: `${config.sql}`")
+      Logger.info(s"Executing standard SQL query (${Priority}): `${config.sql}`")
     }
     if (config.dryRun) {
       dryRunCache.getOrElseUpdate((config.sql, config.flattenResults, config.useLegacySql), run)


### PR DESCRIPTION
Prevent others from being confused like I was in #1718. Basically, just convert the sysprop value to upper case, which is checked everywhere else. I considered just making the check itself in `isInteractive` case insensitive, but then I thought that this problem could regress if anyone ever checks this elsewhere in new code.