### PR TITLE
Set `location` when fetching Job in `JobOps`

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/JobOps.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/JobOps.scala
@@ -94,7 +94,11 @@ private[client] final class JobOps(client: Client) {
         case (bqJob, jobReference) =>
           val jobId = jobReference.getJobId
           try {
-            val poll = client.underlying.jobs().get(client.project, jobId).execute()
+            val poll = client.underlying
+              .jobs()
+              .get(client.project, jobId)
+              .set("location", jobReference.getLocation)
+              .execute()
             val error = poll.getStatus.getErrorResult
             if (error != null) {
               throw new RuntimeException(s"${bqJob.show} failed with error: $error")

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/JobOps.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/JobOps.scala
@@ -97,7 +97,7 @@ private[client] final class JobOps(client: Client) {
             val poll = client.underlying
               .jobs()
               .get(client.project, jobId)
-              .set("location", jobReference.getLocation)
+              .setLocation(jobReference.getLocation)
               .execute()
             val error = poll.getStatus.getErrorResult
             if (error != null) {


### PR DESCRIPTION
For any job not in the locations "US" or "EU", the location is required. This happens when a table is not in one of the multi-regional dataset locations ( such as "northamerica-northeast1" ).

This information is contained in `jobReference`, so pass it along when fetching the job.