### PR TITLE
Adds tf prediction with default-sig

### DIFF
--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TensorflowSpec.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TensorflowSpec.scala
@@ -17,6 +17,8 @@
 
 package com.spotify.scio.tensorflow
 
+import java.nio.FloatBuffer
+import java.nio.charset.StandardCharsets
 import java.util.Collections
 
 import com.spotify.featran.FeatureSpec
@@ -29,7 +31,6 @@ import com.spotify.scio.testing._
 import com.spotify.zoltar.tf.TensorFlowModel
 import org.tensorflow._
 import org.tensorflow.example.Example
-
 import scala.io.Source
 
 private[tensorflow] object TFSavedJob {
@@ -81,9 +82,72 @@ private[tensorflow] object TFSavedJob {
   }
 }
 
+private[tensorflow] object TFWithSigDefSavedJob {
+
+  case class Iris(
+    sepalLength: Option[Double],
+    sepalWidth: Option[Double],
+    petalLength: Option[Double],
+    petalWidth: Option[Double],
+    className: Option[String]
+  )
+
+  val Spec: FeatureSpec[Iris] = FeatureSpec
+    .of[Iris]
+    .optional(_.petalLength)(StandardScaler("petal_length", withMean = true))
+    .optional(_.petalWidth)(StandardScaler("petal_width", withMean = true))
+    .optional(_.sepalLength)(StandardScaler("sepal_length", withMean = true))
+    .optional(_.sepalWidth)(StandardScaler("sepal_width", withMean = true))
+
+  def main(argv: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(argv)
+    val options = TensorFlowModel.Options.builder
+      .tags(Collections.singletonList("serve"))
+      .build
+    val settings =
+      sc.parallelize(List(Source.fromURL(args("settings")).getLines.mkString))
+
+    val collection =
+      sc.parallelize(List(Iris(Some(5.1), Some(3.5), Some(1.4), Some(0.2), Some("Iris-setosa"))))
+
+    Spec
+      .extractWithSettings(collection, settings)
+      .featureValues[Example]
+      .predictWithSigDef(args("savedModelUri"), Seq("classes", "scores"), options) { e =>
+        Map("inputs" -> Tensors.create(Array(e.toByteArray)))
+      } { (_, o) =>
+        val classes = asStringVector(o("classes").asInstanceOf[Tensor[String]])
+        val scores = asFloatVector(o("scores").asInstanceOf[Tensor[Float]])
+        classes zip scores
+      }
+      .flatMap { classesAndScores =>
+        classesAndScores.map {
+          case (clazz, score) =>
+            "%s,%.3f".format(clazz, score)
+        }
+      }
+      .saveAsTextFile(args("output"))
+
+    sc.run().waitUntilDone()
+    ()
+  }
+
+  private def asFloatVector(tensor: Tensor[Float]): Vector[Float] = {
+    val buffer = FloatBuffer.allocate(tensor.numElements)
+    tensor.writeTo(buffer)
+    Vector[Float](buffer.array: _*)
+  }
+
+  private def asStringVector(tensor: Tensor[String]): Vector[String] = {
+    val buffer = Array.ofDim[Array[Byte]](1, tensor.numElements)
+    tensor.copyTo(buffer)
+    Vector(buffer(0).map(bytes => new String(bytes, StandardCharsets.UTF_8)): _*)
+  }
+}
+
 class TensorflowSpec extends PipelineSpec {
 
-  it should "allow saved model prediction" in {
+  "predict" should "allow saved model prediction" in {
     val resource = getClass.getResource("/trained_model")
     val settings = getClass.getResource("/settings.json")
 
@@ -95,4 +159,20 @@ class TensorflowSpec extends PipelineSpec {
       .run()
   }
 
+  "predictWithSigDef" should "allow saved model prediction with default signature" in {
+    val resource = getClass.getResource("/trained_model")
+    val settings = getClass.getResource("/settings.json")
+    val expected = List(
+      "0,0.927",
+      "1,0.066",
+      "2,0.007"
+    )
+
+    JobTest[TFWithSigDefSavedJob.type]
+      .args(s"--savedModelUri=$resource", s"--settings=$settings", "--output=output")
+      .output(TextIO("output")) { out =>
+        out should containInAnyOrder(expected)
+      }
+      .run()
+  }
 }


### PR DESCRIPTION
Zoltar nows loads tensorflow models with their signature definitions
Default one is `serving_default` -- currently, the only one supported
This enables consumers to pass in signature names of tensors and fetchOps

e.g. of signature
```
$ saved_model_cli show --dir scio-tensorflow/src/test/resources/trained_model --all

MetaGraphDef with tag-set: 'serve' contains the following SignatureDefs:

signature_def['classification']:
  The given SavedModel SignatureDef contains the following input(s):
    inputs['inputs'] tensor_info:
        dtype: DT_STRING
        shape: (-1)
        name: input_example_tensor:0
  The given SavedModel SignatureDef contains the following output(s):
    outputs['classes'] tensor_info:
        dtype: DT_STRING
        shape: (-1, 3)
        name: linear/head/Tile:0
    outputs['scores'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1, 3)
        name: linear/head/predictions/probabilities:0
  Method name is: tensorflow/serving/classify

signature_def['predict']:
  The given SavedModel SignatureDef contains the following input(s):
    inputs['examples'] tensor_info:
        dtype: DT_STRING
        shape: (-1)
        name: input_example_tensor:0
  The given SavedModel SignatureDef contains the following output(s):
    outputs['class_ids'] tensor_info:
        dtype: DT_INT64
        shape: (-1, 1)
        name: linear/head/predictions/ExpandDims:0
    outputs['classes'] tensor_info:
        dtype: DT_STRING
        shape: (-1, 1)
        name: linear/head/predictions/str_classes:0
    outputs['logits'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1, 3)
        name: linear/linear_model/weighted_sum:0
    outputs['probabilities'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1, 3)
        name: linear/head/predictions/probabilities:0
  Method name is: tensorflow/serving/predict

signature_def['serving_default']:
  The given SavedModel SignatureDef contains the following input(s):
    inputs['inputs'] tensor_info:
        dtype: DT_STRING
        shape: (-1)
        name: input_example_tensor:0
  The given SavedModel SignatureDef contains the following output(s):
    outputs['classes'] tensor_info:
        dtype: DT_STRING
        shape: (-1, 3)
        name: linear/head/Tile:0
    outputs['scores'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1, 3)
        name: linear/head/predictions/probabilities:0
  Method name is: tensorflow/serving/classify
```

TODO: 

  - make signature configurable, so the caller can choose which signature definition to use