### PR TITLE
Fix join transform names

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
@@ -67,7 +67,7 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * The right side is tiny and fits in memory. The SideInput can be used reused for
    * multiple joins.
    *
-   * Example:
+   * @example
    * {{{
    *   val si = pairSCollRight.asMultiMapSideInput
    *   val joined1 = pairSColl1Left.hashJoin(si)
@@ -94,7 +94,7 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * Perform a left outer join by replicating `that` to all workers. The right side should be tiny
    * and fit in memory.
    *
-   * Example:
+   * @example
    * {{{
    *   val si = pairSCollRight  // Should be tiny
    *   val joined = pairSColl1Left.hashLeftOuterJoin(pairSCollRight)
@@ -111,12 +111,13 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * Perform a left outer join by replicating `that` to all workers. The right side should be tiny
    * and fit in memory.
    *
-   * Example:
+   * @example
    * {{{
    *   val si = pairSCollRight  // Should be tiny
    *   val joined = pairSColl1Left.hashLeftOuterJoin(pairSCollRight)
    * }}}
    * @group join
+   * @param that The tiny SCollection[(K, W)] treated as right side of the join.
    */
   def hashLeftOuterJoin[W: Coder](
     that: SCollection[(K, W)]
@@ -148,7 +149,7 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   /**
    * Perform a left outer join with a MultiMap `SideInput[Map[K, Iterable[V]]`
    *
-   * Example:
+   * @example
    * {{{
    *   val si = pairSCollRight.asMultiMapSideInput
    *   val joined1 = pairSColl1Left.hashLeftOuterJoin(si)
@@ -206,7 +207,7 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   /**
    * Perform a full outer join with a SideMap.
    *
-   * Example:
+   * @example
    * {{{
    *   val si = pairSCollRight.asMultiMapSideInput
    *   val joined1 = pairSColl1Left.hashFullOuterJoin(si)

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
@@ -94,12 +94,34 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * Perform a left outer join by replicating `that` to all workers. The right side should be tiny
    * and fit in memory.
    *
+   * Example:
+   * {{{
+   *   val si = pairSCollRight  // Should be tiny
+   *   val joined = pairSColl1Left.hashLeftOuterJoin(pairSCollRight)
+   * }}}
    * @group join
    */
+  @deprecated("Use SCollection[(K, V)]#hashLeftOuterJoin(pairSColl) instead.", "0.8.0")
   def hashLeftJoin[W: Coder](
     that: SCollection[(K, W)]
   )(implicit koder: Coder[K], voder: Coder[V]): SCollection[(K, (V, Option[W]))] =
-    hashLeftJoin(that.asMultiMapSideInput)
+    hashLeftOuterJoin(that)
+
+  /**
+   * Perform a left outer join by replicating `that` to all workers. The right side should be tiny
+   * and fit in memory.
+   *
+   * Example:
+   * {{{
+   *   val si = pairSCollRight  // Should be tiny
+   *   val joined = pairSColl1Left.hashLeftOuterJoin(pairSCollRight)
+   * }}}
+   * @group join
+   */
+  def hashLeftOuterJoin[W: Coder](
+    that: SCollection[(K, W)]
+  )(implicit koder: Coder[K], voder: Coder[V]): SCollection[(K, (V, Option[W]))] =
+    hashLeftOuterJoin(that.asMultiMapSideInput)
 
   /**
    * Perform a left outer join with a [[SideMap]].
@@ -108,20 +130,20 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * Example replacement:
    * {{{
    *   val si = pairSCollRight.asMultiMapSideInput
-   *   val joined1 = pairSColl1Left.hashLeftJoin(si)
-   *   val joined2 = pairSColl2Left.hashLeftJoin(si)
+   *   val joined1 = pairSColl1Left.hashLeftOuterJoin(si)
+   *   val joined2 = pairSColl2Left.hashLeftOuterJoin(si)
    * }}}
    *
    * @group join
    */
   @deprecated(
-    "Use SCollection[(K, V)]#hashLeftJoin(that) or SCollection[(K, V)]#hashLeftJoin(that.asMultiMapSideInput) instead.",
+    "Use SCollection[(K, V)]#hashLeftOuterJoin(pairSColl) or SCollection[(K, V)]#hashLeftOuterJoin(pairSColl.asMultiMapSideInput) instead.",
     "0.8.0"
   )
   def hashLeftJoin[W: Coder](
     sideMap: SideMap[K, W]
   )(implicit koder: Coder[K], voder: Coder[V]): SCollection[(K, (V, Option[W]))] =
-    hashLeftJoin(sideMap.asImmutableSideInput)
+    hashLeftOuterJoin(sideMap.asImmutableSideInput)
 
   /**
    * Perform a left outer join with a MultiMap `SideInput[Map[K, Iterable[V]]`
@@ -129,12 +151,12 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * Example:
    * {{{
    *   val si = pairSCollRight.asMultiMapSideInput
-   *   val joined1 = pairSColl1Left.hashLeftJoin(si)
-   *   val joined2 = pairSColl2Left.hashLeftJoin(si)
+   *   val joined1 = pairSColl1Left.hashLeftOuterJoin(si)
+   *   val joined2 = pairSColl2Left.hashLeftOuterJoin(si)
    * }}}
    * @group join
    */
-  def hashLeftJoin[W: Coder](
+  def hashLeftOuterJoin[W: Coder](
     sideInput: SideInput[Map[K, Iterable[W]]]
   )(implicit koder: Coder[K], voder: Coder[V]): SCollection[(K, (V, Option[W]))] = self.transform {
     in =>

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -302,16 +302,18 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     ArtisanJoin.right(self.tfName, self, that)
 
   /**
-   * Full outer join for cases when `this` is much larger than `that` which cannot fit in memory,
-   * but contains a mostly overlapping set of keys as `this`, i.e. when the intersection of keys
-   * is sparse in `this`. A Bloom Filter of keys in `that` is used to split `this` into 2
+   * Full outer join for cases when the left collection (`this`) is much larger than the right
+   * collection (`that`) which cannot fit in memory, but contains a mostly overlapping set of keys
+   * as the left collection, i.e. when the intersection of keys is sparse in the left collection.
+   * A Bloom Filter of keys from the right collection (`that`) is used to split `this` into 2
    * partitions. Only those with keys in the filter go through the join and the rest are
    * concatenated. This is useful for joining historical aggregates with incremental updates.
    * Read more about Bloom Filter: [[com.twitter.algebird.BloomFilter]].
    * @group join
-   * @param thatNumKeys An estimate of the number of keys in `that`. This estimate is used to find
-   *                    the size and number of BloomFilters that Scio would use to split
-   *                    `this` into overlap and intersection in a "map" step before an exact join.
+   * @param thatNumKeys An estimate of the number of keys in the right collection `that`.
+   *                    This estimate is used to find the size and number of BloomFilters that Scio
+   *                    would use to split the left collection (`this`) into overlap and
+   *                    intersection in a "map" step before an exact join.
    *                    Having a value close to the actual number improves the false positives
    *                    in intermediate steps which means less shuffle.
    * @param fpProb A fraction in range (0, 1) which would be the accepted false positive
@@ -337,16 +339,18 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   }
 
   /**
-   * Full outer join for cases when `this` is much larger than `that` which cannot fit in memory,
-   * but contains a mostly overlapping set of keys as `this`, i.e. when the intersection of keys
-   * is sparse in `this`. A Bloom Filter of keys in `that` is used to split `this` into 2
+   * Full outer join for cases when the left collection (`this`) is much larger than the right
+   * collection (`that`) which cannot fit in memory, but contains a mostly overlapping set of keys
+   * as the left collection, i.e. when the intersection of keys is sparse in the left collection.
+   * A Bloom Filter of keys from the right collection (`that`) is used to split `this` into 2
    * partitions. Only those with keys in the filter go through the join and the rest are
    * concatenated. This is useful for joining historical aggregates with incremental updates.
    * Read more about Bloom Filter: [[com.twitter.algebird.BloomFilter]].
    * @group join
-   * @param thatNumKeys An estimate of the number of keys in `that`. This estimate is used to find
-   *                    the size and number of BloomFilters that Scio would use to split
-   *                    `this` into overlap and intersection in a "map" step before an exact join.
+   * @param thatNumKeys An estimate of the number of keys in the right collection `that`.
+   *                    This estimate is used to find the size and number of BloomFilters that Scio
+   *                    would use to split the left collection (`this`) into overlap and
+   *                    intersection in a "map" step before an exact join.
    *                    Having a value close to the actual number improves the false positives
    *                    in intermediate steps which means less shuffle.
    * @param fpProb A fraction in range (0, 1) which would be the accepted false positive
@@ -366,16 +370,18 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     sparseFullOuterJoin(that, thatNumKeys, fpProb)
 
   /**
-   * Inner join for cases when `this` is much larger than `that` which cannot fit in memory,
-   * but contains a mostly overlapping set of keys as `this`, i.e. when the intersection of keys
-   * is sparse in `this`. A Bloom Filter of keys in `that` is used to split `this` into 2
+   * Inner join for cases when the left collection (`this`) is much larger than the right
+   * collection (`that`) which cannot fit in memory, but contains a mostly overlapping set of keys
+   * as the left collection, i.e. when the intersection of keys is sparse in the left collection.
+   * A Bloom Filter of keys from the right collection (`that`) is used to split `this` into 2
    * partitions. Only those with keys in the filter go through the join and the rest are filtered
    * out before the join.
    * Read more about Bloom Filter: [[com.twitter.algebird.BloomFilter]].
    * @group join
-   * @param thatNumKeys An estimate of the number of keys in `that`. This estimate is used to find
-   *                    the size and number of BloomFilters that Scio would use to split
-   *                    `this` into overlap and intersection in a "map" step before an exact join.
+   * @param thatNumKeys An estimate of the number of keys in the right collection `that`.
+   *                    This estimate is used to find the size and number of BloomFilters that Scio
+   *                    would use to split the left collection (`this`) into overlap and
+   *                    intersection in a "map" step before an exact join.
    *                    Having a value close to the actual number improves the false positives
    *                    in intermediate steps which means less shuffle.
    * @param fpProb A fraction in range (0, 1) which would be the accepted false positive
@@ -397,16 +403,18 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     }
 
   /**
-   * Left outer join for cases when `this` is much larger than `that` which cannot fit in memory,
-   * but contains a mostly overlapping set of keys as `this`, i.e. when the intersection of keys
-   * is sparse in `this`. A Bloom Filter of keys in `that` is used to split `this` into 2
+   * Left outer join for cases when the left collection (`this`) is much larger than the right
+   * collection (`that`) which cannot fit in memory, but contains a mostly overlapping set of keys
+   * as the left collection, i.e. when the intersection of keys is sparse in the left collection.
+   * A Bloom Filter of keys from the right collection (`that`) is used to split `this` into 2
    * partitions. Only those with keys in the filter go through the join and the rest are
    * concatenated. This is useful for joining historical aggregates with incremental updates.
    * Read more about Bloom Filter: [[com.twitter.algebird.BloomFilter]].
    * @group join
-   * @param thatNumKeys An estimate of the number of keys in `that`. This estimate is used to find
-   *                    the size and number of BloomFilters that Scio would use to split
-   *                    `this` into overlap and intersection in a "map" step before an exact join.
+   * @param thatNumKeys An estimate of the number of keys in the right collection `that`.
+   *                    This estimate is used to find the size and number of BloomFilters that Scio
+   *                    would use to split the left collection (`this`) into overlap and
+   *                    intersection in a "map" step before an exact join.
    *                    Having a value close to the actual number improves the false positives
    *                    in intermediate steps which means less shuffle.
    * @param fpProb A fraction in range (0, 1) which would be the accepted false positive
@@ -429,16 +437,18 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     }
 
   /**
-   * Right outer join for cases when `this` is much larger than `that` which cannot fit in memory,
-   * but contains a mostly overlapping set of keys as `this`, i.e. when the intersection of keys
-   * is sparse in `this`. A Bloom Filter of keys in `that` is used to split `this` into 2
+   * Right outer join for cases when the left collection (`this`) is much larger than the right
+   * collection (`that`) which cannot fit in memory, but contains a mostly overlapping set of keys
+   * as the left collection, i.e. when the intersection of keys is sparse in the left collection.
+   * A Bloom Filter of keys from the right collection (`that`) is used to split `this` into 2
    * partitions. Only those with keys in the filter go through the join and the rest are
    * concatenated. This is useful for joining historical aggregates with incremental updates.
    * Read more about Bloom Filter: [[com.twitter.algebird.BloomFilter]].
    * @group join
-   * @param thatNumKeys An estimate of the number of keys in `that`. This estimate is used to find
-   *                    the size and number of BloomFilters that Scio would use to split
-   *                    `this` into overlap and intersection in a "map" step before an exact join.
+   * @param thatNumKeys An estimate of the number of keys in the right collection `that`.
+   *                    This estimate is used to find the size and number of BloomFilters that Scio
+   *                    would use to split the left collection (`this`) into overlap and
+   *                    intersection in a "map" step before an exact join.
    *                    Having a value close to the actual number improves the false positives
    *                    in intermediate steps which means less shuffle.
    * @param fpProb A fraction in range (0, 1) which would be the accepted false positive
@@ -514,7 +524,6 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    *                    in intermediate steps which means less shuffle.
    * @param fpProb A fraction in range (0, 1) which would be the accepted false positive
    *               probability when discarding elements of `that` in the pre-filter step.
-
    */
   def sparseLookup[A: Coder](that: SCollection[(K, A)], thisNumKeys: Long, fpProb: Double)(
     implicit hash: Hash128[K],

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSkewedSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSkewedSCollectionFunctions.scala
@@ -183,7 +183,97 @@ class PairSkewedSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    *                        [[SCollection.sample(withReplacement:Boolean,fraction:Double)*
    *                        SCollection.sample]].
    */
+  @deprecated("Use SCollection[(K, V)].skewedLeftOuterJoin(right) instead.", "0.8.0")
   def skewedLeftJoin[W: Coder](
+    that: SCollection[(K, W)],
+    hotKeyThreshold: Long = 9000,
+    eps: Double = 0.001,
+    seed: Int = 42,
+    delta: Double = 1e-10,
+    sampleFraction: Double = 1.0,
+    withReplacement: Boolean = true
+  )(
+    implicit hasher: CMSHasher[K],
+    koder: Coder[K],
+    voder: Coder[V]
+  ): SCollection[(K, (V, Option[W]))] =
+    skewedLeftOuterJoin(that, hotKeyThreshold, eps, seed, delta, sampleFraction, withReplacement)
+
+  /**
+   * N to 1 skew-proof flavor of [[PairSCollectionFunctions.leftOuterJoin]].
+   *
+   * Perform a skewed left join where some keys on the left hand may be hot, i.e. appear more than
+   * `hotKeyThreshold` times. Frequency of a key is estimated with `1 - delta` probability, and the
+   * estimate is within `eps * N` of the true frequency.
+   * `true frequency <= estimate <= true frequency + eps * N`, where N is the total size of
+   * the left hand side stream so far.
+   *
+   * @note Make sure to `import com.twitter.algebird.CMSHasherImplicits` before using this join.
+   * @example {{{
+   * // Implicits that enabling CMS-hashing
+   * import com.twitter.algebird.CMSHasherImplicits._
+   *
+   * val keyAggregator = CMS.aggregator[K](eps, delta, seed)
+   * val hotKeyCMS = self.keys.aggregate(keyAggregator)
+   * val p = logs.skewedJoin(logMetadata, hotKeyThreshold = 8500, cms=hotKeyCMS)
+   * }}}
+   *
+   * Read more about CMS: [[com.twitter.algebird.CMSMonoid]].
+   * @group join
+   * @param hotKeyThreshold key with `hotKeyThreshold` values will be considered hot. Some runners
+   *                        have inefficient `GroupByKey` implementation for groups with more than
+   *                        10K values. Thus it is recommended to set `hotKeyThreshold` to below
+   *                        10K, keep upper estimation error in mind.
+   * @param cms left hand side key [[com.twitter.algebird.CMSMonoid]]
+   */
+  @deprecated(
+    "Use SCollection[(K, V)].skewedLeftOuterJoin(right, hotKeyThreshold, cms) instead.",
+    "0.8.0"
+  )
+  def skewedLeftJoin[W: Coder](
+    that: SCollection[(K, W)],
+    hotKeyThreshold: Long,
+    cms: SCollection[CMS[K]]
+  )(implicit koder: Coder[K], voder: Coder[V]): SCollection[(K, (V, Option[W]))] =
+    skewedLeftOuterJoin(that, hotKeyThreshold, cms)
+
+  /**
+   * N to 1 skew-proof flavor of [[PairSCollectionFunctions.leftOuterJoin]].
+   *
+   * Perform a skewed left join where some keys on the left hand may be hot, i.e. appear more than
+   * `hotKeyThreshold` times. Frequency of a key is estimated with `1 - delta` probability, and the
+   * estimate is within `eps * N` of the true frequency.
+   * `true frequency <= estimate <= true frequency + eps * N`, where N is the total size of
+   * the left hand side stream so far.
+   *
+   * @note Make sure to `import com.twitter.algebird.CMSHasherImplicits` before using this join.
+   * @example {{{
+   * // Implicits that enabling CMS-hashing
+   * import com.twitter.algebird.CMSHasherImplicits._
+   *
+   * val p = logs.skewedLeftJoin(logMetadata)
+   * }}}
+   *
+   * Read more about CMS: [[com.twitter.algebird.CMSMonoid]].
+   * @group join
+   * @param hotKeyThreshold key with `hotKeyThreshold` values will be considered hot. Some runners
+   *                        have inefficient `GroupByKey` implementation for groups with more than
+   *                        10K values. Thus it is recommended to set `hotKeyThreshold` to below
+   *                        10K, keep upper estimation error in mind. If you sample input via
+   *                        `sampleFraction` make sure to adjust `hotKeyThreshold` accordingly.
+   * @param eps One-sided error bound on the error of each point query, i.e. frequency estimate.
+   *            Must lie in `(0, 1)`.
+   * @param seed A seed to initialize the random number generator used to create the pairwise
+   *             independent hash functions.
+   * @param delta A bound on the probability that a query estimate does not lie within some small
+   *              interval (an interval that depends on `eps`) around the truth. Must lie in
+   *              `(0, 1)`.
+   * @param sampleFraction left side sample fraction. Default is `1.0` - no sampling.
+   * @param withReplacement whether to use sampling with replacement, see
+   *                        [[SCollection.sample(withReplacement:Boolean,fraction:Double)*
+   *                        SCollection.sample]].
+   */
+  def skewedLeftOuterJoin[W: Coder](
     that: SCollection[(K, W)],
     hotKeyThreshold: Long = 9000,
     eps: Double = 0.001,
@@ -244,7 +334,7 @@ class PairSkewedSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    *                        10K, keep upper estimation error in mind.
    * @param cms left hand side key [[com.twitter.algebird.CMSMonoid]]
    */
-  def skewedLeftJoin[W: Coder](
+  def skewedLeftOuterJoin[W: Coder](
     that: SCollection[(K, W)],
     hotKeyThreshold: Long,
     cms: SCollection[CMS[K]]

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSkewedSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSkewedSCollectionFunctions.scala
@@ -254,7 +254,7 @@ class PairSkewedSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     // Use hash join for hot keys
     val hotJoined = selfPartitions.hot
       .withName("Hash left join hot partitions")
-      .hashLeftJoin(thatPartitions.hot)
+      .hashLeftOuterJoin(thatPartitions.hot)
 
     // Use regular join for the rest of the keys
     val chillJoined = selfPartitions.chill

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/JoinExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/JoinExamples.scala
@@ -132,7 +132,7 @@ object HashJoinExamples {
 
     eventsInfo
     // Hash join uses side input under the hood and is a drop-in replacement for regular join
-      .hashLeftJoin(countryInfo)
+      .hashLeftOuterJoin(countryInfo)
       .map { t =>
         val (countryCode, (eventInfo, countryNameOpt)) = t
         val countryName = countryNameOpt.getOrElse("none")

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairHashSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairHashSCollectionFunctionsTest.scala
@@ -93,31 +93,46 @@ class PairHashSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support hashLeftJoin()" in {
+  it should "support hashLeftOuterJoin()" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
       val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("d", 14)))
-      val p = p1.hashLeftJoin(p2)
+      val p = p1.hashLeftOuterJoin(p2)
+      val pd = p1.hashLeftJoin(p2)
       p should containInAnyOrder(Seq(("a", (1, Some(11))), ("b", (2, Some(12))), ("c", (3, None))))
+      pd should containInAnyOrder(Seq(("a", (1, Some(11))), ("b", (2, Some(12))), ("c", (3, None))))
     }
   }
 
-  it should "support hashLeftJoin() with empty RHS" in {
+  it should "support hashLeftOuterJoin() with empty RHS" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
       val p2 = sc.parallelize(Seq.empty[(String, Int)])
-      val p = p1.hashLeftJoin(p2)
+      val p = p1.hashLeftOuterJoin(p2)
+      val pd = p1.hashLeftJoin(p2)
       val empty = Option.empty[Int]
       p should containInAnyOrder(Seq(("a", (1, empty)), ("b", (2, empty)), ("c", (3, empty))))
+      pd should containInAnyOrder(Seq(("a", (1, empty)), ("b", (2, empty)), ("c", (3, empty))))
     }
   }
 
-  it should "support hashLeftJoin() with duplicate keys" in {
+  it should "support hashLeftOuterJoin() with duplicate keys" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("a", 2), ("b", 3), ("c", 4)))
       val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("b", 13)))
-      val p = p1.hashLeftJoin(p2)
+      val p = p1.hashLeftOuterJoin(p2)
+      val pd = p1.hashLeftJoin(p2) // Test deprecated method.
       p should containInAnyOrder(
+        Seq(
+          ("a", (1, Some(11))),
+          ("a", (2, Some(11))),
+          ("b", (3, Some(12))),
+          ("b", (3, Some(13))),
+          ("c", (4, None))
+        )
+      )
+
+      pd should containInAnyOrder(
         Seq(
           ("a", (1, Some(11))),
           ("a", (2, Some(11))),
@@ -129,10 +144,19 @@ class PairHashSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support hashLeftJoin() with asMultiMapSideInput" in {
+  it should "support hashLeftOuterJoin() with asMultiMapSideInput" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
       val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("d", 14))).asMultiMapSideInput
+      val p = p1.hashLeftOuterJoin(p2)
+      p should containInAnyOrder(Seq(("a", (1, Some(11))), ("b", (2, Some(12))), ("c", (3, None))))
+    }
+  }
+
+  it should "support hashLeftOuterJoin() with SideMap" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
+      val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("d", 14))).toSideMap
       val p = p1.hashLeftJoin(p2)
       p should containInAnyOrder(Seq(("a", (1, Some(11))), ("b", (2, Some(12))), ("c", (3, None))))
     }

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -585,7 +585,7 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
 
   val sparseLhs = Seq(("a", 1), ("a", 2), ("b", 3), ("c", 4))
   val sparseRhs = Seq(("a", 11), ("d", 5))
-  val sparseOuterJoinExpected = Seq(
+  val sparseFullOuterJoinExpected = Seq(
     ("a", (Some(1), Some(11))),
     ("a", (Some(2), Some(11))),
     ("b", (Some(3), None)),
@@ -601,21 +601,32 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
   val sparseLeftOuterJoinExpected =
     Seq(("a", (1, Some(11))), ("a", (2, Some(11))), ("b", (3, None)), ("c", (4, None)))
 
-  it should "support sparseOuterJoin()" in {
+  it should "support sparseFullOuterJoin()" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(sparseLhs)
       val p2 = sc.parallelize(sparseRhs)
-      val p = p1.sparseOuterJoin(p2, 10)
-      p should containInAnyOrder(sparseOuterJoinExpected)
+      val p = p1.sparseFullOuterJoin(p2, 10)
+      val pd = p1.sparseOuterJoin(p2, 10) // Test deprecated method
+      p should containInAnyOrder(sparseFullOuterJoinExpected)
+      pd should containInAnyOrder(sparseFullOuterJoinExpected)
     }
   }
 
-  it should "support sparseOuterJoin() with empty RHS" in {
+  it should "support sparseFullOuterJoin() with empty RHS" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(sparseLhs)
       val p2 = sc.parallelize(Seq[(String, Int)]())
-      val p = p1.sparseOuterJoin(p2, 10)
+      val p = p1.sparseFullOuterJoin(p2, 10)
+      val pd = p1.sparseOuterJoin(p2, 10) // Test deprecated method
       p should containInAnyOrder(
+        Seq[(String, (Option[Int], Option[Int]))](
+          ("a", (Some(1), None)),
+          ("a", (Some(2), None)),
+          ("b", (Some(3), None)),
+          ("c", (Some(4), None))
+        )
+      )
+      pd should containInAnyOrder(
         Seq[(String, (Option[Int], Option[Int]))](
           ("a", (Some(1), None)),
           ("a", (Some(2), None)),
@@ -626,12 +637,14 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support sparseOuterJoin() with partitions" in {
+  it should "support sparseFullOuterJoin() with partitions" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(sparseLhs)
       val p2 = sc.parallelize(sparseRhs)
-      val p = p1.sparseOuterJoin(p2, 1000000000L)
-      p should containInAnyOrder(sparseOuterJoinExpected)
+      val p = p1.sparseFullOuterJoin(p2, 1000000000L)
+      val pd = p1.sparseOuterJoin(p2, 10) // Test deprecated method
+      p should containInAnyOrder(sparseFullOuterJoinExpected)
+      pd should containInAnyOrder(sparseFullOuterJoinExpected)
     }
   }
 

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSkewedSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSkewedSCollectionFunctionsTest.scala
@@ -83,25 +83,39 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support skewedLeftJoin() without hotkeys and no duplicate keys" in {
+  it should "support skewedLeftOuterJoin() without hotkeys and no duplicate keys" in {
     import com.twitter.algebird.CMSHasherImplicits._
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
       val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("b", 13)))
-      val p = p1.skewedLeftJoin(p2, Long.MaxValue, skewEps, skewSeed)
+      val p = p1.skewedLeftOuterJoin(p2, Long.MaxValue, skewEps, skewSeed)
+      val pd = p1.skewedLeftJoin(p2, Long.MaxValue, skewEps, skewSeed)
       p should containInAnyOrder(
+        Seq(("a", (1, Some(11))), ("b", (2, Some(12))), ("b", (2, Some(13))), ("c", (3, None)))
+      )
+      pd should containInAnyOrder(
         Seq(("a", (1, Some(11))), ("b", (2, Some(12))), ("b", (2, Some(13))), ("c", (3, None)))
       )
     }
   }
 
-  it should "support skewedLeftJoin() without hotkeys" in {
+  it should "support skewedLeftOuterJoin() without hotkeys" in {
     import com.twitter.algebird.CMSHasherImplicits._
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("a", 2), ("b", 3), ("c", 4)))
       val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("b", 13)))
