### PR TITLE
Fix: aggregate scio-sql

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -347,6 +347,7 @@ lazy val root: Project = Project("scio", file("."))
     scioTensorFlow,
     scioSchemas,
     scioSpanner,
+    scioSql,
     scioExamples,
     scioRepl,
     scioJmh,


### PR DESCRIPTION
This is preventing `scio-sql` from being published