### PR TITLE
Use BigtableOptions param for BigTable utils

### DIFF
--- a/scio-bigtable/src/it/scala/com/spotify/scio/bigtable/BigtableIT.scala
+++ b/scio-bigtable/src/it/scala/com/spotify/scio/bigtable/BigtableIT.scala
@@ -127,7 +127,7 @@ class BigtableIT extends PipelineSpec {
       s"scio-bigtable-one-cf-table-$uuid" -> List("colfam1"),
       s"scio-bigtable-two-cf-table-$uuid" -> List("colfam1", "colfam2")
     )
-    val channel = ChannelPoolCreator.createPool(bigtableOptions.getAdminHost)
+    val channel = ChannelPoolCreator.createPool(bigtableOptions)
     val executorService = BigtableSessionSharedThreadPools.getInstance().getRetryExecutor
     val client = new BigtableTableAdminGrpcClient(channel, executorService, bigtableOptions)
     val instancePath = s"projects/$projectId/instances/$instanceId"

--- a/scio-bigtable/src/main/java/com/spotify/scio/bigtable/BigtableUtil.java
+++ b/scio-bigtable/src/main/java/com/spotify/scio/bigtable/BigtableUtil.java
@@ -75,7 +75,7 @@ public final class BigtableUtil {
       final Duration sleepDuration
   ) throws IOException, InterruptedException {
     final ChannelPool channelPool =
-        ChannelPoolCreator.createPool(bigtableOptions.getAdminHost());
+        ChannelPoolCreator.createPool(bigtableOptions);
 
     try {
       final BigtableInstanceClient bigtableInstanceClient = new BigtableInstanceGrpcClient(channelPool);

--- a/scio-bigtable/src/main/java/com/spotify/scio/bigtable/ChannelPoolCreator.java
+++ b/scio-bigtable/src/main/java/com/spotify/scio/bigtable/ChannelPoolCreator.java
@@ -22,11 +22,9 @@ import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.io.ChannelPool;
 import com.google.cloud.bigtable.grpc.io.CredentialInterceptorCache;
-import com.google.common.collect.ImmutableList;
 import io.grpc.ClientInterceptor;
 
 import java.io.IOException;
-import java.util.List;
 
 public class ChannelPoolCreator {
   public static final BigtableOptions options = new BigtableOptions.Builder().build();
@@ -41,8 +39,8 @@ public class ChannelPoolCreator {
     }
   }
 
-  public static ChannelPool createPool(final String host) throws IOException {
-    return new ChannelPool(() -> BigtableSession.createNettyChannel(host, options, interceptor),
-        1);
+  public static ChannelPool createPool(final BigtableOptions options) throws IOException {
+    return new ChannelPool(() ->
+        BigtableSession.createNettyChannel(options.getAdminHost(), options, interceptor), 1);
   }
 }

--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/TableAdmin.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/TableAdmin.scala
@@ -39,7 +39,7 @@ object TableAdmin {
     bigtableOptions: BigtableOptions
   )(f: BigtableTableAdminClient => A): Try[A] = {
     val channel =
-      ChannelPoolCreator.createPool(bigtableOptions.getAdminHost)
+      ChannelPoolCreator.createPool(bigtableOptions)
     val executorService =
       BigtableSessionSharedThreadPools.getInstance().getRetryExecutor
     val client = new BigtableTableAdminGrpcClient(channel, executorService, bigtableOptions)


### PR DESCRIPTION
Currently, it is not possible to use local BigTable emulator for integration testing as the current set up ignores BigtableOptions passed as parameters from test to ChannelPoolCreator.createPool method. I changed the method signature rather than adding a method but so not backward comp for users using ChannelPoolCreator.java but I didn see any value in keeping the old method.
Please advice if adding rather changing is prefered? 