### PR TITLE
Add partitionToMap function

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -295,9 +295,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     val partitionKeysIndexed = partitionKeys.toIndexedSeq
 
     partitionKeysIndexed
-      .zip(
-        partition(partitionKeys.size, t => partitionKeysIndexed.indexOf(f(t)))
-      )
+      .zip(partition(partitionKeys.size, t => partitionKeysIndexed.indexOf(f(t))))
       .toMap
   }
 

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -282,6 +282,26 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   }
 
   /**
+   * Partition this SCollection into a map from possible key values to an SCollection of
+   * corresponding elements based on the provided function .
+   *
+   * @param partitionKeys The keys for the output partitions
+   * @param f function that assigns an output partition to each element, should be in the range
+   * of `partitionKeys`
+   * @return partitioned SCollections in a `Map`
+   * @group collection
+   */
+  def partitionToMap[U: Coder](partitionKeys: Set[U], f: T => U): Map[U, SCollection[T]] = {
+    val partitionKeysIndexed = partitionKeys.toIndexedSeq
+
+    partitionKeysIndexed
+      .zip(
+        partition(partitionKeys.size, t => partitionKeysIndexed.indexOf(f(t)))
+      )
+      .toMap
+  }
+
+  /**
    * Partition this SCollection using Object.hashCode() into `n` partitions
    *
    * @param numPartitions number of output partitions

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -277,7 +277,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @group collection
    */
   def partition(p: T => Boolean): (SCollection[T], SCollection[T]) = {
-    val Seq(left, right) = partition(2, t => if (p(t)) 0 else 1)
+    val Seq(left, right) = partition(2, (t: T) => if (p(t)) 0 else 1)
     (left, right)
   }
 
@@ -291,11 +291,11 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @return partitioned SCollections in a `Map`
    * @group collection
    */
-  def partitionToMap[U: Coder](partitionKeys: Set[U], f: T => U): Map[U, SCollection[T]] = {
+  def partition[U: Coder](partitionKeys: Set[U], f: T => U): Map[U, SCollection[T]] = {
     val partitionKeysIndexed = partitionKeys.toIndexedSeq
 
     partitionKeysIndexed
-      .zip(partition(partitionKeys.size, t => partitionKeysIndexed.indexOf(f(t))))
+      .zip(partition(partitionKeys.size, (t: T) => partitionKeysIndexed.indexOf(f(t))))
       .toMap
   }
 

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -277,7 +277,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @group collection
    */
   def partition(p: T => Boolean): (SCollection[T], SCollection[T]) = {
-    val Seq(left, right) = partition(2, (t: T) => if (p(t)) 0 else 1)
+    val Seq(left, right) = partition(2, t => if (p(t)) 0 else 1)
     (left, right)
   }
 
@@ -291,7 +291,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @return partitioned SCollections in a `Map`
    * @group collection
    */
-  def partition[U: Coder](partitionKeys: Set[U], f: T => U): Map[U, SCollection[T]] = {
+  def partitionByKey[U: Coder](partitionKeys: Set[U])(f: T => U): Map[U, SCollection[T]] = {
     val partitionKeysIndexed = partitionKeys.toIndexedSeq
 
     partitionKeysIndexed

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -164,11 +164,11 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
-  it should "support partition() to a map" in {
+  it should "support partitionByKey()" in {
     runWithContext { sc =>
       val m = sc
         .parallelize(Seq("a1", "a2", "a3", "b4", "b5", "c6"))
-        .partition(Set("a", "b", "c"), _.substring(0, 1))
+        .partitionByKey(Set("a", "b", "c"))(_.substring(0, 1))
 
       m("a") should containInAnyOrder(Seq("a1", "a2", "a3"))
       m("b") should containInAnyOrder(Seq("b4", "b5"))

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -164,11 +164,11 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
-  it should "support partitionToMap()" in {
+  it should "support partition() to a map" in {
     runWithContext { sc =>
       val m = sc
         .parallelize(Seq("a1", "a2", "a3", "b4", "b5", "c6"))
-        .partitionToMap(Set("a", "b", "c"), _.substring(0, 1))
+        .partition(Set("a", "b", "c"), _.substring(0, 1))
 
       m("a") should containInAnyOrder(Seq("a1", "a2", "a3"))
       m("b") should containInAnyOrder(Seq("b4", "b5"))

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -164,6 +164,18 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
+  it should "support partitionToMap()" in {
+    runWithContext { sc =>
+      val m = sc
+        .parallelize(Seq("a1", "a2", "a3", "b4", "b5", "c6"))
+        .partitionToMap(Set("a", "b", "c"), _.substring(0, 1))
+
+      m("a") should containInAnyOrder(Seq("a1", "a2", "a3"))
+      m("b") should containInAnyOrder(Seq("b4", "b5"))
+      m("c") should containInAnyOrder(Seq("c6"))
+    }
+  }
+
   it should "support hashPartition() based on Object.hashCode()" in {
     runWithContext { sc =>
       val p = sc.parallelize(Seq(-1, 2, -3, 4, -5, 6)).hashPartition(3)


### PR DESCRIPTION
It can be annoying to be forced to work with Integers while doing partitions. This is a helper method that takes care of that annoyance by allowing the user to give a set of possible outcomes and a function into that set instead.