### PR TITLE
fix NaN handling in Float/Double coders #2111

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
@@ -402,6 +402,7 @@ private object SFloatCoder extends BCoder[Float] {
     } else {
       java.lang.Float.valueOf(value)
     }
+  override def toString: String = "FloatCoder"
 }
 
 private object SDoubleCoder extends BCoder[Double] {
@@ -417,6 +418,7 @@ private object SDoubleCoder extends BCoder[Double] {
     } else {
       java.lang.Double.valueOf(value)
     }
+  override def toString: String = "DoubleCoder"
 }
 
 // scalastyle:off number.of.methods


### PR DESCRIPTION
Beam Java SDK's `{Float,Double}Coder` has `consistentWithEquals() == true` and `structuralValue` like this:

```
  public Object structuralValue(T value) {
    if (value != null && consistentWithEquals()) {
      return value;
    } else {
      try {
        ByteArrayOutputStream os = new ByteArrayOutputStream();
        encode(value, os, Context.OUTER);
        return new StructuralByteArray(os.toByteArray());
      } catch (Exception exn) {
        throw new IllegalArgumentException(
            "Unable to encode element '" + value + "' with coder '" + this + "'.", exn);
      }
    }
  }
```

Boxed `java.lang.{Float,Double}` actually returns true for `NaN`s, i.e. `Double.valueOf(Double.NaN).equals(Double.valueOf(Double.NaN))`, however, I suspect Scala unboxes `Float,Double` under the hood, so currently `bc.structuralValue(Double.NaN) != bc.structuralValue(Double.NaN)` which triggers the mutation detector warning.

Specializing the coders for `NaN` fixes this issue.

This fixes the following warnings in #2111

```
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element [0.0, 5.0, 11.0, 12.0, 200.0, NaN]
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element [0.0, 5.0, 11.0, 12.0, 200.0, NaN]
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element [0.0, 5.0, 11.0, 12.0, 200.0, NaN]
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element [0.0, 5.0, 11.0, 12.0, 200.0, NaN]
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element [0.0, 5.0, 11.0, 12.0, 200.0, NaN]
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element [0.0, 5.0, 11.0, 12.0, 200.0, NaN]
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element [0.0, 5.0, 11.0, 12.0, 200.0, NaN]
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element [0.0, 5.0, 11.0, 12.0, 200.0, NaN]
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element [0.0, 5.0, 11.0, 12.0, 200.0, NaN]
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element [0.0, 5.0, 11.0, 12.0, 200.0, NaN]
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.coders.KvCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element KV{null, (NaN,NaN)}
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element (NaN,NaN)
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.coders.KvCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element KV{null, (NaN,NaN)}
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element (NaN,NaN)
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.coders.KvCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element KV{null, (NaN,NaN)}
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class com.spotify.scio.coders.WrappedBCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element (NaN,NaN)
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.coders.KvCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element KV{null, (NaN,NaN)}
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.coders.KvCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element KV{null, KV{null, (NaN,NaN)}}
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.coders.KvCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element KV{null, (NaN,NaN)}
```