### PR TITLE
Add docs for CoderGrammar

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -354,13 +354,17 @@ private[scio] final case class RecordCoder[T](
  *
  * The CoderGrammar can be used as follows:
  * - To find the Coder being implicitly derived by Scio. (Debugging)
+ *   {{{
  *     def c: Coder[MyType] = Coder[MyType]
+ *   }}}
  *
  * - To generate an implicit instance to be in scope for type T, use [[Coder.gen]]
+ *   {{{
  *     implicit def coderT: Coder[T] = Coder.gen[T]
+ *   }}}
  *
  *   Note: Implicit Coders for all parameters of the constructor of type T should be in scope for
- *         Coder.gen to be able to derive the Coder.
+ *         [[Coder.gen]] to be able to derive the Coder.
  *
  * - To define a Coder of custom type, where the type can be mapped to some other type for which
  *   a Coder is known, use [[Coder.xmap]]
@@ -381,8 +385,11 @@ sealed trait CoderGrammar {
   /**
    * Create an instance of Kryo Coder for a given Type.
    *
-   * Eg: A kryo Coder for org.joda.time.Interval would look like:
+   * Eg:
+   *   A kryo Coder for [[org.joda.time.Interval]] would look like:
+   *   {{{
    *     implicit def jiKryo: Coder[Interval] = Coder.kryo[Interval]
+   *   }}}
    */
   def kryo[T](implicit ct: ClassTag[T]): Coder[T] =
     Fallback[T](ct)
@@ -397,12 +404,14 @@ sealed trait CoderGrammar {
    *
    * Eg: Coder for [[org.joda.time.Interval]] can be defined by having the following implicit in
    *     scope. Without this implicit in scope Coder derivation falls back to Kryo.
+   *     {{{
    *       implicit def jiCoder: Coder[Interval] =
    *         Coder.xmap(Coder[(Long, Long)])(t => new Interval(t._1, t._2),
    *            i => (i.getStartMillis, i.getEndMillis))
-   *      In the above example we implicitly derive Coder[(Long, Long)] and we define two functions,
-   *      one to convert a tuple (Long, Long) to Interval, and a second one to convert an Interval
-   *      to a tuple of (Long, Long)
+   *     }}}
+   *     In the above example we implicitly derive Coder[(Long, Long)] and we define two functions,
+   *     one to convert a tuple (Long, Long) to Interval, and a second one to convert an Interval
+   *     to a tuple of (Long, Long)
    */
   def xmap[A, B](c: Coder[A])(f: A => B, t: B => A): Coder[B] = {
     @inline def toB(bc: BCoder[A]) = new AtomicCoder[B] {

--- a/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
@@ -20,7 +20,7 @@ package com.spotify.scio.coders
 private object Derived extends Serializable {
   import magnolia._
 
-  @inline private def catching[T](msg: => String, stack: Array[StackTraceElement])(v: => T): T =
+  @inline private def catching[T](msg: => String, stack: => Array[StackTraceElement])(v: => T): T =
     try {
       v
     } catch {
@@ -41,7 +41,7 @@ private object Derived extends Serializable {
       i = i + 1
     }
 
-    val stack = CoderException.prepareStackTrace
+    lazy val stack = CoderException.prepareStackTrace
 
     @inline def destruct(v: T): Array[Any] = {
       val arr = new Array[Any](ps.length)

--- a/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
@@ -20,7 +20,7 @@ package com.spotify.scio.coders
 private object Derived extends Serializable {
   import magnolia._
 
-  @inline private def catching[T](msg: => String, stack: => Array[StackTraceElement])(v: => T): T =
+  @inline private def catching[T](msg: => String, stack: Array[StackTraceElement])(v: => T): T =
     try {
       v
     } catch {
@@ -41,7 +41,7 @@ private object Derived extends Serializable {
       i = i + 1
     }
 
-    lazy val stack = CoderException.prepareStackTrace
+    val stack = CoderException.prepareStackTrace
 
     @inline def destruct(v: T): Array[Any] = {
       val arr = new Array[Any](ps.length)

--- a/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
@@ -101,5 +101,16 @@ trait LowPriorityCoderDerivation {
     }
   }
 
+  /**
+   * Derive a Coder for a type T given implicit coders of all parameters in the constructor
+   * of type T is in scope. For sealed trait, implicit coders of parameters of the constructors
+   * of all sub-types should be in scope.
+   *
+   * In case of a missing [[shapeless.LowPriority]] implicit error when calling this method as
+   * [[Coder.gen[Type] ]], it means that Scio is unable to derive a BeamCoder for some parameter
+   * [P] in the constructor of Type. This happens when no implicit Coder instance for type P is
+   * in scope. This is fixed by placing an implicit Coder of type P in scope, using
+   * [[Coder.kryo[P] ]] or defining the Coder manually (see also [[Coder.xmap]])
+   */
   implicit def gen[T]: Coder[T] = macro CoderMacros.wrappedCoder[T]
 }

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/AvroCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/AvroCoders.scala
@@ -105,6 +105,13 @@ private object SpecificFixedCoder {
 
 trait AvroCoders {
   import language.experimental.macros
+
+  /**
+   * Create a Coder for Avro GenericRecord given the schema of the GenericRecord.
+   *
+   * @param schema AvroSchema for the Coder.
+   * @return Coder[GenericRecord]
+   */
   // TODO: Use a coder that does not serialize the schema
   def avroGenericRecordCoder(schema: Schema): Coder[GenericRecord] =
     Coder.beam(AvroCoder.of(schema))


### PR DESCRIPTION
I was trying to speed up my compilation and resorted to adding implicit definitions explicitly using `Coder.gen`, `Coder.kryo` and `Coder.xmap` which means I am somewhat relying on this api.

I am adding a few docs, so that someone reading our code can debug / understand what these functions are doing.