### PR TITLE
Link to Code of Conduct in this repo, fix name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,6 @@ You can also run `~mdoc` to automatically build the documentation on save.
 
 # Code of Conduct
 
-This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to honor this code.
+This project adheres to the [Spotify FOSS Code of Conduct][code-of-conduct]. By participating, you are expected to honor this code.
 
-[code-of-conduct]: https://github.com/spotify/code-of-conduct/blob/master/code-of-conduct.md
+[code-of-conduct]: https://github.com/spotify/scio/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
The Open Code of Conduct is not the one in the link, and we have a local copy in the repo that we can link to rather than the Spotify-wide copy.

Every time I make a new PR after this changes, Github recommends that I reread the CONTRIBUTING,  and upon latest reread I noticed that the wrong name was on our Code of Conduct link. The Open Code of Conduct is no longer being maintained, it looks like (https://github.com/todogroup/opencodeofconduct), and even if it was, it's not the one we currently use anyway. 