### PR TITLE
Fix a NPE in SchemaMaterializer

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/schemas/SchemaMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/SchemaMaterializer.scala
@@ -131,7 +131,7 @@ object SchemaMaterializer {
   }
 
   private def decode[A](schema: OptionType[A])(v: schema.Repr): Option[A] =
-    Option(dispatchDecode(schema.schema)(v))
+    Option(v).map(dispatchDecode(schema.schema))
 
   private def decode[F[_], A: ClassTag](schema: ArrayType[F, A])(v: schema.Repr): F[A] = {
     val values = new Array[A](v.size)

--- a/scio-test/src/test/scala/com/spotify/scio/schemas/SchemaMaterializerTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/schemas/SchemaMaterializerTest.scala
@@ -20,6 +20,7 @@ import org.apache.beam.sdk.schemas.Schema.{Field, FieldType}
 
 import org.scalatest._
 import scala.collection.JavaConverters._
+import org.apache.beam.sdk.values.Row
 
 final class SchemaMaterializerTest extends FlatSpec with Matchers {
 
@@ -78,6 +79,19 @@ final class SchemaMaterializerTest extends FlatSpec with Matchers {
       FieldType.map(FieldType.STRING, FieldType.STRING)
     )
 
+  }
+
+  it should "Support Optional fields when reading a Row" in {
+    case class Bar(s: String, x: Int)
+    case class Foo(a: String, b: Option[Bar])
+    val (schema, to, from) = SchemaMaterializer.materializeWithDefault[Foo](Schema[Foo])
+    val row =
+      Row
+        .withSchema(schema)
+        .addValue("Hello")
+        .addValue(null)
+        .build()
+    from(row) shouldBe Foo("Hello", None)
   }
 
 }


### PR DESCRIPTION
Happens when the `Schema`of a case class includes an `Option[SomeOtherCaseClass]`