### PR TITLE
Separate Implicits for SCollections

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -49,15 +49,7 @@ import scala.concurrent._
 import scala.reflect.ClassTag
 
 /** Convenience functions for creating SCollections. */
-object SCollection {
-
-  /**
-   * Create a union of multiple [[SCollection]] instances.
-   * Will throw an exception if the provided iterable is empty.
-   * For a version that accepts empty iterables, see [[ScioContext#unionAll]].
-   */
-  def unionAll[T: Coder](scs: Iterable[SCollection[T]]): SCollection[T] =
-    scs.head.context.unionAll(scs)
+trait SCollectionImplicits {
 
   import scala.language.implicitConversions
 
@@ -83,8 +75,19 @@ object SCollection {
     s: SCollection[(K, V)]): PairSkewedSCollectionFunctions[K, V] =
     new PairSkewedSCollectionFunctions(s)
 
-  private[scio] final case class State(postCoGroup: Boolean = false)
+}
 
+object SCollection extends SCollectionImplicits {
+
+  /**
+   * Create a union of multiple [[SCollection]] instances.
+   * Will throw an exception if the provided iterable is empty.
+   * For a version that accepts empty iterables, see [[ScioContext#unionAll]].
+   */
+  def unionAll[T: Coder](scs: Iterable[SCollection[T]]): SCollection[T] =
+    scs.head.context.unionAll(scs)
+
+  private[scio] final case class State(postCoGroup: Boolean = false)
 }
 
 // scalastyle:off number.of.methods


### PR DESCRIPTION
I was trying to have an implicit on SCollection which would have an overloaded method already defined in SCollection. I was thinking about this in #1748 

I want have an implicit with a overloaded `join` on SCollection where the join also takes another argument defining counters on unmatched inputs.

```
def join[W](that: SCollection: [(K, W)], unMatchedCounterName = "") {
   // increment counter when a key in this doesn't match with a key in that.
}
```

With this change I would be able to add my implicits with a lower priority than the `makePairSCollectionFunctions` implicit.