### PR TITLE
Add sequence example support to scio-tensorflow

### DIFF
--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TFRecordIO.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TFRecordIO.scala
@@ -18,13 +18,12 @@
 package com.spotify.scio.tensorflow
 
 import com.spotify.scio.ScioContext
-import com.spotify.scio.io.{ScioIO, Tap, TapOf}
+import com.spotify.scio.io.{ScioIO, Tap, TapOf, TapT}
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
 import org.apache.beam.sdk.io.Compression
 import org.apache.beam.sdk.{io => beam}
-import org.tensorflow.example.Example
-
+import org.tensorflow.example.{Example, SequenceExample}
 import scala.concurrent.Future
 
 final case class TFRecordIO(path: String) extends ScioIO[Array[Byte]] {
@@ -67,7 +66,7 @@ final case class TFExampleIO(path: String) extends ScioIO[Example] {
   override type WriteP = TFExampleIO.WriteParam
   override val tapT = TapOf[Example]
 
-  override def testId: String = s"TFRecordIO($path)"
+  override def testId: String = s"TFExampleIO($path)"
 
   override def read(sc: ScioContext, params: ReadP): SCollection[Example] =
     TFRecordMethods.read(sc, path, params).map(Example.parseFrom)
@@ -86,6 +85,26 @@ object TFExampleIO {
   type WriteParam = TFRecordIO.WriteParam
   val ReadParam = TFRecordIO.ReadParam
   val WriteParam = TFRecordIO.WriteParam
+}
+
+final case class TFSequenceExampleIO(path: String) extends ScioIO[SequenceExample] {
+  override type ReadP = TFExampleIO.ReadParam
+  override type WriteP = TFExampleIO.WriteParam
+  override val tapT = TapOf[SequenceExample]
+
+  override def testId: String = s"TFSequenceExampleIO($path)"
+
+  override def read(sc: ScioContext, params: ReadP): SCollection[SequenceExample] =
+    TFRecordMethods.read(sc, path, params).map(SequenceExample.parseFrom)
+
+  override def write(data: SCollection[SequenceExample],
+                     params: WriteP): Future[Tap[SequenceExample]] = {
+    TFRecordMethods.write(data.map(_.toByteArray), path, params)
+    data.context.makeFuture(tap(TFExampleIO.ReadParam(params.compression)))
+  }
+
+  override def tap(params: ReadP): Tap[SequenceExample] =
+    TFRecordMethods.tap(params, path).map(SequenceExample.parseFrom)
 }
 
 private object TFRecordMethods {

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TFRecordIO.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TFRecordIO.scala
@@ -18,12 +18,13 @@
 package com.spotify.scio.tensorflow
 
 import com.spotify.scio.ScioContext
-import com.spotify.scio.io.{ScioIO, Tap, TapOf, TapT}
+import com.spotify.scio.io.{ScioIO, Tap, TapOf}
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
 import org.apache.beam.sdk.io.Compression
 import org.apache.beam.sdk.{io => beam}
 import org.tensorflow.example.{Example, SequenceExample}
+
 import scala.concurrent.Future
 
 final case class TFRecordIO(path: String) extends ScioIO[Array[Byte]] {

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TFScioContextFunctions.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TFScioContextFunctions.scala
@@ -29,8 +29,8 @@ class TFScioContextFunctions(val self: ScioContext) extends AnyVal {
 
   /**
    * Get an SCollection for a TensorFlow TFRecord file. Note that TFRecord files are not
-   * splittable. The recommended record encoding is `org.tensorflow.example.Example` protocol
-   * buffers (which contain `org.tensorflow.example.Features` as a field) serialized as bytes.
+   * splittable. The recommended record encoding is [[org.tensorflow.example.Example]] protocol
+   * buffers (which contain [[org.tensorflow.example.Features]] as a field) serialized as bytes.
    * @group input
    */
   def tfRecordFile(path: String,
@@ -38,8 +38,8 @@ class TFScioContextFunctions(val self: ScioContext) extends AnyVal {
     self.read(TFRecordIO(path))(TFRecordIO.ReadParam(compression))
 
   /**
-   * Get an SCollection of `org.tensorflow.example.Example` from a TensorFlow TFRecord file
-   * encoded as serialized `org.tensorflow.example.Example` protocol buffers.
+   * Get an SCollection of [[org.tensorflow.example.Example]] from a TensorFlow TFRecord file
+   * encoded as serialized [[org.tensorflow.example.Example]] protocol buffers.
    * @group input
    */
   def tfRecordExampleFile(path: String,
@@ -47,8 +47,8 @@ class TFScioContextFunctions(val self: ScioContext) extends AnyVal {
     self.read(TFExampleIO(path))(TFExampleIO.ReadParam(compression))
 
   /**
-   * Get an SCollection of `org.tensorflow.example.SequenceExample` from a TensorFlow TFRecord file
-   * encoded as serialized `org.tensorflow.example.SequenceExample` protocol buffers.
+   * Get an SCollection of [[org.tensorflow.example.SequenceExample]] from a TensorFlow TFRecord
+   * file encoded as serialized [[org.tensorflow.example.SequenceExample]] protocol buffers.
    * @group input
    */
   def tfRecordSequenceExampleFile(
@@ -57,9 +57,9 @@ class TFScioContextFunctions(val self: ScioContext) extends AnyVal {
     self.read(TFSequenceExampleIO(path))(TFExampleIO.ReadParam(compression))
 
   /**
-   * Get an SCollection of `org.tensorflow.example.Example` from a TensorFlow TFRecord file
-   * encoded as serialized `org.tensorflow.example.Example` protocol buffers, along with the
-   * remotely stored `org.tensorflow.metadata.v0.Schema` object available in a DistCache.
+   * Get an SCollection of [[org.tensorflow.example.Example]] from a TensorFlow TFRecord file
+   * encoded as serialized [[org.tensorflow.example.Example]] protocol buffers, along with the
+   * remotely stored [[org.tensorflow.metadata.v0.Schema]] object available in a DistCache.
    * @group input
    */
   def tfRecordExampleFileWithSchema(
@@ -75,9 +75,9 @@ class TFScioContextFunctions(val self: ScioContext) extends AnyVal {
   }
 
   /**
-   * Get an SCollection of `org.tensorflow.example.Example` from a TensorFlow TFRecord file
-   * encoded as serialized `org.tensorflow.example.Example` protocol buffers, along with the
-   * remotely stored `org.tensorflow.metadata.v0.Schema` object available in a DistCache.
+   * Get an SCollection of [[org.tensorflow.example.Example]] from a TensorFlow TFRecord file
+   * encoded as serialized [[org.tensorflow.example.Example]] protocol buffers, along with the
+   * remotely stored [[org.tensorflow.metadata.v0.Schema]] object available in a DistCache.
    * @group input
    */
   def tfRecordSequenceExampleFileWithSchema(path: String,

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowFunctions.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowFunctions.scala
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentMap
 import java.util.function.Function
 
 import com.google.common.collect.Maps
-
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.Tap
 import com.spotify.scio.transforms.DoFnWithResource
@@ -33,7 +32,6 @@ import com.spotify.zoltar.tf.{TensorFlowGraphModel, TensorFlowModel}
 import com.spotify.zoltar.{Model, Models}
 import com.twitter.algebird.{Aggregator, MultiAggregator}
 import javax.annotation.Nullable
-
 import org.apache.beam.sdk.io.{Compression, FileSystems}
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.transforms.DoFn.{ProcessElement, Teardown}
@@ -44,6 +42,7 @@ import org.tensorflow.example.{Example, SequenceExample}
 import org.tensorflow.example.Feature.KindCase
 import org.tensorflow.framework.ConfigProto
 import org.tensorflow.metadata.v0._
+
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.reflect.ClassTag

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowFunctions.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowFunctions.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentMap
 import java.util.function.Function
 
 import com.google.common.collect.Maps
+
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.Tap
 import com.spotify.scio.transforms.DoFnWithResource
@@ -32,17 +33,17 @@ import com.spotify.zoltar.tf.{TensorFlowGraphModel, TensorFlowModel}
 import com.spotify.zoltar.{Model, Models}
 import com.twitter.algebird.{Aggregator, MultiAggregator}
 import javax.annotation.Nullable
+
 import org.apache.beam.sdk.io.{Compression, FileSystems}
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.transforms.DoFn.{ProcessElement, Teardown}
 import org.apache.beam.sdk.util.MimeTypes
 import org.slf4j.LoggerFactory
 import org.tensorflow._
-import org.tensorflow.example.Example
+import org.tensorflow.example.{Example, SequenceExample}
 import org.tensorflow.example.Feature.KindCase
 import org.tensorflow.framework.ConfigProto
 import org.tensorflow.metadata.v0._
-
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.reflect.ClassTag
@@ -448,4 +449,24 @@ final class TFRecordSCollectionFunctions[T <: Array[Byte]](private val self: SCo
     self.asInstanceOf[SCollection[Array[Byte]]].write(TFRecordIO(path))(param)
   }
 
+}
+
+final class TFSequenceExampleSCollectionFunctions[T <: SequenceExample](
+  private val self: SCollection[T])
+    extends AnyVal {
+
+  /**
+   * Saves this SCollection of `org.tensorflow.example.SequenceExample` as a TensorFlow
+   * TFRecord file.
+   *
+   * @return
+   */
+  def saveAsTfSequenceExampleFile(
+    path: String,
+    suffix: String = TFExampleIO.WriteParam.DefaultSuffix,
+    compression: Compression = TFExampleIO.WriteParam.DefaultCompression,
+    numShards: Int = TFExampleIO.WriteParam.DefaultNumShards): Future[Tap[SequenceExample]] = {
+    val param = TFExampleIO.WriteParam(suffix, compression, numShards)
+    self.asInstanceOf[SCollection[SequenceExample]].write(TFSequenceExampleIO(path))(param)
+  }
 }

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowImplicits.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowImplicits.scala
@@ -20,8 +20,7 @@ package com.spotify.scio.tensorflow
 import com.spotify.scio.ScioContext
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.values.SCollection
-import org.tensorflow.example.Example
-
+import org.tensorflow.example.{Example, SequenceExample}
 import scala.reflect.ClassTag
 import scala.language.implicitConversions
 
@@ -65,6 +64,13 @@ trait TensorFlowImplicits {
     s: SCollection[Seq[T]]): SeqTFExampleSCollectionFunctions[T] =
     new SeqTFExampleSCollectionFunctions(s)
 
+  /**
+   * Implicit conversion from [[com.spotify.scio.values.SCollection SCollection]] to
+   * [[TFSequenceExampleSCollectionFunctions]].
+   */
+  implicit def makeSequenceTFExampleSCollectionFunctions[T <: SequenceExample](
+    s: SCollection[T]): TFSequenceExampleSCollectionFunctions[T] =
+    new TFSequenceExampleSCollectionFunctions(s)
 }
 
 /**

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowImplicits.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowImplicits.scala
@@ -21,6 +21,7 @@ import com.spotify.scio.ScioContext
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.values.SCollection
 import org.tensorflow.example.{Example, SequenceExample}
+
 import scala.reflect.ClassTag
 import scala.language.implicitConversions
 

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/MetadataSchemaTest.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/MetadataSchemaTest.scala
@@ -52,7 +52,17 @@ object MetadataSchemaTest {
     "dense_shape" -> longFeature(Seq(100))
   )
 
+  val e1FeatureList = Map[String, FeatureList](
+    "string_list" -> featureList(
+      Seq("one", "two", "eighty")
+        .map(v => Seq(ByteString.copyFromUtf8(v)))
+        .map(byteStrFeature)),
+    "long_list" -> featureList(Seq(1L, 2L, 3L).map(Seq(_)).map(longFeature)),
+    "floats_list" -> featureList(Seq(1.0f, 2.0f, 3.0f).map(Seq(_)).map(floatFeature))
+  )
+
   val examples = Seq(e1Features, e2Features).map(mkExample)
+  val sequenceExamples = Seq(e1Features, e2Features).map(m => mkSequenceExample(m, e1FeatureList))
 
   val expectedSchema = Schema
     .newBuilder()
@@ -131,10 +141,24 @@ object MetadataSchemaTest {
     fb.build
   }
 
+  private def featureList(fs: Seq[Feature]): FeatureList =
+    FeatureList
+      .newBuilder()
+      .addAllFeature(fs.asJava)
+      .build
+
   private def mkExample(features: Map[String, Feature]): Example =
     Example
       .newBuilder()
       .setFeatures(Features.newBuilder().putAllFeature(features.asJava))
+      .build
+
+  private def mkSequenceExample(context: Map[String, Feature],
+                                featureList: Map[String, FeatureList]): SequenceExample =
+    SequenceExample
+      .newBuilder()
+      .setContext(Features.newBuilder().putAllFeature(context.asJava))
+      .setFeatureLists(FeatureLists.newBuilder().putAllFeatureList(featureList.asJava))
       .build
 }
 

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFSequenceExampleIOTest.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFSequenceExampleIOTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.tensorflow
+
+import scala.collection.JavaConverters._
+
+import com.google.protobuf.ByteString
+import org.tensorflow.example._
+
+import com.spotify.scio.testing.ScioIOSpec
+
+object TFSequenceExampleIOTest {
+
+  case class Record(i: Int, ss: Seq[String])
+
+  def toSequenceExample(r: Record): SequenceExample = {
+    val context = Features
+      .newBuilder()
+      .putFeature("i",
+                  Feature
+                    .newBuilder()
+                    .setInt64List(Int64List.newBuilder().addValue(r.i).build())
+                    .build())
+      .build()
+    val fs = r.ss.map { s =>
+      Feature
+        .newBuilder()
+        .setBytesList(
+          BytesList
+            .newBuilder()
+            .addValue(ByteString.copyFromUtf8(s))
+            .build())
+        .build()
+    }
+    val featureLists = FeatureLists
+      .newBuilder()
+      .putFeatureList("ss", FeatureList.newBuilder().addAllFeature(fs.asJava).build())
+      .build()
+    SequenceExample
+      .newBuilder()
+      .setContext(context)
+      .setFeatureLists(featureLists)
+      .build()
+  }
+}
+
+class TFSequenceExampleIOTest extends ScioIOSpec {
+
+  import TFSequenceExampleIOTest._
+
+  "TFSequenceExampleIO" should "work" in {
+    val xs = (1 to 100).map(x => toSequenceExample(Record(x, Seq(x.toString, x.toString))))
+    testTap(xs)(_.saveAsTfSequenceExampleFile(_))(".tfrecords")
+    testJobTest(xs)(TFSequenceExampleIO(_))(_.tfRecordSequenceExampleFile(_))(
+      _.saveAsTfSequenceExampleFile(_)
+    )
+  }
+
+}

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFSequenceExampleIOTest.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFSequenceExampleIOTest.scala
@@ -17,12 +17,11 @@
 
 package com.spotify.scio.tensorflow
 
-import scala.collection.JavaConverters._
-
 import com.google.protobuf.ByteString
+import com.spotify.scio.testing.ScioIOSpec
 import org.tensorflow.example._
 
-import com.spotify.scio.testing.ScioIOSpec
+import scala.collection.JavaConverters._
 
 object TFSequenceExampleIOTest {
 

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFSequenceExampleTest.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFSequenceExampleTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.tensorflow
+
+import com.spotify.scio.ContextAndArgs
+import com.spotify.scio.testing.PipelineSpec
+
+object SequenceExamplesJob {
+  def main(argv: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(argv)
+    sc.parallelize(MetadataSchemaTest.sequenceExamples)
+      .saveAsTfSequenceExampleFile(args("output"))
+    sc.close()
+  }
+}
+
+class TFSequenceExampleTest extends PipelineSpec {
+
+  "SequenceExamplesJob" should "work" in {
+    JobTest[ExamplesJobV2.type]
+      .args("--output=out")
+      .output(TFExampleIO("out"))(_ should haveSize(2))
+      .run()
+  }
+}


### PR DESCRIPTION
Adds support for 9SequenceExample](https://github.com/tensorflow/tensorflow/blob/r1.13/tensorflow/core/example/example.proto) to scio tensorflow.
Addresses https://github.com/spotify/scio/issues/1659.