### PR TITLE
Add batchByKey function

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -798,6 +798,24 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     this.applyPerKey(GroupByKey.create[K, V](), kvIterableToTuple[K, V])
 
   /**
+   * Batches inputs to a desired batch size. Batches will contain only elements of a single key.
+   *
+   * Elements are buffered until there are batchSize elements buffered, at which point they are
+   * outputed to the output [[SCollection]].
+   *
+   * Windows are preserved (batches contain elements from the same window).
+   * Batches may contain elements from more than one bundle.
+   *
+   * @param batchSize
+   *
+   * @group per_key
+   */
+  def batchByKey(
+    batchSize: Long
+  )(implicit koder: Coder[K], voder: Coder[V]): SCollection[(K, Iterable[V])] =
+    this.applyPerKey(GroupIntoBatches.ofSize(batchSize), kvIterableToTuple[K, V])
+
+  /**
    * Return an SCollection with the pairs from `this` whose keys are in `that`.
    *
    * Unlike [[SCollection.intersection]] this preserves duplicates in `this`.

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -323,11 +323,10 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
       val nonEmpty = sc
         .parallelize(Seq(("a", 1), ("a", 10), ("b", 2), ("b", 20)))
         .batchByKey(batchSize)
-
-      nonEmpty should containInAnyOrder(Seq(("a", Iterable(1, 10)), ("b", Iterable(2, 20))))
+        .mapValues(_.toSet)
+      nonEmpty should containInAnyOrder(Seq(("a", Set(1, 10)), ("b", Set(2, 20))))
 
       val empty = sc.empty[(String, Int)]().batchByKey(batchSize)
-
       empty should beEmpty
     }
   }

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -317,6 +317,21 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
+  it should "support batchByKey" in {
+    runWithContext { sc =>
+      val batchSize = 2
+      val nonEmpty = sc
+        .parallelize(Seq(("a", 1), ("a", 10), ("b", 2), ("b", 20)))
+        .batchByKey(batchSize)
+
+      nonEmpty should containInAnyOrder(Seq(("a", Iterable(1, 10)), ("b", Iterable(2, 20))))
+
+      val empty = sc.empty[(String, Int)]().batchByKey(batchSize)
+
+      empty should beEmpty
+    }
+  }
+
   it should "support intersectByKey()" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))


### PR DESCRIPTION
From gitter seems that `batchByKey` might be handy to have.