### PR TITLE
Rename java import

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
@@ -53,8 +53,8 @@ trait JavaCoders {
   implicit def pathCoder: Coder[java.nio.file.Path] =
     Coder.xmap(Coder.beam(StringUtf8Coder.of()))(s => java.nio.file.Paths.get(s), _.toString)
 
-  import java.lang.{Iterable => jIterable}
-  implicit def jIterableCoder[T](implicit c: Coder[T]): Coder[jIterable[T]] =
+  import java.lang.{Iterable => JIterable}
+  implicit def jIterableCoder[T](implicit c: Coder[T]): Coder[JIterable[T]] =
     Coder.transform(c) { bc =>
       Coder.beam(bcoders.IterableCoder.of(bc))
     }


### PR DESCRIPTION
All java aliased imports should start with `J`