### PR TITLE
flink: don't wrap EOFException in WrappedBCoder 

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.coders
 
-import java.io.{InputStream, OutputStream}
+import java.io.{EOFException, InputStream, OutputStream}
 
 import com.spotify.scio.coders.instances.Implicits
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException
@@ -188,12 +188,32 @@ private[scio] case class WrappedBCoder[T](u: BCoder[T]) extends BCoder[T] {
   private def buildException(cause: Throwable): Exception =
     CoderException(stackTrace, cause)
 
+  private val stackSeparator =
+    new StackTraceElement(
+      "——✂——✂——✂—— Materialization point call stack follows ——✂——✂——✂——",
+      "——✂——✂——✂——",
+      "——✂——✂——✂——",
+      0
+    )
+
+  private val separatedStackTrace = Array(stackSeparator) ++ stackTrace
+
+  private def appendMaterializationStack[T <: Throwable](cause: T): T = {
+    val existingStack = cause.getStackTrace
+    val adjustedStack = existingStack ++ separatedStackTrace
+    cause.setStackTrace(adjustedStack)
+    cause
+  }
+
   override def toString: String = u.toString
 
   @inline private def catching[A](a: => A) =
     try {
       a
     } catch {
+      case ex: EOFException =>
+        /* this is used under Flink for internal signalling, and caught above here. */
+        throw appendMaterializationStack(ex)
       case ex: Throwable =>
         throw buildException(ex)
     }


### PR DESCRIPTION
This is a stab at addressing #2024 
In case an EOFException is caught by WrappedBCoder, it is not wrapped but rethrown, as an outer layer of Flink expects to catch it to complete some try-and-recover step.
Wrapping into `CoderException` prevents the outer layer of Flink from catching its signal from the innermost layer.

The base functionality of `CoderException` is preserved by appending the "materialization point" call stack to the actual exception call stack.

Note: I'm thinking about deprecating `CoderException` and applying this stack-decoration procedure to all exceptions, but I am not in a position to assess the potential consequences to existing clients of scio (there doesn't appear any place where CoderException is caught or matched against in the scio repository properly)

