### PR TITLE
Ignore compile test for recursive type Coder derivation

### DIFF
--- a/scio-test/src/test/scala/com/spotify/scio/coders/coders.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/coders.scala
@@ -464,7 +464,10 @@ class CodersTest extends FlatSpec with Matchers {
     case class RecordType(fields: List[SampleField]) extends SampleFieldType
 
     "Coder[SampleField]" should compile
-    "Coder[SampleFieldType]" should compile
+    // deriving this coder under 2.11 will fail
+    // https://github.com/scala/bug/issues/5466
+    // https://github.com/propensive/magnolia/issues/78
+    // "Coder[SampleFieldType]" should compile
 
     SampleField("hello", StringType) coderShould roundtrip()
 


### PR DESCRIPTION
under 2.11 this fails to compile under scalatest

https://github.com/scala/bug/issues/5466
https://github.com/propensive/magnolia/issues/78

/cc @jto