### PR TITLE
Allow user to pass in Bigtable GcRule

### DIFF
--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
@@ -266,7 +266,6 @@ package object bigtable {
      *                                              garbage collection of a cell may occur.
      *                                              Note: minimum granularity is second.
      */
-    @deprecated("this method will be removed; use ensureTablesWithGcRules instead", "Scio 0.8")
     def ensureTablesWithExpiration(
       bigtableOptions: BigtableOptions,
       tablesAndColumnFamiliesWithExpiration: Map[String, List[(String, Option[Duration])]]

--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
@@ -235,7 +235,6 @@ package object bigtable {
      *                                              garbage collection of a cell may occur.
      *                                              Note: minimum granularity is second.
      */
-    @deprecated("this method will be removed; use ensureTablesWithGcRules instead", "Scio 0.8")
     def ensureTablesWithExpiration(
       projectId: String,
       instanceId: String,

--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/package.scala
@@ -17,6 +17,7 @@
 
 package com.spotify.scio
 
+import com.google.bigtable.admin.v2.GcRule
 import com.google.bigtable.v2._
 import com.google.cloud.bigtable.config.BigtableOptions
 import com.google.protobuf.ByteString
@@ -234,6 +235,7 @@ package object bigtable {
      *                                              garbage collection of a cell may occur.
      *                                              Note: minimum granularity is second.
      */
+    @deprecated("this method will be removed; use ensureTablesWithGcRules instead", "Scio 0.8")
     def ensureTablesWithExpiration(
       projectId: String,
       instanceId: String,
@@ -265,6 +267,7 @@ package object bigtable {
      *                                              garbage collection of a cell may occur.
      *                                              Note: minimum granularity is second.
      */
+    @deprecated("this method will be removed; use ensureTablesWithGcRules instead", "Scio 0.8")
     def ensureTablesWithExpiration(
       bigtableOptions: BigtableOptions,
       tablesAndColumnFamiliesWithExpiration: Map[String, List[(String, Option[Duration])]]
@@ -273,6 +276,58 @@ package object bigtable {
         TableAdmin.ensureTablesWithExpiration(
           bigtableOptions,
           tablesAndColumnFamiliesWithExpiration
+        )
+      }
+    }
+
+    /**
+     * Ensure that tables and column families exist.
+     * Checks for existence of tables or creates them if they do not exist.  Also checks for
+     * existence of column families within each table and creates them if they do not exist.
+     *
+     * @param tablesAndColumnFamiliesWithGcRules A map of tables and column families. Keys are
+     *                                           table names. Values are a list of column family
+     *                                           names along with the desired GcRule.
+     */
+    def ensureTablesWithGcRules(
+      projectId: String,
+      instanceId: String,
+      tablesAndColumnFamiliesWithGcRules: Map[String, List[(String, Option[GcRule])]]
+    ): Unit = {
+      if (!self.isTest) {
+        val bigtableOptions = BigtableOptions
+          .builder()
+          .setProjectId(projectId)
+          .setInstanceId(instanceId)
+          .build
+        TableAdmin.ensureTablesWithGcRules(
+          bigtableOptions,
+          tablesAndColumnFamiliesWithGcRules
+        )
+      }
+    }
+
+    /**
+     * Ensure that tables and column families exist.
+     * Checks for existence of tables or creates them if they do not exist.  Also checks for
+     * existence of column families within each table and creates them if they do not exist.
+     *
+     * @param tablesAndColumnFamiliesWithGcRule A map of tables and column families.
+     *                                          Keys are table names. Values are a
+     *                                          list of column family names along with
+     *                                          the desired cell expiration. Cell
+     *                                          expiration is the duration before which
+     *                                          garbage collection of a cell may occur.
+     *                                          Note: minimum granularity is second.
+     */
+    def ensureTablesWithGcRules(
+      bigtableOptions: BigtableOptions,
+      tablesAndColumnFamiliesWithGcRule: Map[String, List[(String, Option[GcRule])]]
+    ): Unit = {
+      if (!self.isTest) {
+        TableAdmin.ensureTablesWithGcRules(
+          bigtableOptions,
+          tablesAndColumnFamiliesWithGcRule
         )
       }
     }


### PR DESCRIPTION
Bigtable's GC policy can be configured to use the max age of a cell, the max
number of versions in a cell, or a combination of the two. Currently scio's
API only lets you specify max age. This PR makes it so the user can pass in
a GcRule, so they can configure GC however they like.