### PR TITLE
Normalizes username in jobName for Scio Repl session.

### DIFF
--- a/scio-repl/src/main/scala/com/spotify/scio/repl/ReplScioContext.scala
+++ b/scio-repl/src/main/scala/com/spotify/scio/repl/ReplScioContext.scala
@@ -24,7 +24,12 @@ class ReplScioContext(options: PipelineOptions, artifacts: List[String])
     extends ScioContext(options, artifacts) {
 
   this.setAppName("sciorepl")
-  this.setJobName(s"""sciorepl-${CoreSysProps.User.value}-${System.currentTimeMillis()}""")
+
+  /** Overwrite job name to default for REPL session */
+  this.setJobName( "sciorepl-%s-%d".format(
+    CoreSysProps.User.value.replaceAll("[^a-z0-9]", "0"),
+    System.currentTimeMillis()
+  ))
 
   /** Enhanced version that dumps REPL session jar. */
   override def close(): ClosedScioContext = {

--- a/scio-repl/src/main/scala/com/spotify/scio/repl/ReplScioContext.scala
+++ b/scio-repl/src/main/scala/com/spotify/scio/repl/ReplScioContext.scala
@@ -23,14 +23,6 @@ import com.spotify.scio.{ClosedScioContext, CoreSysProps, ScioContext}
 class ReplScioContext(options: PipelineOptions, artifacts: List[String])
     extends ScioContext(options, artifacts) {
 
-  this.setAppName("sciorepl")
-
-  /** Overwrite job name to default for REPL session */
-  this.setJobName( "sciorepl-%s-%d".format(
-    CoreSysProps.User.value.replaceAll("[^a-z0-9]", "0"),
-    System.currentTimeMillis()
-  ))
-
   /** Enhanced version that dumps REPL session jar. */
   override def close(): ClosedScioContext = {
     createJar()


### PR DESCRIPTION
This is to remove need for workaround when one must always manually specify new JobName after Scio Repl is started by sc.setJobName("my-job-name").
This will keep stiff jobName as
"sciorepl-%s-%d".format(
    CoreSysProps.User.value.replaceAll("[^a-z0-9]", "0"),
    System.currentTimeMillis()
But users that's username consist of characters not allowed in jobName will be able to save time and not do the workaround.