### PR TITLE
Simplify scio context execution

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -419,8 +419,11 @@ class ScioContext private[scio] (
     }
   }
 
+  private[scio] val testId: Option[String] =
+    Try(optionsAs[ApplicationNameOptions]).toOption.map(_.getAppName).filter(TestUtil.isTestId)
+
   /** Amount of time to block job for. */
-  val awaitDuration: Duration = {
+  private[scio] val awaitDuration: Duration = {
     val blockFor = optionsAs[ScioOptions].getBlockFor
     try {
       Option(blockFor)
@@ -648,9 +651,6 @@ class ScioContext private[scio] (
   // =======================================================================
   // Test wiring
   // =======================================================================
-
-  private[scio] val testId: Option[String] =
-    Try(optionsAs[ApplicationNameOptions]).toOption.map(_.getAppName).filter(TestUtil.isTestId)
 
   /**  Whether this is a test context. */
   def isTest: Boolean = testId.isDefined

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -525,7 +525,7 @@ class ScioContext private[scio] (
    *
    * @return the [[ScioExecutionContext]] for the underlying job execution.
    */
-  def run(): ScioExecutionContext = {
+  def run(): ScioExecutionContext = requireNotClosed {
     _onClose(())
 
     if (_counters.nonEmpty) {

--- a/scio-repl/src/main/scala/com/spotify/scio/repl/ReplScioContext.scala
+++ b/scio-repl/src/main/scala/com/spotify/scio/repl/ReplScioContext.scala
@@ -18,15 +18,15 @@
 package com.spotify.scio.repl
 
 import org.apache.beam.sdk.options.PipelineOptions
-import com.spotify.scio.{ScioContext, ScioExecutionContext, ScioRunner}
+import com.spotify.scio.{ScioContext, ScioExecutionContext}
 
 class ReplScioContext(options: PipelineOptions, artifacts: List[String])
     extends ScioContext(options, artifacts) {
 
   /** Enhanced version that dumps REPL session jar. */
-  override def run(sr: ScioRunner): ScioExecutionContext = {
+  override def run(): ScioExecutionContext = {
     createJar()
-    super.run(sr)
+    super.run()
   }
 
   /** Ensure an operation is called before the pipeline is closed. */


### PR DESCRIPTION
After some more thinking a realized that we are not yet in a position to actually push the privious type of change with support for different `executors`.
This PR reverts the design a little bit back to something in line with alpha1. Apologies for the back and forth but sometimes things just take time.