### PR TITLE
Quiet down code dumper for IntelliJ Scala Plugin

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -464,7 +464,7 @@ private[types] object TypeProvider {
     val classCacheDir = getBQClassCacheDir
     val genSrcFile = classCacheDir.resolve(s"$name-$hash.scala").toFile
 
-    logger.info(s"Will dump generated $name of $owner from $srcFile to $genSrcFile")
+    logger.debug(s"Will dump generated $name of $owner from $srcFile to $genSrcFile")
 
     Files.createParentDirs(genSrcFile)
     Files.asCharSink(genSrcFile, Charsets.UTF_8).write(prettyCode)


### PR DESCRIPTION
IMHO `INFO` level is a bit unnecessary here and polluting terminals on build.