### PR TITLE
add header/footer/prefix/suffix to BinaryIO, fix #1785

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1201,11 +1201,18 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     path: String,
     numShards: Int = 0,
     suffix: String = ".bin",
-    compression: Compression = Compression.UNCOMPRESSED
+    compression: Compression = Compression.UNCOMPRESSED,
+    header: Array[Byte] = Array.emptyByteArray,
+    footer: Array[Byte] = Array.emptyByteArray,
+    framePrefix: Array[Byte] => Array[Byte] = _ => Array.emptyByteArray,
+    frameSuffix: Array[Byte] => Array[Byte] = _ => Array.emptyByteArray
   )(implicit ev: T <:< Array[Byte]): ClosedTap[Nothing] =
     this
       .asInstanceOf[SCollection[Array[Byte]]]
-      .write(BinaryIO(path))(BinaryIO.WriteParam(suffix, numShards, compression))
+      .write(BinaryIO(path))(
+        BinaryIO
+          .WriteParam(suffix, numShards, compression, header, footer, framePrefix, frameSuffix)
+      )
 
   /**
    * Save this SCollection with a custom output transform. The transform should have a unique name.

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1197,6 +1197,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * Save this SCollection as raw bytes. Note that elements must be of type `Array[Byte]`.
    * @group output
    */
+  // scalastyle:off parameter.number
   def saveAsBinaryFile(
     path: String,
     numShards: Int = 0,
@@ -1213,6 +1214,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
         BinaryIO
           .WriteParam(suffix, numShards, compression, header, footer, framePrefix, frameSuffix)
       )
+  // scalastyle:on parameter.number
 
   /**
    * Save this SCollection with a custom output transform. The transform should have a unique name.


### PR DESCRIPTION
Hard to test this though, without writing to files or implementing matching read logic, plus the prefix/suffix logic will be very different.