### PR TITLE
Disable checkVersion in Scio's tests

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,5 @@
 -Dfile.encoding=UTF8
--Dscio.ignore.versionWarning=true
+-Dscio.ignoreVersionWarning=true
 -Xms2G
 -Xmx8G
 -XX:ReservedCodeCacheSize=512m

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,5 @@
 -Dfile.encoding=UTF8
+-Dscio.ignore.versionWarning=true
 -Xms2G
 -Xmx8G
 -XX:ReservedCodeCacheSize=512m

--- a/build.sbt
+++ b/build.sbt
@@ -704,7 +704,8 @@ lazy val scioTensorFlow: Project = Project(
       "io.circe" %% "circe-generic",
       "io.circe" %% "circe-parser"
     ).map(_ % circeVersion),
-    Test / fork := true
+    Test / fork := true,
+    javaOptions += "-Dscio.ignoreVersionWarning=true"
   )
   .dependsOn(
     scioAvro,

--- a/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
@@ -73,6 +73,25 @@ private[scio] object VersionUtil {
   private[scio] def ignoreVersionCheck: Boolean =
     System.getProperty("scio.ignore.versionWarning").trim == "true"
 
+  // scalastyle:off line.size.limit
+  private def messages(current: SemVer, latest: SemVer): Option[String] =
+    (current, latest) match {
+      case (SemVer(0, minor, _, _), SemVer(0, 7, _, _)) if minor < 7 =>
+        import scala.io.AnsiColor._
+        val mess =
+          s"""
+            | ${YELLOW}>${BOLD} Scio 0.7 introduced breaking changes in the API.${RESET}
+            | ${YELLOW}>${RESET} Follow the migration guide to upgrade: https://spotify.github.io/scio/migrations/v0.7.0-Migration-Guide
+            | ${YELLOW}>${RESET} Scio provides automatic migration rules (See migration guide).
+          """.stripMargin
+        Option(mess)
+      case (SemVer(0, minor, _, _), SemVer(0, 8, _, _)) if minor < 8 =>
+        // TODO: write a migration guide to scio 0.8 and link it here
+        None
+      case _ => None
+    }
+  // scalastyle:on line.size.limit
+
   def checkVersion(
     current: String,
     latest: Option[String],
@@ -90,6 +109,7 @@ private[scio] object VersionUtil {
         val v2 = parseVersion(v)
         if (v2 > v1) {
           b.append(s"A newer version of Scio is available: $current -> $v")
+          messages(v1, v2).foreach(m => b.append(m))
         }
       }
       b

--- a/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
@@ -70,19 +70,30 @@ private[scio] object VersionUtil {
     SemVer(m.group(1).toInt, m.group(2).toInt, m.group(3).toInt, snapshot)
   }
 
-  def checkVersion(current: String, latest: Option[String]): Seq[String] = {
-    val b = mutable.Buffer.empty[String]
-    val v1 = parseVersion(current)
-    if (v1.suffix == "-SNAPSHOT") {
-      b.append(s"Using a SNAPSHOT version of Scio: $current")
-    }
-    latest.foreach { v =>
-      val v2 = parseVersion(v)
-      if (v2 > v1) {
-        b.append(s"A newer version of Scio is available: $current -> $v")
+  private[scio] def ignoreVersionCheck: Boolean =
+    System.getProperty("scio.ignore.versionWarning").trim == "true"
+
+  def checkVersion(
+    current: String,
+    latest: Option[String],
+    ignore: Boolean = ignoreVersionCheck
+  ): Seq[String] = {
+    if (ignore) {
+      Nil
+    } else {
+      val b = mutable.Buffer.empty[String]
+      val v1 = parseVersion(current)
+      if (v1.suffix == "-SNAPSHOT") {
+        b.append(s"Using a SNAPSHOT version of Scio: $current")
       }
+      latest.foreach { v =>
+        val v2 = parseVersion(v)
+        if (v2 > v1) {
+          b.append(s"A newer version of Scio is available: $current -> $v")
+        }
+      }
+      b
     }
-    b
   }
 
   def checkVersion(): Unit =

--- a/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
@@ -71,7 +71,9 @@ private[scio] object VersionUtil {
   }
 
   private[scio] def ignoreVersionCheck: Boolean =
-    System.getProperty("scio.ignore.versionWarning").trim == "true"
+    Option(System.getProperty("scio.ignoreVersionWarning"))
+      .map(_.trim == "true")
+      .getOrElse(false)
 
   // scalastyle:off line.size.limit
   private def messages(current: SemVer, latest: SemVer): Option[String] =

--- a/scio-test/src/test/scala/com/spotify/scio/VersionUtilTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/VersionUtilTest.scala
@@ -22,7 +22,7 @@ import org.scalatest._
 class VersionUtilTest extends FlatSpec with Matchers {
 
   private def verifySnapshotVersion(oldVer: String, newVerOpt: Option[String]) =
-    VersionUtil.checkVersion(oldVer, newVerOpt) shouldBe Seq(
+    VersionUtil.checkVersion(oldVer, newVerOpt, ignore = false) shouldBe Seq(
       s"Using a SNAPSHOT version of Scio: $oldVer"
     )
 
@@ -34,14 +34,14 @@ class VersionUtilTest extends FlatSpec with Matchers {
   }
 
   it should "warn about release version" in {
-    VersionUtil.checkVersion("0.1.0-SNAPSHOT", Some("0.1.0")) shouldBe Seq(
+    VersionUtil.checkVersion("0.1.0-SNAPSHOT", Some("0.1.0"), ignore = false) shouldBe Seq(
       "Using a SNAPSHOT version of Scio: 0.1.0-SNAPSHOT",
       "A newer version of Scio is available: 0.1.0-SNAPSHOT -> 0.1.0"
     )
   }
 
   private def verifyNewVersion(oldVer: String, newVer: String) =
-    VersionUtil.checkVersion(oldVer, Some(newVer)) shouldBe Seq(
+    VersionUtil.checkVersion(oldVer, Some(newVer), ignore = false) shouldBe Seq(
       s"A newer version of Scio is available: $oldVer -> $newVer"
     )
 
@@ -57,7 +57,7 @@ class VersionUtilTest extends FlatSpec with Matchers {
       "0.1.1"
     )
     for (i <- versions.indices) {
-      VersionUtil.checkVersion(versions(i), Some(versions(i))) shouldBe Nil
+      VersionUtil.checkVersion(versions(i), Some(versions(i)), ignore = false) shouldBe Nil
       for (j <- (i + 1) until versions.length) {
         verifyNewVersion(versions(i), versions(j))
       }


### PR DESCRIPTION
This PR has 2 goals:

- [x] Make Scio test execution less verbose by disabling VERSION warnings
- [x] Improve the warning message and point users to the migration guides