### PR TITLE
Improve docs for intersectByKey and sparse transforms

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
@@ -147,6 +147,9 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   /**
    * Return an SCollection with the pairs from `this` whose keys are in `that`
    * given `that` is small enough to fit in memory.
+   *
+   * Unlike [[SCollection.intersection]] this preserves duplicates in `this`.
+   *
    * @group per key
    */
   def hashIntersectByKey(
@@ -156,6 +159,9 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
 
   /**
    * Return an SCollection with the pairs from `this` whose keys are in the SideSet `that`.
+   *
+   * Unlike [[SCollection.intersection]] this preserves duplicates in `this`.
+   *
    * @group per key
    */
   def hashIntersectByKey(


### PR DESCRIPTION
 - When working with `intersectByKey` I was somewhat making an incorrect assumption that it removes duplicates much like `intersection`. I thought it would be nice to document this.

- The documentation of the parameters for sparse transforms were not very clear, and it was kind of hard for someone to understand that the transform is doing without having to take a look at the code / understand details about how a Bloom Filter is being used. I think it would be nice to have some additional information so it is easier to use these apis.