### PR TITLE
Make BQ annotations serializable

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/BigQueryTag.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/BigQueryTag.scala
@@ -17,4 +17,4 @@
 
 package com.spotify.scio.bigquery.types
 
-class BigQueryTag extends scala.annotation.StaticAnnotation
+class BigQueryTag extends scala.annotation.StaticAnnotation with Serializable

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -33,7 +33,7 @@ package object types {
    * }}}
    */
   // scalastyle:off class.name
-  final class description(value: String) extends StaticAnnotation
+  final class description(value: String) extends StaticAnnotation with Serializable
   // scalastyle:on class.name
 
 }

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/SchemaProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/SchemaProviderTest.scala
@@ -18,6 +18,7 @@
 package com.spotify.scio.bigquery.types
 
 import com.spotify.scio.bigquery.BigQueryUtil.parseSchema
+import org.apache.beam.sdk.util.SerializableUtils
 import org.scalatest.{FlatSpec, Matchers}
 
 class SchemaProviderTest extends FlatSpec with Matchers {
@@ -78,10 +79,6 @@ class SchemaProviderTest extends FlatSpec with Matchers {
     SchemaProvider.schemaOf[RepeatedNested] shouldBe parseSchema(recordFields("REPEATED"))
   }
 
-  case class User(@description("user name") name: String, @description("user age") age: Int)
-  case class Account(@description("account user") user: User,
-                     @description("in USD") balance: Double)
-
   val userFields =
     s"""
        |"fields": [
@@ -104,6 +101,11 @@ class SchemaProviderTest extends FlatSpec with Matchers {
   it should "support description" in {
     SchemaProvider.schemaOf[User] shouldBe parseSchema(userSchema)
     SchemaProvider.schemaOf[Account] shouldBe parseSchema(accountSchema)
+  }
+
+  it should "have serializable descriptions" in {
+    SerializableUtils.ensureSerializable(User("Michael Jackson", 13))
+    // Micheal Jackson started his solo career in 1971 at the age of 13.
   }
 
 }

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/SchemaProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/SchemaProviderTest.scala
@@ -104,8 +104,8 @@ class SchemaProviderTest extends FlatSpec with Matchers {
   }
 
   it should "have serializable descriptions" in {
-    SerializableUtils.ensureSerializable(User("Michael Jackson", 13))
-    // Micheal Jackson started his solo career in 1971 at the age of 13.
+    // The description annotation should be serializable.
+    SerializableUtils.ensureSerializable(new description(value = "this a field description"))
   }
 
 }

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/Schemas.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/Schemas.scala
@@ -71,4 +71,8 @@ object Schemas {
   case class RepeatedNested(required: List[Required],
                             optional: List[Optional],
                             repeated: List[Repeated])
+
+  case class User(@description("user name") name: String, @description("user age") age: Int)
+  case class Account(@description("account user") user: User,
+                     @description("in USD") balance: Double)
 }

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
@@ -82,6 +82,10 @@ class TypeProviderTest extends FlatSpec with Matchers {
     SerializableUtils.ensureSerializable(S1(1))
   }
 
+  "BigQueryTag" should "be a serializable annotation" in {
+    SerializableUtils.ensureSerializable[BigQueryTag](new BigQueryTag())
+  }
+
   @BigQueryType.fromSchema("""{"fields": [{"name": "f1", "type": "INTEGER"}]}""")
   class MissingMode
 

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
@@ -18,6 +18,7 @@
 package com.spotify.scio.bigquery.types
 
 import com.google.api.services.bigquery.model.TableRow
+import org.apache.beam.sdk.util.SerializableUtils
 import org.joda.time.Instant
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 
@@ -28,12 +29,6 @@ import scala.reflect.runtime.universe._
 object TypeProviderTest {
   @BigQueryType.toTable
   case class RefinedClass(a1: Int)
-}
-
-// TODO: mock BigQueryClient for fromTable and fromQuery
-class TypeProviderTest extends FlatSpec with Matchers {
-
-  val NOW = Instant.now()
 
   @BigQueryType.fromSchema(
     """{"fields": [{"mode": "REQUIRED", "name": "f1", "type": "INTEGER"}]}""")
@@ -55,6 +50,15 @@ class TypeProviderTest extends FlatSpec with Matchers {
   @description("Table S4")
   class S4
 
+}
+
+// TODO: mock BigQueryClient for fromTable and fromQuery
+class TypeProviderTest extends FlatSpec with Matchers {
+
+  val NOW = Instant.now()
+
+  import TypeProviderTest._
+
   "BigQueryType.fromSchema" should "support string literal" in {
     val r = S1(1L)
     r.f1 shouldBe 1L
@@ -72,6 +76,10 @@ class TypeProviderTest extends FlatSpec with Matchers {
 
   it should "support table description" in {
     S4.tableDescription shouldBe "Table S4"
+  }
+
+  it should "be serializable" in {
+    SerializableUtils.ensureSerializable(S1(1))
   }
 
   @BigQueryType.fromSchema("""{"fields": [{"name": "f1", "type": "INTEGER"}]}""")


### PR DESCRIPTION
I was trying to write Scollections to BQ, and for some generic derivations where a nested type contained a class with a big query annotation, I was finding that the annotations are not serializable. I was thinking of making them seralizable because I think that is an easy fix and hopefully wont break anything.

My use case is something like this:
```
//.groupBy(r => r.userId) - usual Scio code.
.bqTrace("gcpproj.dataset.error_records", predicate = _.size > 1) // Trace errors to BQ.
//.flatMap(...) // usual scio code.
```

now my SCollection is of type `[(String, Iterable[CaseClassWithBQAnnotation])]`