### PR TITLE
Add failing test case to recursive coders test

### DIFF
--- a/scio-test/src/test/scala/com/spotify/scio/coders/coders.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/coders.scala
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.coders.Coder.NonDeterministicException
 import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
 import org.scalactic.Equality
 import org.scalatest.{FlatSpec, Matchers}
+import org.apache.beam.sdk.util.SerializableUtils
 
 import scala.collection.JavaConverters._
 import scala.collection.{mutable => mut}
@@ -462,6 +463,9 @@ class CodersTest extends FlatSpec with Matchers {
     case object IntegerType extends SampleFieldType
     case object StringType extends SampleFieldType
     case class RecordType(fields: List[SampleField]) extends SampleFieldType
+
+    noException should be thrownBy SerializableUtils.serializeToByteArray(CoderMaterializer.beamWithDefault(implicitly[Coder[Top]]))
+    noException should be thrownBy SerializableUtils.serializeToByteArray(CoderMaterializer.beamWithDefault(implicitly[Coder[SampleFieldType]]))
 
     "Coder[SampleField]" should compile
     // deriving this coder under 2.11 will fail


### PR DESCRIPTION
Test case illustrating the error reported in #2269 

The test fails on line 468. It passes for `Coder[Top]` (non-recursive co-product), but fails for `Coder[SampleFieldType]` (recursive co-product)