### PR TITLE
Fix equality for mutable bf sparse instances

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/util/BloomFilter.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/BloomFilter.scala
@@ -538,8 +538,8 @@ private[scio] final case class MutableSparseBFInstance[A](
   Equiv[MutableBF[A]] to compare two instances.
    */
   override def equals(obj: Any): Boolean = {
-    obj.isInstanceOf[MutableSparseBFInstance[A]] && {
-      val that = obj.asInstanceOf[MutableSparseBFInstance[A]]
+    obj.isInstanceOf[MutableBF[A]] && {
+      val that = obj.asInstanceOf[MutableBF[A]]
       implicitly[Equiv[MutableBF[A]]].equiv(this, that)
     }
   }

--- a/scio-core/src/main/scala/com/spotify/scio/util/BloomFilter.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/BloomFilter.scala
@@ -38,6 +38,7 @@ package com.spotify.scio.util
  *
  */
 import java.util
+import java.util.Objects
 
 import algebra.BoundedSemilattice
 import com.twitter.algebird.{
@@ -526,6 +527,25 @@ private[scio] final case class MutableSparseBFInstance[A](
     BloomFilter.sizeEstimate(numBits, numHashes, width, 0.05)
 
   def copy: MutableBF[A] = MutableSparseBFInstance(hashes, allHashes.clone)
+
+  /*
+  We override equals and hashCode specifically for MutableSparseBFInstance[A]
+  because this implementation has a delayed initialization, which means hashes
+  for all elements added are kept in a mutable.Buffer[Array[Int]] till contains
+  is called for the first time.
+
+  mutable.Buffer[Array[T]] cannot be compared with equals, hence we use
+  Equiv[MutableBF[A]] to compare two instances.
+   */
+  override def equals(obj: Any): Boolean = {
+    obj.isInstanceOf[MutableSparseBFInstance[A]] && {
+      val that = obj.asInstanceOf[MutableSparseBFInstance[A]]
+      implicitly[Equiv[MutableBF[A]]].equiv(this, that)
+    }
+  }
+
+  // Object.hashCode() is based on the hashing algorithm, and the elements added only.
+  override def hashCode(): Int = Objects.hash(hashes, allHashes)
 }
 
 /**


### PR DESCRIPTION
Yesterday I noticed that the `Coder.structuralValue` for `MutableSparseBFInstance` doesn't match for equivalent instances, and we get a warning from Beam's `MutationDetector`

This is happening because `Object.equals` for `mutable.Buffer[Array[Int]]` calls `Array.equals` for each element in the buffer, but `Array.equals` doesn't compare by each element in the array.

This PR fixes this by defining `hashCode` and `equals` for the `MutableSparseBFInstance`. This problem doesn't affect the other sub classes of `MutableBF`.


Detailed debug:
```scala
scala> import scala.collection.mutable
import scala.collection.mutable

scala> val v1 = mutable.Buffer[Array[Int]]()
v1: scala.collection.mutable.Buffer[Array[Int]] = ArrayBuffer()

scala> v1.append(Array(1, 2, 3))

scala> val v2 = mutable.Buffer[Array[Int]]()
v2: scala.collection.mutable.Buffer[Array[Int]] = ArrayBuffer()

scala> v2.append(Array(1, 2, 3))

scala> v1.equals(v2)
res2: Boolean = false

scala>

```