### PR TITLE
[wip] Add BigQuery Geography support

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -196,7 +196,11 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[LocalDateTime] =>
           q"_root_.com.spotify.scio.bigquery.DateTime.parse($s)"
 
-        case t if isCaseClass(c)(t) =>
+        case t if t =:= typeOf[Geography] =>
+          // different than nested record match below, even though this is a case class
+          q"_root_.com.spotify.scio.bigquery.types.Geography($s)"
+
+        case t if isCaseClass(c)(t) => // nested records
           val fn = TermName("r" + t.typeSymbol.name)
           q"""{
                 val $fn = $tree.asInstanceOf[_root_.java.util.Map[String, AnyRef]]
@@ -300,7 +304,11 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[LocalDateTime] =>
           q"_root_.com.spotify.scio.bigquery.DateTime($tree)"
 
-        case t if isCaseClass(c)(t) =>
+        case t if t =:= typeOf[Geography] =>
+          // different than nested record match below, even though this is a case class
+          q"$tree.wkt"
+
+        case t if isCaseClass(c)(t) => // nested records
           val fn = TermName("r" + t.typeSymbol.name)
           q"""{
                 val $fn = $tree

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -76,6 +76,7 @@ private[types] object SchemaProvider {
       case t if t =:= typeOf[LocalDate]     => ("DATE", Iterable.empty)
       case t if t =:= typeOf[LocalTime]     => ("TIME", Iterable.empty)
       case t if t =:= typeOf[LocalDateTime] => ("DATETIME", Iterable.empty)
+      case t if t =:= typeOf[Geography]     => ("GEOGRAPHY", Iterable.empty)
 
       case t if isCaseClass(t) => ("RECORD", toFields(t))
       case _                   => throw new RuntimeException(s"Unsupported type: $tpe")

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -271,7 +271,7 @@ private[types] object TypeProvider {
         case "DATE"              => (tq"_root_.org.joda.time.LocalDate", Nil)
         case "TIME"              => (tq"_root_.org.joda.time.LocalTime", Nil)
         case "DATETIME"          => (tq"_root_.org.joda.time.LocalDateTime", Nil)
-        case "GEOGRAPHY"         =>
+        case "GEOGRAPHY" =>
           (tq"_root_.com.spotify.scio.bigquery.types.Geography", Nil)
         case "RECORD" | "STRUCT" =>
           val name = NameProvider.getUniqueName(tfs.getName)

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -192,6 +192,14 @@ private[types] object TypeProvider {
         val traits = (if (fields.size <= 22) Seq(fnTrait) else Seq()) ++ defTblDesc
           .map(_ => tq"${p(c, SType)}.HasTableDescription")
         val taggedFields = fields.map {
+          case q"$m val $n: com.spotify.scio.bigquery.types.Geography = $rhs" =>
+            provider.initializeToTable(c)(m, n, tq"_root_.java.lang.String")
+            c.universe.ValDef(
+              c.universe.Modifiers(m.flags, m.privateWithin, m.annotations),
+              n,
+              tq"_root_.java.lang.String @${typeOf[BigQueryTag]}",
+              q"{$rhs}.wkt"
+            )
           case ValDef(m, n, tpt, rhs) =>
             provider.initializeToTable(c)(m, n, tpt)
             c.universe.ValDef(
@@ -263,6 +271,8 @@ private[types] object TypeProvider {
         case "DATE"              => (tq"_root_.org.joda.time.LocalDate", Nil)
         case "TIME"              => (tq"_root_.org.joda.time.LocalTime", Nil)
         case "DATETIME"          => (tq"_root_.org.joda.time.LocalDateTime", Nil)
+        case "GEOGRAPHY"         =>
+          (tq"_root_.com.spotify.scio.bigquery.types.Geography", Nil)
         case "RECORD" | "STRUCT" =>
           val name = NameProvider.getUniqueName(tfs.getName)
           val (fields, records) = toFields(tfs.getFields)

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -192,7 +192,7 @@ private[types] object TypeProvider {
         val traits = (if (fields.size <= 22) Seq(fnTrait) else Seq()) ++ defTblDesc
           .map(_ => tq"${p(c, SType)}.HasTableDescription")
         val taggedFields = fields.map {
-          case q"$m val $n: com.spotify.scio.bigquery.types.Geography = $rhs" =>
+          case q"$m val $n: _root_.com.spotify.scio.bigquery.types.Geography = $rhs" =>
             provider.initializeToTable(c)(m, n, tq"_root_.java.lang.String")
             c.universe.ValDef(
               c.universe.Modifiers(m.flags, m.privateWithin, m.annotations),

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -36,5 +36,12 @@ package object types {
   final class description(value: String) extends StaticAnnotation with Serializable
   // scalastyle:on class.name
 
+  /**
+    * Case class to serve as raw type for Geography instances to distinguish them from Strings.
+    *
+    * See also https://cloud.google.com/bigquery/docs/gis-data
+    *
+    * @param wkt Well Known Text formatted string that BigQuery displays for Geography
+    */
   case class Geography(wkt: String)
 }

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -37,11 +37,11 @@ package object types {
   // scalastyle:on class.name
 
   /**
-    * Case class to serve as raw type for Geography instances to distinguish them from Strings.
-    *
-    * See also https://cloud.google.com/bigquery/docs/gis-data
-    *
-    * @param wkt Well Known Text formatted string that BigQuery displays for Geography
-    */
+   * Case class to serve as raw type for Geography instances to distinguish them from Strings.
+   *
+   * See also https://cloud.google.com/bigquery/docs/gis-data
+   *
+   * @param wkt Well Known Text formatted string that BigQuery displays for Geography
+   */
   case class Geography(wkt: String)
 }

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -36,4 +36,5 @@ package object types {
   final class description(value: String) extends StaticAnnotation with Serializable
   // scalastyle:on class.name
 
+  case class Geography(wkt: String)
 }

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
@@ -88,6 +88,7 @@ final class ConverterProviderSpec
       o.timeF.isDefined shouldBe r.containsKey("timeF")
       o.datetimeF.isDefined shouldBe r.containsKey("datetimeF")
       o.bigDecimalF.isDefined shouldBe r.containsKey("bigDecimalF")
+      o.geographyF.isDefined shouldBe r.containsKey("geographyF")
     }
   }
 

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -42,9 +42,19 @@ class ConverterProviderTest extends FlatSpec with Matchers {
   }
   // scalastyle:on no.whitespace.before.left.bracket
 
+  it should "handle required geography type" in {
+    val wkt = "POINT (30 10)"
+    RequiredGeo.fromTableRow(TableRow("a" -> wkt)) shouldBe RequiredGeo(Geography(wkt))
+    BigQueryType.toTableRow[RequiredGeo](RequiredGeo(Geography(wkt))) shouldBe TableRow("a" -> wkt)
+  }
+
 }
 
 object ConverterProviderTest {
+
+  @BigQueryType.toTable
+  case class RequiredGeo(a: Geography)
+
   @BigQueryType.toTable
   case class Required(a: String)
 

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/SchemaProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/SchemaProviderTest.scala
@@ -40,7 +40,8 @@ class SchemaProviderTest extends FlatSpec with Matchers {
        |  {"mode": "$mode", "name": "dateF", "type": "DATE"},
        |  {"mode": "$mode", "name": "timeF", "type": "TIME"},
        |  {"mode": "$mode", "name": "datetimeF", "type": "DATETIME"},
-       |  {"mode": "$mode", "name": "bigDecimalF", "type": "NUMERIC"}
+       |  {"mode": "$mode", "name": "bigDecimalF", "type": "NUMERIC"},
+       |  {"mode": "$mode", "name": "geographyF", "type": "GEOGRAPHY"}
        |]
        |""".stripMargin
 

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/Schemas.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/Schemas.scala
@@ -36,7 +36,8 @@ object Schemas {
     dateF: LocalDate,
     timeF: LocalTime,
     datetimeF: LocalDateTime,
-    bigDecimalF: BigDecimal
+    bigDecimalF: BigDecimal,
+    geographyF: Geography
   )
   case class Optional(
     boolF: Option[Boolean],
@@ -51,7 +52,8 @@ object Schemas {
     dateF: Option[LocalDate],
     timeF: Option[LocalTime],
     datetimeF: Option[LocalDateTime],
-    bigDecimalF: Option[BigDecimal]
+    bigDecimalF: Option[BigDecimal],
+    geographyF: Option[Geography]
   )
   case class Repeated(
     boolF: List[Boolean],
@@ -66,7 +68,8 @@ object Schemas {
     dateF: List[LocalDate],
     timeF: List[LocalTime],
     datetimeF: List[LocalDateTime],
-    bigDecimalF: List[BigDecimal]
+    bigDecimalF: List[BigDecimal],
+    geographyF: List[Geography]
   )
 
   // records

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
@@ -555,5 +555,22 @@ class TypeProviderTest extends FlatSpec with Matchers {
     noException should be thrownBy
       BigQueryType[TypeProviderTest.RefinedClass with BigQueryType.HasAnnotation]
   }
+
+
+  @BigQueryType.fromSchema(
+    """
+      |{"fields": [{"mode": "REQUIRED", "name": "f1", "type": "GEOGRAPHY"}]}
+    """.stripMargin)
+  class GeoRecordFrom
+
+  @BigQueryType.toTable
+  case class GeoRecordTo(f1: Geography)
+
+  it should "#1882: support GEOGRAPHY type" in {
+    val wkt = "POINT (30 10)"
+    val cc = GeoRecordFrom(Geography(wkt))
+    cc.f1 shouldBe Geography(wkt)
+    GeoRecordTo(Geography(wkt))
+  }
 }
 // scalastyle:on number.of.types

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
@@ -555,10 +555,7 @@ class TypeProviderTest extends FlatSpec with Matchers {
     noException should be thrownBy
       BigQueryType[TypeProviderTest.RefinedClass with BigQueryType.HasAnnotation]
   }
-
-
-  @BigQueryType.fromSchema(
-    """
+  @BigQueryType.fromSchema("""
       |{"fields": [{"mode": "REQUIRED", "name": "f1", "type": "GEOGRAPHY"}]}
     """.stripMargin)
   class GeoRecordFrom


### PR DESCRIPTION
fixes #1882 

I made a wrapper case class instead of an annotation because I feel that keeping a 1:1 correspondence between Scala types and BQ types is worth the additional import on the user side if they work with geography types. I don't feel that strongly about this, let me know if you would like it changed. 

Before merge, I would like guidance on how to test this. I don't see any public datasets in BQ to write integration tests against with a GEOGRAPHY type - maybe I missed one? I can make a private dataset with an appropriate column but I'm not sure where is the best place to write a pipeline to test it against, and I couldn't find any good examples of test pipelines like that.  I don't think it should be merged as is, without testing that importing/exporting from BigQuery works in "real life" in addition to in the unit tests!