### PR TITLE
Explicitly name the transform in close() that initializes counters

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -556,7 +556,7 @@ class ScioContext private[scio] (val options: PipelineOptions, private var artif
 
     if (_counters.nonEmpty) {
       val counters = _counters.toArray
-      this.parallelize(Seq(0)).map { _ =>
+      this.parallelize(Seq(0)).withName("Initialize counters").map { _ =>
         counters.foreach(_.inc(0))
       }
     }


### PR DESCRIPTION
I was going through some internally filed issues & saw some confusion about the graph produced for jobs with counters, which on `close()` materialize a singleton SCollection that iterates over counters and calls `.inc(0)` on each:

<img width="475" alt="Screen Shot 2019-07-11 at 1 20 17 PM" src="https://user-images.githubusercontent.com/1360529/61071398-ff220e80-a3de-11e9-916d-cb704e7aa267.png">

I thought it would be helpful to add an explicit name to that ptransform to make it more clear to the user what's going on:

<img width="251" alt="Screen Shot 2019-07-11 at 1 46 52 PM" src="https://user-images.githubusercontent.com/1360529/61072966-63929d00-a3e2-11e9-8675-f8aa76771444.png">