### PR TITLE
Kieran/it docs

### DIFF
--- a/site/src/paradox/Getting-Started.md
+++ b/site/src/paradox/Getting-Started.md
@@ -29,7 +29,7 @@ export SBT_OPTS="-Xmx8G -Xms8G -Xss1M -XX:MaxMetaspaceSize=1G -XX:+CMSClassUnloa
 To ensure the project loads and builds successfully, run the following sbt command so that all custom tasks are executed
 
 ```bash
-sbt compile test:compile it:compile
+sbt compile test:compile
 ```
 
 ## Running the Examples

--- a/site/src/paradox/dev/build.md
+++ b/site/src/paradox/dev/build.md
@@ -30,6 +30,8 @@ Define `bigquery.project` as a system property. The value can by anything since 
 sbt -Dbigquery.project=dummy-project test
 ```
 
+Tasks within the 'it' (integration testing) configuration `it:{compile,test}` currently require access to datasets hosted in an internal Spotify project. External users must authenticate against their own GCP project, through the steps outlined in [Getting Started](https://spotify.github.io/scio/Getting-Started.html).
+
 ## IntelliJ IDEA
 
 When opening the project in IntelliJ IDEA, tick "Use sbt shell:" both "for imports" and "for builds".


### PR DESCRIPTION
Update docs for external users looking to compile the source code. Warns that the default config relies on access to internal Spotify GCP project.