### PR TITLE
AvroType macro shouldn't generate duplicate record classes fix #2264)

### DIFF
--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/TypeProvider.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/TypeProvider.scala
@@ -285,6 +285,8 @@ private[types] object TypeProvider {
       val recordClasses = f
         .flatMap(_._2)
         .groupBy(_.asInstanceOf[ClassDef].name)
+        // note that if there are conflicting definitions of a nested record type, the Avro schema
+        // parser itself will catch it before getting to this step.
         .map { case (_, cDefs) => cDefs.head } // Don't generate duplicate case classes
         .toSeq
 

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/TypeProvider.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/TypeProvider.scala
@@ -279,7 +279,16 @@ private[types] object TypeProvider {
     def extractFields(className: String, schema: Schema): (Seq[Tree], Seq[Tree]) = {
       val f = schema.getFields.asScala
         .map(f => extractField(className, f.name, f.schema))
-      (f.map(_._1), f.flatMap(_._2))
+
+      val fields = f.map(_._1)
+
+      val recordClasses = f
+        .flatMap(_._2)
+        .groupBy(_.asInstanceOf[ClassDef].name)
+        .map { case (_, cDefs) => cDefs.head } // Don't generate duplicate case classes
+        .toSeq
+
+      (fields, recordClasses)
     }
 
     val r = annottees.map(_.tree) match {

--- a/scio-avro/src/test/scala/com/spotify/scio/avro/types/TypeProviderTest.scala
+++ b/scio-avro/src/test/scala/com/spotify/scio/avro/types/TypeProviderTest.scala
@@ -584,6 +584,34 @@ class TypeProviderTest extends FlatSpec with Matchers {
     Artisanal1Field.getClass.getMethods
       .map(_.getName) should not contain "tupled"
   }
+
+  @AvroType.fromSchema("""
+     |{
+     |  "type": "record",
+     |  "name": "Record",
+     |  "fields": [
+     |    {
+     |      "name": "a",
+     |      "type": {
+     |        "type": "record",
+     |        "name": "ReusedRecord",
+     |        "fields": [
+     |          {"name": "f1", "type": "int"}
+     |        ]
+     |      }
+     |  },
+     |  {"name": "b", "type": "ReusedRecord"}
+     |]}""".stripMargin)
+  class RecordWithReusedRecordType
+
+  it should "support re-used record definitions" in {
+    val nested1 = RecordWithReusedRecordType$ReusedRecord(1)
+    val nested2 = RecordWithReusedRecordType$ReusedRecord(2)
+    val record = RecordWithReusedRecordType(nested1, nested2)
+    record.a shouldBe nested1
+    record.b shouldBe nested2
+  }
+
   @AvroType.toSchema
   case class ToSchema(
     boolF: Boolean,


### PR DESCRIPTION
fix #2264