### PR TITLE
Support passing Assertions directly to `JobTest` `output`

### DIFF
--- a/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
@@ -127,7 +127,7 @@ object JobTest {
      * @param assertion assertion for output data. See [[SCollectionMatchers]] for available
      *                  matchers on an [[com.spotify.scio.values.SCollection SCollection]].
      */
-    def output[T](io: ScioIO[T])(assertion: SCollection[T] => _): Builder = {
+    def output[T](io: ScioIO[T])(assertion: SCollection[T] => Any): Builder = {
       require(!state.output.contains(io.toString), "Duplicate test output: " + io.toString)
       state = state.copy(
         output = state.output + (io.testId -> assertion

--- a/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
@@ -126,8 +126,10 @@ object JobTest {
      *
      * @param assertion assertion for output data. See [[SCollectionMatchers]] for available
      *                  matchers on an [[com.spotify.scio.values.SCollection SCollection]].
+     * @tparam A        type of assertion (discarded) -- will be treated as [[scala.Unit]]
+     *                  (but can be [[org.scalatest.Assertion]])
      */
-    def output[T](io: ScioIO[T])(assertion: SCollection[T] => Unit): Builder = {
+    def output[T, A](io: ScioIO[T])(assertion: SCollection[T] => A): Builder = {
       require(!state.output.contains(io.toString), "Duplicate test output: " + io.toString)
       state = state.copy(
         output = state.output + (io.testId -> assertion

--- a/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
@@ -126,10 +126,8 @@ object JobTest {
      *
      * @param assertion assertion for output data. See [[SCollectionMatchers]] for available
      *                  matchers on an [[com.spotify.scio.values.SCollection SCollection]].
-     * @tparam A        type of assertion (discarded) -- will be treated as [[scala.Unit]]
-     *                  (but can be [[org.scalatest.Assertion]])
      */
-    def output[T, A](io: ScioIO[T])(assertion: SCollection[T] => A): Builder = {
+    def output[T](io: ScioIO[T])(assertion: SCollection[T] => _): Builder = {
       require(!state.output.contains(io.toString), "Duplicate test output: " + io.toString)
       state = state.copy(
         output = state.output + (io.testId -> assertion

--- a/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
@@ -936,6 +936,19 @@ class JobTestTest extends PipelineSpec {
     }
   }
 
+  class JobTestWithNonUnitAssertion extends PipelineSpec {
+    import com.spotify.scio.testing.{JobTest => InternalJobTest}
+    "JobTestWithNonUnitAssertion" should "work" in {
+      InternalJobTest[ObjectFileJob.type]
+        .args("--input=in.avro", "--output=out.avro")
+        .input(ObjectFileIO[Int]("in.avro"), Seq(1, 2, 3))
+        // warns given flag `-Ywarn-value-discard`
+        // if `output` only accepts `SCollection[_] => Unit`
+        // instead of `SCollection[_] => Assertion`
+        .output(ObjectFileIO[Int]("out.avro"))(_ should containInAnyOrder(Seq(1, 2, 3)))
+    }
+  }
+
   // scalastyle:off line.contains.tab
   // scalastyle:off line.size.limit
   private val runMissedMessage =


### PR DESCRIPTION
The instructions and examples for `JobTest` `output` assertions warn if
run with `-Ywarn-value-discard`, because the compiler sees the `Unit` as
being discarded.  Most of the tests I can see fix this by returning `()`
_after_ the assertion, but this shouldn't be necessary.  This commit
changes the `assertion` to be `SCollection[T] => _`, where `_` is
(obviously) discarded.  The `assertion` is still converted using
`.asInstanceOf[SCollection[_] => Unit]` (so there's no actual behavior
change), but now passing `Assertion`s will work without a hitch.

Also see: [relevant discussion in
Gitter](https://gitter.im/spotify/scio?at=5d0bf10e4b0b7b477b2c14f2)