### PR TITLE
Implement saveAsDynamicProtobufFile

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/AvroBytesUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/AvroBytesUtil.scala
@@ -43,7 +43,7 @@ private[scio] object AvroBytesUtil {
     s
   }
 
-  def encode[T](coder: BCoder[T], obj: T, schema: ASchema = schema): GenericRecord = {
+  def encode[T](coder: BCoder[T], obj: T): GenericRecord = {
     val bytes = CoderUtils.encodeToByteArray(coder, obj)
     val record = new GenericData.Record(schema)
     record.put("bytes", ByteBuffer.wrap(bytes))

--- a/scio-core/src/main/scala/com/spotify/scio/coders/AvroBytesUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/AvroBytesUtil.scala
@@ -43,7 +43,7 @@ private[scio] object AvroBytesUtil {
     s
   }
 
-  def encode[T](coder: BCoder[T], obj: T): GenericRecord = {
+  def encode[T](coder: BCoder[T], obj: T, schema: ASchema = schema): GenericRecord = {
     val bytes = CoderUtils.encodeToByteArray(coder, obj)
     val record = new GenericData.Record(schema)
     record.put("bytes", ByteBuffer.wrap(bytes))

--- a/scio-core/src/main/scala/com/spotify/scio/io/dynamic/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/dynamic/package.scala
@@ -138,10 +138,10 @@ package object dynamic {
       suffix: String = ".protobuf",
       codec: CodecFactory = CodecFactory.deflateCodec(6),
       metadata: Map[String, AnyRef] = Map.empty
-    )(destinationFn: T => String)(implicit cd: ClassTag[T]): Future[Tap[T]] = {
+    )(destinationFn: T => String)(implicit cd: ClassTag[T], coder: ScioCoder[T]): Future[Tap[T]] = {
       val elemCoder = CoderMaterializer.beam(
         self.context,
-        ScioCoder[T]
+        coder
       )
       self.saveAsDynamicAvroFile(
         path,
@@ -149,10 +149,10 @@ package object dynamic {
         AvroBytesUtil.schema,
         suffix,
         codec,
-        metadata + ("protobuf.generic.schema" -> AvroBytesUtil.schema)
+        metadata + ("protobuf.generic.schema" -> AvroBytesUtil.schema.toString)
       )(
         destinationFn,
-        (t, _) => AvroBytesUtil.encode(elemCoder, t)
+        (t, s) => AvroBytesUtil.encode(elemCoder, t, s)
       )
     }
   }

--- a/scio-core/src/main/scala/com/spotify/scio/io/dynamic/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/dynamic/package.scala
@@ -25,7 +25,7 @@ import org.apache.avro.Schema
 import org.apache.avro.file.CodecFactory
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.specific.SpecificRecordBase
-import org.apache.beam.sdk.coders.{Coder, StringUtf8Coder}
+import org.apache.beam.sdk.coders.StringUtf8Coder
 import org.apache.beam.sdk.io.AvroIO.RecordFormatter
 import org.apache.beam.sdk.io.{Compression, FileIO}
 import org.apache.beam.sdk.{io => beam}

--- a/scio-core/src/main/scala/com/spotify/scio/io/dynamic/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/dynamic/package.scala
@@ -18,7 +18,7 @@
 package com.spotify.scio.io
 
 import com.google.protobuf.Message
-import com.spotify.scio.coders.{AvroBytesUtil, CoderMaterializer, Coder => ScioCoder}
+import com.spotify.scio.coders.{AvroBytesUtil, Coder, CoderMaterializer}
 import com.spotify.scio.util.Functions
 import com.spotify.scio.values.SCollection
 import me.lyh.protobuf.generic
@@ -141,9 +141,9 @@ package object dynamic {
       metadata: Map[String, AnyRef] = Map.empty
     )(destinationFn: T => String)(implicit ct: ClassTag[T]): Future[Tap[T]] = {
       val protoCoder =
-        ScioCoder
+        Coder
           .protoMessageCoder[Message](ct.asInstanceOf[ClassTag[Message]])
-          .asInstanceOf[ScioCoder[T]]
+          .asInstanceOf[Coder[T]]
 
       val elemCoder = CoderMaterializer.beam(self.context, protoCoder)
       val schemaJson = generic.Schema.of[Message](ct.asInstanceOf[ClassTag[Message]]).toJson

--- a/scio-core/src/main/scala/com/spotify/scio/io/dynamic/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/dynamic/package.scala
@@ -134,7 +134,7 @@ package object dynamic {
       suffix: String = ".protobuf.avro",
       codec: CodecFactory = CodecFactory.deflateCodec(6),
       metadata: Map[String, AnyRef] = Map.empty
-    )(destinationFn: T => String)(implicit ct: ClassTag[T], coder: Coder[T]): Future[Tap[T]] = {
+    )(destinationFn: T => String)(implicit coder: Coder[T]): Future[Tap[T]] = {
       if (self.context.isTest) {
         throw new NotImplementedError(
           "Protobuf file with dynamic destinations cannot be used in a test context"

--- a/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
@@ -176,7 +176,6 @@ class DynamicFileTest extends PipelineSpec {
   it should "support Proto files" in {
     val tmpDir = Files.createTempDirectory("dynamic-io-")
     val sc1 = ScioContext()
-    implicit val coder: Coder[SimplePB] = Coder.protoMessageCoder[SimplePB]
 
     val newProtobuf = (x: Int) => SimplePB.newBuilder().setPlays(x).setTrackId(s"track$x").build()
 

--- a/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
@@ -177,7 +177,6 @@ class DynamicFileTest extends PipelineSpec {
     val sc1 = ScioContext()
 
     val newProtobuf = (x: Int) => SimplePB.newBuilder().setPlays(x).setTrackId(s"track$x").build()
-
     sc1
       .parallelize(1 to 10)
       .map(newProtobuf)

--- a/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
@@ -99,7 +99,7 @@ class DynamicFileTest extends PipelineSpec {
   it should "support generic Avro files" in {
     val tmpDir = Files.createTempDirectory("dynamic-io-")
     val sc1 = ScioContext()
-    implicit val coder: Coder[GenericRecord] = Coder.avroGenericRecordCoder(schema)
+    implicit val coder = Coder.avroGenericRecordCoder(schema)
     sc1
       .parallelize(1 to 10)
       .map(newGenericRecord)

--- a/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
@@ -99,7 +99,7 @@ class DynamicFileTest extends PipelineSpec {
   it should "support generic Avro files" in {
     val tmpDir = Files.createTempDirectory("dynamic-io-")
     val sc1 = ScioContext()
-    implicit val coder = Coder.avroGenericRecordCoder(schema)
+    implicit val coder: Coder[GenericRecord] = Coder.avroGenericRecordCoder(schema)
     sc1
       .parallelize(1 to 10)
       .map(newGenericRecord)
@@ -176,10 +176,10 @@ class DynamicFileTest extends PipelineSpec {
     val tmpDir = Files.createTempDirectory("dynamic-io-")
     val sc1 = ScioContext()
 
-    val newProtobuf = (x: Int) => SimplePB.newBuilder().setPlays(x).setTrackId(s"track$x").build()
+    val mkProto = (x: Int) => SimplePB.newBuilder().setPlays(x).setTrackId(s"track$x").build()
     sc1
       .parallelize(1 to 10)
-      .map(newProtobuf)
+      .map(mkProto)
       .saveAsDynamicProtobufFile(tmpDir.toString) { r =>
         (r.getPlays % 2).toString
       }
@@ -189,8 +189,8 @@ class DynamicFileTest extends PipelineSpec {
     val sc2 = ScioContext()
     val lines0 = sc2.protobufFile[SimplePB](s"$tmpDir/0/*.protobuf")
     val lines1 = sc2.protobufFile[SimplePB](s"$tmpDir/1/*.protobuf")
-    lines0 should containInAnyOrder((1 to 10).filter(_ % 2 == 0).map(newProtobuf))
-    lines1 should containInAnyOrder((1 to 10).filter(_ % 2 == 1).map(newProtobuf))
+    lines0 should containInAnyOrder((1 to 10).filter(_ % 2 == 0).map(mkProto))
+    lines1 should containInAnyOrder((1 to 10).filter(_ % 2 == 1).map(mkProto))
     sc2.close()
     FileUtils.deleteDirectory(tmpDir.toFile)
   }

--- a/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
@@ -19,11 +19,10 @@ package com.spotify.scio.io.dynamic
 
 import java.nio.file.{Files, Path}
 
-import com.spotify.scio.ScioContext
+import com.spotify.scio._
 import com.spotify.scio.avro.AvroUtils._
 import com.spotify.scio.avro._
 import com.spotify.scio.coders.Coder
-import com.spotify.scio.coders.Coder._
 import com.spotify.scio.proto.SimpleV2.SimplePB
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.values.WindowOptions


### PR DESCRIPTION
I would find useful to have this function implemented in scio library. I didn't add it directly to the `DynamicIoSCollection` because `T` in this case needs to have super type `Message` so I created new type class `DynamicProtoSCollection` for this purpose. 

I will add tests if this solution is approved by @nevillelyh.