### PR TITLE
Remote sys.exit from code path which is used in tests

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -99,7 +99,7 @@ private object RunnerContext {
 /** Convenience object for creating [[ScioContext]] and [[Args]]. */
 object ContextAndArgs {
 
-  sealed trait ArgsParser[F[_]] {
+  trait ArgsParser[F[_]] {
     type ArgsType
     type UsageOrHelp = String
     type Result = Either[UsageOrHelp, (PipelineOptions, ArgsType)]


### PR DESCRIPTION
`sys.exit` makes user code fail with unpredictable and uninterpretable results.
This PR replaces it with exceptions.