### PR TITLE
bigtable: Add setCellExpiration

### DIFF
--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/TableAdmin.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/TableAdmin.scala
@@ -102,7 +102,7 @@ object TableAdmin {
     bigtableOptions: BigtableOptions,
     tablesAndColumnFamiliesWithExpiration: Map[String, List[(String, Option[Duration])]]
   ): Unit = {
-    val tablesAndColumnFamilies = tablesAndColumnFamiliesWithExpiration.mapValues { _.unzip._1 }
+    val tablesAndColumnFamilies = tablesAndColumnFamiliesWithExpiration.mapValues(_.unzip._1)
     ensureTablesImpl(bigtableOptions, tablesAndColumnFamilies).flatMap { _ =>
       setCellExpiration(bigtableOptions, tablesAndColumnFamiliesWithExpiration)
     }.get

--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/TableAdmin.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/TableAdmin.scala
@@ -67,7 +67,7 @@ object TableAdmin {
       )
       .getTablesList
       .asScala
-      .map(t => t.getName)
+      .map(_.getName)
       .toSet
   }
 

--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
@@ -299,9 +299,8 @@ package object bigtable {
       bigtableOptions: BigtableOptions,
       tablesAndColumnFamilies: Map[String, List[String]],
       cellExpiration: Duration
-    ): Unit = {
+    ): Unit =
       TableAdmin.setCellExpiration(bigtableOptions, tablesAndColumnFamilies, cellExpiration)
-    }
   }
 
   /**

--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
@@ -198,32 +198,7 @@ package object bigtable {
           .setProjectId(projectId)
           .setInstanceId(instanceId)
           .build
-        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies, None)
-      }
-    }
-
-    /**
-     * Ensure that tables and column families exist.
-     * Checks for existence of tables or creates them if they do not exist.  Also checks for
-     * existence of column families within each table and creates them if they do not exist.
-     *
-     * @param tablesAndColumnFamilies A map of tables and column families.  Keys are table names.
-     *                                Values are a list of column family names.
-     * @param cellExpiration The duration before which garbage collection of a cell may occur.
-     *                       Note: minimum granularity is second.
-     */
-    def ensureTables(
-      projectId: String,
-      instanceId: String,
-      tablesAndColumnFamilies: Map[String, List[String]],
-      cellExpiration: Option[Duration]
-    ): Unit = {
-      if (!self.isTest) {
-        val bigtableOptions = new BigtableOptions.Builder()
-          .setProjectId(projectId)
-          .setInstanceId(instanceId)
-          .build
-        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies, cellExpiration)
+        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies)
       }
     }
 
@@ -240,7 +215,7 @@ package object bigtable {
       tablesAndColumnFamilies: Map[String, List[String]]
     ): Unit = {
       if (!self.isTest) {
-        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies, None)
+        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies)
       }
     }
 
