### PR TITLE
Add Paradise dependency back to scio-repl classpath (fix #2265)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -848,7 +848,8 @@ lazy val scioRepl: Project = Project(
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
       "jline" % "jline" % jlineVersion,
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-      "com.nrinaudo" %% "kantan.csv" % kantanCsvVersion
+      "com.nrinaudo" %% "kantan.csv" % kantanCsvVersion,
+      "org.scalamacros" % "paradise" % scalaMacrosVersion cross CrossVersion.full
     ),
     assemblyJarName in assembly := s"scio-repl-${version.value}.jar"
   )


### PR DESCRIPTION
fixes #2265 

I added the dependency back from [#2130](https://github.com/spotify/scio/pull/2130/files#diff-fdc3abdfd754eeb24090dbd90aeec2ceL808)