### PR TITLE
Wrap unsafe access of nullable fields and methods in try

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
@@ -253,7 +253,7 @@ private[client] final class QueryOps(client: Client, tableService: TableOps, job
   }
 
   private def isInvalidQuery(e: GoogleJsonResponseException): Boolean =
-    e.getDetails.getErrors.get(0).getReason == "invalidQuery"
+    Try(e.getDetails.getErrors.get(0).getReason).map(_ == "invalidQuery").getOrElse(false)
 
   private[scio] def isLegacySql(sqlQuery: String, flattenResults: Boolean = false): Boolean = {
     val dryRun =

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
@@ -254,8 +254,8 @@ private[client] final class QueryOps(client: Client, tableService: TableOps, job
 
   private def isInvalidQuery(e: GoogleJsonResponseException): Boolean =
     Option(e.getDetails)
-      .flatMap(details => Option(details.getErrors.asScala))
-      .flatMap(errors => errors.headOption)
+      .flatMap(details => Option(details.getErrors))
+      .flatMap(_.asScala.headOption)
       .exists(_.getReason == "invalidQuery")
 
   private[scio] def isLegacySql(sqlQuery: String, flattenResults: Boolean = false): Boolean = {

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
@@ -253,7 +253,10 @@ private[client] final class QueryOps(client: Client, tableService: TableOps, job
   }
 
   private def isInvalidQuery(e: GoogleJsonResponseException): Boolean =
-    Try(e.getDetails.getErrors.get(0).getReason).map(_ == "invalidQuery").getOrElse(false)
+    Option(e.getDetails)
+      .flatMap(details => Option(details.getErrors.asScala))
+      .flatMap(errors => errors.headOption)
+      .exists(_.getReason == "invalidQuery")
 
   private[scio] def isLegacySql(sqlQuery: String, flattenResults: Boolean = false): Boolean = {
     val dryRun =


### PR DESCRIPTION
The purpose of this PR is to address a NPE that can occur when the method `isInvalidQuery` is called in response to a failed dry run query after determining neither the standard or legacy Sql comments have been set in the query.