@@ -249,58 +224,55 @@ package object bigtable {
      * Checks for existence of tables or creates them if they do not exist.  Also checks for
      * existence of column families within each table and creates them if they do not exist.
      *
-     * @param tablesAndColumnFamilies A map of tables and column families.  Keys are table names.
-     *                                Values are a list of column family names.
-     * @param cellExpiration The duration before which garbage collection of a cell may occur.
-     *                       Note: minimum granularity is second.
+     * @param tablesAndColumnFamiliesWithExpiration A map of tables and column families.
+     *                                              Keys are table names. Values are a
+     *                                              list of column family names along with
+     *                                              the desired cell expiration. Cell
+     *                                              expiration is the duration before which
+     *                                              garbage collection of a cell may occur.
+     *                                              Note: minimum granularity is second.
      */
-    def ensureTables(
-      bigtableOptions: BigtableOptions,
-      tablesAndColumnFamilies: Map[String, List[String]],
-      cellExpiration: Option[Duration]
+    def ensureTablesWithExpiration(
+      projectId: String,
+      instanceId: String,
+      tablesAndColumnFamiliesWithExpiration: Map[String, List[(String, Option[Duration])]]
     ): Unit = {
       if (!self.isTest) {
-        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies, cellExpiration)
+        val bigtableOptions = new BigtableOptions.Builder()
+          .setProjectId(projectId)
+          .setInstanceId(instanceId)
+          .build
+        TableAdmin.ensureTablesWithExpiration(
+          bigtableOptions,
+          tablesAndColumnFamiliesWithExpiration
+        )
       }
     }
 
     /**
-     * Set cell expiration.
-     * Adds or modifies a cell expiration rule for the provided tables and column families.
+     * Ensure that tables and column families exist.
+     * Checks for existence of tables or creates them if they do not exist.  Also checks for
+     * existence of column families within each table and creates them if they do not exist.
      *
-     * @param tablesAndColumnFamilies A map of tables and column families.  Keys are table names.
-     *                                Values are a list of column family names.
-     * @param cellExpiration The duration before which garbage collection of a cell may occur.
-     *                       Note: minimum granularity is second.
+     * @param tablesAndColumnFamiliesWithExpiration A map of tables and column families.
+     *                                              Keys are table names. Values are a
+     *                                              list of column family names along with
+     *                                              the desired cell expiration. Cell
+     *                                              expiration is the duration before which
+     *                                              garbage collection of a cell may occur.
+     *                                              Note: minimum granularity is second.
      */
-    def setCellExpiration(
-      projectId: String,
-      instanceId: String,
-      tablesAndColumnFamilies: Map[String, List[String]],
-      cellExpiration: Duration
-    ): Unit = {
-      val bigtableOptions = new BigtableOptions.Builder()
-        .setProjectId(projectId)
-        .setInstanceId(instanceId)
-        .build
-      TableAdmin.setCellExpiration(bigtableOptions, tablesAndColumnFamilies, cellExpiration)
-    }
-
-    /**
-     * Set cell expiration.
-     * Adds or modifies a cell expiration rule for the provided tables and column families.
-     *
-     * @param tablesAndColumnFamilies A map of tables and column families.  Keys are table names.
-     *                                Values are a list of column family names.
-     * @param cellExpiration The duration before which garbage collection of a cell may occur.
-     *                       Note: minimum granularity is second.
-     */
-    def setCellExpiration(
+    def ensureTablesWithExpiration(
       bigtableOptions: BigtableOptions,
-      tablesAndColumnFamilies: Map[String, List[String]],
-      cellExpiration: Duration
-    ): Unit =
-      TableAdmin.setCellExpiration(bigtableOptions, tablesAndColumnFamilies, cellExpiration)
+      tablesAndColumnFamiliesWithExpiration: Map[String, List[(String, Option[Duration])]]
+    ): Unit = {
+      if (!self.isTest) {
+        TableAdmin.ensureTablesWithExpiration(
+          bigtableOptions,
+          tablesAndColumnFamiliesWithExpiration
+        )
+      }
+    }
   }
 
   /**

--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
@@ -218,6 +218,41 @@ package object bigtable {
         TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies)
       }
     }
+
+    /**
+     * Set cell expiration.
+     * Adds or modifies a cell expiration rule for the provided tables and column families.
+     *
+     * @param tablesAndColumnFamilies A map of tables and column families.  Keys are table names.
+     *                                Values are a list of column family names.
+     * @param cellExpiration The duration before which garbage collection of a cell may occur.
+     *                       Note: minimum granularity is second.
+     */
+    def setCellExpiration(projectId: String,
+                          instanceId: String,
+                          tablesAndColumnFamilies: Map[String, List[String]],
+                          cellExpiration: Duration): Unit = {
+      val bigtableOptions = new BigtableOptions.Builder()
+        .setProjectId(projectId)
+        .setInstanceId(instanceId)
+        .build
+      TableAdmin.setCellExpiration(bigtableOptions, tablesAndColumnFamilies, cellExpiration)
+    }
+
+    /**
+     * Set cell expiration.
+     * Adds or modifies a cell expiration rule for the provided tables and column families.
+     *
+     * @param tablesAndColumnFamilies A map of tables and column families.  Keys are table names.
+     *                                Values are a list of column family names.
+     * @param cellExpiration The duration before which garbage collection of a cell may occur.
+     *                       Note: minimum granularity is second.
+     */
+    def setCellExpiration(bigtableOptions: BigtableOptions,
+                          tablesAndColumnFamilies: Map[String, List[String]],
+                          cellExpiration: Duration): Unit = {
+      TableAdmin.setCellExpiration(bigtableOptions, tablesAndColumnFamilies, cellExpiration)
+    }
   }
 
   /**

--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
@@ -198,7 +198,32 @@ package object bigtable {
           .setProjectId(projectId)
           .setInstanceId(instanceId)
           .build
-        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies)
+        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies, None)
+      }
+    }
+
+    /**
+     * Ensure that tables and column families exist.
+     * Checks for existence of tables or creates them if they do not exist.  Also checks for
+     * existence of column families within each table and creates them if they do not exist.
+     *
+     * @param tablesAndColumnFamilies A map of tables and column families.  Keys are table names.
+     *                                Values are a list of column family names.
+     * @param cellExpiration The duration before which garbage collection of a cell may occur.
+     *                       Note: minimum granularity is second.
+     */
+    def ensureTables(
+      projectId: String,
+      instanceId: String,
+      tablesAndColumnFamilies: Map[String, List[String]],
+      cellExpiration: Option[Duration]
+    ): Unit = {
+      if (!self.isTest) {
+        val bigtableOptions = new BigtableOptions.Builder()
+          .setProjectId(projectId)
+          .setInstanceId(instanceId)
+          .build
+        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies, cellExpiration)
       }
     }
 
