### PR TITLE
Check name uniqueness without running on dataflow

### DIFF
--- a/scio-test/src/it/scala/com/spotify/scio/ScioContextIT.scala
+++ b/scio-test/src/it/scala/com/spotify/scio/ScioContextIT.scala
@@ -24,7 +24,7 @@ import com.spotify.scio.util.ScioUtil
 import org.apache.beam.runners.dataflow.DataflowRunner
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions
 import org.apache.beam.sdk.io.FileSystems
-import org.apache.beam.sdk.options.{ApplicationNameOptions, PipelineOptions, PipelineOptionsFactory}
+import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
 import org.scalatest._
 
 class ScioContextIT extends FlatSpec with Matchers {
@@ -54,20 +54,6 @@ class ScioContextIT extends FlatSpec with Matchers {
     tempLocation shouldBe gcpTempLocation
     ScioUtil.isRemoteUri(new URI(gcpTempLocation)) shouldBe true
     ()
-  }
-
-  it should "#1323: generate unique SCollection names" in {
-    val options = PipelineOptionsFactory.create()
-    options.setRunner(classOf[DataflowRunner])
-    options.as(classOf[ApplicationNameOptions]).setAppName("ScioContextIT")
-    options.as(classOf[GcpOptions]).setProject(ItUtils.project)
-    val sc = ScioContext(options)
-
-    val s1 = sc.empty[(String, Int)]()
-    val s2 = sc.empty[(String, Double)]()
-    s1.join(s2)
-
-    noException shouldBe thrownBy { sc.run() }
   }
 
   it should "register remote file systems in the test context" in {

--- a/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -23,12 +23,10 @@ import java.nio.file.Files
 import com.spotify.scio.io.TextIO
 import com.spotify.scio.metrics.Metrics
 import com.spotify.scio.options.ScioOptions
-import com.spotify.scio.testing.util.ItUtils
 import com.spotify.scio.testing.{PipelineSpec, TestValidationOptions}
 import com.spotify.scio.util.ScioUtil
 import org.apache.beam.runners.direct.DirectRunner
-import org.apache.beam.sdk.extensions.gcp.options.GcpOptions
-import org.apache.beam.sdk.options.{ApplicationNameOptions, PipelineOptions, PipelineOptionsFactory}
+import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
 import org.apache.beam.sdk.testing.PAssert
 import org.apache.beam.sdk.transforms.Create
 

--- a/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -23,10 +23,12 @@ import java.nio.file.Files
 import com.spotify.scio.io.TextIO
 import com.spotify.scio.metrics.Metrics
 import com.spotify.scio.options.ScioOptions
+import com.spotify.scio.testing.util.ItUtils
 import com.spotify.scio.testing.{PipelineSpec, TestValidationOptions}
 import com.spotify.scio.util.ScioUtil
 import org.apache.beam.runners.direct.DirectRunner
-import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions
+import org.apache.beam.sdk.options.{ApplicationNameOptions, PipelineOptions, PipelineOptionsFactory}
 import org.apache.beam.sdk.testing.PAssert
 import org.apache.beam.sdk.transforms.Create
 
@@ -210,5 +212,17 @@ class ScioContextTest extends PipelineSpec {
       .committed
 
     actualCommitedCounterValue shouldBe Some(0)
+  }
+
+  it should "#1323: generate unique SCollection names" in {
+    val options = PipelineOptionsFactory.create()
+    options.setStableUniqueNames(PipelineOptions.CheckEnabled.ERROR)
+    val sc = ScioContext(options)
+
+    val s1 = sc.empty[(String, Int)]()
+    val s2 = sc.empty[(String, Double)]()
+    s1.join(s2)
+
+    noException shouldBe thrownBy { sc.run() }
   }
 }


### PR DESCRIPTION
With this option set to `ERROR` we can test the same expected behaviour as submitting the job to Dataflow.