### PR TITLE
Make scio-test test suite compile faster

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -260,7 +260,9 @@ lazy val macroSettings = Def.settings(
   libraryDependencies +=
     compilerPlugin(
       "org.scalamacros" % "paradise" % scalaMacrosVersion cross CrossVersion.full
-    )
+    ),
+  // see MacroSettings.scala
+  scalacOptions += "-Xmacro-settings:cache-implicit-schemas=true"
 )
 
 lazy val directRunnerDependency =

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -72,7 +72,9 @@ object Scalac {
       "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
       "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
       "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.,
-      "-Ydelambdafy:inline" // Set the strategy used for translating lambdas into JVM code to "inline"
+      "-Ydelambdafy:inline", // Set the strategy used for translating lambdas into JVM code to "inline"
+      "-Ybackend-parallelism",
+      "8"
     )
   }
 

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
@@ -18,7 +18,7 @@ package com.spotify.scio.schemas
 
 import java.util.{List => jList, Map => jMap}
 
-import com.spotify.scio.{MacroSettings, FeatureFlag}
+import com.spotify.scio.{FeatureFlag, MacroSettings}
 import com.spotify.scio.schemas.instances.AllInstances
 import com.spotify.scio.util.ScioUtil
 import org.apache.beam.sdk.schemas.Schema.FieldType

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
@@ -199,17 +199,6 @@ private[scio] trait SchemaMacroHelpers {
     ctx.Expr[Schema[_]](q"$untypedTree.value")
   }
 
