### PR TITLE
Update avro docs

### DIFF
--- a/scripts/make-site.sh
+++ b/scripts/make-site.sh
@@ -2,7 +2,7 @@
 
 # generate new site locally
 # target/site/index.html
-# SOCCO=true sbt scio-examples/clean scio-examples/compile site/makeSite
+SOCCO=true sbt scio-examples/clean scio-examples/compile site/makeSite
 
 # generate new site and push to GitHub
-SOCCO=true sbt scio-examples/clean scio-examples/compile site/ghpagesPushSite
+#SOCCO=true sbt scio-examples/clean scio-examples/compile site/ghpagesPushSite

--- a/site/src/paradox/internals/Coders.md
+++ b/site/src/paradox/internals/Coders.md
@@ -28,7 +28,7 @@ case class Foo(x: Int, s: String)
 def sc: SCollection[Foo] = ??? // Beam will need an org.apache.beam.sdk.coders.Coder[Foo]
 ```
 
-## Scio < `0.7.0`
+## Scio `0.6.x` and below
 
 In Scio `0.6.x` and below, Scio would delegate this serialization process to [Kryo](https://github.com/EsotericSoftware/kryo). Kryo's job is to automagically "generate" the serialization logic for any type. The benefit is you don't really have to care about serialization most of the time when writing pipelines with Scio. Using Beam, you would need to explicitly set the coder every time you use a `PTtransform`.
 
@@ -39,7 +39,7 @@ While it saves a lot of work, it also has a few drawbacks:
 - Kryo coders are very dynamic and it can be hard to know exactly which coder is used for a given class.
 - Kryo coders do not always play well with Beam, and sometime can cause weird runtime exceptions. For example, Beam may sometimes throw an `IllegalMutationException` because of the default Kryo coder implementation.
 
-## Scio >= `0.7.0`
+## Scio `0.7.0` and above
 
 In Scio `0.7.0` and above, the Scala compiler will try to find the correct instance of `Coder` at compile time.
 In most cases, the compiler should be able to either directly find a proper `Coder` implementation, or derive one automatically.
@@ -74,7 +74,6 @@ Coder[Demo]
 
 sealed class hierarchy are also supported:
 
-
 ```scala mdoc
 sealed trait Top
 final case class TA(anInt: Int, aString: String) extends Top
@@ -89,6 +88,7 @@ Sometimes, no `Coder` instance can be found, and it's impossible to automaticall
 In that case, Scio will fallback to a Kryo coder for that specific type, and if the scalac flag `-Xmacro-settings:show-coder-fallback=true` is set, a warning message will be displayed __at compile time__. This message should help you fix the warning.
 
 While compiling the following with `-Xmacro-settings:show-coder-fallback=true`
+
 ```scala mdoc:reset
 import com.spotify.scio.coders._
 val localCoder = Coder[java.util.Locale]
@@ -131,7 +131,6 @@ Warning: No implicit Coder found for the following type:
 Here for example, the compiler could not find a proper instance of `Coder[Locale]`, and suggest you implement one yourself.
 
 Note that this message is not limited to direct invocation of fallback. For example, if you declare a case class that uses `Locale` internally, the compiler will show the same warning:
-
 
 ```scala mdoc:reset
 import com.spotify.scio.coders._

--- a/site/src/paradox/io/Avro.md
+++ b/site/src/paradox/io/Avro.md
@@ -4,43 +4,80 @@
 
 Scio comes with support for reading Avro files. Avro supports generic or specific records, Scio supports both via the same method (`avroFile`), but depending on the type parameter.
 
-### Specific record:
+### Read Specific records
 
-```
-# SpecificRecordClass is compiled from Avro schema files
-sc.avroFile[SpecificRecordClass]("gs://path-to-data/lake/part-*.avro")
-  .map(record => ???)
-# `record` is of your SpecificRecordClass type
+```scala mdoc:reset:silent
+import com.spotify.scio.ScioContext
+import com.spotify.scio.avro._
+
+import org.apache.avro.specific.SpecificRecord
+
+def sc: ScioContext = ???
+
+// SpecificRecordClass is compiled from Avro schema files
+def result = sc.avroFile[SpecificRecord]("gs://path-to-data/lake/part-*.avro")
 ```
 
-### Generic record:
+### Read Generic records
 
-```
+```scala mdoc:reset:silent
+import com.spotify.scio.ScioContext
+import com.spotify.scio.avro._
+
 import org.apache.avro.generic.GenericRecord
-sc.avroFile[GenericRecord]("gs://path-to-data/lake/part-*.avro", yourAvroSchema)
-  .map(record => ???)
-# `record` is of GenericRecord type
+import org.apache.avro.Schema
+
+def yourAvroSchema: Schema = ???
+
+def sc: ScioContext = ???
+
+def result = sc.avroFile[GenericRecord]("gs://path-to-data/lake/part-*.avro", yourAvroSchema)
+// `record` is of GenericRecord type
 ```
 
 ## Write Avro files
 
 Scio comes with support for writing Avro files. Avro supports generic or specific records, Scio supports both via the same method (`saveAsAvroFile`), but depending on the type of the content of `SCollection`.
 
-### Specific record:
+### Write Specific records
 
-```
-# type of Avro specific records will hold information about schema,
-# therefor Scio will figure out the schema by itself
-sc.map(<build Avro specific records>)
-  .saveAsAvroFile("gs://path-to-data/lake/output")
+```scala mdoc:reset:silent
+import com.spotify.scio.values.SCollection
+import com.spotify.scio.avro._
+
+import org.apache.avro.specific.SpecificRecord
+
+case class Foo(x: Int, s: String)
+def sc: SCollection[Foo] = ???
+
+// convert to avro SpecificRecord
+def fn(f: Foo): SpecificRecord = ???
+
+// type of Avro specific records will hold information about schema,
+// therefor Scio will figure out the schema by itself
+
+def result =  sc.map(fn).saveAsAvroFile("gs://path-to-data/lake/output")
 ```
 
-### Generic record:
+### Write Generic records
 
-```
-# writing Avro generic records requires additional argument `schema`
-sc.map(<build Avro generic records>)
-  .saveAsAvroFile("gs://path-to-data/lake/output", schema = yourAvroSchema)
+```scala mdoc:reset:silent
+import com.spotify.scio.values.SCollection
+import com.spotify.scio.avro._
+
+import org.apache.avro.generic.GenericRecord
+import org.apache.avro.Schema
+
+case class Foo(x: Int, s: String)
+def sc: SCollection[Foo] = ???
+
+def yourAvroSchema: Schema = ???
+
+// convert to avro SpecificRecord
+def fn(f: Foo): GenericRecord = ???
+
+// writing Avro generic records requires additional argument `schema`
+def result =  sc.map(fn).saveAsAvroFile("gs://path-to-data/lake/output", schema = yourAvroSchema)
 ```
 
 ## Rules for schema evolution


### PR DESCRIPTION
Paradox 0.6.0 is more strict now and it doesn't allow duplicate anchors. Also updated `avro` examples to use `mdoc`