### PR TITLE
Add helpers for tensorflow IO using tfexample-derive

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -745,7 +745,6 @@ lazy val scioTensorFlow: Project = Project(
       "org.tensorflow" % "tensorflow" % tensorFlowVersion,
       "org.tensorflow" % "proto" % tensorFlowVersion,
       "org.apache.commons" % "commons-compress" % commonsCompress,
-      "me.lyh" %% "shapeless-datatype-tensorflow" % shapelessDatatypeVersion,
       "com.spotify" %% "featran-core" % featranVersion,
       "com.spotify" %% "featran-scio" % featranVersion,
       "com.spotify" %% "featran-tensorflow" % featranVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,7 @@ val shapelessDatatypeVersion = "0.1.10"
 val slf4jVersion = "1.7.28"
 val sparkeyVersion = "3.0.0"
 val tensorFlowVersion = "1.13.1"
+val tfexampleDeriveVersion = "0.2.3"
 val zoltarVersion = "0.5.4"
 val magnoliaVersion = "0.10.1-jto"
 val grpcVersion = "1.17.1"
@@ -748,6 +749,7 @@ lazy val scioTensorFlow: Project = Project(
       "com.spotify" %% "featran-core" % featranVersion,
       "com.spotify" %% "featran-scio" % featranVersion,
       "com.spotify" %% "featran-tensorflow" % featranVersion,
+      "com.spotify" %% "tfexample-derive" % tfexampleDeriveVersion,
       "com.spotify" % "zoltar-api" % zoltarVersion,
       "com.spotify" % "zoltar-tensorflow" % zoltarVersion
     ),

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
@@ -105,8 +105,8 @@ final class ExampleConverterSCollectionOps[T](private val self: SCollection[T]) 
     suffix: String = TFExampleIO.WriteParam.DefaultSuffix,
     compression: Compression = TFExampleIO.WriteParam.DefaultCompression,
     numShards: Int = TFExampleIO.WriteParam.DefaultNumShards
-  )(implicit conv: ExampleConverter[T]): ClosedTap[Example] =
-    new ExampleSCollectionOps(self.map(conv.toExample))
+  )(implicit converter: ExampleConverter[T]): ClosedTap[Example] =
+    new ExampleSCollectionOps(self.map(converter.toExample))
       .saveAsTfRecordFile(path, suffix, compression, numShards)
 }
 

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/ScioContextSyntax.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/ScioContextSyntax.scala
@@ -20,8 +20,10 @@ package com.spotify.scio.tensorflow.syntax
 import java.nio.file.Files
 
 import com.spotify.scio.ScioContext
+import com.spotify.scio.coders.Coder
 import com.spotify.scio.tensorflow.{TFExampleIO, TFRecordIO, TFSequenceExampleIO}
 import com.spotify.scio.values.{DistCache, SCollection}
+import com.spotify.tfexample.derive.ExampleConverter
 import org.apache.beam.sdk.io.Compression
 import org.tensorflow.example.{Example, SequenceExample}
 import org.tensorflow.metadata.v0._
@@ -101,6 +103,18 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
 
     (tfRecordSequenceExampleFile(path, compression), distCache)
   }
+
+  /**
+   * Get an SCollection of type `T` from a TensorFlow TFRecord file encoded as serialized
+   * [[org.tensorflow.example.Example]] protocol buffers, using
+   * [[com.spotify.tfexample.derive.ExampleConverter]] to convert to `T`.
+   * @group input
+   */
+  def tfRecordFileAsObject[T: Coder](
+    path: String,
+    compression: Compression = Compression.AUTO
+  )(implicit converter: ExampleConverter[T]): SCollection[T] =
+    tfRecordExampleFile(path, compression).flatMap(converter.fromExample)
 }
 
 trait ScioContextSyntax {

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFExampleIOTest.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFExampleIOTest.scala
@@ -18,12 +18,12 @@
 package com.spotify.scio.tensorflow
 
 import com.spotify.scio.testing._
-import shapeless.datatype.tensorflow._
+import com.spotify.tfexample.derive.ExampleConverter
 
 object TFExampleIOTest {
   case class Record(i: Int, s: String)
 
-  val recordT: TensorFlowType[Record] = TensorFlowType[Record]
+  val recordT: ExampleConverter[Record] = ExampleConverter[Record]
 }
 
 class TFExampleIOTest extends ScioIOSpec {

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFExampleTest.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFExampleTest.scala
@@ -111,7 +111,7 @@ class TFExampleTest extends PipelineSpec {
 
   "ReadAndSaveIrisJob" should "work" in {
     val testInput = List(Iris(Some(5.1), Some(3.5), Some(1.4), Some(0.2), Some("Iris-setosa")))
-        .map(ExampleConverter[Iris].toExample)
+      .map(ExampleConverter[Iris].toExample)
 
     JobTest[ReadAndSaveIrisJob.type]
       .args("--input=in", "--output=out")


### PR DESCRIPTION
Using https://github.com/spotify/tfexample-derive, converters between case classes and Tensorflow Example protos can be automatically derived. This PR adds some helpers in `scio-tensorflow` for being able to read and write TF record files without users needing to manually do the conversion.