### PR TITLE
Expose Beam's AvroIO.parseGenericRecords

### DIFF
--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
@@ -21,7 +21,7 @@ import com.google.protobuf.Message
 import com.spotify.scio.avro.types.AvroType.HasAvroAnnotation
 import com.spotify.scio.coders.{AvroBytesUtil, Coder, CoderMaterializer}
 import com.spotify.scio.io._
-import com.spotify.scio.util.ScioUtil
+import com.spotify.scio.util.{Functions, ScioUtil}
 import com.spotify.scio.values._
 import com.spotify.scio.{avro, ScioContext}
 import org.apache.avro.Schema
@@ -218,6 +218,45 @@ final case class GenericRecordIO[T: ClassTag: Coder](path: String, schema: Schem
 
   override def tap(read: ReadP): Tap[T] =
     GenericRecordTap[T](ScioUtil.addPartSuffix(path), schema)
+}
+
+/**
+ * Given a parseFn, read [[org.apache.avro.generic.GenericRecord GenericRecord]]
+ * and apply a function mapping [[GenericRecord => T]] before producing output.
+ * This IO applies the function at the time to de-serialising Avro GenericRecords.
+ *
+ * This IO doesn't define write, and should not be used to write Avro GenericRecords.
+ */
+final case class GenericRecordParseIO[T](path: String, parseFn: GenericRecord => T)(
+  implicit coder: Coder[T]
+) extends AvroIO[T] {
+  override type ReadP = Unit
+  override type WriteP = Nothing // Output is not defined for Avro Generic Parse IO.
+
+  override def testId: String = s"AvroIO($path)"
+
+  /**
+   * Get an SCollection[T] by applying the [[parseFn]] on
+   * [[org.apache.avro.generic.GenericRecord GenericRecord]]
+   * from an Avro file.
+   */
+  override protected def read(sc: ScioContext, params: Unit): SCollection[T] = {
+    val t = beam.AvroIO
+      .parseGenericRecords(
+        Functions
+          .serializableFn(parseFn)
+      )
+      .from(path)
+      .withCoder(CoderMaterializer.beamWithDefault(coder))
+
+    sc.wrap(sc.applyInternal(t))
+  }
+
+  /**
+   * Writes are undefined for [[GenericRecordParseIO]] since it is used only for reading.
+   */
+  override protected def write(data: SCollection[T], params: Nothing): Tap[T] = ???
+  override def tap(read: Unit): Tap[T] = ???
 }
 
 object AvroIO {

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
@@ -242,9 +242,7 @@ final case class GenericRecordParseIO[T](path: String, parseFn: GenericRecord =>
    */
   override protected def read(sc: ScioContext, params: Unit): SCollection[T] = {
     val t = beam.AvroIO
-      .parseGenericRecords(
-        Functions.serializableFn(parseFn)
-      )
+      .parseGenericRecords(Functions.serializableFn(parseFn))
       .from(path)
       .withCoder(CoderMaterializer.beam(sc, coder))
 

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
@@ -55,7 +55,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
    * parseFn to map a serialized [[org.apache.avro.generic.GenericRecord GenericRecord]]
    * to type [[T]]
    */
-  def avroFile[T: Coder](path: String, parseFn: GenericRecord => T): SCollection[T] =
+  def parseAvroFile[T: Coder](path: String)(parseFn: GenericRecord => T): SCollection[T] =
     self.read(GenericRecordParseIO[T](path, parseFn))
 
   /**

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
@@ -24,6 +24,7 @@ import com.spotify.scio.avro.types.AvroType.HasAvroAnnotation
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.values._
 import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
 import org.apache.avro.specific.SpecificRecord
 
 import scala.language.implicitConversions
@@ -48,6 +49,14 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
    */
   def avroFile[T: ClassTag: Coder](path: String, schema: Schema): SCollection[T] =
     self.read(GenericRecordIO[T](path, schema))
+
+  /**
+   * Get an SCollection of type [[T]] for data stored in Avro format after applying
+   * parseFn to map a serialized [[org.apache.avro.generic.GenericRecord GenericRecord]]
+   * to type [[T]]
+   */
+  def avroFile[T: Coder](path: String, parseFn: GenericRecord => T): SCollection[T] =
+    self.read(GenericRecordParseIO[T](path, parseFn))
 
   /**
    * Get an SCollection of type [[org.apache.avro.specific.SpecificRecord SpecificRecord]]

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/taps.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/taps.scala
@@ -73,7 +73,7 @@ final case class GenericRecordParseTap[T: Coder](
       .avroFile[GenericRecord](schema = null)
       .map(parseFn)
 
-  override def open(sc: ScioContext): SCollection[T] = sc.avroFile(path, parseFn)
+  override def open(sc: ScioContext): SCollection[T] = sc.parseAvroFile(path)(parseFn)
 }
 
 /**

--- a/scio-test/src/test/scala/com/spotify/scio/io/ScioIOTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/ScioIOTest.scala
@@ -67,8 +67,7 @@ class ScioIOTest extends ScioIOSpec {
     val xs = (1 to 100).map(PartialFieldsAvro)
     // No test for saveAsAvroFile because parseFn is only for i/p
     testJobTest(xs)(AvroIO(_))(
-      _.avroFile[PartialFieldsAvro](
-        _,
+      _.parseAvroFile[PartialFieldsAvro](_)(
         (gr: GenericRecord) => PartialFieldsAvro(gr.get("int_field").asInstanceOf[Int])
       )
     )(_.saveAsAvroFile(_, schema = schema))

--- a/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
@@ -76,8 +76,7 @@ object GenericParseFnAvroFileJob {
 
   def main(cmdlineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdlineArgs)
-    sc.avroFile[PartialFieldsAvro](
-        args("input"),
+    sc.parseAvroFile[PartialFieldsAvro](args("input"))(
         (gr: GenericRecord) => PartialFieldsAvro(gr.get("int_field").asInstanceOf[Int])
       )
       .map(a => AvroUtils.newGenericRecord(a.intField))

--- a/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
@@ -22,7 +22,7 @@ import com.google.datastore.v1.Entity
 import com.google.datastore.v1.client.DatastoreHelper.{makeKey, makeValue}
 import com.spotify.scio._
 import com.spotify.scio.avro.AvroUtils.{newGenericRecord, newSpecificRecord}
-import com.spotify.scio.avro.{AvroUtils, _}
+import com.spotify.scio.avro._
 import com.spotify.scio.bigquery._
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.io._


### PR DESCRIPTION
Beam has an Api to apply a parseFn on Generic Records before reading them to a type `T`. Currently Scio's `AvroIO` doesn't provide a way to access this API and also benefit from `JobTest`.

This PR adds access to `AvroIO.parseGenericRecords` as a Scio `AvroIO`

Motivation is [here](https://docs.google.com/document/d/1m5M0JgjrmRca8qWtzsJa5lJoCGBqRqRcv5h0JaE3NYE/edit#heading=h.q4tiuatwvivr).

TODO
 - Find out if this is the appropriate way to expose this API.
 - ~Add unit tests.~