### PR TITLE
reduce guava usage

### DIFF
--- a/scio-bigquery/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PatchedBigQueryTableRowIterator.java
+++ b/scio-bigquery/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PatchedBigQueryTableRowIterator.java
@@ -17,9 +17,9 @@
  */
 package org.apache.beam.sdk.io.gcp.bigquery;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 
 import com.google.api.client.googleapis.services.AbstractGoogleClientRequest;
 import com.google.api.client.util.BackOff;

--- a/scio-cassandra/cassandra2/src/main/java/org/apache/cassandra/db/DeletionInfo.java
+++ b/scio-cassandra/cassandra2/src/main/java/org/apache/cassandra/db/DeletionInfo.java
@@ -24,9 +24,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 
-import com.google.common.base.Objects;
-import com.google.common.collect.Iterators;
-
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Objects;
 import org.apache.cassandra.cache.IMeasurableMemory;
 import org.apache.cassandra.db.composites.CType;
 import org.apache.cassandra.db.composites.Composite;

--- a/scio-cassandra/cassandra2/src/main/scala/com/spotify/scio/cassandra/DataTypeExternalizer.scala
+++ b/scio-cassandra/cassandra2/src/main/scala/com/spotify/scio/cassandra/DataTypeExternalizer.scala
@@ -18,10 +18,10 @@
 package com.spotify.scio.cassandra
 
 import java.lang.{Iterable => JIterable}
-import java.util.{Collection => JCollection}
+import java.util.{ArrayList => JArrayList, Collection => JCollection}
 
 import com.datastax.driver.core.DataType
-import com.google.common.collect.{ImmutableList, ImmutableSet, Lists}
+import com.google.common.collect.{ImmutableList, ImmutableSet}
 import com.twitter.chill._
 
 import scala.collection.JavaConverters._
