### PR TITLE
Tensorflow example predict

### DIFF
--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
@@ -22,7 +22,7 @@ import java.time.Duration
 import com.spotify.zoltar.tf.{TensorFlowLoader, TensorFlowModel}
 import com.spotify.zoltar.{Model, Models}
 import org.apache.beam.sdk.transforms.DoFn
-import org.apache.beam.sdk.transforms.DoFn.{ProcessElement, Setup, Teardown}
+import org.apache.beam.sdk.transforms.DoFn.{ProcessElement, Teardown}
 import org.slf4j.LoggerFactory
 import org.tensorflow._
 import org.tensorflow.example.Example

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
@@ -144,7 +144,7 @@ object SavedBundlePredictDoFn {
       val exportedFetchOps = model.outputsNameMap().asScala.toMap
       fetchOps
         .map { tensorIds =>
-          tensorIds.map { tensorId =>
+          tensorIds.iterator.map { tensorId =>
             tensorId -> exportedFetchOps(tensorId)
           }.toMap
         }
@@ -153,14 +153,16 @@ object SavedBundlePredictDoFn {
 
     override def extractInput(input: T): Map[String, Tensor[_]] = {
       val extractedInput = inFn(input)
-      extractedInput.map {
+      extractedInput.iterator.map {
         case (tensorId, tensor) =>
           model.inputsNameMap().get(tensorId) -> tensor
       }.toMap
     }
 
     override def extractOutput(input: T, out: Map[String, Tensor[_]]): V =
-      outFn(input, requestedFetchOps.mapValues(out(_)))
+      outFn(input, requestedFetchOps.iterator.map{ case (tensorId, opName) =>
+        tensorId -> out(opName)
+      }.toMap)
 
     override def outputTensorNames: Seq[String] = requestedFetchOps.values.toSeq
   }
@@ -182,7 +184,7 @@ object SavedBundlePredictDoFn {
         val exportedFetchOps = model.outputsNameMap().asScala.toMap
         fetchOps
           .map { tensorIds =>
-            tensorIds.map { tensorId =>
+            tensorIds.iterator.map { tensorId =>
               tensorId -> exportedFetchOps(tensorId)
             }.toMap
           }
@@ -197,6 +199,8 @@ object SavedBundlePredictDoFn {
       }
 
       override def extractOutput(input: T, out: Map[String, Tensor[_]]): V =
-        outFn(input, requestedFetchOps.mapValues(out(_)))
+        outFn(input, requestedFetchOps.iterator.map{ case (tensorId, opName) =>
+          tensorId -> out(opName)
+        }.toMap)
     }
 }

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
@@ -91,8 +91,10 @@ private[tensorflow] abstract class SavedBundlePredictDoFn[T, V](
 
   override def withRunner(f: Session#Runner => V): V = f(getResource.instance().session().runner())
 
-  def id(): String =
-    (Seq("tf", uri, signatureName) ++ options.tags.asScala.mkString(";")).mkString(":")
+  def id(): String = {
+    val tokens = Seq("tf", uri, signatureName) ++ Seq(options.tags.asScala.mkString(";"))
+    tokens.mkString(":")
+  }
 
   @Teardown
   def teardown(): Unit = {

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
@@ -131,7 +131,6 @@ object SavedBundlePredictDoFn {
 
     override def outputTensorNames: Seq[String] = fetchOps
 
-
     override def extractInput(input: T): Map[String, Tensor[_]] = {
       val i = model.inputsNameMap().get(exampleTensorName)
       Map(i -> Tensors.create(input.toByteArray))

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
@@ -19,6 +19,7 @@ package com.spotify.scio.tensorflow
 
 import java.time.Duration
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
+import java.util.function.Function
 
 import com.spotify.zoltar.tf.{TensorFlowLoader, TensorFlowModel}
 import com.spotify.zoltar.Model
@@ -94,10 +95,13 @@ private[tensorflow] abstract class SavedBundlePredictDoFn[T, V](
     @transient lazy val model = getResource
       .computeIfAbsent(
         modelId,
-        (_: String) =>
-          TensorFlowLoader
-            .create(Id.create(modelId), uri, options, signatureName)
-            .get(Duration.ofDays(Integer.MAX_VALUE))
+        new Function[String, TensorFlowModel] {
+          override def apply(v1: String): TensorFlowModel =
+            TensorFlowLoader
+              .create(Id.create(modelId), uri, options, signatureName)
+              .get(Duration.ofDays(Integer.MAX_VALUE))
+
+        }
       )
     model
   }

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
@@ -202,8 +202,8 @@ object SavedBundlePredictDoFn {
       override def outputTensorNames: Seq[String] = requestedFetchOps.values.toSeq
 
       override def extractInput(input: T): Map[String, Tensor[_]] = {
-        val opeName = getModel.inputsNameMap().get(exampleTensorName)
-        Map(opeName -> Tensors.create(Array(input.toByteArray)))
+        val opName = getModel.inputsNameMap().get(exampleTensorName)
+        Map(opName -> Tensors.create(Array(input.toByteArray)))
       }
 
       override def extractOutput(input: T, out: Map[String, Tensor[_]]): V =

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
@@ -98,7 +98,8 @@ final class ExampleSCollectionOps[T <: Example](private val self: SCollection[T]
    * @param options        configuration parameters for the session specified as a
    *                       `com.spotify.zoltar.tf.TensorFlowModel.Options`.
    * @param exampleInputOp name of [[org.tensorflow.Operation]]s to feed an example.
-   * @param signatureName  name of [[org.tensorflow.framework.SignatureDef]]s to be used to run the prediction.
+   * @param signatureName  name of [[org.tensorflow.framework.SignatureDef]]s to be used
+   *                       to run the prediction.
    * @param outFn          translates output of prediction from map of output-operation ->
    *                       [[org.tensorflow.Tensor Tensor]], to elements of V. This method takes
    *                       ownership of the [[org.tensorflow.Tensor Tensor]]s.
@@ -110,7 +111,7 @@ final class ExampleSCollectionOps[T <: Example](private val self: SCollection[T]
     signatureName: String = "serving_default"
   )(outFn: (T, Map[String, Tensor[_]]) => V): SCollection[V] =
     self.parDo(
-      SavedBundlePredictDoFn.forTensorflowExample[T, V](
+      SavedBundlePredictDoFn.forTensorFlowExample[T, V](
         savedModelUri,
         exampleInputOp,
         signatureName,

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
@@ -91,16 +91,28 @@ final class ExampleSCollectionOps[T <: Example](private val self: SCollection[T]
     self.asInstanceOf[SCollection[Example]].write(TFExampleIO(path))(param)
   }
 
+  /**
+   * Predict/infer/forward-pass on a TensorFlow Saved Model.
+   *
+   * @param savedModelUri  URI of Saved TensorFlow model
+   * @param options        configuration parameters for the session specified as a
+   *                       `com.spotify.zoltar.tf.TensorFlowModel.Options`.
+   * @param exampleInputOp name of [[org.tensorflow.Operation]]s to feed an example.
+   * @param signatureName  name of [[org.tensorflow.framework.SignatureDef]]s to be used to run the prediction.
+   * @param outFn          translates output of prediction from map of output-operation ->
+   *                       [[org.tensorflow.Tensor Tensor]], to elements of V. This method takes
+   *                       ownership of the [[org.tensorflow.Tensor Tensor]]s.
+   */
   def predict[V: Coder](
     savedModelUri: String,
     options: TensorFlowModel.Options,
-    exampleInputTensorName: String = "inputs",
+    exampleInputOp: String = "inputs",
     signatureName: String = "serving_default"
   )(outFn: (T, Map[String, Tensor[_]]) => V): SCollection[V] =
     self.parDo(
       SavedBundlePredictDoFn.forTensorflowExample[T, V](
         savedModelUri,
-        exampleInputTensorName,
+        exampleInputOp,
         signatureName,
         options,
         outFn

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
@@ -60,7 +60,7 @@ final class PredictSCollectionOps[T: ClassTag](private val self: SCollection[T])
     savedModelUri: String,
     fetchOps: Seq[String],
     options: TensorFlowModel.Options,
-    signatureName: String = "serving_default"
+    signatureName: String = PredictSCollectionOps.DefaultSignatureName
   )(inFn: T => Map[String, Tensor[_]])(outFn: (T, Map[String, Tensor[_]]) => V): SCollection[V] =
     self.parDo(
       SavedBundlePredictDoFn
@@ -87,8 +87,8 @@ final class PredictSCollectionOps[T: ClassTag](private val self: SCollection[T])
   def predictWithSigDef[V: Coder, W](
     savedModelUri: String,
     options: TensorFlowModel.Options,
-    fetchOps: Option[Seq[String]] = None,
-    signatureName: String = "serving_default"
+    fetchOps: Option[Seq[String]] = PredictSCollectionOps.DefaultFetchOps,
+    signatureName: String = PredictSCollectionOps.DefaultSignatureName
   )(inFn: T => Map[String, Tensor[_]])(outFn: (T, Map[String, Tensor[_]]) => V): SCollection[V] =
     self.parDo(
       SavedBundlePredictDoFn
@@ -113,9 +113,9 @@ final class PredictSCollectionOps[T: ClassTag](private val self: SCollection[T])
   def predictTfExamples[V: Coder](
     savedModelUri: String,
     options: TensorFlowModel.Options,
-    exampleInputOp: String = "inputs",
-    fetchOps: Option[Seq[String]] = None,
-    signatureName: String = "serving_default"
+    exampleInputOp: String = PredictSCollectionOps.DefaultExampleInputOp,
+    fetchOps: Option[Seq[String]] = PredictSCollectionOps.DefaultFetchOps,
+    signatureName: String = PredictSCollectionOps.DefaultSignatureName
   )(outFn: (T, Map[String, Tensor[_]]) => V)(implicit ev: T <:< Example): SCollection[V] =
     self.parDo(
       SavedBundlePredictDoFn.forTensorFlowExample[T, V](
@@ -127,6 +127,12 @@ final class PredictSCollectionOps[T: ClassTag](private val self: SCollection[T])
         outFn
       )
     )
+}
+
+object PredictSCollectionOps {
+  val DefaultSignatureName: String = "serving_default"
+  val DefaultExampleInputOp: String = "inputs"
+  val DefaultFetchOps: Option[Seq[String]] = None
 }
 
 final class ExampleSCollectionOps[T <: Example](private val self: SCollection[T]) extends AnyVal {

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFExampleTest.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFExampleTest.scala
@@ -20,7 +20,7 @@ package com.spotify.scio.tensorflow
 import com.spotify.featran.{FeatureSpec, MultiFeatureSpec}
 import com.spotify.featran.transformers.{OneHotEncoder, StandardScaler}
 import com.spotify.scio._
-import com.spotify.scio.tensorflow.TFSavedJob.Iris
+import com.spotify.scio.tensorflow.TFSavedSpec.Iris
 import com.spotify.scio.testing._
 import org.tensorflow.example.Example
 

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TensorflowSpec.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TensorflowSpec.scala
@@ -115,7 +115,7 @@ private[tensorflow] object TFSavedExampleJob {
         savedModelUri = args("savedModelUri"),
         options = options,
         exampleInputOp = "linear/head/predictions/class_ids"
-      ){ (r, o) =>
+      ) { (r, o) =>
         (r, o.map {
           case (a, outTensor) =>
             val output = Array.ofDim[Long](1)

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TensorflowSpec.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TensorflowSpec.scala
@@ -114,7 +114,7 @@ private[tensorflow] object TFSavedExampleJob {
       .predict(
         savedModelUri = args("savedModelUri"),
         options = options,
-        exampleInputTensorName = "linear/head/predictions/class_ids"
+        exampleInputOp = "linear/head/predictions/class_ids"
       ){ (r, o) =>
         (r, o.map {
           case (a, outTensor) =>


### PR DESCRIPTION
There are two main changes in this PR:
1) Simplify the tensorflow dofns by removing the resources, since they are not needed.
2) Add a predict function that uses the signature definition to get the input and output tensors.

It is similar to #2342 but are not doing the same thing.