### PR TITLE
Fix AvroIO type bounds

### DIFF
--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
@@ -27,7 +27,7 @@ import com.spotify.scio.{avro, ScioContext}
 import org.apache.avro.Schema
 import org.apache.avro.file.CodecFactory
 import org.apache.avro.generic.GenericRecord
-import org.apache.avro.specific.SpecificRecordBase
+import org.apache.avro.specific.SpecificRecord
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.transforms.{DoFn, SerializableFunction}
 import org.apache.beam.sdk.{io => beam}
@@ -149,7 +149,7 @@ sealed trait AvroIO[T] extends ScioIO[T] {
 
 }
 
-final case class SpecificRecordIO[T <: SpecificRecordBase: ClassTag: Coder](path: String)
+final case class SpecificRecordIO[T <: SpecificRecord: ClassTag: Coder](path: String)
     extends AvroIO[T] {
   override type ReadP = Unit
   override type WriteP = AvroIO.WriteParam
@@ -157,7 +157,7 @@ final case class SpecificRecordIO[T <: SpecificRecordBase: ClassTag: Coder](path
   override def testId: String = s"AvroIO($path)"
 
   /**
-   * Get an SCollection of [[org.apache.avro.specific.SpecificRecordBase SpecificRecordBase]]
+   * Get an SCollection of [[org.apache.avro.specific.SpecificRecord SpecificRecord]]
    * from an Avro file.
    */
   override def read(sc: ScioContext, params: ReadP): SCollection[T] = {
@@ -167,7 +167,7 @@ final case class SpecificRecordIO[T <: SpecificRecordBase: ClassTag: Coder](path
   }
 
   /**
-   * Save this SCollection of [[org.apache.avro.specific.SpecificRecordBase SpecificRecordBase]] as
+   * Save this SCollection of [[org.apache.avro.specific.SpecificRecord SpecificRecord]] as
    * an Avro file.
    */
   override def write(data: SCollection[T], params: WriteP): Tap[T] = {

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/SCollectionSyntax.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/SCollectionSyntax.scala
@@ -25,7 +25,7 @@ import com.spotify.scio.io.ClosedTap
 import com.spotify.scio.values._
 import org.apache.avro.Schema
 import org.apache.avro.file.CodecFactory
-import org.apache.avro.specific.SpecificRecordBase
+import org.apache.avro.specific.SpecificRecord
 
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
@@ -35,7 +35,7 @@ final class GenericRecordSCollectionOps[T](private val self: SCollection[T]) ext
 
   /**
    * Save this SCollection of type
-   * [[org.apache.avro.specific.SpecificRecordBase SpecificRecordBase]] as an Avro file.
+   * [[org.apache.avro.specific.SpecificRecord SpecificRecord]] as an Avro file.
    */
   // scalastyle:off parameter.number
   def saveAsAvroFile(path: String,
@@ -67,12 +67,12 @@ final class GenericRecordSCollectionOps[T](private val self: SCollection[T]) ext
   }
 }
 
-final class SpecificRecordSCollectionOps[T <: SpecificRecordBase](private val self: SCollection[T])
+final class SpecificRecordSCollectionOps[T <: SpecificRecord](private val self: SCollection[T])
     extends AnyVal {
 
   /**
    * Save this SCollection of type
-   * [[org.apache.avro.specific.SpecificRecordBase SpecificRecordBase]] as an Avro file.
+   * [[org.apache.avro.specific.SpecificRecord SpecificRecord]] as an Avro file.
    *
    */
   def saveAsAvroFile(path: String,
@@ -136,7 +136,7 @@ trait SCollectionSyntax {
   implicit def avroGenericRecordSCollectionOps[T](
     c: SCollection[T]): GenericRecordSCollectionOps[T] = new GenericRecordSCollectionOps[T](c)
 
-  implicit def avroSpecificRecordSCollectionOps[T <: SpecificRecordBase](
+  implicit def avroSpecificRecordSCollectionOps[T <: SpecificRecord](
     c: SCollection[T]): SpecificRecordSCollectionOps[T] = new SpecificRecordSCollectionOps[T](c)
 
   implicit def avroTypedAvroSCollectionOps[T <: HasAvroAnnotation](

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
@@ -24,7 +24,7 @@ import com.spotify.scio.avro.types.AvroType.HasAvroAnnotation
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.values._
 import org.apache.avro.Schema
-import org.apache.avro.specific.SpecificRecordBase
+import org.apache.avro.specific.SpecificRecord
 
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
@@ -50,10 +50,10 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
     self.read(GenericRecordIO[T](path, schema))
 
   /**
-   * Get an SCollection of type [[org.apache.avro.specific.SpecificRecordBase SpecificRecordBase]]
+   * Get an SCollection of type [[org.apache.avro.specific.SpecificRecord SpecificRecord]]
    * for an Avro file.
    */
-  def avroFile[T <: SpecificRecordBase: ClassTag: Coder](path: String): SCollection[T] =
+  def avroFile[T <: SpecificRecord: ClassTag: Coder](path: String): SCollection[T] =
     self.read(SpecificRecordIO[T](path))
 
   /**

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/taps.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/taps.scala
@@ -26,7 +26,7 @@ import com.spotify.scio.values._
 import com.twitter.chill.Externalizer
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
-import org.apache.avro.specific.SpecificRecordBase
+import org.apache.avro.specific.SpecificRecord
 
 import scala.concurrent.Future
 import scala.reflect.ClassTag
@@ -47,9 +47,9 @@ final case class GenericRecordTap[T: ClassTag: Coder](path: String,
 }
 
 /**
- * Tap for [[org.apache.avro.specific.SpecificRecordBase SpecificRecordBase]] Avro files.
+ * Tap for [[org.apache.avro.specific.SpecificRecord SpecificRecord]] Avro files.
  */
-final case class SpecificRecordTap[T <: SpecificRecordBase: ClassTag: Coder](path: String)
+final case class SpecificRecordTap[T <: SpecificRecord: ClassTag: Coder](path: String)
     extends Tap[T] {
 
   override def value: Iterator[T] = FileStorage(path).avroFile[T]()
@@ -88,9 +88,9 @@ final case class AvroTaps(self: Taps) {
     self.mkTap(s"Avro: $path", () => self.isPathDone(path), () => GenericRecordTap[T](path, schema))
 
   /** Get a `Future[Tap[T]]` for
-   * [[org.apache.avro.specific.SpecificRecordBase SpecificRecordBase]] Avro file.
+   * [[org.apache.avro.specific.SpecificRecord SpecificRecord]] Avro file.
    */
-  def avroFile[T <: SpecificRecordBase: ClassTag: Coder](path: String): Future[Tap[T]] =
+  def avroFile[T <: SpecificRecord: ClassTag: Coder](path: String): Future[Tap[T]] =
     self.mkTap(s"Avro: $path", () => self.isPathDone(path), () => SpecificRecordTap[T](path))
 
   /** Get a `Future[Tap[T]]` for typed Avro source. */


### PR DESCRIPTION
`0.7.4` accidentally introduced a breaking change because of stricter than necessary type bounds on `AvroIO`. This hsould fix it.