### PR TITLE
Add direct dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,10 @@ val generatedGrpcGaVersion = "1.43.0"
 val generatedGrpcBetaVersion = "0.44.0"
 val googleClientsVersion = "1.27.0"
 val googleApiServicesBigQuery = "v2-rev20181104-1.27.0"
+val bigdataossVersion = "1.9.16"
+val gaxVersion = "1.38.0"
+val googleAuthVersion = "0.12.0"
+val bigQueryStorageVersion = "0.79.0-alpha"
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts :=
@@ -519,6 +523,21 @@ lazy val scioBigQuery: Project = Project(
     commonSettings ++ macroSettings ++ itSettings ++ beamRunnerSettings,
     description := "Scio add-on for Google BigQuery",
     libraryDependencies ++= Seq(
+      "com.google.protobuf" % "protobuf-java" % protobufVersion,
+      "org.apache.avro" % "avro" % avroVersion,
+      "com.google.cloud.bigdataoss" % "util" % bigdataossVersion,
+      "com.google.api" % "gax" % gaxVersion,
+      "com.google.api-client" % "google-api-client" % googleClientsVersion,
+      "com.google.apis" % "google-api-services-bigquery" % googleApiServicesBigQuery,
+      "com.google.api.grpc" % "proto-google-cloud-bigquerystorage-v1beta1" % generatedGrpcBetaVersion,
+      "com.google.http-client" % "google-http-client" % googleClientsVersion,
+      "com.google.http-client" % "google-http-client-jackson2" % googleClientsVersion,
+      "com.google.auth" % "google-auth-library-credentials" % googleAuthVersion,
+      "com.google.auth" % "google-auth-library-oauth2-http" % googleAuthVersion,
+      "com.google.cloud" % "google-cloud-bigquerystorage" % bigQueryStorageVersion,
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
+      "org.apache.beam" % "beam-sdks-java-extensions-google-cloud-platform-core" % beamVersion,
+      "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion,
       "commons-io" % "commons-io" % commonsIoVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -385,7 +385,9 @@ lazy val scioCore: Project = Project(
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "me.lyh" %% "protobuf-generic" % protobufGenericVersion,
       "org.apache.xbean" % "xbean-asm7-shaded" % asmVersion,
-      "io.grpc" % "grpc-all" % grpcVersion exclude ("io.opencensus", "opencensus-api"),
+      "io.grpc" % "grpc-core" % grpcVersion,
+      "io.grpc" % "grpc-auth" % grpcVersion,
+      "io.grpc" % "grpc-netty" % grpcVersion,
       "com.github.alexarchambault" %% "case-app" % caseappVersion,
       "org.scalatest" %% "scalatest" % scalatestVersion % Test
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -88,6 +88,7 @@ val gaxVersion = "1.38.0"
 val googleAuthVersion = "0.12.0"
 val bigQueryStorageVersion = "0.79.0-alpha"
 val httpCoreVersion = "4.4.11"
+val googleCloudSpannerVersion = "1.6.0"
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts :=
@@ -815,8 +816,11 @@ lazy val scioSpanner: Project = Project(
     commonSettings ++ itSettings ++ beamRunnerSettings,
     description := "Scio add-on for Google Cloud Spanner",
     libraryDependencies ++= Seq(
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
+      "com.google.cloud" % "google-cloud-spanner" % googleCloudSpannerVersion,
       "org.scalatest" %% "scalatest" % scalatestVersion % "it"
-    )
+    ),
+    beamSDKIODependencies
   )
   .dependsOn(
     scioCore,

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ val chillVersion = "0.9.3"
 val circeVersion = "0.11.1"
 val commonsIoVersion = "2.6"
 val commonsMath3Version = "3.6.1"
+val commonsLang3Version = "3.6"
 val commonsCompressVersion = "1.19"
 val commonsTextVersion = "1.8"
 val commonsCompress = "1.19"
@@ -432,7 +433,8 @@ lazy val scioSql: Project = Project(
     description := "Scio - SQL extension",
     libraryDependencies ++= Seq(
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
-      "org.apache.beam" % "beam-sdks-java-extensions-sql" % beamVersion
+      "org.apache.beam" % "beam-sdks-java-extensions-sql" % beamVersion,
+      "org.apache.commons" % "commons-lang3" % commonsLang3Version
     )
   )
   .dependsOn(

--- a/build.sbt
+++ b/build.sbt
@@ -545,10 +545,15 @@ lazy val scioBigtable: Project = Project(
   .settings(
     description := "Scio add-on for Google Cloud Bigtable",
     libraryDependencies ++= Seq(
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
+      "joda-time" % "joda-time" % jodaTimeVersion,
+      "com.google.protobuf" % "protobuf-java" % protobufVersion,
+      "com.google.cloud.bigtable" % "bigtable-client-core" % bigtableClientVersion,
+      "com.google.api.grpc" % "proto-google-cloud-bigtable-v2" % generatedGrpcBetaVersion,
+      "com.novocode" % "junit-interface" % junitInterfaceVersion,
+      "org.apache.beam" % "beam-runners-direct-java" % beamVersion % "test",
       "org.scalatest" %% "scalatest" % scalatestVersion % "test",
       "org.hamcrest" % "hamcrest-all" % hamcrestVersion % "test",
-      "org.apache.beam" % "beam-runners-direct-java" % beamVersion % "test",
-      "com.novocode" % "junit-interface" % junitInterfaceVersion,
       "junit" % "junit" % junitVersion % "test"
     ),
     beamSDKIODependencies

--- a/build.sbt
+++ b/build.sbt
@@ -87,6 +87,7 @@ val bigdataossVersion = "1.9.16"
 val gaxVersion = "1.38.0"
 val googleAuthVersion = "0.12.0"
 val bigQueryStorageVersion = "0.79.0-alpha"
+val httpCoreVersion = "4.4.11"
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts :=
@@ -646,7 +647,9 @@ lazy val scioElasticsearch2: Project = Project(
     commonSettings,
     description := "Scio add-on for writing to Elasticsearch",
     libraryDependencies ++= Seq(
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.elasticsearch" % "elasticsearch" % elasticsearch2Version
     )
   )
@@ -662,7 +665,10 @@ lazy val scioElasticsearch5: Project = Project(
     commonSettings,
     description := "Scio add-on for writing to Elasticsearch",
     libraryDependencies ++= Seq(
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
+      "org.elasticsearch" % "elasticsearch" % elasticsearch5Version,
       "org.elasticsearch.client" % "transport" % elasticsearch5Version
     )
   )
@@ -678,7 +684,11 @@ lazy val scioElasticsearch6: Project = Project(
     commonSettings,
     description := "Scio add-on for writing to Elasticsearch",
     libraryDependencies ++= Seq(
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
+      "org.elasticsearch" % "elasticsearch" % elasticsearch6Version,
+      "org.elasticsearch" % "elasticsearch-x-content" % elasticsearch6Version,
       "org.elasticsearch.client" % "transport" % elasticsearch6Version
     )
   )
@@ -694,7 +704,12 @@ lazy val scioElasticsearch7: Project = Project(
     commonSettings,
     description := "Scio add-on for writing to Elasticsearch",
     libraryDependencies ++= Seq(
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
+      "org.apache.httpcomponents" % "httpcore" % httpCoreVersion,
+      "org.elasticsearch" % "elasticsearch-x-content" % elasticsearch7Version,
+      "org.elasticsearch.client" % "elasticsearch-rest-client" % elasticsearch7Version,
       "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % elasticsearch7Version
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -725,6 +725,9 @@ lazy val scioExtra: Project = Project(
     commonSettings ++ itSettings,
     description := "Scio extra utilities",
     libraryDependencies ++= Seq(
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
+      "com.google.apis" % "google-api-services-bigquery" % googleApiServicesBigQuery,
+      "org.apache.avro" % "avro" % avroVersion,
       "com.spotify" % "annoy" % annoyVersion,
       "com.spotify.sparkey" % "sparkey" % sparkeyVersion,
       "com.twitter" %% "algebird-core" % algebirdVersion,
@@ -732,9 +735,11 @@ lazy val scioExtra: Project = Project(
       "net.pishen" %% "annoy4s" % annoy4sVersion,
       "org.scalanlp" %% "breeze" % breezeVersion,
       "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion,
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.scalatest" %% "scalatest" % scalatestVersion % "test",
       "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test"
     ),
+    beamSDKIODependencies,
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core",
       "io.circe" %% "circe-generic",

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ val chillVersion = "0.9.3"
 val circeVersion = "0.11.1"
 val commonsIoVersion = "2.6"
 val commonsMath3Version = "3.6.1"
+val commonsCompressVersion = "1.19"
 val commonsTextVersion = "1.8"
 val commonsCompress = "1.19"
 val elasticsearch2Version = "2.4.6"
@@ -49,7 +50,7 @@ val gcsVersion = "1.8.0"
 val guavaVersion = "25.1-jre"
 val hadoopVersion = "2.7.7"
 val hamcrestVersion = "1.3"
-val jacksonScalaModuleVersion = "2.9.10"
+val jacksonVersion = "2.9.10"
 val javaLshVersion = "0.12"
 val jlineVersion = "2.14.6"
 val jodaTimeVersion = "2.10.5"
@@ -76,6 +77,11 @@ val grpcVersion = "1.17.1"
 val caseappVersion = "2.0.0-M9"
 val sparkVersion = "2.4.3"
 val caffeineVersion = "2.8.0"
+val bigtableClientVersion = "1.8.0"
+val generatedGrpcGaVersion = "1.43.0"
+val generatedGrpcBetaVersion = "0.44.0"
+val googleClientsVersion = "1.27.0"
+val googleApiServicesBigQuery = "v2-rev20181104-1.27.0"
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts :=
@@ -372,23 +378,34 @@ lazy val scioCore: Project = Project(
       "org.apache.beam" % "beam-runners-spark" % beamVersion % Provided exclude (
         "com.fasterxml.jackson.module", "jackson-module-scala_2.11"
       ),
+      "com.chuusai" %% "shapeless" % shapelessVersion,
       "com.twitter" %% "algebird-core" % algebirdVersion,
       "com.twitter" %% "chill" % chillVersion,
       "com.twitter" %% "chill-algebird" % chillVersion,
       "com.twitter" % "chill-protobuf" % chillVersion,
       "com.esotericsoftware" % "kryo-shaded" % kryoVersion,
       "commons-io" % "commons-io" % commonsIoVersion,
+      "org.apache.avro" % "avro" % avroVersion,
       "org.apache.commons" % "commons-math3" % commonsMath3Version,
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonScalaModuleVersion,
+      "org.apache.commons" % "commons-compress" % commonsCompressVersion,
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+      "me.lyh" %% "protobuf-generic" % protobufGenericVersion,
+      "org.apache.xbean" % "xbean-asm7-shaded" % asmVersion,
       "com.google.auto.service" % "auto-service" % autoServiceVersion,
       "com.google.guava" % "guava" % guavaVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
-      "me.lyh" %% "protobuf-generic" % protobufGenericVersion,
-      "org.apache.xbean" % "xbean-asm7-shaded" % asmVersion,
+      "com.google.apis" % "google-api-services-bigquery" % googleApiServicesBigQuery,
+      "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % generatedGrpcGaVersion,
+      "com.google.api.grpc" % "proto-google-cloud-datastore-v1" % generatedGrpcBetaVersion,
+      "com.google.http-client" % "google-http-client" % googleClientsVersion,
+      "com.google.http-client" % "google-http-client-jackson2" % googleClientsVersion,
       "io.grpc" % "grpc-core" % grpcVersion,
       "io.grpc" % "grpc-auth" % grpcVersion,
       "io.grpc" % "grpc-netty" % grpcVersion,
       "com.github.alexarchambault" %% "case-app" % caseappVersion,
+      "joda-time" % "joda-time" % jodaTimeVersion,
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.scalatest" %% "scalatest" % scalatestVersion % Test
     ),
     magnoliaDependencies

--- a/build.sbt
+++ b/build.sbt
@@ -88,6 +88,7 @@ val googleAuthVersion = "0.12.0"
 val bigQueryStorageVersion = "0.79.0-alpha"
 val httpCoreVersion = "4.4.11"
 val googleCloudSpannerVersion = "1.6.0"
+val datastoreV1ProtoClientVersion = "1.6.0"
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts :=
@@ -890,14 +891,25 @@ lazy val scioExamples: Project = Project(
   .settings(macroSettings)
   .settings(
     libraryDependencies ++= Seq(
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
+      "org.apache.beam" % "beam-sdks-java-extensions-google-cloud-platform-core" % beamVersion,
+      "org.apache.avro" % "avro" % avroVersion,
+      "com.google.cloud.datastore" % "datastore-v1-proto-client" % datastoreV1ProtoClientVersion,
+      "com.google.api.grpc" % "proto-google-cloud-datastore-v1" % generatedGrpcBetaVersion,
+      "com.google.api.grpc" % "proto-google-cloud-bigtable-v2" % generatedGrpcBetaVersion,
+      "com.google.cloud.sql" % "mysql-socket-factory" % "1.0.15",
+      "com.google.apis" % "google-api-services-bigquery" % googleApiServicesBigQuery,
+      "org.tensorflow" % "proto" % tensorFlowVersion,
       "me.lyh" %% "shapeless-datatype-avro" % shapelessDatatypeVersion,
       "me.lyh" %% "shapeless-datatype-datastore" % shapelessDatatypeVersion,
       "me.lyh" %% "shapeless-datatype-tensorflow" % shapelessDatatypeVersion,
       "mysql" % "mysql-connector-java" % "8.0.18",
-      "com.google.cloud.sql" % "mysql-socket-factory" % "1.0.15",
+      "joda-time" % "joda-time" % jodaTimeVersion,
+      "com.github.alexarchambault" %% "case-app" % caseappVersion,
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
       "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test"
     ),
+    beamSDKIODependencies,
     // exclude problematic sources if we don't have GCP credentials
     excludeFilter in unmanagedSources := {
       if (BuildCredentials.exists) {

--- a/build.sbt
+++ b/build.sbt
@@ -596,11 +596,15 @@ lazy val scioCassandra2: Project = Project(
     commonSettings ++ itSettings,
     description := "Scio add-on for Apache Cassandra 2.x",
     libraryDependencies ++= Seq(
+      "com.google.protobuf" % "protobuf-java" % protobufVersion,
+      "com.google.guava" % "guava" % guavaVersion,
+      "com.twitter" %% "chill" % chillVersion,
       "com.datastax.cassandra" % "cassandra-driver-core" % "3.8.0",
       ("org.apache.cassandra" % "cassandra-all" % "2.2.15")
         .exclude("ch.qos.logback", "logback-classic")
         .exclude("org.slf4j", "log4j-over-slf4j"),
-      "org.apache.hadoop" % "hadoop-client" % hadoopVersion
+      "org.apache.hadoop" % "hadoop-common" % hadoopVersion,
+      "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion
     )
   )
   .dependsOn(
@@ -616,12 +620,17 @@ lazy val scioCassandra3: Project = Project(
     commonSettings ++ itSettings,
     description := "Scio add-on for Apache Cassandra 3.x",
     libraryDependencies ++= Seq(
+      "com.google.protobuf" % "protobuf-java" % protobufVersion,
+      "com.google.guava" % "guava" % guavaVersion,
+      "com.twitter" %% "chill" % chillVersion,
       "com.datastax.cassandra" % "cassandra-driver-core" % "3.8.0",
       ("org.apache.cassandra" % "cassandra-all" % "3.11.5")
         .exclude("ch.qos.logback", "logback-classic")
         .exclude("org.slf4j", "log4j-over-slf4j"),
-      "org.apache.hadoop" % "hadoop-client" % hadoopVersion,
-      "org.scalatest" %% "scalatest" % scalatestVersion % "test"
+      "org.apache.hadoop" % "hadoop-common" % hadoopVersion,
+      "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion,
+      "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion % Test
     )
   )
   .dependsOn(

--- a/build.sbt
+++ b/build.sbt
@@ -504,6 +504,9 @@ lazy val scioAvro: Project = Project(
     commonSettings ++ macroSettings ++ itSettings,
     description := "Scio add-on for working with Avro",
     libraryDependencies ++= Seq(
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
+      "com.twitter" %% "chill" % chillVersion,
+      "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "org.apache.avro" % "avro" % avroVersion exclude ("com.thoughtworks.paranamer", "paranamer"),
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-simple" % slf4jVersion % "test,it",

--- a/build.sbt
+++ b/build.sbt
@@ -491,7 +491,8 @@ lazy val scioMacros: Project = Project(
   libraryDependencies ++= Seq(
     "com.chuusai" %% "shapeless" % shapelessVersion,
     "com.esotericsoftware" % "kryo-shaded" % kryoVersion,
-    "org.apache.beam" % "beam-sdks-java-extensions-sql" % beamVersion
+    "org.apache.beam" % "beam-sdks-java-extensions-sql" % beamVersion,
+    "org.apache.avro" % "avro" % avroVersion
   ),
   magnoliaDependencies
 )

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ val commonsMath3Version = "3.6.1"
 val commonsLang3Version = "3.6"
 val commonsCompressVersion = "1.19"
 val commonsTextVersion = "1.8"
-val commonsCompress = "1.19"
 val elasticsearch2Version = "2.4.6"
 val elasticsearch5Version = "5.6.16"
 val elasticsearch6Version = "6.8.3"
@@ -842,20 +841,18 @@ lazy val scioTensorFlow: Project = Project(
     Compile / managedSourceDirectories := (Compile / managedSourceDirectories).value
       .filterNot(_.getPath.endsWith("/src_managed/main")),
     libraryDependencies ++= Seq(
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.tensorflow" % "tensorflow" % tensorFlowVersion,
       "org.tensorflow" % "proto" % tensorFlowVersion,
-      "org.apache.commons" % "commons-compress" % commonsCompress,
+      "org.apache.commons" % "commons-compress" % commonsCompressVersion,
       "com.spotify" %% "featran-core" % featranVersion,
       "com.spotify" %% "featran-scio" % featranVersion,
       "com.spotify" %% "featran-tensorflow" % featranVersion,
       "com.spotify" % "zoltar-api" % zoltarVersion,
-      "com.spotify" % "zoltar-tensorflow" % zoltarVersion
+      "com.spotify" % "zoltar-tensorflow" % zoltarVersion,
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
+      "me.lyh" %% "shapeless-datatype-tensorflow" % shapelessDatatypeVersion % Test
     ),
-    libraryDependencies ++= Seq(
-      "io.circe" %% "circe-core",
-      "io.circe" %% "circe-generic",
-      "io.circe" %% "circe-parser"
-    ).map(_ % circeVersion),
     javaOptions += "-Dscio.ignoreVersionWarning=true"
   )
   .dependsOn(

--- a/build.sbt
+++ b/build.sbt
@@ -906,6 +906,7 @@ lazy val scioExamples: Project = Project(
       "mysql" % "mysql-connector-java" % "8.0.18",
       "joda-time" % "joda-time" % jodaTimeVersion,
       "com.github.alexarchambault" %% "case-app" % caseappVersion,
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
       "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test"
     ),
@@ -943,7 +944,12 @@ lazy val scioRepl: Project = Project(
     libraryDependencies ++= Seq(
       "org.apache.beam" % "beam-runners-direct-java" % beamVersion,
       "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion,
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
+      "org.apache.beam" % "beam-sdks-java-extensions-google-cloud-platform-core" % beamVersion,
+      "org.apache.avro" % "avro" % avroVersion,
+      "commons-io" % "commons-io" % commonsIoVersion,
       "org.apache.commons" % "commons-text" % commonsTextVersion,
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
       "jline" % "jline" % jlineVersion,
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,

--- a/project/CheckBeamDependencies.scala
+++ b/project/CheckBeamDependencies.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function.{Function => JFunction}
+
+import sbt._
+import Keys._
+import sbt.plugins.JvmPlugin
+
+import scala.sys.process._
+
+object CheckBeamDependencies extends AutoPlugin {
+  override def requires: JvmPlugin.type = sbt.plugins.JvmPlugin
+  override def trigger: PluginTrigger = allRequirements
+
+  object autoImport {
+    val checkBeamDependencies = taskKey[Unit]("check beam dependencies")
+  }
+  import autoImport._
+
+  private[this] val beamDeps = new ConcurrentHashMap[String, Map[String, Set[String]]]()
+
+  private def resolveBeamDependencies(deps: Seq[(String, String)]): Map[String, Set[String]] =
+    deps
+      .filter(d => d._1.startsWith("org.apache.beam"))
+      .map {
+        case (orgName, rev) =>
+          beamDeps.computeIfAbsent(
+            orgName,
+            new JFunction[String, Map[String, Set[String]]] {
+              override def apply(key: String): Map[String, Set[String]] = {
+                val output = s"coursier resolve $key:$rev" lineStream_!
+
+                output
+                  .flatMap { dep =>
+                    dep.split(":").toList match {
+                      case org :: name :: rev :: _ => Some((s"$org:$name", rev))
+                      case _                       => None
+                    }
+                  }
+                  .toList
+                  .groupBy(_._1)
+                  .mapValues(_.map(_._2).toSet)
+              }
+            }
+          )
+      }
+      .foldLeft(Map.empty[String, Set[String]])(_ ++ _)
+
+  override lazy val projectSettings = Seq(
+    checkBeamDependencies := {
+      val deps = libraryDependencies.value.map { m =>
+        (s"${m.organization}:${m.name}", m.revision)
+      }
+      val beamDependencies = resolveBeamDependencies(deps)
+      val projectBeamDeps = deps
+        .map { dep =>
+          (dep, beamDependencies.getOrElse(dep._1, Nil))
+        }
+        .collect {
+          case ((dep, version), beamVersions) => beamVersions.map(v => (dep, (version, v)))
+        }
+        .flatten
+
+      streams.value.log.warn {
+        (thisProjectRef.value.project :: projectBeamDeps.collect {
+          case (org, (v1, v2)) if v1 != v2 =>
+            s"* $org:$v1 -> beam: $v2"
+        }.toList).mkString("\n")
+      }
+    }
+  )
+}


### PR DESCRIPTION
This PR adds all the dependencies that we use directly in our code; the added libs are mostly the ones we were using transitively from `beam` libs and versions are kept consistent with `beam`;

The purpose of this is to 1) avoid conflicts with transitive deps 2) make clear what we are really using