-  private val cache = scala.collection.concurrent.TrieMap.empty[String, Schema[_]]
-
-  def materializeImplicitSchema[A: ctx.WeakTypeTag]: Schema[A] =
-    cacheImplicitSchemas match {
-      case FeatureFlag.Enable =>
-        val key = weakTypeTag[A].tpe.dealias.toString()
-        cache.getOrElseUpdate(key, ctx.eval(inferImplicitSchema[A])).asInstanceOf[Schema[A]]
-      case _ =>
-        ctx.eval(inferImplicitSchema[A])
-    }
-
   implicit def liftTupleTag[A: ctx.WeakTypeTag]: Liftable[TupleTag[A]] = Liftable[TupleTag[A]] {
     x =>
       q"new _root_.org.apache.beam.sdk.values.TupleTag[${weakTypeOf[A]}](${x.getId()})"

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
@@ -181,11 +181,12 @@ private[scio] trait SchemaMacroHelpers {
     inferImplicitSchema(weakTypeOf[A]).asInstanceOf[ctx.Expr[Schema[A]]]
 
   def inferImplicitSchema(t: ctx.Type): ctx.Expr[Schema[_]] = {
-    val tp = ctx.typecheck(tq"_root_.com.spotify.scio.schemas.Schema[$t]", ctx.TYPEmode).tpe
+    val tp = ctx.typecheck(
+      tq"_root_.shapeless.Cached[_root_.com.spotify.scio.schemas.Schema[$t]]", ctx.TYPEmode).tpe
     val typedTree = ctx.inferImplicitValue(tp, silent = false)
     val untypedTree = ctx.untypecheck(typedTree.duplicate)
 
-    ctx.Expr[Schema[_]](untypedTree)
+    ctx.Expr[Schema[_]](q"$untypedTree.value")
   }
 
   implicit def liftTupleTag[A: ctx.WeakTypeTag]: Liftable[TupleTag[A]] = Liftable[TupleTag[A]] {

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
@@ -180,6 +180,9 @@ private[scio] trait SchemaMacroHelpers {
 
   val cacheImplicitSchemas = MacroSettings.cacheImplicitSchemas(ctx)
 
+  def untyped[A: ctx.WeakTypeTag](expr: ctx.Expr[Schema[A]]): ctx.Expr[Schema[A]] =
+    ctx.Expr[Schema[A]](ctx.untypecheck(expr.tree.duplicate))
+
   def inferImplicitSchema[A: ctx.WeakTypeTag]: ctx.Expr[Schema[A]] =
     inferImplicitSchema(weakTypeOf[A]).asInstanceOf[ctx.Expr[Schema[A]]]
 

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/To.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/To.scala
@@ -23,6 +23,7 @@ import org.apache.beam.sdk.schemas.{Schema => BSchema, SchemaCoder}
 import scala.collection.JavaConverters._
 import scala.language.experimental.macros
 import scala.annotation.tailrec
+import scala.tools.reflect.ToolBox
 
 sealed trait To[I, O] extends (SCollection[I] => SCollection[O])
 
@@ -163,6 +164,48 @@ object To {
     macro ToMacro.safeImpl[I, O]
 }
 
+import scala.reflect.macros._
+import reflect.runtime.{universe => u}
+
+private[scio] final class FastEval(evalToolBox: ToolBox[u.type]) {
+
+  def eval[T](ctx: blackbox.Context)(expr: ctx.Expr[T]): T = {
+    import ctx.universe._
+
+    //scalastyle:off
+    val evalImporter =
+      u.internal
+        .createImporter(ctx.universe)
+        .asInstanceOf[u.Importer { val from: ctx.universe.type }]
+    //scalastyle:on
+
+    expr.tree match {
+      case Literal(Constant(value)) =>
+        ctx.eval[T](expr)
+      case _ =>
+        val imported = evalImporter.importTree(expr.tree)
+        evalToolBox.eval(imported).asInstanceOf[T]
+    }
+  }
+}
+
+/**
+ * Provide faster evaluation of tree by reusing the same toolbox
+ * This is faster bc. resusing the same toolbox also meas reusing the same classloader,
+ * which saves disks IOs since we don't load the same classes from disk multiple times
+ */
+private[scio] final object FastEval {
+  import scala.tools.reflect._
+
+  private lazy val tl: ToolBox[u.type] = {
+    val evalMirror = scala.reflect.runtime.currentMirror
+    evalMirror.mkToolBox()
+  }
+
+  def apply[T](ctx: blackbox.Context)(expr: ctx.Expr[T]): T =
+    new FastEval(tl).eval(ctx)(expr)
+}
+
 object ToMacro {
   import scala.reflect.macros._
   def safeImpl[I: c.WeakTypeTag, O: c.WeakTypeTag](
@@ -175,8 +218,8 @@ object ToMacro {
     val tpeI = weakTypeOf[I]
     val tpeO = weakTypeOf[O]
 
-    val (sIn, sOut) =
-      c.eval(c.Expr[(Schema[I], Schema[O])](q"(${untyped(iSchema)}, ${untyped(oSchema)})"))
+    val expr = c.Expr[(Schema[I], Schema[O])](q"(${untyped(iSchema)}, ${untyped(oSchema)})")
+    val (sIn, sOut) = FastEval(c)(expr)
 
     val schemaOut: BSchema = SchemaMaterializer.fieldType(sOut).getRowSchema()
     val schemaIn: BSchema = SchemaMaterializer.fieldType(sIn).getRowSchema()

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/To.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/To.scala
@@ -176,8 +176,11 @@ object ToMacro {
     val tpeO = weakTypeOf[O]
 
     val (sIn, sOut) =
-      c.eval(c.Expr[(Schema[I], Schema[O])](
-        q"""(${inferImplicitSchema(tpeI)}, ${inferImplicitSchema(tpeO)})"""))
+      c.eval(
+        c.Expr[(Schema[I], Schema[O])](q"""(${inferImplicitSchema(tpeI)}, ${inferImplicitSchema(
+          tpeO
+        )})""")
+      )
 
     val schemaOut: BSchema = SchemaMaterializer.fieldType(sOut).getRowSchema()
     val schemaIn: BSchema = SchemaMaterializer.fieldType(sIn).getRowSchema()

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/To.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/To.scala
@@ -175,8 +175,9 @@ object ToMacro {
     val tpeI = weakTypeOf[I]
     val tpeO = weakTypeOf[O]
 
-    val sOut = materializeImplicitSchema[O]
-    val sIn = materializeImplicitSchema[I]
+    val (sIn, sOut) =
+      c.eval(c.Expr[(Schema[I], Schema[O])](
+        q"""(${inferImplicitSchema(tpeI)}, ${inferImplicitSchema(tpeO)})"""))
 
     val schemaOut: BSchema = SchemaMaterializer.fieldType(sOut).getRowSchema()
     val schemaIn: BSchema = SchemaMaterializer.fieldType(sIn).getRowSchema()

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/To.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/To.scala
@@ -176,11 +176,7 @@ object ToMacro {
     val tpeO = weakTypeOf[O]
 
     val (sIn, sOut) =
-      c.eval(
-        c.Expr[(Schema[I], Schema[O])](q"""(${inferImplicitSchema(tpeI)}, ${inferImplicitSchema(
-          tpeO
-        )})""")
-      )
+      c.eval(c.Expr[(Schema[I], Schema[O])](q"(${untyped(iSchema)}, ${untyped(oSchema)})"))
 
     val schemaOut: BSchema = SchemaMaterializer.fieldType(sOut).getRowSchema()
     val schemaIn: BSchema = SchemaMaterializer.fieldType(sIn).getRowSchema()

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/To.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/To.scala
@@ -175,8 +175,8 @@ object ToMacro {
     val tpeI = weakTypeOf[I]
     val tpeO = weakTypeOf[O]
 
-    val sOut = c.eval(inferImplicitSchema(tpeO))
-    val sIn = c.eval(inferImplicitSchema(tpeI))
+    val sOut = materializeImplicitSchema[O]
+    val sIn = materializeImplicitSchema[I]
 
     val schemaOut: BSchema = SchemaMaterializer.fieldType(sOut).getRowSchema()
     val schemaIn: BSchema = SchemaMaterializer.fieldType(sIn).getRowSchema()

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query1.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query1.scala
@@ -79,12 +79,11 @@ object Query1 {
     assertConcrete[A](c)
     assertConcrete[B](c)
 
-    val schemas: (Schema[A], Schema[B]) = c.eval(
-      c.Expr(q"(${inferImplicitSchema[A]}, ${inferImplicitSchema[B]})")
-    )
+    val (sIn, sOut) =
+      c.eval(c.Expr[(Schema[A], Schema[B])](q"(${untyped(iSchema)}, ${untyped(oSchema)})"))
 
     val sq = Query1[A, B](cons(c)(query), tupleTag(c)(aTag))
-    typecheck(sq)(schemas._1, schemas._2)
+    typecheck(sq)(sIn, sOut)
       .fold(
         err => c.abort(c.enclosingPosition, err),
         _ => c.Expr[Query1[A, B]](q"_root_.com.spotify.scio.sql.Query1($query, $aTag)")

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query1.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query1.scala
@@ -80,7 +80,7 @@ object Query1 {
     assertConcrete[B](c)
 
     val (sIn, sOut) =
-      c.eval(c.Expr[(Schema[A], Schema[B])](q"(${untyped(iSchema)}, ${untyped(oSchema)})"))
+      FastEval(c)(c.Expr[(Schema[A], Schema[B])](q"(${untyped(iSchema)}, ${untyped(oSchema)})"))
 
     val sq = Query1[A, B](cons(c)(query), tupleTag(c)(aTag))
     typecheck(sq)(sIn, sOut)

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query10.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query10.scala
@@ -185,7 +185,7 @@ object Query10 {
       schemas10,
       schemas11
     ) =
-      c.eval(
+      FastEval(c)(
         c.Expr[
           (
             Schema[A],

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query10.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query10.scala
@@ -172,27 +172,40 @@ object Query10 {
     assertConcrete[J](c)
     assertConcrete[R](c)
 
-    val schemas: (
-      Schema[A],
-      Schema[B],
-      Schema[C],
-      Schema[D],
-      Schema[E],
-      Schema[F],
-      Schema[G],
-      Schema[H],
-      Schema[I],
-      Schema[J],
-      Schema[R]
-    ) = c.eval(
-      c.Expr(
-        q"(${inferImplicitSchema[A]}, ${inferImplicitSchema[B]}, ${inferImplicitSchema[C]}, ${inferImplicitSchema[
-          D
-        ]}, ${inferImplicitSchema[E]}, ${inferImplicitSchema[F]}, ${inferImplicitSchema[G]}, ${inferImplicitSchema[
-          H
-        ]}, ${inferImplicitSchema[I]}, ${inferImplicitSchema[J]}, ${inferImplicitSchema[R]})"
+    val (
+      schemas1,
+      schemas2,
+      schemas3,
+      schemas4,
+      schemas5,
+      schemas6,
+      schemas7,
+      schemas8,
+      schemas9,
+      schemas10,
+      schemas11
+    ) =
+      c.eval(
+        c.Expr[
+          (
+            Schema[A],
+            Schema[B],
+            Schema[C],
+            Schema[D],
+            Schema[E],
+            Schema[F],
+            Schema[G],
+            Schema[H],
+            Schema[I],
+            Schema[J],
+            Schema[R]
+          )
+        ](
+          q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(dSchema)}, ${untyped(eSchema)}, ${untyped(
+            fSchema
+          )}, ${untyped(gSchema)}, ${untyped(hSchema)}, ${untyped(iSchema)}, ${untyped(jSchema)}, ${untyped(rSchema)})"
+        )
       )
-    )
 
     val sq = Query10[A, B, C, D, E, F, G, H, I, J, R](
       cons(c)(query),
@@ -208,17 +221,17 @@ object Query10 {
       tupleTag(c)(jTag)
     )
     typecheck(sq)(
-      schemas._1,
-      schemas._2,
-      schemas._3,
-      schemas._4,
-      schemas._5,
-      schemas._6,
-      schemas._7,
-      schemas._8,
-      schemas._9,
-      schemas._10,
-      schemas._11
+      schemas1,
+      schemas2,
+      schemas3,
+      schemas4,
+      schemas5,
+      schemas6,
+      schemas7,
+      schemas8,
+      schemas9,
+      schemas10,
+      schemas11
     ).fold(
       err => c.abort(c.enclosingPosition, err),
       _ =>

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query2.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query2.scala
@@ -87,7 +87,7 @@ object Query2 {
     assertConcrete[R](c)
 
     val (schemas1, schemas2, schemas3) =
-      c.eval(
+      FastEval(c)(
         c.Expr[(Schema[A], Schema[B], Schema[R])](
           q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(rSchema)})"
         )

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query2.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query2.scala
@@ -86,12 +86,15 @@ object Query2 {
     assertConcrete[B](c)
     assertConcrete[R](c)
 
-    val schemas: (Schema[A], Schema[B], Schema[R]) = c.eval(
-      c.Expr(q"(${inferImplicitSchema[A]}, ${inferImplicitSchema[B]}, ${inferImplicitSchema[R]})")
-    )
+    val (schemas1, schemas2, schemas3) =
+      c.eval(
+        c.Expr[(Schema[A], Schema[B], Schema[R])](
+          q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(rSchema)})"
+        )
+      )
 
     val sq = Query2[A, B, R](cons(c)(query), tupleTag(c)(aTag), tupleTag(c)(bTag))
-    typecheck(sq)(schemas._1, schemas._2, schemas._3)
+    typecheck(sq)(schemas1, schemas2, schemas3)
       .fold(
         err => c.abort(c.enclosingPosition, err),
         _ => c.Expr[Query2[A, B, R]](q"_root_.com.spotify.scio.sql.Query2($query, $aTag, $bTag)")

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query3.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query3.scala
@@ -97,7 +97,7 @@ object Query3 {
     assertConcrete[R](c)
 
     val (schemas1, schemas2, schemas3, schemas4) =
-      c.eval(
+      FastEval(c)(
         c.Expr[(Schema[A], Schema[B], Schema[C], Schema[R])](
           q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(rSchema)})"
         )

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query3.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query3.scala
@@ -96,15 +96,16 @@ object Query3 {
     assertConcrete[C](c)
     assertConcrete[R](c)
 
-    val schemas: (Schema[A], Schema[B], Schema[C], Schema[R]) = c.eval(
-      c.Expr(
-        q"(${inferImplicitSchema[A]}, ${inferImplicitSchema[B]}, ${inferImplicitSchema[C]}, ${inferImplicitSchema[R]})"
+    val (schemas1, schemas2, schemas3, schemas4) =
+      c.eval(
+        c.Expr[(Schema[A], Schema[B], Schema[C], Schema[R])](
+          q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(rSchema)})"
+        )
       )
-    )
 
     val sq =
       Query3[A, B, C, R](cons(c)(query), tupleTag(c)(aTag), tupleTag(c)(bTag), tupleTag(c)(cTag))
-    typecheck(sq)(schemas._1, schemas._2, schemas._3, schemas._4)
+    typecheck(sq)(schemas1, schemas2, schemas3, schemas4)
       .fold(
         err => c.abort(c.enclosingPosition, err),
         _ =>

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query4.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query4.scala
@@ -107,7 +107,7 @@ object Query4 {
     assertConcrete[R](c)
 
     val (schemas1, schemas2, schemas3, schemas4, schemas5) =
-      c.eval(
+      FastEval(c)(
         c.Expr[(Schema[A], Schema[B], Schema[C], Schema[D], Schema[R])](
           q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(dSchema)}, ${untyped(rSchema)})"
         )

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query4.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query4.scala
@@ -106,11 +106,12 @@ object Query4 {
     assertConcrete[D](c)
     assertConcrete[R](c)
 
-    val schemas: (Schema[A], Schema[B], Schema[C], Schema[D], Schema[R]) = c.eval(
-      c.Expr(
-        q"(${inferImplicitSchema[A]}, ${inferImplicitSchema[B]}, ${inferImplicitSchema[C]}, ${inferImplicitSchema[D]}, ${inferImplicitSchema[R]})"
+    val (schemas1, schemas2, schemas3, schemas4, schemas5) =
+      c.eval(
+        c.Expr[(Schema[A], Schema[B], Schema[C], Schema[D], Schema[R])](
+          q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(dSchema)}, ${untyped(rSchema)})"
+        )
       )
-    )
 
     val sq = Query4[A, B, C, D, R](
       cons(c)(query),
@@ -119,7 +120,7 @@ object Query4 {
       tupleTag(c)(cTag),
       tupleTag(c)(dTag)
     )
-    typecheck(sq)(schemas._1, schemas._2, schemas._3, schemas._4, schemas._5)
+    typecheck(sq)(schemas1, schemas2, schemas3, schemas4, schemas5)
       .fold(
         err => c.abort(c.enclosingPosition, err),
         _ =>

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query5.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query5.scala
@@ -113,13 +113,12 @@ object Query5 {
     assertConcrete[E](c)
     assertConcrete[R](c)
 
-    val schemas: (Schema[A], Schema[B], Schema[C], Schema[D], Schema[E], Schema[R]) = c.eval(
-      c.Expr(
-        q"(${inferImplicitSchema[A]}, ${inferImplicitSchema[B]}, ${inferImplicitSchema[C]}, ${inferImplicitSchema[
-          D
-        ]}, ${inferImplicitSchema[E]}, ${inferImplicitSchema[R]})"
+    val (schemas1, schemas2, schemas3, schemas4, schemas5, schemas6) =
+      c.eval(
+        c.Expr[(Schema[A], Schema[B], Schema[C], Schema[D], Schema[E], Schema[R])](
+          q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(dSchema)}, ${untyped(eSchema)}, ${untyped(rSchema)})"
+        )
       )
-    )
 
     val sq = Query5[A, B, C, D, E, R](
       cons(c)(query),
@@ -129,7 +128,7 @@ object Query5 {
       tupleTag(c)(dTag),
       tupleTag(c)(eTag)
     )
-    typecheck(sq)(schemas._1, schemas._2, schemas._3, schemas._4, schemas._5, schemas._6)
+    typecheck(sq)(schemas1, schemas2, schemas3, schemas4, schemas5, schemas6)
       .fold(
         err => c.abort(c.enclosingPosition, err),
         _ =>

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query5.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query5.scala
@@ -114,7 +114,7 @@ object Query5 {
     assertConcrete[R](c)
 
     val (schemas1, schemas2, schemas3, schemas4, schemas5, schemas6) =
-      c.eval(
+      FastEval(c)(
         c.Expr[(Schema[A], Schema[B], Schema[C], Schema[D], Schema[E], Schema[R])](
           q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(dSchema)}, ${untyped(eSchema)}, ${untyped(rSchema)})"
         )

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query6.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query6.scala
@@ -120,12 +120,12 @@ object Query6 {
     assertConcrete[F](c)
     assertConcrete[R](c)
 
-    val schemas: (Schema[A], Schema[B], Schema[C], Schema[D], Schema[E], Schema[F], Schema[R]) =
+    val (schemas1, schemas2, schemas3, schemas4, schemas5, schemas6, schemas7) =
       c.eval(
-        c.Expr(
-          q"(${inferImplicitSchema[A]}, ${inferImplicitSchema[B]}, ${inferImplicitSchema[C]}, ${inferImplicitSchema[
-            D
-          ]}, ${inferImplicitSchema[E]}, ${inferImplicitSchema[F]}, ${inferImplicitSchema[R]})"
+        c.Expr[(Schema[A], Schema[B], Schema[C], Schema[D], Schema[E], Schema[F], Schema[R])](
+          q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(dSchema)}, ${untyped(
+            eSchema
+          )}, ${untyped(fSchema)}, ${untyped(rSchema)})"
         )
       )
 
@@ -138,21 +138,14 @@ object Query6 {
       tupleTag(c)(eTag),
       tupleTag(c)(fTag)
     )
-    typecheck(sq)(
-      schemas._1,
-      schemas._2,
-      schemas._3,
-      schemas._4,
-      schemas._5,
-      schemas._6,
-      schemas._7
-    ).fold(
-      err => c.abort(c.enclosingPosition, err),
-      _ =>
-        c.Expr[Query6[A, B, C, D, E, F, R]](
-          q"_root_.com.spotify.scio.sql.Query6($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag)"
-        )
-    )
+    typecheck(sq)(schemas1, schemas2, schemas3, schemas4, schemas5, schemas6, schemas7)
+      .fold(
+        err => c.abort(c.enclosingPosition, err),
+        _ =>
+          c.Expr[Query6[A, B, C, D, E, F, R]](
+            q"_root_.com.spotify.scio.sql.Query6($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag)"
+          )
+      )
   }
 }
 

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query6.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query6.scala
@@ -121,7 +121,7 @@ object Query6 {
     assertConcrete[R](c)
 
     val (schemas1, schemas2, schemas3, schemas4, schemas5, schemas6, schemas7) =
-      c.eval(
+      FastEval(c)(
         c.Expr[(Schema[A], Schema[B], Schema[C], Schema[D], Schema[E], Schema[F], Schema[R])](
           q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(dSchema)}, ${untyped(
             eSchema

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query7.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query7.scala
@@ -135,7 +135,7 @@ object Query7 {
     assertConcrete[R](c)
 
     val (schemas1, schemas2, schemas3, schemas4, schemas5, schemas6, schemas7, schemas8) =
-      c.eval(
+      FastEval(c)(
         c.Expr[
           (Schema[A], Schema[B], Schema[C], Schema[D], Schema[E], Schema[F], Schema[G], Schema[R])
         ](q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(dSchema)}, ${untyped(

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query7.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query7.scala
@@ -134,14 +134,13 @@ object Query7 {
     assertConcrete[G](c)
     assertConcrete[R](c)
 
-    val schemas
-      : (Schema[A], Schema[B], Schema[C], Schema[D], Schema[E], Schema[F], Schema[G], Schema[R]) =
+    val (schemas1, schemas2, schemas3, schemas4, schemas5, schemas6, schemas7, schemas8) =
       c.eval(
-        c.Expr(
-          q"(${inferImplicitSchema[A]}, ${inferImplicitSchema[B]}, ${inferImplicitSchema[C]}, ${inferImplicitSchema[
-            D
-          ]}, ${inferImplicitSchema[E]}, ${inferImplicitSchema[F]}, ${inferImplicitSchema[G]}, ${inferImplicitSchema[R]})"
-        )
+        c.Expr[
+          (Schema[A], Schema[B], Schema[C], Schema[D], Schema[E], Schema[F], Schema[G], Schema[R])
+        ](q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(dSchema)}, ${untyped(
+          eSchema
+        )}, ${untyped(fSchema)}, ${untyped(gSchema)}, ${untyped(rSchema)})")
       )
 
     val sq = Query7[A, B, C, D, E, F, G, R](
@@ -154,22 +153,14 @@ object Query7 {
       tupleTag(c)(fTag),
       tupleTag(c)(gTag)
     )
-    typecheck(sq)(
-      schemas._1,
-      schemas._2,
-      schemas._3,
-      schemas._4,
-      schemas._5,
-      schemas._6,
-      schemas._7,
-      schemas._8
-    ).fold(
-      err => c.abort(c.enclosingPosition, err),
-      _ =>
-        c.Expr[Query7[A, B, C, D, E, F, G, R]](
-          q"_root_.com.spotify.scio.sql.Query7($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag)"
-        )
-    )
+    typecheck(sq)(schemas1, schemas2, schemas3, schemas4, schemas5, schemas6, schemas7, schemas8)
+      .fold(
+        err => c.abort(c.enclosingPosition, err),
+        _ =>
+          c.Expr[Query7[A, B, C, D, E, F, G, R]](
+            q"_root_.com.spotify.scio.sql.Query7($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag)"
+          )
+      )
   }
 }
 

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query8.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query8.scala
@@ -153,7 +153,7 @@ object Query8 {
     assertConcrete[R](c)
 
     val (schemas1, schemas2, schemas3, schemas4, schemas5, schemas6, schemas7, schemas8, schemas9) =
-      c.eval(
+      FastEval(c)(
         c.Expr[
           (
             Schema[A],

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query8.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query8.scala
@@ -152,23 +152,24 @@ object Query8 {
     assertConcrete[H](c)
     assertConcrete[R](c)
 
-    val schemas: (
-      Schema[A],
-      Schema[B],
-      Schema[C],
-      Schema[D],
-      Schema[E],
-      Schema[F],
-      Schema[G],
-      Schema[H],
-      Schema[R]
-    ) = c.eval(
-      c.Expr(
-        q"(${inferImplicitSchema[A]}, ${inferImplicitSchema[B]}, ${inferImplicitSchema[C]}, ${inferImplicitSchema[D]}, ${inferImplicitSchema[
-          E
-        ]}, ${inferImplicitSchema[F]}, ${inferImplicitSchema[G]}, ${inferImplicitSchema[H]}, ${inferImplicitSchema[R]})"
+    val (schemas1, schemas2, schemas3, schemas4, schemas5, schemas6, schemas7, schemas8, schemas9) =
+      c.eval(
+        c.Expr[
+          (
+            Schema[A],
+            Schema[B],
+            Schema[C],
+            Schema[D],
+            Schema[E],
+            Schema[F],
+            Schema[G],
+            Schema[H],
+            Schema[R]
+          )
+        ](q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(dSchema)}, ${untyped(
+          eSchema
+        )}, ${untyped(fSchema)}, ${untyped(gSchema)}, ${untyped(hSchema)}, ${untyped(rSchema)})")
       )
-    )
 
     val sq = Query8[A, B, C, D, E, F, G, H, R](
       cons(c)(query),
@@ -182,15 +183,15 @@ object Query8 {
       tupleTag(c)(hTag)
     )
     typecheck(sq)(
-      schemas._1,
-      schemas._2,
-      schemas._3,
-      schemas._4,
-      schemas._5,
-      schemas._6,
-      schemas._7,
-      schemas._8,
-      schemas._9
+      schemas1,
+      schemas2,
+      schemas3,
+      schemas4,
+      schemas5,
+      schemas6,
+      schemas7,
+      schemas8,
+      schemas9
     ).fold(
       err => c.abort(c.enclosingPosition, err),
       _ =>

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query9.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query9.scala
@@ -161,26 +161,38 @@ object Query9 {
     assertConcrete[I](c)
     assertConcrete[R](c)
 
-    val schemas: (
-      Schema[A],
-      Schema[B],
-      Schema[C],
-      Schema[D],
-      Schema[E],
-      Schema[F],
-      Schema[G],
-      Schema[H],
-      Schema[I],
-      Schema[R]
-    ) = c.eval(
-      c.Expr(
-        q"(${inferImplicitSchema[A]}, ${inferImplicitSchema[B]}, ${inferImplicitSchema[C]}, ${inferImplicitSchema[
-          D
-        ]}, ${inferImplicitSchema[E]}, ${inferImplicitSchema[F]}, ${inferImplicitSchema[G]}, ${inferImplicitSchema[
-          H
-        ]}, ${inferImplicitSchema[I]}, ${inferImplicitSchema[R]})"
+    val (
+      schemas1,
+      schemas2,
+      schemas3,
+      schemas4,
+      schemas5,
+      schemas6,
+      schemas7,
+      schemas8,
+      schemas9,
+      schemas10
+    ) =
+      c.eval(
+        c.Expr[
+          (
+            Schema[A],
+            Schema[B],
+            Schema[C],
+            Schema[D],
+            Schema[E],
+            Schema[F],
+            Schema[G],
+            Schema[H],
+            Schema[I],
+            Schema[R]
+          )
+        ](
+          q"(${untyped(aSchema)}, ${untyped(bSchema)}, ${untyped(cSchema)}, ${untyped(dSchema)}, ${untyped(
+            eSchema
+          )}, ${untyped(fSchema)}, ${untyped(gSchema)}, ${untyped(hSchema)}, ${untyped(iSchema)}, ${untyped(rSchema)})"
+        )
       )
-    )
 
     val sq = Query9[A, B, C, D, E, F, G, H, I, R](
       cons(c)(query),
@@ -195,16 +207,16 @@ object Query9 {
       tupleTag(c)(iTag)
     )
     typecheck(sq)(
-      schemas._1,
-      schemas._2,
-      schemas._3,
-      schemas._4,
-      schemas._5,
-      schemas._6,
-      schemas._7,
-      schemas._8,
-      schemas._9,
-      schemas._10
+      schemas1,
+      schemas2,
+      schemas3,
+      schemas4,
+      schemas5,
+      schemas6,
+      schemas7,
+      schemas8,
+      schemas9,
+      schemas10
     ).fold(
       err => c.abort(c.enclosingPosition, err),
       _ =>

--- a/scio-core/src/main/scala/com/spotify/scio/sql/Query9.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/sql/Query9.scala
@@ -173,7 +173,7 @@ object Query9 {
       schemas9,
       schemas10
     ) =
-      c.eval(
+      FastEval(c)(
         c.Expr[
           (
             Schema[A],

--- a/scio-macros/src/main/scala/com/spotify/scio/MacroSettings.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/MacroSettings.scala
@@ -21,7 +21,7 @@ import scala.reflect.macros.{blackbox, whitebox}
 
 private[scio] sealed trait FeatureFlag
 private[scio] object FeatureFlag {
-  case object Enable  extends FeatureFlag
+  case object Enable extends FeatureFlag
   case object Disable extends FeatureFlag
 }
 
@@ -31,20 +31,25 @@ private[scio] final object MacroSettings {
     val ss: Map[String, String] =
       settings
         .map(_.split("="))
-        .map { case Array(k, v) =>
-          (k.trim, v.trim)
-        }.toMap
+        .map {
+          case Array(k, v) =>
+            (k.trim, v.trim)
+        }
+        .toMap
 
-    ss.get(name).map {
-      case "true" =>
-        FeatureFlag.Enable
-      case "false" =>
-        FeatureFlag.Disable
-      case v =>
-        throw new IllegalArgumentException(
-          s"""Invalid value for setting -Xmacro-settings:$name,""" +
-            s"""expected "true" or "false", got $v""")
-    }.getOrElse(default)
+    ss.get(name)
+      .map {
+        case "true" =>
+          FeatureFlag.Enable
+        case "false" =>
+          FeatureFlag.Disable
+        case v =>
+          throw new IllegalArgumentException(
+            s"""Invalid value for setting -Xmacro-settings:$name,""" +
+              s"""expected "true" or "false", got $v"""
+          )
+      }
+      .getOrElse(default)
   }
 
   /**

--- a/scio-macros/src/main/scala/com/spotify/scio/MacroSettings.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/MacroSettings.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio
+
+import scala.reflect.macros.{blackbox, whitebox}
+
+private[scio] sealed trait FeatureFlag
+private[scio] object FeatureFlag {
+  case object Enable  extends FeatureFlag
+  case object Disable extends FeatureFlag
+}
+
+private[scio] final object MacroSettings {
+
+  private def getFlag(settings: List[String])(name: String, default: FeatureFlag): FeatureFlag = {
+    val ss: Map[String, String] =
+      settings
+        .map(_.split("="))
+        .map { case Array(k, v) =>
+          (k.trim, v.trim)
+        }.toMap
+
+    ss.get(name).map {
+      case "true" =>
+        FeatureFlag.Enable
+      case "false" =>
+        FeatureFlag.Disable
+      case v =>
+        throw new IllegalArgumentException(
+          s"""Invalid value for setting -Xmacro-settings:$name,""" +
+            s"""expected "true" or "false", got $v""")
+    }.getOrElse(default)
+  }
+
+  /**
+   * Makes it possible to configure fallback warnings by passing
+   * "-Xmacro-settings:show-coder-fallback=true" as a Scalac option.
+   */
+  def showCoderFallback(c: whitebox.Context): FeatureFlag =
+    getFlag(c.settings)("show-coder-fallback", FeatureFlag.Disable)
+
+  /**
+   * Aggressively cache Schema implicit definitions to speed up compilation.
+   * This might lead to the incorrect implicit definition to be selected
+   * since implicits may escape their scope.
+   */
+  def cacheImplicitSchemas(c: blackbox.Context): FeatureFlag =
+    getFlag(c.settings)("cache-implicit-schemas", FeatureFlag.Disable)
+}

--- a/scio-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.coders
 
-import com.spotify.scio.{MagnoliaMacros, MacroSettings, FeatureFlag}
+import com.spotify.scio.{FeatureFlag, MacroSettings, MagnoliaMacros}
 
 import scala.reflect.macros._
 

--- a/scio-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.coders
 
-import com.spotify.scio.MagnoliaMacros
+import com.spotify.scio.{MagnoliaMacros, MacroSettings, FeatureFlag}
 
 import scala.reflect.macros._
 
@@ -26,9 +26,6 @@ private[coders] object CoderMacros {
   private[this] var verbose = true
   private[this] val reported: scala.collection.mutable.Set[(String, String)] =
     scala.collection.mutable.Set.empty
-
-  private[this] val ShowWarnDefault = false
-  private[this] val ShowWarnSettingRegex = "show-coder-fallback=(true|false)".r
 
   private[this] val BlacklistedTypes = List("org.apache.beam.sdk.values.Row")
 
@@ -43,18 +40,6 @@ private[coders] object CoderMacros {
         """.stripMargin
     )
 
-  /**
-   * Makes it possible to configure fallback warnings by passing
-   * "-Xmacro-settings:show-coder-fallback=true" as a Scalac option.
-   */
-  private[this] def showWarn(c: whitebox.Context) =
-    c.settings
-      .collectFirst {
-        case ShowWarnSettingRegex(value) =>
-          value.toBoolean
-      }
-      .getOrElse(ShowWarnDefault)
-
   // scalastyle:off method.length
   // scalastyle:off cyclomatic.complexity
   def issueFallbackWarning[T: c.WeakTypeTag](
@@ -62,7 +47,7 @@ private[coders] object CoderMacros {
   )(lp: c.Expr[shapeless.LowPriority]): c.Tree = {
     import c.universe._
 
-    val show = showWarn(c)
+    val show = MacroSettings.showCoderFallback(c) == FeatureFlag.Enable
 
     val wtt = weakTypeOf[T]
     val TypeRef(_, sym, args) = wtt

--- a/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
@@ -132,6 +132,37 @@ object TestData {
 
   case class Order(order_id: Long, price: Long, site_id: Long)
   val orders = List(Order(1, 2, 2), Order(2, 2, 1), Order(1, 4, 3), Order(3, 2, 1), Order(3, 3, 1))
+
+  // Schemas
+  implicit def schemaFoo = Schema.gen[Foo]
+  implicit def schemaBar = Schema.gen[Bar]
+  implicit def schemaResult = Schema.gen[Result]
+  implicit def schemaUser = Schema.gen[User]
+  implicit def schemaUserId = Schema.gen[UserId]
+  implicit def schemaUserWithId = Schema.gen[UserWithId]
+  implicit def schemaUserWithFallBack = Schema.gen[UserWithFallBack]
+  implicit def schemaUserWithOption = Schema.gen[UserWithOption]
+  implicit def schemaUserWithList = Schema.gen[UserWithList]
+  implicit def schemaUserWithJList = Schema.gen[UserWithJList]
+  implicit def schemaUserWithMap = Schema.gen[UserWithMap]
+  implicit def schemaUserWithInstant = Schema.gen[UserWithInstant]
+  implicit def schemaOrder = Schema.gen[Order]
+
+  // Coders
+  implicit def coderLocale = Coder.kryo[Locale]
+  implicit def coderFoo = Coder.gen[Foo]
+  implicit def coderBar = Coder.gen[Bar]
+  implicit def coderResult = Coder.gen[Result]
+  implicit def coderUser = Coder.gen[User]
+  implicit def coderUserId = Coder.gen[UserId]
+  implicit def coderUserWithId = Coder.gen[UserWithId]
+  implicit def coderUserWithFallBack = Coder.gen[UserWithFallBack]
+  implicit def coderUserWithOption = Coder.gen[UserWithOption]
+  implicit def coderUserWithList = Coder.gen[UserWithList]
+  implicit def coderUserWithJList = Coder.gen[UserWithJList]
+  implicit def coderUserWithMap = Coder.gen[UserWithMap]
+  implicit def coderUserWithInstant = Coder.gen[UserWithInstant]
+  implicit def coderOrder = Coder.gen[Order]
 }
 
 class BeamSQLTest extends PipelineSpec {

--- a/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
@@ -133,25 +133,9 @@ object TestData {
   case class Order(order_id: Long, price: Long, site_id: Long)
   val orders = List(Order(1, 2, 2), Order(2, 2, 1), Order(1, 4, 3), Order(3, 2, 1), Order(3, 3, 1))
 
-  // Schemas
-  implicit def schemaFoo = Schema.gen[Foo]
-  implicit def schemaBar = Schema.gen[Bar]
-  implicit def schemaResult = Schema.gen[Result]
-  implicit def schemaUser = Schema.gen[User]
-  implicit def schemaUserId = Schema.gen[UserId]
-  implicit def schemaUserWithId = Schema.gen[UserWithId]
-  implicit def schemaUserWithFallBack = Schema.gen[UserWithFallBack]
-  implicit def schemaUserWithOption = Schema.gen[UserWithOption]
-  implicit def schemaUserWithList = Schema.gen[UserWithList]
-  implicit def schemaUserWithJList = Schema.gen[UserWithJList]
-  implicit def schemaUserWithMap = Schema.gen[UserWithMap]
-  implicit def schemaUserWithInstant = Schema.gen[UserWithInstant]
-  implicit def schemaOrder = Schema.gen[Order]
-
   // Coders
   implicit def coderLocale = Coder.kryo[Locale]
   implicit def coderFoo = Coder.gen[Foo]
-  implicit def coderBar = Coder.gen[Bar]
   implicit def coderResult = Coder.gen[Result]
   implicit def coderUser = Coder.gen[User]
   implicit def coderUserId = Coder.gen[UserId]
@@ -572,13 +556,13 @@ class BeamSQLTest extends PipelineSpec {
       .to[TinyTo](To.unsafe) should containInAnyOrder(tinyTo)
 
     sc.parallelize(from)
-      .to[To1](To.safe) should containInAnyOrder(to)
+      .to(To.safe[From0, To1]) should containInAnyOrder(to)
 
     sc.parallelize(javaUsers)
-      .to[JavaCompatibleUser](To.safe) should containInAnyOrder(expectedJavaCompatUsers)
+      .to(To.safe[UserBean, JavaCompatibleUser]) should containInAnyOrder(expectedJavaCompatUsers)
 
     sc.parallelize(from)
-      .to[TinyTo](To.safe) should containInAnyOrder(tinyTo)
+      .to(To.safe[From0, TinyTo]) should containInAnyOrder(tinyTo)
   }
 
   it should "Support LogicalTypes" in runWithContext { sc =>

--- a/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
@@ -134,19 +134,19 @@ object TestData {
   val orders = List(Order(1, 2, 2), Order(2, 2, 1), Order(1, 4, 3), Order(3, 2, 1), Order(3, 3, 1))
 
   // Coders
-  implicit def coderLocale = Coder.kryo[Locale]
-  implicit def coderFoo = Coder.gen[Foo]
-  implicit def coderResult = Coder.gen[Result]
-  implicit def coderUser = Coder.gen[User]
-  implicit def coderUserId = Coder.gen[UserId]
-  implicit def coderUserWithId = Coder.gen[UserWithId]
-  implicit def coderUserWithFallBack = Coder.gen[UserWithFallBack]
-  implicit def coderUserWithOption = Coder.gen[UserWithOption]
-  implicit def coderUserWithList = Coder.gen[UserWithList]
-  implicit def coderUserWithJList = Coder.gen[UserWithJList]
-  implicit def coderUserWithMap = Coder.gen[UserWithMap]
-  implicit def coderUserWithInstant = Coder.gen[UserWithInstant]
-  implicit def coderOrder = Coder.gen[Order]
+  implicit def coderLocale: Coder[Locale] = Coder.kryo[Locale]
+  implicit def coderFoo: Coder[Foo] = Coder.gen[Foo]
+  implicit def coderResult: Coder[Result] = Coder.gen[Result]
+  implicit def coderUser: Coder[User] = Coder.gen[User]
+  implicit def coderUserId: Coder[UserId] = Coder.gen[UserId]
+  implicit def coderUserWithId: Coder[UserWithId] = Coder.gen[UserWithId]
+  implicit def coderUserWithFallBack: Coder[UserWithFallBack] = Coder.gen[UserWithFallBack]
+  implicit def coderUserWithOption: Coder[UserWithOption] = Coder.gen[UserWithOption]
+  implicit def coderUserWithList: Coder[UserWithList] = Coder.gen[UserWithList]
+  implicit def coderUserWithJList: Coder[UserWithJList] = Coder.gen[UserWithJList]
+  implicit def coderUserWithMap: Coder[UserWithMap] = Coder.gen[UserWithMap]
+  implicit def coderUserWithInstant: Coder[UserWithInstant] = Coder.gen[UserWithInstant]
+  implicit def coderOrder: Coder[Order] = Coder.gen[Order]
 }
 
 class BeamSQLTest extends PipelineSpec {

--- a/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/sql/BeamSQLTest.scala
@@ -603,10 +603,10 @@ class BeamSQLTest extends PipelineSpec {
       .to[CompatibleAvroTestRecord](To.unsafe) should containInAnyOrder(expectedAvro)
 
     sc.parallelize(avroUsers)
-      .to[AvroCompatibleUser](To.safe) should containInAnyOrder(expected)
+      .to(To.safe[avro.User, AvroCompatibleUser]) should containInAnyOrder(expected)
 
     sc.parallelize(avroWithNullable)
-      .to[CompatibleAvroTestRecord](To.safe) should containInAnyOrder(expectedAvro)
+      .to(To.safe[avro.TestRecord, CompatibleAvroTestRecord]) should containInAnyOrder(expectedAvro)
   }
 
   "String interpolation" should "support simple queries" in runWithContext { sc =>

--- a/scripts/sql.py
+++ b/scripts/sql.py
@@ -204,7 +204,7 @@ def mkMacro(n):
     assertConcrete[R](c)
 
     val ({schema_tuple_vals}, schemas{n_p}) =
-        c.eval(
+        FastEval(c)(
             c.Expr[({schemas}, Schema[R])](
                 q"({infer_schemas}, ${{untyped(rSchema)}})"))
 

--- a/scripts/sql.py
+++ b/scripts/sql.py
@@ -203,12 +203,13 @@ def mkMacro(n):
     {assert_concrete}
     assertConcrete[R](c)
 
-    val schemas: ({schemas}, Schema[R]) = c.eval(
-      c.Expr(q"({infer_schemas}, ${{inferImplicitSchema[R]}})")
-    )
+    val ({schema_tuple_vals}, schemas{n_p}) =
+        c.eval(
+            c.Expr[({schemas}, Schema[R])](
+                q"({infer_schemas}, ${{untyped(rSchema)}})"))
 
     val sq = Query{n}[{types}, R](cons(c)(query), {tuple_tags})
-    typecheck(sq)({schema_tuple_vals}, schemas._{n_p})
+    typecheck(sq)({schema_tuple_vals}, schemas{n_p})
       .fold(
         err => c.abort(c.enclosingPosition, err),
         _ => c.Expr[Query{n}[{types}, R]](q"_root_.com.spotify.scio.sql.Query{n}($query, {tag_trees})")
@@ -219,8 +220,8 @@ def mkMacro(n):
         types=mkTypes(n),
         weak_bounds=mkBounds(n, "c.WeakTypeTag"),
         schemas=", ".join(mkValsFmt(n, "Schema[{upperIdx}]")),
-        schema_tuple_vals=", ".join(mkValsFmt(n, "schemas._{idx}")),
-        infer_schemas=", ".join(mkValsFmt(n, "${{inferImplicitSchema[{upperIdx}]}}")),
+        schema_tuple_vals=", ".join(mkValsFmt(n, "schemas{idx}")),
+        infer_schemas=", ".join(mkValsFmt(n, "${{untyped({lowerIdx}Schema)}}")),
         expr_tuple_tag=", ".join(
             mkValsFmt(n, "{lowerIdx}Tag: c.Expr[TupleTag[{upperIdx}]]")
         ),


### PR DESCRIPTION
I've added some cache to speed up things a bit. 
I *think* that most of the compilation time is actually spent waiting because of classloading and locks in the compiler intermal when schemas are `eval`'d  in `ToMacro.safeImpl`. 

More specifically, there's a lot of waiting happening in [here](https://github.com/scala/scala/blob/2.13.x/src/reflect/scala/reflect/runtime/SymbolLoaders.scala#L135-L184).

Maybe we can avoid loading java classes by redesigning `Schema` ?