### PR TITLE
BeamSQL string interpolation 

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
@@ -45,6 +45,8 @@ final case class Record[T] private (
 ) extends Schema[T] {
   type Repr = Row
 
+  override def toString: String =
+    s"Record(${schemas.toList}, $construct, $destruct)"
 }
 
 object Record {
@@ -113,10 +115,10 @@ private[scio] object SchemaTypes {
   def equal(s1: BSchema.FieldType, s2: BSchema.FieldType): Boolean =
     (s1.getTypeName == s2.getTypeName) && (s1.getTypeName match {
       case BSchema.TypeName.ROW =>
-        s1.getRowSchema.getFields.asScala
-          .map(_.getType)
-          .zip(s2.getRowSchema.getFields.asScala.map(_.getType))
-          .forall { case (l, r) => equal(l, r) }
+        val s1Types = s1.getRowSchema.getFields.asScala.map(_.getType)
+        val s2Types = s2.getRowSchema.getFields.asScala.map(_.getType)
+        s1Types.length == s2Types.length &&
+        s1Types.zip(s2Types).forall { case (l, r) => equal(l, r) }
       case BSchema.TypeName.ARRAY =>
         equal(s1.getCollectionElementType, s2.getCollectionElementType)
       case BSchema.TypeName.MAP =>

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
@@ -112,13 +112,17 @@ private[scio] case class ScalarWrapper[T](value: T) extends AnyVal
 
 private[scio] object SchemaTypes {
 
+  private[this] def compareRows(s1: BSchema.FieldType, s2: BSchema.FieldType): Boolean = {
+    val s1Types = s1.getRowSchema.getFields.asScala.map(_.getType)
+    val s2Types = s2.getRowSchema.getFields.asScala.map(_.getType)
+    (s1Types.length == s2Types.length) &&
+    s1Types.zip(s2Types).forall { case (l, r) => equal(l, r) }
+  }
+
   def equal(s1: BSchema.FieldType, s2: BSchema.FieldType): Boolean =
     (s1.getTypeName == s2.getTypeName) && (s1.getTypeName match {
       case BSchema.TypeName.ROW =>
-        val s1Types = s1.getRowSchema.getFields.asScala.map(_.getType)
-        val s2Types = s2.getRowSchema.getFields.asScala.map(_.getType)
-        s1Types.length == s2Types.length &&
-        s1Types.zip(s2Types).forall { case (l, r) => equal(l, r) }
+        compareRows(s1, s2)
       case BSchema.TypeName.ARRAY =>
         equal(s1.getCollectionElementType, s2.getCollectionElementType)
       case BSchema.TypeName.MAP =>

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/SchemaMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/SchemaMaterializer.scala
@@ -106,6 +106,7 @@ object SchemaMaterializer {
     val vs = v.getValues
     val values = new Array[Any](size)
     var i = 0
+    assert(size == record.schemas.length, s"Record $record and value $v sizes do not match")
     while (i < size) {
       val (_, schema) = record.schemas(i)
       val v = vs.get(i)

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
@@ -41,7 +41,7 @@ object Sql {
   private[sql] val BeamProviderName = "beam"
   private[sql] val SCollectionTypeName = "SCOLLECTION"
 
-  def defaultTag[A]: TupleTag[A] = new TupleTag[A](SCollectionTypeName)
+  private[scio] def defaultTag[A]: TupleTag[A] = new TupleTag[A](SCollectionTypeName)
 
   def from[A: Schema](sc: SCollection[A]): SqlSCollection[A] = new SqlSCollection(sc)
 

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
@@ -41,7 +41,7 @@ object Sql {
   private[sql] val BeamProviderName = "beam"
   val SCollectionTypeName = "SCOLLECTION"
 
-  def defaultTag[A] = new TupleTag[A](SCollectionTypeName)
+  def defaultTag[A]: TupleTag[A] = new TupleTag[A](SCollectionTypeName)
 
   def from[A: Schema](sc: SCollection[A]): SqlSCollection[A] = new SqlSCollection(sc)
 

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
@@ -312,8 +312,11 @@ object QueryMacros {
     import c.universe._
     val wtt = weakTypeOf[A].dealias
     val isVal = wtt <:< typeOf[AnyVal]
+    val isSealed =
+      if (wtt.typeSymbol.isClass) wtt.typeSymbol.asClass.isSealed
+      else false
     val isAbstract = wtt.typeSymbol.asType.isAbstract
-    if (!isVal && isAbstract)
+    if (!isVal && isAbstract && !isSealed)
       c.abort(c.enclosingPosition, s"$wtt is an abstract type, expected a concrete type.")
     else
       ()

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
@@ -39,7 +39,7 @@ import scala.collection.JavaConverters._
 object Sql {
 
   private[sql] val BeamProviderName = "beam"
-  private[sql] val SCollectionTypeName = "SCOLLECTION"
+  val SCollectionTypeName = "SCOLLECTION"
 
   def from[A: Schema](sc: SCollection[A]): SqlSCollection[A] = new SqlSCollection(sc)
 
@@ -155,6 +155,7 @@ object Queries {
    */
   def typecheck[A: Schema, B: Schema](q: Query[A, B]): Either[String, Query[A, B]] = {
     val schema: BSchema = SchemaMaterializer.fieldType(Schema[A]).getRowSchema
+    // TODO: add null check on schema. If A is a scalar (Int, String,...) schema will be null
     val expectedSchema: BSchema =
       Schema[B] match {
         case s: Record[B] =>

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
@@ -39,7 +39,7 @@ import scala.collection.JavaConverters._
 object Sql {
 
   private[sql] val BeamProviderName = "beam"
-  val SCollectionTypeName = "SCOLLECTION"
+  private[sql] val SCollectionTypeName = "SCOLLECTION"
 
   def defaultTag[A]: TupleTag[A] = new TupleTag[A](SCollectionTypeName)
 
@@ -313,13 +313,15 @@ object QueryMacros {
     val wtt = weakTypeOf[A].dealias
     val isVal = wtt <:< typeOf[AnyVal]
     val isSealed =
-      if (wtt.typeSymbol.isClass) wtt.typeSymbol.asClass.isSealed
-      else false
+      if (wtt.typeSymbol.isClass) {
+        wtt.typeSymbol.asClass.isSealed
+      } else false
     val isAbstract = wtt.typeSymbol.asType.isAbstract
-    if (!isVal && isAbstract && !isSealed)
+    if (!isVal && isAbstract && !isSealed) {
       c.abort(c.enclosingPosition, s"$wtt is an abstract type, expected a concrete type.")
-    else
+    } else {
       ()
+    }
   }
 
   def typedImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: blackbox.Context)(query: c.Expr[String])(

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Sql.scala
@@ -136,9 +136,11 @@ final class SqlSCollection2[A: Schema, B: Schema](a: SCollection[A], b: SCollect
 
 }
 
-final case class Query[A, B](query: String,
-                             tag: TupleTag[A] = Sql.defaultTag[A],
-                             udfs: List[Udf] = Nil)
+final case class Query[A, B](
+  query: String,
+  tag: TupleTag[A] = Sql.defaultTag[A],
+  udfs: List[Udf] = Nil
+)
 
 final case class Query2[A, B, R](
   query: String,
@@ -252,10 +254,12 @@ object Queries {
       }
       .mkString("\n")
 
-  private[this] def typecheck(query: String,
-                              inferredSchemas: List[(String, BSchema)],
-                              expectedSchema: BSchema,
-                              udfs: List[Udf]): Either[String, String] = {
+  private[this] def typecheck(
+    query: String,
+    inferredSchemas: List[(String, BSchema)],
+    expectedSchema: BSchema,
+    udfs: List[Udf]
+  ): Either[String, String] = {
     ScioUtil
       .toEither(schema(query, inferredSchemas, udfs))
       .left
@@ -326,9 +330,9 @@ object QueryMacros {
     }
   }
 
-  def typedImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: blackbox.Context)(query: c.Expr[String])(
-    iSchema: c.Expr[Schema[A]],
-    oSchema: c.Expr[Schema[B]]): c.Expr[Query[A, B]] = {
+  def typedImpl[A: c.WeakTypeTag, B: c.WeakTypeTag](c: blackbox.Context)(
+    query: c.Expr[String]
+  )(iSchema: c.Expr[Schema[A]], oSchema: c.Expr[Schema[B]]): c.Expr[Query[A, B]] = {
     import c.universe._
 
     assertConcrete[A](c)
@@ -357,12 +361,13 @@ object QueryMacros {
       )
   }
 
-  def typed2Impl[A: c.WeakTypeTag, B: c.WeakTypeTag, R: c.WeakTypeTag](c: blackbox.Context)(
-    query: c.Expr[String],
-    aTag: c.Expr[TupleTag[A]],
-    bTag: c.Expr[TupleTag[B]])(aSchema: c.Expr[Schema[A]],
-                               bSchema: c.Expr[Schema[B]],
-                               oSchema: c.Expr[Schema[R]]): c.Expr[Query2[A, B, R]] = {
+  def typed2Impl[A: c.WeakTypeTag, B: c.WeakTypeTag, R: c.WeakTypeTag](
+    c: blackbox.Context
+  )(query: c.Expr[String], aTag: c.Expr[TupleTag[A]], bTag: c.Expr[TupleTag[B]])(
+    aSchema: c.Expr[Schema[A]],
+    bSchema: c.Expr[Schema[B]],
+    oSchema: c.Expr[Schema[R]]
+  ): c.Expr[Query2[A, B, R]] = {
 
     import c.universe._
 

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Udf.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Udf.scala
@@ -20,7 +20,7 @@ import org.apache.beam.sdk.extensions.sql.BeamSqlUdf
 import org.apache.beam.sdk.transforms.Combine.CombineFn
 import org.apache.beam.sdk.transforms.SerializableFunction
 
-sealed trait Udf
+sealed trait Udf { val fnName: String }
 
 private final case class UdfFromSerializableFn[I, O](
   fnName: String,

--- a/scio-core/src/main/scala/com/spotify/scio/sql/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/package.scala
@@ -186,7 +186,7 @@ package sql {
       (sa, sb, sc, scha, schab, schac)
     }
 
-    def tagFor(t: Type, lbl: String) = {
+    def tagFor(t: Type, lbl: String): Tree = {
       q"""
         new _root_.org.apache.beam.sdk.values.TupleTag[$t]($lbl)
       """

--- a/scio-core/src/main/scala/com/spotify/scio/sql/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/package.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio
+
+import com.spotify.scio.values.SCollection
+import com.spotify.scio.schemas.Schema
+import org.apache.beam.sdk.values.TupleTag
+
+import scala.language.implicitConversions
+
+package object sql {
+
+  sealed trait SQLBuilder {
+    def as[B: Schema]: SCollection[B]
+  }
+
+  sealed trait SqlParam
+  final case class SCollectionRef[A: Schema](coll: SCollection[A]) extends SqlParam {
+    type _A = A
+    val schema = Schema[A]
+  }
+  final case class UdfRef(udf: Udf) extends SqlParam
+
+  implicit def toUdfRef(udf: Udf): SqlParam = new UdfRef(udf)
+  implicit def toSCollectionRef[A: Schema](coll: SCollection[A]): SqlParam =
+    new SCollectionRef[A](coll)
+
+  final implicit class SqlInterpolator(val sc: StringContext) extends AnyVal {
+
+    // TODO: typed SQL ?
+    // TODO: at least 1 params is a SCollectionRef
+    def sql(p0: SqlParam, ps: SqlParam*): SQLBuilder = {
+      val params = p0 :: ps.toList
+      val tags =
+        params.zipWithIndex.collect {
+          case (ref @ SCollectionRef(scoll), i) =>
+            (scoll.name, (ref, new TupleTag[ref._A](s"SCOLLECTION_$i")))
+        }.toMap
+
+      val udfs =
+        params.collect {
+          case UdfRef(u) => u
+        }
+
+      val strings = sc.parts.iterator
+      val expressions = params.iterator
+      var buf = new StringBuffer(strings.next)
+      while (strings.hasNext) {
+        val param = expressions.next
+        val p =
+          param match {
+            case SCollectionRef(scoll) =>
+              tags(scoll.name)._2.getId
+            case UdfRef(udf) =>
+              udf.fnName
+          }
+        buf.append(p)
+        buf.append(strings.next)
+      }
+      val q = buf.toString
+
+      tags.toList match {
+        case (name, (ref, tag)) :: Nil =>
+          new SQLBuilder {
+            def as[B: Schema] =
+              Sql
+                .from(ref.coll)(ref.schema)
+                .queryAs(new Query[ref._A, B](q, tag, udfs))
+          }
+        case (name0, (ref0, tag0)) :: (name1, (ref1, tag1)) :: Nil =>
+          new SQLBuilder {
+            def as[B: Schema] =
+              Sql
+                .from(ref0.coll, ref1.coll)(ref0.schema, ref1.schema)
+                .queryAs(new Query2[ref0._A, ref1._A, B](q, tag0, tag1, udfs))
+          }
+        case _ =>
+          throw new IllegalArgumentException("WUUUUTTT????")
+      }
+    }
+
+    // def sql[A: Schema](coll: SCollection[A]): SQLBuilder = {
+    //   val strings = sc.parts.iterator
+    //   val name = Sql.SCollectionTypeName
+    //   var buf = new StringBuffer(strings.next)
+    //   while (strings.hasNext) {
+    //     buf.append(name)
+    //     buf.append(strings.next)
+    //   }
+
+    //   new SQLBuilder {
+    //     val q = buf.toString
+    //     val tag = new TupleTag[A](name)
+    //     def as[B: Schema] = Sql.from(coll).queryAs(new Query[A, B](q, tag))
+    //   }
+    // }
+  }
+
+}

--- a/scio-core/src/main/scala/com/spotify/scio/sql/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/package.scala
@@ -68,7 +68,7 @@ package object sql {
   implicit def toSCollectionRef[A: Schema](coll: SCollection[A]): SqlParam =
     new SCollectionRef[A](coll)
 
-  final implicit class SqlInterpolator(val sc: StringContext) extends AnyVal {
+  final implicit class SqlInterpolator(private val sc: StringContext) extends AnyVal {
 
     private def paramToString(tags: Map[String, (SCollectionRef[_], TupleTag[_])])(
       p: SqlParam): String =

--- a/scio-core/src/main/scala/com/spotify/scio/sql/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/package.scala
@@ -214,6 +214,7 @@ package sql {
       // Yo Dawg i herd you like macros...
       //
       // The following tree generates an anonymous class to lazily expand tsqlImpl.
+      //
       // It basically acts as curryfication of the macro,
       // where the interpolated String and it's parameters are partially applied
       // while the expected output type (and therefore the expected data schema) stays unapplied.
@@ -298,8 +299,7 @@ package sql {
 
       val scs: List[(Tree, Type)] =
         ss.map { p =>
-          val tpe = p.actualType
-          val a = tpe.typeArgs.head
+          val a = p.actualType.typeArgs.head
           (p.tree, a)
         }.toList
 
@@ -319,7 +319,7 @@ package sql {
           val (implA, implB, sIn, sOut) =
             inferImplicitSchemas[B](t0)
 
-          // Yo Dawg i herd you like macros...
+          // ... so I put a macro in your macro so you can compile while you compile
           val q = q"_root_.com.spotify.scio.sql.Queries.typed[$t0, $wttB]($sql)"
 
           c.Expr[SCollection[B]](q"""

--- a/scio-macros/src/main/scala/com/spotify/scio/IsJava.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/IsJava.scala
@@ -81,7 +81,8 @@ object IsJavaBean {
       checkGetterAndSetters(c)(wtt)
       q"null: _root_.com.spotify.scio.IsJavaBean[$wtt]"
     } else {
-      c.abort(c.enclosingPosition, s"$wtt is not a Java class")
+      c.abort(c.enclosingPosition,
+              s"$wtt is not a Java class. (isJava: ${sym.isJava}, isClass: ${sym.isClass})")
     }
   }
 }

--- a/scio-macros/src/main/scala/com/spotify/scio/IsJava.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/IsJava.scala
@@ -81,8 +81,10 @@ object IsJavaBean {
       checkGetterAndSetters(c)(wtt)
       q"null: _root_.com.spotify.scio.IsJavaBean[$wtt]"
     } else {
-      c.abort(c.enclosingPosition,
-              s"$wtt is not a Java class. (isJava: ${sym.isJava}, isClass: ${sym.isClass})")
+      c.abort(
+        c.enclosingPosition,
+        s"$wtt is not a Java class. (isJava: ${sym.isJava}, isClass: ${sym.isClass})"
+      )
     }
   }
 }

--- a/scio-test/src/test/java/com/spotify/scio/sql/j/Customer.java
+++ b/scio-test/src/test/java/com/spotify/scio/sql/j/Customer.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spotify.scio.sql.j;
+
+import java.io.Serializable;
+import java.util.Objects;
+import org.apache.beam.sdk.schemas.JavaBeanSchema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+
+/** Describes a customer. */
+@DefaultSchema(JavaBeanSchema.class)
+public class Customer implements Serializable {
+  private String name;
+  private int id;
+  private String countryOfResidence;
+
+  public Customer(int id, String name, String countryOfResidence) {
+    this.id = id;
+    this.name = name;
+    this.countryOfResidence = countryOfResidence;
+  }
+
+  public Customer() {}
+
+  public String getName() {
+    return name;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public String getCountryOfResidence() {
+    return countryOfResidence;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public void setCountryOfResidence(String countryOfResidence) {
+    this.countryOfResidence = countryOfResidence;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Customer customer = (Customer) o;
+    return id == customer.id
+        && Objects.equals(name, customer.name)
+        && Objects.equals(countryOfResidence, customer.countryOfResidence);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, id, countryOfResidence);
+  }
+}

--- a/scio-test/src/test/java/com/spotify/scio/sql/j/Order.java
+++ b/scio-test/src/test/java/com/spotify/scio/sql/j/Order.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spotify.scio.sql.j;
+
+import java.io.Serializable;
+import java.util.Objects;
+import org.apache.beam.sdk.schemas.JavaBeanSchema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+
+/** Describes an order. */
+@DefaultSchema(JavaBeanSchema.class)
+public class Order implements Serializable {
+  private int id;
+  private int customerId;
+
+  public Order(int id, int customerId) {
+    this.id = id;
+    this.customerId = customerId;
+  }
+
+  public Order() {}
+
+  public int getId() {
+    return id;
+  }
+
+  public int getCustomerId() {
+    return customerId;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public void setCustomerId(int customerId) {
+    this.customerId = customerId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Order order = (Order) o;
+    return id == order.id && customerId == order.customerId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, customerId);
+  }
+}

--- a/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
@@ -545,8 +545,10 @@ class BeamSQLTest extends PipelineSpec {
       }
 
     val q =
-      Query[avro.User, (Int, String, String)]("SELECT id, first_name, last_name from SCOLLECTION",
-                                              Sql.defaultTag)
+      Query[avro.User, (Int, String, String)](
+        "SELECT id, first_name, last_name from SCOLLECTION",
+        Sql.defaultTag
+      )
 
     sc.parallelize(avroUsers).queryAs(q) should containInAnyOrder(expected)
   }

--- a/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
@@ -321,6 +321,12 @@ class BeamSQLTest extends PipelineSpec {
     cast should containInAnyOrder(expectedCast)
   }
 
+  it should "support tags" in runWithContext { sc =>
+    val a = sc.parallelize(users)
+    val q = new Query[User, String]("select username from A", new TupleTag[User]("A"))
+    a.queryAs(q) shouldNot beEmpty
+  }
+
   it should "support JOIN" in runWithContext { sc =>
     val a = sc.parallelize(users)
     val b = sc.parallelize(users)
@@ -401,7 +407,7 @@ class BeamSQLTest extends PipelineSpec {
   it should "provide a typecheck method for tests" in {
     object checkOK {
       def apply[A: Schema, B: Schema](q: String): Assertion =
-        Queries.typecheck(Query[A, B](q)) should be('right)
+        Queries.typecheck(Query[A, B](q, Sql.defaultTag)) should be('right)
 
       def apply[A: Schema, B: Schema, C: Schema](
         q: String,
@@ -413,7 +419,7 @@ class BeamSQLTest extends PipelineSpec {
 
     object checkNOK {
       def apply[A: Schema, B: Schema](q: String): Assertion =
-        Queries.typecheck(Query[A, B](q)) should be('left)
+        Queries.typecheck(Query[A, B](q, Sql.defaultTag)) should be('left)
 
       def apply[A: Schema, B: Schema, C: Schema](
         q: String,
@@ -539,7 +545,8 @@ class BeamSQLTest extends PipelineSpec {
       }
 
     val q =
-      Query[avro.User, (Int, String, String)]("SELECT id, first_name, last_name from SCOLLECTION")
+      Query[avro.User, (Int, String, String)]("SELECT id, first_name, last_name from SCOLLECTION",
+                                              Sql.defaultTag)
 
     sc.parallelize(avroUsers).queryAs(q) should containInAnyOrder(expected)
   }

--- a/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
@@ -17,7 +17,6 @@
 package com.spotify.scio.sql
 
 import com.spotify.scio.bean.UserBean
-import com.spotify.scio.schemas.{Schema, To}
 import com.spotify.scio.values.SCollection
 import com.spotify.scio.testing.PipelineSpec
 import org.apache.beam.sdk.values.TupleTag

--- a/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
@@ -79,6 +79,28 @@ class TypedBeamSQLTest extends PipelineSpec {
     """ shouldNot compile
   }
 
+  it should "support generic definitions if the query string is a stable value" in {
+    def genericA[A: Schema]: Query[A, (String, Int)] =
+      Queries.typed[A, (String, Int)]("select name, age from SCOLLECTION")
+
+    "genericA[UserBean]" should compile
+    "genericA[String]" shouldNot compile
+
+    def genericB[B: Schema]: Query[UserBean, B] =
+      Queries.typed[UserBean, B]("select name, age from SCOLLECTION")
+
+    "genericB[(String, Int)]" should compile
+    "genericB[String]" shouldNot compile
+
+    def genericAB[A: Schema, B: Schema]: Query[A, B] =
+      Queries.typed[A, B]("select name, age from SCOLLECTION")
+
+    "genericAB[UserBean, (String, Int)]" should compile
+    "genericAB[UserBean, String]" shouldNot compile
+    "genericAB[String, (String, Int)]" should compile
+    "genericAB[String, String]" should compile
+  }
+
   it should "typecheck classes compatibilty" in {
     import TypeConvertionsTestData._
     """To.safe[TinyTo, From0]""" shouldNot compile
@@ -162,5 +184,4 @@ class TypedBeamSQLTest extends PipelineSpec {
         WHERE $customers.name = 'Grault'
       """
   }
-
 }

--- a/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
@@ -112,7 +112,20 @@ class TypedBeamSQLTest extends PipelineSpec {
       tsql"SELECT $a.username FROM $a JOIN $b ON $a.username = $b.username"
     """ shouldNot compile
 
-  // TODO: test inline SCollection definition in tsql query
+  }
+
+  it should "support inline scollection definition" in runWithContext { sc =>
+    """
+    val a = sc.parallelize(users)
+    val r: SCollection[String] =
+      tsql"SELECT A._1 FROM ${a.map(u => (u.username, u.age))} A"
+    """ should compile
+
+    """
+    val a = sc.parallelize(users)
+    val r: SCollection[Int] =
+      tsql"SELECT A._1 FROM ${a.map(u => (u.username, u.age))} A"
+    """ shouldNot compile
   }
 
 }

--- a/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
@@ -18,6 +18,7 @@ package com.spotify.scio.sql
 
 import com.spotify.scio.bean.UserBean
 import com.spotify.scio.schemas.To
+import com.spotify.scio.values.SCollection
 import com.spotify.scio.testing.PipelineSpec
 import org.apache.beam.sdk.values.TupleTag
 
@@ -82,4 +83,19 @@ class TypedBeamSQLTest extends PipelineSpec {
     """To.safe[TinyTo, From0]""" shouldNot compile
     """To.safe[From0, CompatibleAvroTestRecord]""" shouldNot compile
   }
+
+  "String interpolation" should "statically check interpolated queries" in runWithContext { sc =>
+    """
+    def coll: SCollection[(Int, String)] =
+      sc.parallelize((1 to 10).toList.map(i => (i, i.toString)))
+    val r: SCollection[Int] = tsql"SELECT _1 FROM $coll"
+    """ should compile
+
+    """
+    def coll: SCollection[(Int, String)] =
+      sc.parallelize((1 to 10).toList.map(i => (i, i.toString)))
+    val r: SCollection[String] = tsql"SELECT _1 FROM $coll"
+    """ shouldNot compile
+  }
+
 }

--- a/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
@@ -86,26 +86,26 @@ class TypedBeamSQLTest extends PipelineSpec {
   }
 
   "String interpolation" should "statically check interpolated queries" in runWithContext { sc =>
-    tsql"""
+    """
     def coll: SCollection[(Int, String)] =
       sc.parallelize((1 to 10).toList.map(i => (i, i.toString)))
     val r: SCollection[Int] = tsql"SELECT _1 FROM $coll"
     """ should compile
 
-    tsql"""
+    """
     def coll: SCollection[(Int, String)] =
       sc.parallelize((1 to 10).toList.map(i => (i, i.toString)))
     val r: SCollection[String] = tsql"SELECT _1 FROM $coll"
     """ shouldNot compile
 
-    tsql"""
+    """
     val a = sc.parallelize(users)
     val b = sc.parallelize(users)
     val r: SCollection[String] =
       tsql"SELECT $a.username FROM $a JOIN $b ON $a.username = $b.username"
     """ should compile
 
-    tsql"""
+    """
     val a = sc.parallelize(users)
     val b = sc.parallelize(users)
     val r: SCollection[Int] =

--- a/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
@@ -79,27 +79,7 @@ class TypedBeamSQLTest extends PipelineSpec {
     """ shouldNot compile
   }
 
-  it should "support generic definitions if the query string is a stable value" in {
-    def genericA[A: Schema]: Query[A, (String, Int)] =
-      Queries.typed[A, (String, Int)]("select name, age from SCOLLECTION")
-
-    "genericA[UserBean]" should compile
-    "genericA[String]" shouldNot compile
-
-    def genericB[B: Schema]: Query[UserBean, B] =
-      Queries.typed[UserBean, B]("select name, age from SCOLLECTION")
-
-    "genericB[(String, Int)]" should compile
-    "genericB[String]" shouldNot compile
-
-    def genericAB[A: Schema, B: Schema]: Query[A, B] =
-      Queries.typed[A, B]("select name, age from SCOLLECTION")
-
-    "genericAB[UserBean, (String, Int)]" should compile
-    "genericAB[UserBean, String]" shouldNot compile
-    "genericAB[String, (String, Int)]" should compile
-    "genericAB[String, String]" should compile
-  }
+  // TODO: test type alias support
 
   it should "typecheck classes compatibilty" in {
     import TypeConvertionsTestData._

--- a/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/TypedBeamSQLTest.scala
@@ -78,7 +78,19 @@ class TypedBeamSQLTest extends PipelineSpec {
     """ shouldNot compile
   }
 
-  // TODO: test type alias support
+  it should "support type aliases" in {
+    import Queries.typed
+
+    """
+    type R = (String, Long)
+    typed[Bar, R]("select `SCOLLECTION`.`f`.`s`, l from SCOLLECTION")
+    """ should compile
+
+    """
+    type B = Bar
+    typed[B, (String, Long)]("select `SCOLLECTION`.`f`.`s`, l from SCOLLECTION")
+    """ should compile
+  }
 
   it should "typecheck classes compatibility" in {
     import TypeConvertionsTestData._


### PR DESCRIPTION
This PR add support for SQL and Typed SQL String interpolation.

## SQL support

```scala
val in = sc.parallelize(users)
val r = in.queryAs[(String, Int)]("select username, age from SCOLLECTION")
```

can now be writen

```scala
val in = sc.parallelize(users)
val r = sql"select username, age from $in".as[(String, Int)]
```

## Typed SQL

```scala
val a = sc.parallelize(users)
val b = sc.parallelize(users)

val result = 
  Sql.from(a, b).queryAs[String](
    Queries.typed(
      """
        SELECT a.username 
        FROM B a 
        JOIN A b ON a.username = b.username
      """, new TupleTag[User]("A"), new TupleTag[User]("B")))
```

can now be writen

```scala
val a = sc.parallelize(users)
val b = sc.parallelize(users)

val result = 
  tsql"""
    SELECT $a.username 
    FROM $a 
    JOIN $b ON $a.username = $b.username
  """.as[String]
```


## TODO

- [x] Compile time typechecking ?
- [x] Check that the parameter list contains at leat one `SCollection`
- [x] Write more tests
- [x] Consistent syntax and type inference between `sql` and `tsql`
- [ ] ~Works with generic definitions like:~ (not possible)

```scala
def test[B: Schema] =
  Queries.typed[UserBean, B]("select name, age from SCOLLECTION")
```

- [ ] Profit