### PR TITLE
Fix java.time.Instant coder

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
@@ -123,7 +123,10 @@ trait JavaCoders {
   implicit def beamKVCoder[K: Coder, V: Coder]: Coder[KV[K, V]] = Coder.kv(Coder[K], Coder[V])
 
   implicit def jInstantCoder: Coder[Instant] =
-    Coder.xmap(Coder.jLongCoder)(Instant.ofEpochMilli(_), _.toEpochMilli)
+    Coder.xmap(Coder.pairCoder(jLongCoder, jIntegerCoder))(
+      pair => Instant.ofEpochSecond(pair._1, pair._2.toLong),
+      instant => (instant.getEpochSecond, instant.getNano)
+    )
 
   implicit def coderJEnum[E <: java.lang.Enum[E]: ClassTag]: Coder[E] =
     Coder.beam(SerializableCoder.of(ScioUtil.classOf[E]))

--- a/scio-test/src/test/scala/com/spotify/scio/coders/coders.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/coders.scala
@@ -242,9 +242,10 @@ class CodersTest extends FlatSpec with Matchers {
   it should "Serialize java's Instant" in {
     import java.time.{Instant => jInstant}
 
-    // Both thow exceptions but they should be unusual enough to not be an issue
-    // jInstant.MIN coderShould notFallback()
-    // jInstant.MAX coderShould notFallback()
+    // Support full nano range
+    jInstant.ofEpochSecond(0, 123123123) coderShould notFallback()
+    jInstant.MIN coderShould notFallback()
+    jInstant.MAX coderShould notFallback()
     jInstant.EPOCH coderShould notFallback()
     jInstant.now coderShould notFallback()
   }


### PR DESCRIPTION
- Support full Instant precision
- Support full range of Instant values