### PR TITLE
Change not to call String.format when fromQuery has only single argument

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -407,7 +407,11 @@ private[types] object TypeProvider {
   }
 
   private def formatString(xs: List[Any]): String =
-    xs.head.asInstanceOf[String].format(xs.tail: _*)
+    xs match {
+      case (head: String) :: Nil  => head
+      case (head: String) :: tail => head.format(tail: _*)
+      case _                      => ""
+    }
 
   /** Generate a case class. */
   private def caseClass(

--- a/site/src/paradox/io/Type-Safe-BigQuery.md
+++ b/site/src/paradox/io/Type-Safe-BigQuery.md
@@ -55,7 +55,7 @@ import com.spotify.scio.bigquery.types.BigQueryType
 class Row
 
 // generate new query strings at runtime
-val newQuery = Row.query.format(args(0))
+val newQuery = Row.query(args(0))
 ```
 
 There's also a `$LATEST` placeholder for table partitions. The latest common partition for all tables with the placeholder will be used.
@@ -70,7 +70,7 @@ import com.spotify.scio.bigquery.types.BigQueryType
 class Row
 
 // generate new query strings at runtime
-val newQuery = Row.query.format(args(0), args(0))
+val newQuery = Row.query(args(0), args(0))
 ```
 
 ### BigQueryType.fromSchema


### PR DESCRIPTION
I tried to compile following code, but it was not able to be compiled because `%Y(/m/d)` was handled as format string.
```
@BigQueryType.fromQuery("""#standardSQL
SELECT id, created, updated, FORMAT_TIMESTAMP("%Y-%m-%d", created, 'Asia/Tokyo') AS created_day FROM `table`""")
  class Row
```

Next, I changed like this, so it could be compiled. But actual executed query had double `%`. 
```
@BigQueryType.fromQuery("""#standardSQL
SELECT id, created, updated, FORMAT_TIMESTAMP("%%Y-%%m-%%d", created, 'Asia/Tokyo') AS created_day FROM `table`""")
  class Row
```

So, I took this workaround.
```
@BigQueryType.fromQuery("""#standardSQL
SELECT id, created, updated, FORMAT_TIMESTAMP("%s", created, 'Asia/Tokyo') AS created_day FROM `table`""", "%Y-%m-%d")
  class Row
```
and interpolated at runtime.
```
sc.typedBigQuery[Row](Row.query("%y-%m-%d"))
``` 

I think this behavior of fromQuery is not intuitive.














































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































