### PR TITLE
Wrap PubsubWithAttributes Write in composite PTransform (fix #2286)

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/io/PubsubIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/PubsubIO.scala
@@ -21,12 +21,14 @@ import com.google.protobuf.Message
 import com.spotify.scio.ScioContext
 import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.testing.TestDataManager
-import com.spotify.scio.util.{JMapWrapper, ScioUtil}
+import com.spotify.scio.util.{Functions, JMapWrapper, ScioUtil}
 import com.spotify.scio.values.SCollection
 import org.apache.avro.specific.SpecificRecordBase
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessageWithAttributesCoder
 import org.apache.beam.sdk.io.gcp.{pubsub => beam}
+import org.apache.beam.sdk.transforms.{PTransform, ParDo}
 import org.apache.beam.sdk.util.CoderUtils
+import org.apache.beam.sdk.values.{PCollection, PDone}
 import org.joda.time.Instant
 
 import scala.collection.JavaConverters._
@@ -102,7 +104,7 @@ private final case class PubsubIOWithoutAttributes[T: ClassTag: Coder](
     } else if (classOf[Message] isAssignableFrom cls) {
       val t = setup(beam.PubsubIO.readProtos(cls.asSubclass(classOf[Message])))
       sc.wrap(sc.applyInternal(t)).asInstanceOf[SCollection[T]]
-    } else if (classOf[PubsubMessage] isAssignableFrom cls) {
+    } else if (classOf[beam.PubsubMessage] isAssignableFrom cls) {
       val t = setup(beam.PubsubIO.readMessages())
       sc.wrap(sc.applyInternal(t)).asInstanceOf[SCollection[T]]
     } else {
@@ -139,9 +141,9 @@ private final case class PubsubIOWithoutAttributes[T: ClassTag: Coder](
     } else if (classOf[Message] isAssignableFrom cls) {
       val t = setup(beam.PubsubIO.writeProtos(cls.asInstanceOf[Class[Message]]))
       data.asInstanceOf[SCollection[Message]].applyInternal(t)
-    } else if (classOf[PubsubMessage] isAssignableFrom cls) {
+    } else if (classOf[beam.PubsubMessage] isAssignableFrom cls) {
       val t = setup(beam.PubsubIO.writeMessages())
-      data.asInstanceOf[SCollection[PubsubMessage]].applyInternal(t)
+      data.asInstanceOf[SCollection[beam.PubsubMessage]].applyInternal(t)
     } else {
       val coder = CoderMaterializer.beam(data.context, Coder[T])
       val t = setup(beam.PubsubIO.writeMessages())
@@ -210,13 +212,21 @@ private final case class PubsubIOWithAttributes[T: ClassTag: Coder](
       w = w.withTimestampAttribute(timestampAttribute)
     }
     val coder = CoderMaterializer.beam(data.context, Coder[T])
-    data
-      .map { kv =>
-        val payload = CoderUtils.encodeToByteArray(coder, kv._1)
-        val attributes = kv._2.asJava
-        new beam.PubsubMessage(payload, attributes)
-      }
-      .applyInternal(w)
+
+    data.applyInternal(new PTransform[PCollection[WithAttributeMap], PDone]() {
+      override def expand(input: PCollection[WithAttributeMap]): PDone =
+        input
+          .apply(
+            "Encode Pubsub message and attributes",
+            ParDo.of(Functions.mapFn[WithAttributeMap, beam.PubsubMessage] { kv =>
+              val payload = CoderUtils.encodeToByteArray(coder, kv._1)
+              val attributes = kv._2.asJava
+              new beam.PubsubMessage(payload, attributes)
+            })
+          )
+          .setCoder(PubsubMessageWithAttributesCoder.of())
+          .apply("Write to Pubsub", w)
+    })
 
     EmptyTap
   }


### PR DESCRIPTION
fix #2286 

For a job that looks like: `scoll.parallelize(...).map(...).withName("Custom Pubsub Write Name").saveAsPubsubWithAttributes[Foo](...)`, the resulting top-level graph looks like: 

<img width="219" alt="Screen Shot 2019-10-04 at 11 06 53 AM" src="https://user-images.githubusercontent.com/1360529/66227244-cd9da400-e6aa-11e9-858b-0d2d374aeafb.png">

And expands into:
<img width="244" alt="Screen Shot 2019-10-04 at 11 07 03 AM" src="https://user-images.githubusercontent.com/1360529/66227270-da21fc80-e6aa-11e9-9373-56cfb2f35d19.png">