### PR TITLE
Deprecate hashFilter(SideSet)

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -514,8 +514,17 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    *
    * @group transform
    */
+  @deprecated("use SCollection[T]#hashFilter(right.asSetSingletonSideInput) instead", "0.8.0")
   def hashFilter(that: SideSet[T])(implicit coder: Coder[T]): SCollection[T] =
-    self.map((_, ())).hashIntersectByKey(that).keys
+    self.map((_, ())).hashIntersectByKey(that.side).keys
+
+  /**
+   * Return a new SCollection containing only the elements that also exist in the `SideInput`.
+   *
+   * @group transform
+   */
+  def hashFilter(sideInput: SideInput[Set[T]])(implicit coder: Coder[T]): SCollection[T] =
+    self.map((_, ())).hashIntersectByKey(sideInput).keys
 
   /**
    * Create tuples of the elements in this SCollection by applying `f`.

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairHashSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairHashSCollectionFunctionsTest.scala
@@ -251,4 +251,22 @@ class PairHashSCollectionFunctionsTest extends PipelineSpec {
       p should containInAnyOrder(Seq(("a", 1), ("b", 2), ("b", 4)))
     }
   }
+
+  it should "support hashFilter() with asSetSingletonSideInput" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq("a", "b", "c", "b"))
+      val p2 = sc.parallelize(Seq[String]("a", "a", "b", "e")).asSetSingletonSideInput
+      val p = p1.hashFilter(p2)
+      p should containInAnyOrder(Seq("a", "b", "b"))
+    }
+  }
+
+  it should "support hashFilter() with SideSet" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq("a", "b", "c", "b"))
+      val p2 = sc.parallelize(Seq[String]("a", "a", "b", "e")).toSideSet
+      val p = p1.hashFilter(p2)
+      p should containInAnyOrder(Seq("a", "b", "b"))
+    }
+  }
 }


### PR DESCRIPTION
With `SideSet[T]` deprecated in favour of `SideInput[Set[T]]`, we can deprecate `hashFilter` as well.

I couldn't find a test for it, so added this.

Question: Naming of `hashFilter` => `filterWithSideInput` 