@@ -215,7 +240,27 @@ package object bigtable {
       tablesAndColumnFamilies: Map[String, List[String]]
     ): Unit = {
       if (!self.isTest) {
-        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies)
+        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies, None)
+      }
+    }
+
+    /**
+     * Ensure that tables and column families exist.
+     * Checks for existence of tables or creates them if they do not exist.  Also checks for
+     * existence of column families within each table and creates them if they do not exist.
+     *
+     * @param tablesAndColumnFamilies A map of tables and column families.  Keys are table names.
+     *                                Values are a list of column family names.
+     * @param cellExpiration The duration before which garbage collection of a cell may occur.
+     *                       Note: minimum granularity is second.
+     */
+    def ensureTables(
+      bigtableOptions: BigtableOptions,
+      tablesAndColumnFamilies: Map[String, List[String]],
+      cellExpiration: Option[Duration]
+    ): Unit = {
+      if (!self.isTest) {
+        TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies, cellExpiration)
       }
     }
 
@@ -228,10 +273,12 @@ package object bigtable {
      * @param cellExpiration The duration before which garbage collection of a cell may occur.
      *                       Note: minimum granularity is second.
      */
-    def setCellExpiration(projectId: String,
-                          instanceId: String,
-                          tablesAndColumnFamilies: Map[String, List[String]],
-                          cellExpiration: Duration): Unit = {
+    def setCellExpiration(
+      projectId: String,
+      instanceId: String,
+      tablesAndColumnFamilies: Map[String, List[String]],
+      cellExpiration: Duration
+    ): Unit = {
       val bigtableOptions = new BigtableOptions.Builder()
         .setProjectId(projectId)
         .setInstanceId(instanceId)
@@ -248,9 +295,11 @@ package object bigtable {
      * @param cellExpiration The duration before which garbage collection of a cell may occur.
      *                       Note: minimum granularity is second.
      */
-    def setCellExpiration(bigtableOptions: BigtableOptions,
-                          tablesAndColumnFamilies: Map[String, List[String]],
-                          cellExpiration: Duration): Unit = {
+    def setCellExpiration(
+      bigtableOptions: BigtableOptions,
+      tablesAndColumnFamilies: Map[String, List[String]],
+      cellExpiration: Duration
+    ): Unit = {
       TableAdmin.setCellExpiration(bigtableOptions, tablesAndColumnFamilies, cellExpiration)
     }
   }


### PR DESCRIPTION
When creating new tables it is common to configure "cell expiration" / "garbage collection" as well.

---

I'm looking for some advice on testing strategy. The tests in `scio-bigtable` are currently pretty sparse.

I've tested against my own Bigtable instance with the following code:

```scala
package com.spotify.scio.bigtable

import com.google.cloud.bigtable.config.BigtableOptions
import org.joda.time.Duration
import org.scalatest._


class TableAdminTest extends FlatSpec with Matchers {

  private val bigtableOptions = new BigtableOptions.Builder()
    .setProjectId("sp-ml-infra")
    .setInstanceId("test-tfrecords-loader")
    .build

  private val duration = Duration.standardDays(7)

  private def set(xs: Map[String, List[String]]): Unit = {
    TableAdmin.setCellExpiration(bigtableOptions, xs, duration)
    TableAdmin.setCellExpiration(bigtableOptions, xs, duration)
  }

  private def ensure(xs: Map[String, List[String]], duration: Option[Duration]): Unit = {
    TableAdmin.ensureTables(bigtableOptions, xs, duration)
  }

  "TableAdmin.setCellExpiration" should "support setCellExpiration" in {
    set(Map("brianm-test" -> List("family1", "family2")))
  }

  "TableAdmin.setCellExpiration" should "skip setCellExpiration when family doesn't exist" in {
    set(Map("brianm-test" -> List("does-not-exist")))
  }

  "TableAdmin.setCellExpiration" should "skip setCellExpiration when table doesn't exist" in {
    set(Map("does-not-exist" -> List("does-not-exist")))
  }

  "TableAdmin.ensureTables" should "skip setCellExpiration when not provided" in {
    ensure(Map("new-table-1" -> List("does-not-exist")), None)
  }

  "TableAdmin.ensureTables" should "set setCellExpiration when provided" in {
    ensure(Map("new-table-1" -> List("does-not-exist")), Some(duration))
  }

}
```

```
sbt:scio-bigtable> testOnly com.spotify.scio.bigtable.TableAdminTest
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Updating gcRule for column families List(family1, family2) in projects/sp-ml-infra/instances/test-tfrecords-loader/tables/brianm-test
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Updating gcRule for column families List(family1, family2) in projects/sp-ml-infra/instances/test-tfrecords-loader/tables/brianm-test
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Skipping modification for non-existent column family does-not-exist in table projects/sp-ml-infra/instances/test-tfrecords-loader/tables/brianm-test
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Skipping modification for non-existent column family does-not-exist in table projects/sp-ml-infra/instances/test-tfrecords-loader/tables/brianm-test
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Skipping modification for non-existent table projects/sp-ml-infra/instances/test-tfrecords-loader/tables/does-not-exist
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Skipping modification for non-existent table projects/sp-ml-infra/instances/test-tfrecords-loader/tables/does-not-exist
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Ensuring tables and column families exist in instance test-tfrecords-loader
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Table new-table-1 exists
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Column families List(does-not-exist) exist in projects/sp-ml-infra/instances/test-tfrecords-loader/tables/new-table-1
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Ensuring tables and column families exist in instance test-tfrecords-loader
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Table new-table-1 exists
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Column families List(does-not-exist) exist in projects/sp-ml-infra/instances/test-tfrecords-loader/tables/new-table-1
[pool-87-thread-4-ScalaTest-running-TableAdminTest] INFO com.spotify.scio.bigtable.TableAdmin$ - Updating gcRule for column families List(does-not-exist) in projects/sp-ml-infra/instances/test-tfrecords-loader/tables/new-table-1
[info] TableAdminTest:
[info] TableAdmin.setCellExpiration
[info] - should support setCellExpiration (4 seconds, 314 milliseconds)
[info] TableAdmin.setCellExpiration
[info] - should skip setCellExpiration when family doesn't exist (1 second, 388 milliseconds)
[info] TableAdmin.setCellExpiration
[info] - should skip setCellExpiration when table doesn't exist (514 milliseconds)
[info] TableAdmin.ensureTables
[info] - should skip setCellExpiration when not provided (611 milliseconds)
[info] TableAdmin.ensureTables
[info] - should set setCellExpiration when provided (2 seconds, 350 milliseconds)
[info] ScalaTest
[info] Run completed in 9 seconds, 367 milliseconds.
[info] Total number of tests run: 5
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 5, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 5, Failed 0, Errors 0, Passed 5
[success] Total time: 14 s, completed Jul 16, 2019, 2:21:55 PM
```