-      val p = p1.skewedLeftJoin(p2, Long.MaxValue, skewEps, skewSeed)
+      val p = p1.skewedLeftOuterJoin(p2, Long.MaxValue, skewEps, skewSeed)
+      val pd = p1.skewedLeftJoin(p2, Long.MaxValue, skewEps, skewSeed)
       p should containInAnyOrder(
+        Seq(
+          ("a", (1, Some(11))),
+          ("a", (2, Some(11))),
+          ("b", (3, Some(12))),
+          ("b", (3, Some(13))),
+          ("c", (4, None))
+        )
+      )
+      pd should containInAnyOrder(
         Seq(
           ("a", (1, Some(11))),
           ("a", (2, Some(11))),
@@ -113,14 +127,24 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support skewedLeftJoin() with hotkey" in {
+  it should "support skewedLeftOuterJoin() with hotkey" in {
     import com.twitter.algebird.CMSHasherImplicits._
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("a", 2), ("b", 3), ("c", 4)))
       val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("b", 13)))
       // set threshold to 2, to hash join on "a"
-      val p = p1.skewedLeftJoin(p2, 2, skewEps, skewSeed)
+      val p = p1.skewedLeftOuterJoin(p2, 2, skewEps, skewSeed)
+      val pd = p1.skewedLeftJoin(p2, 2, skewEps, skewSeed)
       p should containInAnyOrder(
+        Seq(
+          ("a", (1, Some(11))),
+          ("a", (2, Some(11))),
+          ("b", (3, Some(12))),
+          ("b", (3, Some(13))),
+          ("c", (4, None))
+        )
+      )
+      pd should containInAnyOrder(
         Seq(
           ("a", (1, Some(11))),
           ("a", (2, Some(11))),
@@ -132,7 +156,7 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support skewedLeftJoin() with 0.5 sample" in {
+  it should "support skewedLeftOuterJoin() with 0.5 sample" in {
     import com.twitter.algebird.CMSHasherImplicits._
     runWithContext { sc =>
       val p1 =
@@ -140,8 +164,19 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec {
       val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("b", 13)))
 
       // set threshold to 3, given 0.5 fraction for sample - "a" should not be hash joined
-      val p = p1.skewedLeftJoin(p2, 3, skewEps, skewSeed, sampleFraction = 0.5)
+      val p = p1.skewedLeftOuterJoin(p2, 3, skewEps, skewSeed, sampleFraction = 0.5)
+      val pd = p1.skewedLeftJoin(p2, 3, skewEps, skewSeed, sampleFraction = 0.5)
       p should containInAnyOrder(
+        Seq(
+          ("a", (1, Some(11))),
+          ("a", (2, Some(11))),
+          ("a", (3, Some(11))),
+          ("b", (3, Some(12))),
+          ("b", (3, Some(13))),
+          ("c", (4, None))
+        )
+      )
+      pd should containInAnyOrder(
         Seq(
           ("a", (1, Some(11))),
           ("a", (2, Some(11))),
@@ -154,15 +189,17 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support skewedLeftJoin() with empty key count (no hash join)" in {
+  it should "support skewedLeftOuterJoin() with empty key count (no hash join)" in {
     import com.twitter.algebird.CMSHasherImplicits._
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("a", 2), ("b", 3)))
       val p2 = sc.parallelize(Seq(("a", 11)))
 
       // Small sample size to force empty key count
-      val p = p1.skewedLeftJoin(p2, 3, skewEps, skewSeed, sampleFraction = 0.01)
+      val p = p1.skewedLeftOuterJoin(p2, 3, skewEps, skewSeed, sampleFraction = 0.01)
+      val pd = p1.skewedLeftJoin(p2, 3, skewEps, skewSeed, sampleFraction = 0.01)
       p should containInAnyOrder(Seq(("a", (2, Some(11))), ("a", (1, Some(11))), ("b", (3, None))))
+      pd should containInAnyOrder(Seq(("a", (2, Some(11))), ("a", (1, Some(11))), ("b", (3, None))))
     }
   }
 


### PR DESCRIPTION
Fixes #2441 

Rename the following transforms (deprecating the old names)
```
p1.hashLeftJoin() -> p1.hashLeftOuterJoin()
p1.skewedLeftJoin() -> p1.skewedLeftOuterJoin()
p1.sparseOuterJoin() -> p1.sparseFullOuterJoin()
```

TODO 
Scala fix rules.