### PR TITLE
Add DelegatingSideInput and TypedSparkeySideInput.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,7 @@ val magnoliaVersion = "0.11.0"
 val grpcVersion = "1.17.1"
 val caseappVersion = "2.0.0-M9"
 val sparkVersion = "2.4.3"
+val caffeineVersion = "2.8.0"
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts :=
@@ -650,6 +651,7 @@ lazy val scioExtra: Project = Project(
       "info.debatty" % "java-lsh" % javaLshVersion,
       "net.pishen" %% "annoy4s" % annoy4sVersion,
       "org.scalanlp" %% "breeze" % breezeVersion,
+      "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion,
       "org.scalatest" %% "scalatest" % scalatestVersion % "test",
       "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test"
     ),

--- a/scio-core/src/main/scala/com/spotify/scio/values/SideInput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SideInput.scala
@@ -125,11 +125,11 @@ private[values] class MultiMapSideInput[K, V](val view: PCollectionView[JMap[K, 
     JMapWrapper.ofMultiMap(context.sideInput(view))
 }
 
-private[scio] class DelegatingSideInput[A, B](val si: SideInput[A], val mapper: A => B)
+private[values] class DelegatingSideInput[A, B](val si: SideInput[A], val mapper: A => B)
     extends SideInput[B] {
   override def get[I, O](context: DoFn[I, O]#ProcessContext): B = mapper(si.get(context))
 
-  val view: PCollectionView[_] = si.view
+  private[values] val view: PCollectionView[_] = si.view
 }
 
 /** Encapsulate context of one or more [[SideInput]]s in an [[SCollectionWithSideInput]]. */

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyUri.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyUri.scala
@@ -21,7 +21,6 @@ import java.io.File
 import java.net.URI
 import java.nio.file.{Files, Paths}
 
-import com.github.benmanes.caffeine.cache.Cache
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.util.{RemoteFileUtil, ScioUtil}
 import com.spotify.sparkey.extra.ThreadLocalSparkeyReader
@@ -40,12 +39,6 @@ import scala.collection.JavaConverters._
 trait SparkeyUri extends Serializable {
   val basePath: String
   def getReader: SparkeyReader
-  def getTypedReader[T >: Null <: AnyRef](
-    decoder: Array[Byte] => T,
-    cache: Cache[String, T] = null
-  ): TypedSparkeyReader[T] =
-    new TypedSparkeyReader[T](getReader, decoder, cache)
-
   private[sparkey] def exists: Boolean
   override def toString: String = basePath
 }

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyUri.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyUri.scala
@@ -21,8 +21,9 @@ import java.io.File
 import java.net.URI
 import java.nio.file.{Files, Paths}
 
-import com.spotify.scio.util.{RemoteFileUtil, ScioUtil}
+import com.github.benmanes.caffeine.cache.Cache
 import com.spotify.scio.coders.Coder
+import com.spotify.scio.util.{RemoteFileUtil, ScioUtil}
 import com.spotify.sparkey.extra.ThreadLocalSparkeyReader
 import com.spotify.sparkey.{Sparkey, SparkeyReader}
 import org.apache.beam.sdk.options.PipelineOptions
@@ -39,6 +40,12 @@ import scala.collection.JavaConverters._
 trait SparkeyUri extends Serializable {
   val basePath: String
   def getReader: SparkeyReader
+  def getTypedReader[T >: Null <: AnyRef](
+    decoder: Array[Byte] => T,
+    cache: Cache[String, T] = null
+  ): TypedSparkeyReader[T] =
+    new TypedSparkeyReader[T](getReader, decoder, cache)
+
   private[sparkey] def exists: Boolean
   override def toString: String = basePath
 }

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -337,11 +337,9 @@ package object sparkey {
       extends RichStringSparkeyReader(sparkey) {
 
     override def get(key: String): Option[String] =
-      Option(cache.get(
-        key,
-        new JFunction[String, String] {
-          override def apply(k: String): String = sparkey.getAsString(k)
-        }))
+      Option(cache.get(key, new JFunction[String, String] {
+        override def apply(k: String): String = sparkey.getAsString(k)
+      }))
 
     def close(): Unit = {
       sparkey.close()

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -316,7 +316,7 @@ package object sparkey {
       extends RichStringSparkeyReader(sparkey) {
 
     override def get(key: String): Option[String] =
-      Option(cache.get(key, k => sparkey.getAsString(k)))
+      Option(cache.get(key, sparkey.getAsString))
 
     def close(): Unit = {
       sparkey.close()
@@ -349,7 +349,7 @@ package object sparkey {
 
     override def get(key: String): Option[T] =
       cacheOpt
-        .map(cache => Option(cache.get(key, k => loadValueFromSparkey(k).orNull)))
+        .map(cache => Option(cache.get(key, (k: String) => loadValueFromSparkey(k).orNull)))
         .getOrElse(loadValueFromSparkey(key))
 
     override def iterator: Iterator[(String, T)] =

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/MockCache.java
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/MockCache.java
@@ -1,0 +1,112 @@
+package com.spotify.scio.extra.sparkey;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Policy;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * MockCache is a global singleton Cache object that can be "serialized" for use in tests.
+ * This allows us to verify the Cache is being used correctly when used with
+ * CachedSparkeySideInput, as long as the test runner and the code under test are using the
+ * same JVM. (The serialization of this Cache has been disabled, as all instances share the same
+ * underlying Caffeine cache.)
+ */
+public class MockCache implements Cache<String, Object>, Externalizable {
+  private final static Cache<String, Object> cache =
+      Caffeine.newBuilder().recordStats().build();
+
+  public static void reset() { cache.invalidateAll(); }
+
+  public static MockCache getInstance() { return new MockCache(); }
+
+  public static CacheStats getStats() { return cache.stats(); }
+
+  @Nullable
+  @Override
+  public Object getIfPresent(final Object key) {
+    return cache.getIfPresent(key);
+  }
+
+  @Nullable
+  @Override
+  public Object get(@NonNull final String key,
+                       @NonNull final Function<? super String, ? extends Object> mappingFunction) {
+    return cache.get(key, mappingFunction);
+  }
+
+  @Override
+  public Map<String, Object> getAllPresent(final Iterable<?> keys) {
+    return cache.getAllPresent(keys);
+  }
+
+  @Override
+  public void put(final String key, final Object value) {
+    cache.put(key, value);
+  }
+
+  @Override
+  public void putAll(final Map<? extends String, ? extends Object> m) {
+    cache.putAll(m);
+  }
+
+  @Override
+  public void invalidate(final Object key) {
+    cache.invalidate(key);
+  }
+
+  @Override
+  public void invalidateAll(final Iterable<?> keys) {
+    cache.invalidateAll(keys);
+  }
+
+  @Override
+  public void invalidateAll() {
+    cache.invalidateAll();
+  }
+
+  @Override
+  public @NonNegative long estimatedSize() {
+    return 0;
+  }
+
+  @Override
+  public CacheStats stats() {
+    return cache.stats();
+  }
+
+  @Override
+  public ConcurrentMap<String, Object> asMap() {
+    return cache.asMap();
+  }
+
+  @Override
+  public void cleanUp() {
+    cache.cleanUp();
+  }
+
+  @Override
+  public @NonNull Policy<String, Object> policy() {
+    return null;
+  }
+
+  @Override
+  public void writeExternal(final ObjectOutput out) throws IOException {
+    // Not implemented on purpose, as all this class does is access the static cache on this class.
+  }
+
+  @Override
+  public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
+    // Not implemented on purpose, as all this class does is access the static cache on this class.
+  }
+}

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/MockCache.java
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/MockCache.java
@@ -44,7 +44,7 @@ public class MockCache implements Cache<String, Object>, Externalizable {
   @Nullable
   @Override
   public Object get(@NonNull final String key,
-                       @NonNull final Function<? super String, ? extends Object> mappingFunction) {
+                    @NonNull final Function<? super String, ? extends Object> mappingFunction) {
     return cache.get(key, mappingFunction);
   }
 

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/MockCache.java
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/MockCache.java
@@ -23,10 +23,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * underlying Caffeine cache.)
  */
 public class MockCache implements Cache<String, Object>, Externalizable {
-  private final static Cache<String, Object> cache =
-      Caffeine.newBuilder().recordStats().build();
+  private static Cache<String, Object> cache = null;
 
-  public static void reset() { cache.invalidateAll(); }
+  static {
+    reset();
+  }
+
+  public static void reset() { cache = Caffeine.newBuilder().recordStats().build(); }
 
   public static MockCache getInstance() { return new MockCache(); }
 

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
@@ -206,7 +206,6 @@ class SparkeyTest extends PipelineSpec {
     for (ext <- Seq(".spi", ".spl")) new File(basePath + ext).delete()
   }
 
-
   it should "support iteration with .asTypedSparkeySideInput" in {
     val sc = ScioContext()
 

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
@@ -151,7 +151,9 @@ class SparkeyTest extends PipelineSpec {
     val sparkey = sc.parallelize(typedSideData).mapValues(_.map(_.toString).mkString(",")).asSparkey
     val sparkeyMaterialized = sparkey.materialize
 
-    val si = sparkey.asTypedSparkeySideInput[Seq[Int]](new String(_).split(",").toSeq.map(_.toInt))
+    val si = sparkey.asTypedSparkeySideInput[Seq[Int]] { b: Array[Byte] =>
+      new String(b).split(",").toSeq.map(_.toInt)
+    }
 
     val result = sc
       .parallelize(input)
@@ -181,10 +183,9 @@ class SparkeyTest extends PipelineSpec {
     val sparkey = sc.parallelize(typedSideData).mapValues(_.mkString(",")).asSparkey
     val sparkeyMaterialized = sparkey.materialize
 
-    val si = sparkey.asTypedSparkeySideInput[Object](
-      bytes => new String(bytes).split(",").map(_.toInt).toSeq,
-      MockCache.getInstance
-    )
+    val si = sparkey.asTypedSparkeySideInput[Object](MockCache.getInstance) { b: Array[Byte] =>
+      new String(b).split(",").map(_.toInt).toSeq
+    }
 
     val result = sc
       .parallelize(input)

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideInputTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideInputTest.scala
@@ -310,9 +310,9 @@ class SCollectionWithSideInputTest extends PipelineSpec {
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(1))
       val p2 = sc.parallelize(sideData).asListSideInput
-      val p3 = p2.map(seq => seq.map { case (k, v) => (k, v * 2) })
+      val p3 = p2.map(seq => seq.map { case (k, v) => (k, v * 2) }.toSet)
       val s = p1.withSideInputs(p3).map((i, s) => (i, s(p3))).toSCollection
-      s should containSingleValue((1, sideData.map { case (k, v) => (k, v * 2) }))
+      s should containSingleValue((1, sideData.map { case (k, v) => (k, v * 2) }.toSet))
     }
   }
 
@@ -328,7 +328,7 @@ class SCollectionWithSideInputTest extends PipelineSpec {
         .asListSideInput
         .map(seq => seq.map(_ * 2))
       val s = p1.withSideInputs(p2).map((x, s) => (x, s(p2))).toSCollection
-      s should forAll[(Int, Seq[Int])](t => (1 to t._1).toSet == t._2.map(_ * 2).toSet)
+      s should forAll[(Int, Seq[Int])](t => (1 to t._1).map(_ * 2).toSet == t._2.toSet)
     }
   }
 }

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideInputTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideInputTest.scala
@@ -296,4 +296,39 @@ class SCollectionWithSideInputTest extends PipelineSpec {
     }
   }
 
+  it should "allow mapping over a SingletonSideInput" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(1))
+      val p2 = sc.parallelize(Seq(sideData)).asSingletonSideInput
+      val p3 = p2.map(seq => seq.map { case (k, v) => (k, v * 2) })
+      val s = p1.withSideInputs(p3).map((i, s) => (i, s(p3))).toSCollection
+      s should containSingleValue((1, sideData.map { case (k, v) => (k, v * 2) }))
+    }
+  }
+
+  it should "allow mapping over a ListSideInput" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(1))
+      val p2 = sc.parallelize(sideData).asListSideInput
+      val p3 = p2.map(seq => seq.map { case (k, v) => (k, v * 2) })
+      val s = p1.withSideInputs(p3).map((i, s) => (i, s(p3))).toSCollection
+      s should containSingleValue((1, sideData.map { case (k, v) => (k, v * 2) }))
+    }
+  }
+
+  it should "support windowed and mapped asListSideInput" in {
+    runWithContext { sc =>
+      val p1 = sc
+        .parallelizeTimestamped(timestampedData)
+        .withFixedWindows(Duration.standardSeconds(1))
+      val p2 = sc
+        .parallelizeTimestamped(timestampedData)
+        .withFixedWindows(Duration.standardSeconds(1))
+        .flatMap(x => 1 to x)
+        .asListSideInput
+        .map(seq => seq.map(_ * 2))
+      val s = p1.withSideInputs(p2).map((x, s) => (x, s(p2))).toSCollection
+      s should forAll[(Int, Seq[Int])](t => (1 to t._1).toSet == t._2.map(_ * 2).toSet)
+    }
+  }
 }


### PR DESCRIPTION
Should solve #1967 and #2101.

This PR adds:
 - a `DelegatingSideInput[A, B]` class, which allows users to do `SideInput[A]#map(f: A => B): DelegatingSideInput[A, B]`
 - a `TypedSparkeyReader[T]` with a `decoder: Array[Byte] => T` and an optional `cache: Cache[String, T]`
 - a `CachedStringSparkeyReader`, with a mandatory `cache: Cache[String, String]`
 - a `MockCache` Java class that implements `caffeine.Cache` for use in tests, to ensure the cache is used as expected.
 - tests for all of the above.