### PR TITLE
Make recursive coders serializable

### DIFF
--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -457,14 +457,15 @@ final class CoderTest extends FlatSpec with Matchers {
   }
 
   it should "support derivation of recursive types" in {
-    case class SampleField(name: String, fieldType: SampleFieldType)
-    sealed trait SampleFieldType
-    case object IntegerType extends SampleFieldType
-    case object StringType extends SampleFieldType
-    case class RecordType(fields: List[SampleField]) extends SampleFieldType
+    import RecursiveCase._
 
-    noException should be thrownBy SerializableUtils.serializeToByteArray(CoderMaterializer.beamWithDefault(implicitly[Coder[Top]]))
-    noException should be thrownBy SerializableUtils.serializeToByteArray(CoderMaterializer.beamWithDefault(implicitly[Coder[SampleFieldType]]))
+    noException should be thrownBy
+      SerializableUtils.serializeToByteArray(CoderMaterializer.beamWithDefault(Coder[Top]))
+
+    noException should be thrownBy
+      SerializableUtils.serializeToByteArray(
+        CoderMaterializer.beamWithDefault(Coder[SampleFieldType])
+      )
 
     "Coder[SampleField]" should compile
     // deriving this coder under 2.11 will fail
@@ -481,4 +482,14 @@ final class CoderTest extends FlatSpec with Matchers {
       )
     ) coderShould roundtrip()
   }
+}
+
+object RecursiveCase {
+  case class SampleField(name: String, fieldType: SampleFieldType)
+  sealed trait SampleFieldType
+  case object IntegerType extends SampleFieldType
+  case object StringType extends SampleFieldType
+  case class RecordType(fields: List[SampleField]) extends SampleFieldType
+
+  implicit val coderSampleFieldType = Coder.gen[SampleField]
 }

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.coders.Coder.NonDeterministicException
 import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
 import org.scalactic.Equality
 import org.scalatest.{FlatSpec, Matchers}
+import org.apache.beam.sdk.util.SerializableUtils
 
 import scala.collection.JavaConverters._
 import scala.collection.{mutable => mut}
@@ -461,6 +462,9 @@ final class CoderTest extends FlatSpec with Matchers {
     case object IntegerType extends SampleFieldType
     case object StringType extends SampleFieldType
     case class RecordType(fields: List[SampleField]) extends SampleFieldType
+
+    noException should be thrownBy SerializableUtils.serializeToByteArray(CoderMaterializer.beamWithDefault(implicitly[Coder[Top]]))
+    noException should be thrownBy SerializableUtils.serializeToByteArray(CoderMaterializer.beamWithDefault(implicitly[Coder[SampleFieldType]]))
 
     "Coder[SampleField]" should compile
     // deriving this coder under 2.11 will fail


### PR DESCRIPTION
(partially) Fixes #2269
The coder derivation still needs to happen in a "safe" location bc. Magnolia generates a `lazy val`