### PR TITLE
PairSCollectionFunctions: recover from a Failure coder as well as from a bad coder

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -25,11 +25,9 @@ import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.util._
 import com.spotify.scio.util.random.{BernoulliValueSampler, PoissonValueSampler}
 import com.twitter.algebird.{Aggregator, Hash128, Monoid, Semigroup}
-import org.apache.beam.sdk.coders.KvCoder
 import org.apache.beam.sdk.transforms._
 import org.apache.beam.sdk.values.{KV, PCollection, PCollectionView}
 import org.slf4j.LoggerFactory
-import scala.util.Try
 
 private object PairSCollectionFunctions {
 

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -105,9 +105,8 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
           .apply("TupleToKv", toKvTransform)
           .setCoder(CoderMaterializer.kvCoder[K, V](context))
           .apply(t)
-        if (!(Try(kv.getCoder.isInstanceOf[KvCoder[_, _]]).getOrElse(false))) {
-          kv = kv.setCoder(CoderMaterializer.kvCoder[K, UI](context))
-        }
+          .setCoder(CoderMaterializer.kvCoder[K, UI](context))
+
         kv.apply("KvToTuple", ParDo.of(Functions.mapFn[KV[K, UI], (K, UO)](f)))
           .setCoder(CoderMaterializer.beam(context, Coder[(K, UO)]))
       }

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.coders.KvCoder
 import org.apache.beam.sdk.transforms._
 import org.apache.beam.sdk.values.{KV, PCollection, PCollectionView}
 import org.slf4j.LoggerFactory
+import scala.util.Try
 
 private object PairSCollectionFunctions {
 
@@ -104,7 +105,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
           .apply("TupleToKv", toKvTransform)
           .setCoder(CoderMaterializer.kvCoder[K, V](context))
           .apply(t)
-        if (!kv.getCoder.isInstanceOf[KvCoder[_, _]]) {
+        if (!(Try(kv.getCoder.isInstanceOf[KvCoder[_, _]]).getOrElse(false))) {
           kv = kv.setCoder(CoderMaterializer.kvCoder[K, UI](context))
         }
         kv.apply("KvToTuple", ParDo.of(Functions.mapFn[KV[K, UI], (K, UO)](f)))


### PR DESCRIPTION
While trying to implement `SCollection[(K,V)].scanLeft[U: Coder](init: U)(op: (U, V) => V)`, I needed to use `applyPerKeyDoFn`. While running that, I encountered a problem in PairSCollectionFunctions.scala#L107

The intent of the original code appeared to be, if there is a coder with the proper shape, keep using it, otherwise overwrite with a code made for KV[K,V]. This would have worked pre-BEAM 2.0 where .getCoder didn't throw an exception if the coder was a failure.

This patch fixes that, by swallowing exceptions related to .getCoder following the `coderOrFailure.failure` path and handling that as a mis-shaped coder.