### PR TITLE
Truncate app args if long (#2172)

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -383,13 +383,26 @@ object ScioContext {
     } else {
       val args = Args(appArgs)
       if (appArgs.nonEmpty) {
+        val argString = args.toString("", ", ", "")
+        val sanitizedArgString =
+          if (argString.length > appArgStringMaxLength) {
+            log.warn("Truncating long app arguments")
+            argString.substring(0, appArgStringMaxLength) + " [...]"
+          } else {
+            argString
+          }
+
         pipelineOpts
           .as(classOf[ScioOptions])
-          .setAppArguments(args.toString("", ", ", ""))
+          .setAppArguments(sanitizedArgString)
       }
       (pipelineOpts, args)
     }
   }
+
+  // Used to trim app args for UI if too long to avoid
+  // contributing to an exceeded upload size limit.
+  private val appArgStringMaxLength = 50000
 
   import scala.language.implicitConversions
 


### PR DESCRIPTION
Prevents long app args from contributing to upload bloat, which can e.g. cause Dataflow to reject a job upload for being too large.

I went with a pretty arbitrary number for the limit, but the limits Dataflow declares in its error messages are thus:
> SDK pipeline options or staging file list exceeds size limit. Please keep their length under 256K Bytes each and 512K Bytes in total.

Will add a test but just want to check first that this is what was intended.

Fixes #2172.