### PR TITLE
Automatically generate names for saveAsCustomOutput and customInput.

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -823,7 +823,7 @@ class ScioContext private[scio] (
       if (this.isTest) {
         TestDataManager.getInput(testId.get)(CustomIO[T](this.tfName)).toSCollection(this)
       } else {
-        wrap(this.applyInternal(name, transform))
+        wrap(this.applyInternal(transform))
       }
     }
 

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -813,6 +813,21 @@ class ScioContext private[scio] (
     }
 
   /**
+   * Get an SCollection with a custom input transform.
+   * @group input
+   */
+  def customInput[T: Coder, I >: PBegin <: PInput](
+    transform: PTransform[I, PCollection[T]]
+  ): SCollection[T] =
+    requireNotClosed {
+      if (this.isTest) {
+        TestDataManager.getInput(testId.get)(CustomIO[T](this.tfName)).toSCollection(this)
+      } else {
+        wrap(this.applyInternal(name, transform))
+      }
+    }
+
+  /**
    * Generic read method for all `ScioIO[T]` implementations, which will invoke the provided IO's
    * [[com.spotify.scio.io.ScioIO[T]#readWithContext]] method along with read configurations
    * passed in. The IO class can delegate test-specific behavior if necessary.

--- a/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
@@ -110,7 +110,7 @@ object MaterializeTap {
     new MaterializeTap(path, CoderMaterializer.beam(context, Coder[T]))
 }
 
-final case class ClosedTap[T] private (private[scio] val underlying: Tap[T]) {
+final case class ClosedTap[T] (private[scio] val underlying: Tap[T]) {
   /**
    * Get access to the underlying Tap. The ScioContext has to be ran before.
    * An instance of ScioResult is returned by ScioContext when the context is closed.

--- a/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
@@ -110,7 +110,7 @@ object MaterializeTap {
     new MaterializeTap(path, CoderMaterializer.beam(context, Coder[T]))
 }
 
-final case class ClosedTap[T] (private[scio] val underlying: Tap[T]) {
+final case class ClosedTap[T](private[scio] val underlying: Tap[T]) {
   /**
    * Get access to the underlying Tap. The ScioContext has to be ran before.
    * An instance of ScioResult is returned by ScioContext when the context is closed.

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1295,7 +1295,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     if (context.isTest) {
       TestDataManager.getOutput(context.testId.get)(CustomIO[T](this.tfName))(this)
     } else {
-      this.applyInternal(name, transform)
+      this.applyInternal(transform)
     }
 
     ClosedTap[Nothing](EmptyTap)

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1285,6 +1285,22 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     ClosedTap[Nothing](EmptyTap)
   }
 
+  /**
+   * Save this SCollection with a custom output transform.
+   * @group output
+   */
+  def saveAsCustomOutput[O <: POutput](
+    transform: PTransform[PCollection[T], O]
+  ): ClosedTap[Nothing] = {
+    if (context.isTest) {
+      TestDataManager.getOutput(context.testId.get)(CustomIO[T](this.tfName))(this)
+    } else {
+      this.applyInternal(name, transform)
+    }
+
+    ClosedTap[Nothing](EmptyTap)
+  }
+
   private[scio] def saveAsInMemoryTap(implicit coder: Coder[T]): ClosedTap[T] = {
     val tap = new InMemoryTap[T]
     InMemorySink.save(tap.id, this)


### PR DESCRIPTION
Also make `ClosedTap`'s constructor public, since its apply was already public.
See https://github.com/spotify/scio/issues/2447

Let me know if there's anything else I need to do on this PR!