### PR TITLE
Use consistent types across sparse transforms

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -880,7 +880,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    */
   def sparseIntersectByKey(
     that: SCollection[K],
-    thatNumKeys: Int,
+    thatNumKeys: Long,
     computeExact: Boolean = false,
     fpProb: Double = 0.01
   )(implicit koder: Coder[K], voder: Coder[V], hash: Hash128[K]): SCollection[(K, V)] =


### PR DESCRIPTION
Partially fixes #2103 