### PR TITLE
fix NPE in scio-bigtable's ChannelPoolCreator when credentials aren't set

### DIFF
--- a/scio-bigtable/src/main/java/com/spotify/scio/bigtable/ChannelPoolCreator.java
+++ b/scio-bigtable/src/main/java/com/spotify/scio/bigtable/ChannelPoolCreator.java
@@ -27,7 +27,7 @@ import io.grpc.ClientInterceptor;
 import java.io.IOException;
 
 public class ChannelPoolCreator {
-  public static final BigtableOptions options = new BigtableOptions.Builder().build();
+  private static final BigtableOptions options = BigtableOptions.builder().build();
   private static ClientInterceptor[] interceptors;
 
   static {


### PR DESCRIPTION
Noticed this while running a Bigtable write using the emulator tool, which doesn't set credentials. The Bigtable client lib will just return a null `ClientInterceptor` in that case (which is still valid; the Netty channel creator takes in 0 or more `ClientInterceptor` args), which we weren't handling properly.