### PR TITLE
fix BigQuery cache handling when GCP credentials are missing, #2272

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,6 @@ commands:
         keys:
         - v7-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/dependencies.cache.tmp" }}
         - v7-dependencies-
-    - run: ./scripts/gen_schemas.sh
     - run:
         name: setup
         command: |
@@ -81,7 +80,7 @@ commands:
 
           if [ -n "$CIRCLE_PR_USERNAME" ]; then
             echo "Scala $SCALA_VERSION, forked PR #$CIRCLE_PR_NUMBER from $CIRCLE_PR_USERNAME/$CIRCLE_PR_REPONAME"
-            echo 'export SBT_OPTS="-Dbigquery.project=dummy-project"' >> $BASH_ENV
+            ./scripts/bootstrap.sh
           else
             echo "Scala $SCALA_VERSION, branch: $CIRCLE_BRANCH"
             echo 'export SBT_OPTS="-Dbigquery.project=data-integration-test -Dbigquery.secret=$GOOGLE_APPLICATION_CREDENTIALS"' >> $BASH_ENV

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,3 +8,6 @@ SCHEMAS_DIR=/tmp/scio-bigquery-$USER/.bigquery/
 
 mkdir -p $SCHEMAS_DIR
 cp -v scripts/bigquery/* $SCHEMAS_DIR
+
+echo "Adding BigQuery flags"
+echo "-Dbigquery.project=dummy-project" >> .jvmopts

--- a/scripts/gen_schemas.sh
+++ b/scripts/gen_schemas.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "Restoring cached BigQuery schemas"
 
-SCHEMAS_DIR=/tmp/scio-bigquery-circleci/.bigquery/
+SCHEMAS_DIR=/tmp/scio-bigquery-$USER/.bigquery/
 
 mkdir -p $SCHEMAS_DIR
 cp -v scripts/bigquery/* $SCHEMAS_DIR

--- a/site/src/paradox/Getting-Started.md
+++ b/site/src/paradox/Getting-Started.md
@@ -51,7 +51,7 @@ Unlike Hadoop, Scio or Dataflow input should be file patterns and not directorie
 Use the @javadoc[`DataflowRunner`](org.apache.beam.runners.dataflow.DataflowRunner) to execute pipelines on Google Cloud Dataflow service using managed resources in the Google Cloud Platform.
 
 ```
-neville@localhost scio $ sbt -Dbigquery.project=<BILLING_PROJECT>
+neville@localhost scio $ sbt
 [info] ...
 > project scio-examples
 [info] ...

--- a/site/src/paradox/dev/build.md
+++ b/site/src/paradox/dev/build.md
@@ -4,18 +4,20 @@
 
 ```bash
 git clone https://github.com/spotify/scio.git
+cd scio
 ```
 
 ## Compiling
 
 Copy the pre generated BigQuery schemas:
+Bootstrap BigQuery schemas cache and flags if you don't have Google Cloud Platform credentials.
 
 ```bash
-cp -r scripts/bigquery .bigquery
+./scripts/bootstrap.sh
 ```
 
-Define `bigquery.project` as a system property. You can use any value since we will be using the pre generated schemas.
+Build the source
 
 ```bash
-sbt -Dbigquery.project=dummy compile
+sbt compile
 ```


### PR DESCRIPTION
Turns out we `gen_schemas.sh` set up cache for everything in `scio-examples` already, but `bigquery` instance in `TypeProvider` is not truly lazy even when no BQ requests are needed.

https://github.com/spotify/scio/blob/master/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala#L48

Adding `-Dbigquery.project=` to `.jvmopts` is the easy solution but may not work for some cases depending on how IntelliJ runs sbt. Alternatively we can make that `bigquery` instance and its usage, i.e. in `BigQueryPartitionUtil` lazier.

cc @psobot 