### PR TITLE
Improve back compat with Scio 0.7

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -867,6 +867,7 @@ class ScioContext private[scio] (
       )
     }
 
+  // scalastyle:off line.size.limit
   @deprecated(
     "\n⛔" +
       "\n⛔️  makeFuture is PRIVATE and you should NOT be using it" +
@@ -878,6 +879,7 @@ class ScioContext private[scio] (
       "\n⛔️",
     since = "0.8.0"
   )
+  // scalastyle:on line.size.limit
   private[scio] def makeFuture[T](value: Tap[T]): Future[Tap[T]] =
     Future.successful(value)
 

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -55,6 +55,7 @@ import scala.io.Source
 import scala.reflect.ClassTag
 import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success, Try}
+import scala.concurrent.Future
 
 /** Runner specific context. */
 trait RunnerContext {
@@ -305,6 +306,17 @@ trait ScioExecutionContext {
     duration: Duration = awaitDuration,
     cancelJob: Boolean = cancelJob
   ): ScioResult
+}
+
+object ScioExecutionContext {
+  import scala.language.implicitConversions
+  @deprecated(
+    "ScioContext.close now returns a ScioExecutionContext instead of a ScioResult." +
+      " See https://spotify.github.io/scio/migrations/v0.8.0.html#sciocontext",
+    since = "0.8.0"
+  )
+  implicit def toResult(sec: ScioExecutionContext): ScioResult =
+    sec.waitUntilDone(Duration.Inf)
 }
 
 /** Companion object for [[ScioContext]]. */
@@ -854,6 +866,20 @@ class ScioContext private[scio] (
         )
       )
     }
