### PR TITLE
Default insert error transform for BQ IO

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -230,7 +230,7 @@ object BigQueryTable {
       : SCollection[DefaultExtendedErrorInfo.Info] => Unit =
       // A NoOp on the extended error output, so that we don't have DropInputs
       // in the pipeline graph.
-      _.withName("Ignore ExtendedErrorInfo").map(_ => ())
+      _.withName("DropFailedInserts").map(_ => ())
 
     @inline final def apply(
       s: TableSchema,

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -228,7 +228,8 @@ object BigQueryTable {
     private[bigquery] val DefaultExtendedErrorInfo: ExtendedErrorInfo = ExtendedErrorInfo.Disabled
     private[bigquery] val DefaultInsertErrorTransform
       : SCollection[DefaultExtendedErrorInfo.Info] => Unit =
-      // A NoOp on the extended error output, so that we don't have DropInputs in the pipeline graph.
+      // A NoOp on the extended error output, so that we don't have DropInputs
+      // in the pipeline graph.
       _.withName("Ignore ExtendedErrorInfo").map(_ => ())
 
     @inline final def apply(

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -228,7 +228,7 @@ object BigQueryTable {
     private[bigquery] val DefaultExtendedErrorInfo: ExtendedErrorInfo = ExtendedErrorInfo.Disabled
     private[bigquery] val DefaultInsertErrorTransform
       : SCollection[DefaultExtendedErrorInfo.Info] => Unit =
-      // A NoOp on the extended error output, so that we don't have DropInputs
+      // A NoOp on the failed inserts, so that we don't have DropInputs (UnconsumedReads)
       // in the pipeline graph.
       _.withName("DropFailedInserts").map(_ => ())
 
@@ -499,7 +499,10 @@ object BigQueryTyped {
       private[bigquery] val DefaultTimePartitioning: TimePartitioning = null
       private[bigquery] val DefaultExtendedErrorInfo: ExtendedErrorInfo = ExtendedErrorInfo.Disabled
       private[bigquery] val DefaultInsertErrorTransform
-        : SCollection[DefaultExtendedErrorInfo.Info] => Unit = _ => ()
+        : SCollection[DefaultExtendedErrorInfo.Info] => Unit =
+        // A NoOp on the failed inserts, so that we don't have DropInputs (UnconsumedReads)
+        // in the pipeline graph.
+        _.withName("DropFailedInserts").map(_ => ())
 
       @inline final def apply(
         wd: WriteDisposition,

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -227,7 +227,9 @@ object BigQueryTable {
     private[bigquery] val DefaultTimePartitioning: TimePartitioning = null
     private[bigquery] val DefaultExtendedErrorInfo: ExtendedErrorInfo = ExtendedErrorInfo.Disabled
     private[bigquery] val DefaultInsertErrorTransform
-      : SCollection[DefaultExtendedErrorInfo.Info] => Unit = _ => ()
+      : SCollection[DefaultExtendedErrorInfo.Info] => Unit =
+      // A NoOp on the extended error output, so that we don't have DropInputs in the pipeline graph.
+      _.withName("Ignore ExtendedErrorInfo").map(_ => ())
 
     @inline final def apply(
       s: TableSchema,

--- a/scio-test/src/test/scala/com/spotify/scio/io/ScioIOTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/ScioIOTest.scala
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer
 
 import com.google.datastore.v1.Entity
 import com.google.datastore.v1.client.DatastoreHelper
+import com.spotify.scio.ScioContext
 import com.spotify.scio.avro.AvroUtils.schema
 import com.spotify.scio.avro._
 import com.spotify.scio.bigquery._
@@ -28,6 +29,13 @@ import com.spotify.scio.coders.Coder
 import com.spotify.scio.proto.Track.TrackPB
 import com.spotify.scio.testing._
 import org.apache.avro.generic.GenericRecord
+import org.apache.beam.sdk.Pipeline.PipelineVisitor
+import org.apache.beam.sdk.io.Read
+import org.apache.beam.sdk.runners.TransformHierarchy
+import org.apache.beam.sdk.values.PValue
+
+import scala.collection.mutable
+import scala.collection.JavaConverters._
 
 object ScioIOTest {
   @AvroType.toSchema
@@ -96,6 +104,62 @@ class ScioIOTest extends ScioIOSpec {
   it should "work with typed BigQuery" in {
     val xs = (1 to 100).map(x => BQRecord(x, x.toString, (1 to x).map(_.toString).toList))
     testJobTest(xs)(BigQueryIO(_))(_.typedBigQuery(_))(_.saveAsTypedBigQuery(_))
+  }
+
+  it should "not have unconsumed errors" in {
+    /*
+    The `BigQueryIO`'s write, runs a Beam's BQ IO which creates a `Read` Transform to return the
+    failed inserts or insert errors.
+
+    The `saveAsBigQuery` in Scio is designed to return a `ClosedTap` and by default drops insert
+    errors.
+
+    This test makes sure that the dropped insert errors do not appear as an unconsumed read
+    outside the transform writing to Big Query.
+     */
+
+    val xs = (1 to 100).map(x => TableRow("x" -> x.toString))
+
+    // We create a BigQuery write.
+    val context = ScioContext()
+    context
+      .parallelize(xs)
+      .saveAsBigQuery(tableSpec = "project:dataset.dummy", createDisposition = CREATE_NEVER)
+
+    // We want to validate on the job graph, and we need not actually execute the pipeline.
+
+    /*
+     To make sure there are no dangling reads transforms, we visit all PTransforms,
+     and find the inputs at each stage, and mark those inputs as consumed by putting them
+     in consumedOutputs. We also check if each transform is a `Read` and if so we extract them
+     as well.
+
+     This is copied from Beam's test for UnconsumedReads.
+     */
+    val consumedOutputs = mutable.HashSet[PValue]()
+
+    val allReads = mutable.HashSet[PValue]()
+    context.pipeline.traverseTopologically(
+      new PipelineVisitor.Defaults {
+
+        override def visitPrimitiveTransform(node: TransformHierarchy#Node): Unit =
+          consumedOutputs ++= node.getInputs.values().asScala
+
+        override def visitValue(
+          value: PValue,
+          producer: TransformHierarchy#Node
+        ): Unit = {
+          if (producer.getTransform.isInstanceOf[Read.Bounded[_]] ||
+              producer.getTransform.isInstanceOf[Read.Unbounded[_]]) {
+            allReads += value
+          }
+        }
+      }
+    )
+
+    val unconsumedReads = allReads -- consumedOutputs
+
+    unconsumedReads shouldBe empty
   }
 
   "TableRowJsonIO" should "work" in {


### PR DESCRIPTION
By default Beam adds a DropInput transform outside the transform writing to BQ. This leads to some not-so-easy-to-reason-about boxes in the Dataflow graph. This eagerly adds a no-op by default instead of relying on Beam to use Drop Inputs.

Follow up on #1864 

TODO
 - ~Set this if `ExtendedErrorInfo` is disabled, else leave it as is.~
 - ~Test this via some integration test (?) / Check the UI on an integration test.~