### PR TITLE
(fix #1891) Allow TestStream as JobTest input

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -676,9 +676,7 @@ class ScioContext private[scio] (val options: PipelineOptions, private var artif
   ): SCollection[T] =
     requireNotClosed {
       if (this.isTest) {
-        this.parallelize(
-          TestDataManager.getInput(testId.get)(CustomIO[T](name)).asInstanceOf[Seq[T]]
-        )
+        TestDataManager.getInput(testId.get)(CustomIO[T](name)).toSCollection(this)
       } else {
         wrap(this.pipeline.apply(name, transform))
       }

--- a/scio-core/src/main/scala/com/spotify/scio/io/PubsubIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/PubsubIO.scala
@@ -189,7 +189,7 @@ private final case class PubsubIOWithAttributes[T: ClassTag: Coder](
   override def readTest(sc: ScioContext, params: ReadP)(
     implicit coder: Coder[WithAttributeMap]
   ): SCollection[WithAttributeMap] = {
-    val read = sc.parallelize(TestDataManager.getInput(sc.testId.get)(this))
+    val read = TestDataManager.getInput(sc.testId.get)(this).toSCollection(sc)
 
     if (timestampAttribute != null) {
       read.timestampBy(kv => new Instant(kv._2(timestampAttribute)))

--- a/scio-core/src/main/scala/com/spotify/scio/io/ScioIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/ScioIO.scala
@@ -82,11 +82,8 @@ trait ScioIO[T] {
 
   protected def readTest(sc: ScioContext, params: ReadP)(
     implicit coder: Coder[T]
-  ): SCollection[T] = {
-    sc.parallelize(
-      TestDataManager.getInput(sc.testId.get)(this).asInstanceOf[Seq[T]]
-    )
-  }
+  ): SCollection[T] =
+    TestDataManager.getInput(sc.testId.get)(this).toSCollection(sc)
 
   protected def read(sc: ScioContext, params: ReadP): SCollection[T]
 

--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -26,7 +26,7 @@ import org.apache.beam.sdk.values.{PBegin, PCollection, PInput}
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.{Set => MSet}
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Success, Try}
 
 /* Inputs are Scala Iterables to be parallelized for TestPipeline, or PTransforms to be applied */
 private[scio] trait JobInputSource[T] {
@@ -46,11 +46,11 @@ private[scio] case class PTransformInputSource[T](
   override def toSCollection(sc: ScioContext)(implicit coder: Coder[T]): SCollection[T] =
     sc.wrap(sc.applyInternal(transform))
 
-  override def toString: String = transform.toString
+  override def toString: String = transform.getName
 }
 
 private[scio] case class IterableInputSource[T](iterable: Iterable[T]) extends JobInputSource[T] {
-  override val asIterable = Try(iterable)
+  override val asIterable = Success(iterable)
   override def toSCollection(sc: ScioContext)(implicit coder: Coder[T]): SCollection[T] =
     sc.parallelize(iterable)
   override def toString: String = iterable.toString

--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -29,12 +29,12 @@ import scala.collection.mutable.{Set => MSet}
 import scala.util.{Failure, Success, Try}
 
 /* Inputs are Scala Iterables to be parallelized for TestPipeline, or PTransforms to be applied */
-private[scio] trait JobInputSource[T] {
+private[scio] sealed trait JobInputSource[T] {
   def toSCollection(sc: ScioContext)(implicit coder: Coder[T]): SCollection[T]
   val asIterable: Try[Iterable[T]]
 }
 
-private[scio] case class PTransformInputSource[T](
+private[scio] final case class PTransformInputSource[T](
   transform: PTransform[_ >: PBegin <: PInput, PCollection[T]]
 ) extends JobInputSource[T] {
   override val asIterable = Failure(
@@ -49,7 +49,9 @@ private[scio] case class PTransformInputSource[T](
   override def toString: String = transform.getName
 }
 
-private[scio] case class IterableInputSource[T](iterable: Iterable[T]) extends JobInputSource[T] {
+private[scio] final case class IterableInputSource[T](
+  iterable: Iterable[T]
+) extends JobInputSource[T] {
   override val asIterable = Success(iterable)
   override def toSCollection(sc: ScioContext)(implicit coder: Coder[T]): SCollection[T] =
     sc.parallelize(iterable)

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1054,7 +1054,6 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   )(implicit ev: T <:< String): SCollection[U] =
     if (context.isTest) {
       val id = context.testId.get
-
       this
         .asInstanceOf[SCollection[String]]
         .flatMap(s => TestDataManager.getInput(id)(ReadIO(s)).asIterable.get)

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1054,9 +1054,10 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   )(implicit ev: T <:< String): SCollection[U] =
     if (context.isTest) {
       val id = context.testId.get
+
       this
         .asInstanceOf[SCollection[String]]
-        .flatMap(s => TestDataManager.getInput(id)(ReadIO(s)))
+        .flatMap(s => TestDataManager.getInput(id)(ReadIO(s)).asIterable.get)
     } else {
       this.asInstanceOf[SCollection[String]].applyTransform(read)
     }
@@ -1069,7 +1070,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
       val id = context.testId.get
       this
         .asInstanceOf[SCollection[String]]
-        .flatMap(s => TestDataManager.getInput(id)(ReadIO(s)))
+        .flatMap(s => TestDataManager.getInput(id)(ReadIO(s)).asIterable.get)
     } else {
       this
         .asInstanceOf[SCollection[String]]

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/WindowedWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/WindowedWordCount.scala
@@ -30,14 +30,14 @@ import java.util.concurrent.ThreadLocalRandom
 import com.spotify.scio._
 import com.spotify.scio.examples.common.ExampleData
 import org.apache.beam.sdk.io.FileSystems
-import org.apache.beam.sdk.transforms.windowing.IntervalWindow
+import org.apache.beam.sdk.transforms.windowing.{GlobalWindow, IntervalWindow}
 import org.apache.beam.sdk.util.MimeTypes
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{Duration, Instant}
 
 object WindowedWordCount {
 
-  private val WINDOW_SIZE = 10L
+  private val WINDOW_SIZE = Duration.standardMinutes(10L)
   private val formatter = ISODateTimeFormat.hourMinute
 
   def main(cmdlineArgs: Array[String]): Unit = {
@@ -49,15 +49,17 @@ object WindowedWordCount {
 
     // Parse command line arguments
     val input = args.getOrElse("input", ExampleData.KING_LEAR)
-    val windowSize =
-      Duration.standardMinutes(args.long("windowSize", WINDOW_SIZE))
+    val windowSize = Option(args("windowSize")).map(new Duration(_)).getOrElse(WINDOW_SIZE)
     val minTimestamp =
       args.long("minTimestampMillis", System.currentTimeMillis())
     val maxTimestamp =
       args.long("maxTimestampMillis", minTimestamp + Duration.standardHours(1).getMillis)
 
+    val outputGlobalWindow = args.boolean("outputGlobalWindow", false)
+
     // Open text files as an `SCollection[String]`
-    sc.textFile(input)
+    val wordCounts = sc
+      .textFile(input)
       .transform("random timestamper") {
         // Assign random timestamps to each element
         _.timestampBy { _ =>
@@ -79,8 +81,15 @@ object WindowedWordCount {
           // Group elements by window to get `(IntervalWindow, Iterable[(String, Long)])
           .groupByKey
       }
+
+    if (outputGlobalWindow) {
+      wordCounts
+        .withWindow[GlobalWindow]
+        .flatMap { case ((_, counts), _) => counts }
+        .saveAsTextFile("output.txt")
+    } else {
       // Write values in each group to a separate text file
-      .map {
+      wordCounts.map {
         case (w, vs) =>
           val outputShard =
             "%s-%s-%s".format(args("output"), formatter.print(w.start()), formatter.print(w.end()))
@@ -89,6 +98,7 @@ object WindowedWordCount {
           vs.foreach { case (k, v) => out.write(s"$k: $v\n".getBytes) }
           out.close()
       }
+    }
 
     // Close the context and execute the pipeline
     sc.close()

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/WindowedWordCountTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/WindowedWordCountTest.scala
@@ -32,7 +32,7 @@ class WindowedWordCountTest extends PipelineSpec {
         "--outputGlobalWindow=true",
         "--output=output.txt"
       )
-      .pInput(
+      .inputStream(
         TextIO("input.txt"),
         testStreamOf[String]
           .advanceWatermarkTo(baseTime)

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/WindowedWordCountTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/WindowedWordCountTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.examples.extra
+
+import com.spotify.scio.io.TextIO
+import com.spotify.scio.testing._
+import org.joda.time.{Duration, Instant}
+
+class WindowedWordCountTest extends PipelineSpec {
+  private val baseTime = new Instant(0)
+
+  "WindowedWordCount" should "work" in {
+    JobTest[com.spotify.scio.examples.WindowedWordCount.type]
+      .args(
+        "--input=input.txt",
+        s"--windowSize=PT0.1S", // 100 ms, in ISO-8601 standard used by Joda for Duration parsing
+        "--outputGlobalWindow=true",
+        "--output=output.txt"
+      )
+      .pInput(
+        TextIO("input.txt"),
+        testStreamOf[String]
+          .advanceWatermarkTo(baseTime)
+          .addElements("a b b c")
+          .advanceWatermarkTo(baseTime.plus(Duration.millis(150)))
+          .addElements("b e")
+          .advanceWatermarkToInfinity()
+      )
+      .output(TextIO("output.txt"))(
+        _ should containInAnyOrder(Seq("(a,1)", "(b,2)", "(b,1)", "(c,1)", "(e,1)"))
+      )
+      .run()
+  }
+}

--- a/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
@@ -99,7 +99,7 @@ object JobTest {
     }
 
     /**
-     * Feed an input in the form of a raw Iterable[T] to the pipeline being tested. Note that
+     * Feed an input in the form of a raw `Iterable[T]` to the pipeline being tested. Note that
      * `TestIO[T]` must match the one used inside the pipeline, e.g. `AvroIO[MyRecord]("in.avro")`
      * with `sc.avroFile[MyRecord]("in.avro")`.
      */
@@ -107,8 +107,8 @@ object JobTest {
       input(io, IterableInputSource(value))
 
     /**
-     * Feed an input in the form of a PTransform[PBegin, PCollection[T] to the pipeline being
-     * tested. Note that PTransform inputs may not be supported for all TestIO[T] types.
+     * Feed an input in the form of a `PTransform[PBegin, PCollection[T]]` to the pipeline being
+     * tested. Note that `PTransform` inputs may not be supported for all `TestIO[T]` types.
      */
     def inputStream[T](io: ScioIO[T], stream: TestStream[T]): Builder =
       input(io, TestStreamInputSource(stream))

--- a/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
@@ -23,8 +23,7 @@ import com.spotify.scio.ScioResult
 import com.spotify.scio.io.ScioIO
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
-import org.apache.beam.sdk.transforms.PTransform
-import org.apache.beam.sdk.values.{PBegin, PCollection, PInput}
+import org.apache.beam.sdk.testing.TestStream
 import org.apache.beam.sdk.{metrics => beam}
 
 import scala.reflect.ClassTag
@@ -111,11 +110,8 @@ object JobTest {
      * Feed an input in the form of a PTransform[PBegin, PCollection[T] to the pipeline being
      * tested. Note that PTransform inputs may not be supported for all TestIO[T] types.
      */
-    def pInput[T](
-      io: ScioIO[T],
-      transform: PTransform[_ >: PBegin <: PInput, PCollection[T]]
-    ): Builder =
-      input(io, PTransformInputSource(transform))
+    def inputStream[T](io: ScioIO[T], stream: TestStream[T]): Builder =
+      input(io, TestStreamInputSource(stream))
 
     private def input[T](io: ScioIO[T], value: JobInputSource[T]): Builder = {
       require(!state.input.contains(io.toString), "Duplicate test input: " + io.toString)

--- a/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
@@ -584,7 +584,7 @@ class JobTestTest extends PipelineSpec {
     JobTest[ReadAllJob.type]
       .args("--input=in.txt", "--output=out.txt")
       .input(TextIO("in.txt"), Seq("a", "b"))
-      .input(ReadIO[String]("a"), Seq("a1", "a2"))
+      .input(ReadIO("a"), Seq("a1", "a2"))
       .input(ReadIO("b"), Seq("b1", "b2"))
       .output(TextIO("out.txt")) { coll =>
         coll should containInAnyOrder(xs)


### PR DESCRIPTION
I wasn't able to overload the existing [`def input[T](io: ScioIO[T], value: Iterable[T]): Builder =...`](https://github.com/spotify/scio/blob/f4ff6be66116f0268797fe43107fe2f09a451154/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala#L105) method without breaking non-explicitly-typed IO construction (like `BigQueryIO("foo")` or `ReadIO("bar")`) so I created a new method `pInput` ... not super happy with the clarity of that method name so any suggestions appreciated!