### PR TITLE
Change default fpProb of sparseIntersectByKey

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -755,7 +755,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     that: SCollection[K],
     thatNumKeys: Int,
     computeExact: Boolean = false,
-    fpProb: Double = 0.1
+    fpProb: Double = 0.01
   )(implicit koder: Coder[K], voder: Coder[V], hash: Hash128[K]): SCollection[(K, V)] = {
     val rhsBfs = that.map(k => (k, ())).optimalKeysBloomFiltersAsSideInputs(thatNumKeys, fpProb)
     val n = rhsBfs.size


### PR DESCRIPTION
While debugging some code from keys, I saw that they were experimenting with `sparseIntersectByKey` and they were seeing a very high false positives.

For all other sparse implementations we have `0.01` or 1% as expected false positive probability. In the pipelines I maintain, 1% sounds reasonable and works well. I am not sure if there is a particular reason for having 10% false positives for this transform. I believe we should have an opinionated and same default for all sparse transforms in Scio.

Is there a particular reason for having high false positives for this specific transform that I should be aware of?