@@ -51,7 +51,7 @@ private final class DataTypeKryoInstantiator extends EmptyScalaKryoInstantiator 
 private trait ImmutableCollectionSerializer[M] extends KSerializer[M] {
   def readList[T](kser: Kryo, in: Input): JCollection[T] = {
     val size = in.readInt(true)
-    val list = Lists.newArrayList[T]()
+    val list = new JArrayList[T]()
     (1 to size).foreach(_ => list.add(kser.readClassAndObject(in).asInstanceOf[T]))
     list
   }

--- a/scio-elasticsearch/es2/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/scio-elasticsearch/es2/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -17,10 +17,9 @@
 
 package org.apache.beam.sdk.io.elasticsearch;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
@@ -51,6 +50,7 @@ import org.apache.beam.sdk.util.Sleeper;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;

--- a/scio-elasticsearch/es5/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/scio-elasticsearch/es5/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -17,10 +17,9 @@
 
 package org.apache.beam.sdk.io.elasticsearch;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
@@ -51,6 +50,7 @@ import org.apache.beam.sdk.util.Sleeper;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;

--- a/scio-elasticsearch/es6/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/scio-elasticsearch/es6/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -17,10 +17,9 @@
 
 package org.apache.beam.sdk.io.elasticsearch;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
@@ -51,6 +50,7 @@ import org.apache.beam.sdk.util.Sleeper;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;

--- a/scio-elasticsearch/es7/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/scio-elasticsearch/es7/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -17,11 +17,9 @@
 
 package org.apache.beam.sdk.io.elasticsearch;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
@@ -51,6 +49,7 @@ import org.apache.beam.sdk.util.Sleeper;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.http.HttpHost;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -295,7 +294,7 @@ public class ElasticsearchIO {
 
       @Setup
       public void setup() throws Exception {
-        Preconditions.checkArgument(
+        checkArgument(
             this.clientSupplier.get().ping(RequestOptions.DEFAULT),
             "Elasticsearch client not reachable"
         );

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/AutoComplete.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/AutoComplete.scala
@@ -24,7 +24,6 @@
 // --outputToBigqueryTable=true --outputToDatastore=false --output=[DATASET].auto_complete"`
 package com.spotify.scio.examples.complete
 
-import com.google.common.collect.ImmutableMap
 import com.google.datastore.v1.Entity
 import com.google.datastore.v1.client.DatastoreHelper.{makeKey, makeValue}
 import com.spotify.scio._
@@ -101,14 +100,14 @@ object AutoComplete {
         Entity
           .newBuilder()
           .putAllProperties(
-            ImmutableMap.of("tag", makeValue(p._1).build(), "count", makeValue(p._2).build())
+            Map("tag" -> makeValue(p._1).build(), "count" -> makeValue(p._2).build()).asJava
           )
       ).build()
     }
     Entity
       .newBuilder()
       .setKey(key)
-      .putAllProperties(ImmutableMap.of("candidates", makeValue(candidates.asJava).build()))
+      .putAllProperties(Map("candidates" -> makeValue(candidates.asJava).build()).asJava)
       .build()
   }
 


### PR DESCRIPTION
Here're the only remaining non-vendored Guava usage after this change.

```
// public API
scio-bigtable/src/it/scala/com/spotify/scio/bigtable/BigtableBenchmark.scala:import com.google.common.cache.CacheBuilder
scio-bigtable/src/it/scala/com/spotify/scio/bigtable/BigtableBenchmark.scala:import com.google.common.util.concurrent.{Futures, ListenableFuture, MoreExecutors}
scio-bigtable/src/main/java/com/spotify/scio/bigtable/BigtableDoFn.java:import com.google.common.util.concurrent.ListenableFuture;
scio-bigtable/src/test/scala/com/spotify/scio/bigtable/BigtableDoFnTest.scala:import com.google.common.cache.{Cache, CacheBuilder}
scio-bigtable/src/test/scala/com/spotify/scio/bigtable/BigtableDoFnTest.scala:import com.google.common.util.concurrent.{Futures, ListenableFuture}

// Cassandra internals
scio-cassandra/cassandra2/src/main/scala/com/spotify/scio/cassandra/DataTypeExternalizer.scala:import com.google.common.collect.{ImmutableList, ImmutableSet}
scio-cassandra/cassandra3/src/main/scala/com/spotify/scio/cassandra/DataTypeExternalizer.scala:import com.google.common.collect.{ImmutableList, ImmutableSet}

// public API
scio-core/src/main/java/com/spotify/scio/transforms/BaseAsyncLookupDoFn.java:import com.google.common.cache.Cache;
scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java:import com.google.common.util.concurrent.*;
scio-core/src/main/java/com/spotify/scio/transforms/GuavaAsyncDoFn.java:import com.google.common.util.concurrent.ListenableFuture;
scio-core/src/main/java/com/spotify/scio/transforms/GuavaAsyncLookupDoFn.java:import com.google.common.util.concurrent.ListenableFuture;

// Beam Java SDK examples
scio-examples/src/main/java/org/apache/beam/examples/common/ExampleUtils.java:import com.google.common.collect.ImmutableList;
scio-examples/src/main/java/org/apache/beam/examples/common/ExampleUtils.java:import com.google.common.util.concurrent.Uninterruptibles;
scio-examples/src/main/java/org/apache/beam/examples/common/WriteOneFilePerWindow.java:import static com.google.common.base.MoreObjects.firstNonNull;
scio-examples/src/main/java/org/apache/beam/examples/complete/AutoComplete.java:import static com.google.common.base.Preconditions.checkArgument;
scio-examples/src/main/java/org/apache/beam/examples/complete/AutoComplete.java:import com.google.common.base.MoreObjects;
scio-examples/src/main/java/org/apache/beam/examples/complete/game/StatefulTeamScore.java:import static com.google.common.base.MoreObjects.firstNonNull;
scio-examples/src/main/java/org/apache/beam/examples/complete/game/utils/WriteToText.java:import static com.google.common.base.Preconditions.checkArgument;
scio-examples/src/main/java/org/apache/beam/examples/snippets/Snippets.java:import com.google.common.collect.ImmutableList;
scio-examples/src/main/java/org/apache/beam/examples/subprocess/kernel/SubProcessCommandLineArgs.java:import com.google.common.collect.Lists;
scio-examples/src/test/java/org/apache/beam/examples/DebuggingWordCountTest.java:import com.google.common.io.Files;
scio-examples/src/test/java/org/apache/beam/examples/cookbook/MaxPerKeyExamplesTest.java:import com.google.common.collect.ImmutableList;
scio-examples/src/test/java/org/apache/beam/examples/cookbook/TriggerExampleTest.java:import com.google.common.base.Joiner;
scio-examples/src/test/java/org/apache/beam/examples/cookbook/TriggerExampleTest.java:import com.google.common.collect.Lists;

// public API
scio-test/src/test/scala/com/spotify/scio/transforms/AsyncDoFnSpec.scala:import com.google.common.util.concurrent.{ListenableFuture, SettableFuture}
scio-test/src/test/scala/com/spotify/scio/transforms/AsyncDoFnTest.scala:import com.google.common.util.concurrent.{ListenableFuture, MoreExecutors}
scio-test/src/test/scala/com/spotify/scio/transforms/AsyncLookupDoFnTest.scala:import com.google.common.cache.{Cache, CacheBuilder}
scio-test/src/test/scala/com/spotify/scio/transforms/AsyncLookupDoFnTest.scala:import com.google.common.util.concurrent.{Futures, ListenableFuture}
```