### PR TITLE
Add fix for BinaryIO output filenames.

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/io/BinaryIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/BinaryIO.scala
@@ -47,6 +47,7 @@ final case class BinaryIO(path: String) extends ScioIO[Array[Byte]] {
         .via(new BytesSink(params.header, params.footer, params.framePrefix, params.frameSuffix))
         .withCompression(params.compression)
         .withNumShards(params.numShards)
+        .withPrefix(BinaryIO.WriteParam.DefaultPrefix)
         .withSuffix(params.suffix)
         .to(pathWithShards(path))
     )
@@ -56,12 +57,13 @@ final case class BinaryIO(path: String) extends ScioIO[Array[Byte]] {
   override def tap(params: Nothing): Tap[Nothing] = EmptyTap
 
   private[scio] def pathWithShards(path: String) =
-    path.replaceAll("\\/+$", "") + "/part"
+    path.replaceAll("\\/+$", "")
 }
 
 object BinaryIO {
 
   object WriteParam {
+    private[scio] val DefaultPrefix = "part"
     private[scio] val DefaultSuffix = ".bin"
     private[scio] val DefaultNumShards = 0
     private[scio] val DefaultCompression = Compression.UNCOMPRESSED


### PR DESCRIPTION
The current `BinaryIO` writer (used by `saveAsBinaryFile`) unfortunately writes to the wrong path. When specifying an output `$path` to write to, the current version of Scio writes binary files in `$path/part/output-[...].bin` due to the default usage of [`org.apache.beam.sdk.io.FileIO`, which sets its filename prefix to `output`](https://github.com/apache/beam/blob/1031fdf456b91a03567f0df2df19f23c5aa89a5a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java#L1244-L1248) and has slightly different file naming behaviour than `org.apache.beam.sdk.io.TextIO`.

This PR changes this behaviour to be in line with `TextIO`, meaning that files are written to `$path/part-nnnnn-of-mmmmm$suffix` instead. A test is also added to verify the expected filenames are written.

(cc @ClaireMcGinty, @regadas, @nevillelyh)