+
+  @deprecated(
+    "\n⛔" +
+      "\n⛔️  makeFuture is PRIVATE and you should NOT be using it" +
+      "\n⛔️     - Scio's internals were simplified and it removed the need for makeFuture" +
+      "\n⛔️     - The current implementation is only there for back-compatibility" +
+      "\n⛔️     - There's NO GUARANTEE that its behavior is 100% similar to Scio < 0.8" +
+      "\n⛔️     - IT WILL BE REMOVED VERY SOON!" +
+      "\n⛔️ https://spotify.github.io/scio/migrations/v0.8.0.html#scala-concurrent-future-removed-from-scioios️" +
+      "\n⛔️",
+    since = "0.8.0"
+  )
+  private[scio] def makeFuture[T](value: Tap[T]): Future[Tap[T]] =
+    Future.successful(value)
 
   /**
    * Distribute a local Scala `Map` to form an SCollection.

--- a/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
@@ -62,7 +62,7 @@ abstract class ScioResult private[scio] (val internal: PipelineResult) {
   def isTest: Boolean = false
 
   @deprecated(
-    "ScioResult is guaranteed to com completed in Scio > 0.8.0",
+    "ScioResult is guaranteed to be completed in Scio > 0.8.0",
     since = "0.8.0"
   )
   def isCompleted: Boolean = true

--- a/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
@@ -32,6 +32,7 @@ import org.apache.beam.sdk.{PipelineResult, metrics => beam}
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 import scala.util.Try
+import scala.concurrent.Future
 
 /** Represent a Beam runner specific result. */
 trait RunnerResult {
@@ -59,6 +60,13 @@ abstract class ScioResult private[scio] (val internal: PipelineResult) {
 
   /** Whether this is the result of a test. */
   def isTest: Boolean = false
+
+  @deprecated(
+    "Scio 0.8 does not use Futures anymore. You can simply use the 'state' directly to get a State",
+    since = "0.8.0"
+  )
+  def finalState: Future[State] =
+    Future.successful(state)
 
   /** Pipeline's current state. */
   def state: State = Try(internal.getState).getOrElse(State.UNKNOWN)

--- a/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioResult.scala
@@ -62,6 +62,12 @@ abstract class ScioResult private[scio] (val internal: PipelineResult) {
   def isTest: Boolean = false
 
   @deprecated(
+    "ScioResult is guaranteed to com completed in Scio > 0.8.0",
+    since = "0.8.0"
+  )
+  def isCompleted: Boolean = true
+
+  @deprecated(
     "Scio 0.8 does not use Futures anymore. You can simply use the 'state' directly to get a State",
     since = "0.8.0"
   )

--- a/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
@@ -19,7 +19,7 @@ package com.spotify.scio.io
 
 import java.util.UUID
 
-import com.spotify.scio.ScioContext
+import com.spotify.scio.{ScioContext, ScioResult}
 import com.spotify.scio.coders.AvroBytesUtil
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.coders.{Coder, CoderMaterializer}
@@ -110,4 +110,11 @@ object MaterializeTap {
     new MaterializeTap(path, CoderMaterializer.beam(context, Coder[T]))
 }
 
-final case class ClosedTap[T] private (private[scio] val underlying: Tap[T])
+final case class ClosedTap[T] private (private[scio] val underlying: Tap[T]) {
+  /**
+   * Get access to the underlying Tap. The ScioContext has to be ran before.
+   * An instance of ScioResult is returned by ScioContext when the context is closed.
+   * @see ScioContext.run
+   */
+  def get(result: ScioResult): Tap[T] = result.tap(this)
+}

--- a/scio-core/src/main/scala/com/spotify/scio/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/package.scala
@@ -30,6 +30,7 @@ package object scio {
   import scala.concurrent.Await
   import com.spotify.scio.io.Tap
 
+  // scalastyle:off line.size.limit
   @deprecated(
     "waitForResult is deprecated since Scio 0.8 does not rely on Future anymore." +
       " see https://spotify.github.io/scio/migrations/v0.8.0.html#scala-concurrent-future-removed-from-scioios for more information",
@@ -64,4 +65,5 @@ package object scio {
     def waitForResult(atMost: Duration = Duration.Inf): Tap[T] =
       Await.result(self.flatMap(identity), atMost)
   }
+  // scalastyle:on line.size.limit
 }

--- a/scio-core/src/main/scala/com/spotify/scio/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/package.scala
@@ -24,4 +24,34 @@ package com.spotify
  * import com.spotify.scio._
  * }}}
  */
-package object scio
+package object scio {
+  import scala.concurrent.duration.Duration
+  import scala.concurrent.Future
+  import scala.concurrent.Await
+  import com.spotify.scio.io.Tap
+
+  @deprecated(
+    "waitForResult is deprecated since Scio 0.8 does not rely on Future anymore." +
+      " see https://spotify.github.io/scio/migrations/v0.8.0.html#scala-concurrent-future-removed-from-scioios for more information",
+    since = "0.8.0"
+  )
+  implicit class WaitableFutureTap[T](self: Future[Tap[T]]) {
+    def waitForResult(atMost: Duration = Duration.Inf): Tap[T] =
+      Await.result(self, atMost)
+  }
+
+  /**
+   * Wait for nested [[com.spotify.scio.io.Tap Tap]] to be available, flatten result and get Tap
+   * reference from `Future`.
+   */
+  @deprecated(
+    "waitForResult is deprecated since Scio 0.8 does not rely on Future anymore." +
+      " see https://spotify.github.io/scio/migrations/v0.8.0.html#scala-concurrent-future-removed-from-scioios for more information",
+    since = "0.8.0"
+  )
+  implicit class WaitableNestedFutureTap[T](self: Future[Future[Tap[T]]]) {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    def waitForResult(atMost: Duration = Duration.Inf): Tap[T] =
+      Await.result(self.flatMap(identity), atMost)
+  }
+}

--- a/scio-core/src/main/scala/com/spotify/scio/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/package.scala
@@ -40,6 +40,16 @@ package object scio {
       Await.result(self, atMost)
   }
 
+  @deprecated(
+    "waitForResult is deprecated since Scio 0.8 does not rely on Future anymore." +
+      " see https://spotify.github.io/scio/migrations/v0.8.0.html#scala-concurrent-future-removed-from-scioios for more information",
+    since = "0.8.0"
+  )
+  implicit class WaitableClosedTap[T](self: com.spotify.scio.io.ClosedTap[T]) {
+    def waitForResult(atMost: Duration = Duration.Inf): Tap[T] =
+      self.underlying
+  }
+
   /**
    * Wait for nested [[com.spotify.scio.io.Tap Tap]] to be available, flatten result and get Tap
    * reference from `Future`.

--- a/scio-core/src/main/scala/com/spotify/scio/transforms/package.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/transforms/package.scala
@@ -28,6 +28,7 @@ import com.spotify.scio.values.SCollection
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.transforms.{DoFn, ParDo}
 import org.apache.beam.sdk.values.{TupleTag, TupleTagList}
+import com.google.common.util.concurrent.ListenableFuture
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -36,6 +37,25 @@ import scala.util.{Failure, Success, Try}
  * Main package for transforms APIs. Import all.
  */
 package object transforms {
+  @deprecated(
+    "Class AsyncLookupDoFn was renamed to BaseAsyncLookupDoFn." +
+      "see https://spotify.github.io/scio/migrations/v0.8.0.html#async-dofns for more information",
+    "0.8.0"
+  )
+  type AsyncLookupDoFn[A, B, C] =
+    BaseAsyncLookupDoFn[A, B, C, ListenableFuture[_], BaseAsyncLookupDoFn.Try[B]]
+
+  @deprecated(
+    "Class AsyncLookupDoFn was renamed to BaseAsyncLookupDoFn." +
+      "see https://spotify.github.io/scio/migrations/v0.8.0.html#async-dofns for more information",
+    "0.8.0"
+  )
+  object AsyncLookupDoFn {
+    type Try[T] = BaseAsyncLookupDoFn.Try[T]
+    type CacheSupplier[A, B, K] = BaseAsyncLookupDoFn.CacheSupplier[A, B, K]
+    type NoOpCacheSupplier[A, B] = BaseAsyncLookupDoFn.NoOpCacheSupplier[A, B]
+  }
+
   /**
    * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with
    * [[java.net.URI URI]] methods.


### PR DESCRIPTION
This PR add type aliases and implicit conversions to limit the impact of breaking changes in our users. I'm testing them by migrating internal pipelines at Spotify.