### PR TITLE
Shameera/scalafix that to rhs

### DIFF
--- a/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -7,7 +7,9 @@ import com.spotify.scio.values.SCollection
 
 object FixJoinNames {
 
-  def changeJoinNames(lhs: SCollection[(Int, String)], rhs: SCollection[(Int, String)]
+  def changeJoinNames(
+    lhs: SCollection[(Int, String)],
+    rhs: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
     lhs.hashLeftJoin(rhs)
     lhs.sparseOuterJoin(rhs, 3)
@@ -15,17 +17,14 @@ object FixJoinNames {
   }
 
   def example(): Unit = {
-    def hashLeftJoin(a: String): Int =  {
+    def hashLeftJoin(a: String): Int =
       a.length
-    }
 
-    def sparseOuterJoin(a: String): Int = {
+    def sparseOuterJoin(a: String): Int =
       a.length
-    }
 
-    def skewedLeftJoin(that: String): Int = {
+    def skewedLeftJoin(that: String): Int =
       that.length
-    }
 
     hashLeftJoin("test")
     sparseOuterJoin("test")

--- a/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -11,7 +11,6 @@ object FixJoinNames {
     lhs: SCollection[(Int, String)],
     rhs: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
-    lhs.leftOuterJoin(rhs)
     lhs.hashLeftJoin(rhs)
     lhs.sparseOuterJoin(rhs, 3)
     lhs.skewedLeftJoin(rhs)
@@ -29,17 +28,14 @@ object FixJoinNames {
   }
 
   def example(): Unit = {
-    def hashLeftJoin(a: String): Int =  {
+    def hashLeftJoin(a: String): Int =
       a.length
-    }
 
-    def sparseOuterJoin(a: String): Int = {
+    def sparseOuterJoin(a: String): Int =
       a.length
-    }
 
-    def skewedLeftJoin(that: String): Int = {
+    def skewedLeftJoin(that: String): Int =
       that.length
-    }
 
     hashLeftJoin("test")
     sparseOuterJoin("test")

--- a/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -27,4 +27,22 @@ object FixJoinNames {
     lhs.sparseOuterJoin(that = rhs, thatNumKeys = 3)
     lhs.skewedLeftJoin(that = rhs)
   }
+
+  def example(): Unit = {
+    def hashLeftJoin(a: String): Int =  {
+      a.length
+    }
+
+    def sparseOuterJoin(a: String): Int = {
+      a.length
+    }
+
+    def skewedLeftJoin(that: String): Int = {
+      that.length
+    }
+
+    hashLeftJoin("test")
+    sparseOuterJoin("test")
+    skewedLeftJoin("test")
+  }
 }

--- a/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -16,15 +16,13 @@ object FixJoinNames {
     lhs.skewedLeftJoin(rhs)
   }
 
-  def changeNamesAndArgs(
-    lhs: SCollection[(Int, String)],
-    rhs: SCollection[(Int, String)]
+  def changeNamesAndArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
-    lhs.leftOuterJoin(that = rhs)
-    lhs.hashLeftJoin(that = rhs)
-    lhs.sparseOuterJoin(that = rhs, 3)
-    lhs.sparseOuterJoin(that = rhs, thatNumKeys = 3)
-    lhs.skewedLeftJoin(that = rhs)
+    lhs.leftOuterJoin(that = rightHS)
+    lhs.hashLeftJoin(that = rightHS)
+    lhs.sparseOuterJoin(that = rightHS, 3)
+    lhs.sparseOuterJoin(that = rightHS, thatNumKeys = 3)
+    lhs.skewedLeftJoin(that = rightHS)
   }
 
   def example(): Unit = {

--- a/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -18,16 +18,45 @@ object FixJoinNames {
 
   def changeNamesAndArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
-    lhs.leftOuterJoin(that = rightHS)
     lhs.hashLeftJoin(that = rightHS)
     lhs.sparseOuterJoin(that = rightHS, 3)
     lhs.sparseOuterJoin(that = rightHS, thatNumKeys = 3)
     lhs.skewedLeftJoin(that = rightHS)
   }
 
-  def example(): Unit = {
-    def hashLeftJoin(a: String): Int =
-      a.length
+  def changeArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]
+  ): Unit = {
+    lhs.join(that = rightHS)
+    lhs.fullOuterJoin(that = rightHS)
+    lhs.leftOuterJoin(that = rightHS)
+    lhs.rightOuterJoin(that = rightHS)
+    lhs.sparseOuterJoin(that = rightHS, thatNumKeys = 4L, fpProb = 0.01)
+    lhs.sparseLeftOuterJoin(that = rightHS, thatNumKeys = 4)
+    lhs.sparseRightOuterJoin(that = rightHS, thatNumKeys = 2)
+    lhs.cogroup(that = rightHS)
+    lhs.cogroup(that1 = rightHS, that2 = rightHS)
+    lhs.cogroup(that1 = rightHS, that2 = rightHS, that3 = rightHS)
+    lhs.groupWith(that = rightHS)
+    lhs.groupWith(that1 = rightHS, that2 = rightHS)
+    lhs.groupWith(that1 = rightHS, that2 = rightHS, that3 = rightHS)
+    lhs.sparseLookup(that = rightHS, thisNumKeys = 1)
+    lhs.sparseLookup(that1 = rightHS, that2 = rightHS, 3)
+
+    lhs.skewedJoin(that = rightHS)
+    lhs.skewedLeftJoin(that = rightHS)
+    lhs.skewedFullOuterJoin(that = rightHS)
+
+    lhs.hashJoin(that = rightHS)
+    lhs.hashFullOuterJoin(that = rightHS)
+    lhs.hashLeftJoin(that = rightHS)
+    lhs.hashIntersectByKey(that = rightHS.map(a => a._1))
+  }
+
+  def example(lhs: SCollection[(Int, String)], right: SCollection[String]): Unit = {
+    def hashLeftJoin(lhs: SCollection[(Int, String)]
+    ): SCollection[(Int, (String, Option[String]))]  =  {
+      lhs.hashLeftJoin(that = right.map(a => (a.length, a)))
+    }
 
     def sparseOuterJoin(a: String): Int =
       a.length
@@ -35,7 +64,7 @@ object FixJoinNames {
     def skewedLeftJoin(that: String): Int =
       that.length
 
-    hashLeftJoin("test")
+    hashLeftJoin(lhs)
     sparseOuterJoin("test")
     skewedLeftJoin("test")
   }

--- a/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -11,23 +11,20 @@ object FixJoinNames {
     lhs: SCollection[(Int, String)],
     rhs: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
+    lhs.leftOuterJoin(rhs)
     lhs.hashLeftJoin(rhs)
     lhs.sparseOuterJoin(rhs, 3)
     lhs.skewedLeftJoin(rhs)
   }
 
-  def example(): Unit = {
-    def hashLeftJoin(a: String): Int =
-      a.length
-
-    def sparseOuterJoin(a: String): Int =
-      a.length
-
-    def skewedLeftJoin(that: String): Int =
-      that.length
-
-    hashLeftJoin("test")
-    sparseOuterJoin("test")
-    skewedLeftJoin("test")
+  def changeNamesAndArgs(
+    lhs: SCollection[(Int, String)],
+    rhs: SCollection[(Int, String)]
+  ): SCollection[(Int, (String, Option[String]))] = {
+    lhs.leftOuterJoin(that = rhs)
+    lhs.hashLeftJoin(that = rhs)
+    lhs.sparseOuterJoin(that = rhs, 3)
+    lhs.sparseOuterJoin(that = rhs, thatNumKeys = 3)
+    lhs.skewedLeftJoin(that = rhs)
   }
 }

--- a/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/input-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -16,7 +16,9 @@ object FixJoinNames {
     lhs.skewedLeftJoin(rhs)
   }
 
-  def changeNamesAndArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]
+  def changeNamesAndArgs(
+    lhs: SCollection[(Int, String)],
+    rightHS: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
     lhs.hashLeftJoin(that = rightHS)
     lhs.sparseOuterJoin(that = rightHS, 3)
@@ -24,8 +26,7 @@ object FixJoinNames {
     lhs.skewedLeftJoin(that = rightHS)
   }
 
-  def changeArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]
-  ): Unit = {
+  def changeArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]): Unit = {
     lhs.join(that = rightHS)
     lhs.fullOuterJoin(that = rightHS)
     lhs.leftOuterJoin(that = rightHS)
@@ -53,10 +54,10 @@ object FixJoinNames {
   }
 
   def example(lhs: SCollection[(Int, String)], right: SCollection[String]): Unit = {
-    def hashLeftJoin(lhs: SCollection[(Int, String)]
-    ): SCollection[(Int, (String, Option[String]))]  =  {
+    def hashLeftJoin(
+      lhs: SCollection[(Int, String)]
+    ): SCollection[(Int, (String, Option[String]))] =
       lhs.hashLeftJoin(that = right.map(a => (a.length, a)))
-    }
 
     def sparseOuterJoin(a: String): Int =
       a.length

--- a/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -13,7 +13,9 @@ object FixJoinNames {
     lhs.skewedLeftOuterJoin(rhs)
   }
 
-  def changeNamesAndArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]
+  def changeNamesAndArgs(
+    lhs: SCollection[(Int, String)],
+    rightHS: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
     lhs.hashLeftOuterJoin(rhs = rightHS)
     lhs.sparseFullOuterJoin(rhs = rightHS, 3)
@@ -21,8 +23,7 @@ object FixJoinNames {
     lhs.skewedLeftOuterJoin(rhs = rightHS)
   }
 
-  def changeArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]
-  ): Unit = {
+  def changeArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]): Unit = {
     lhs.join(rhs = rightHS)
     lhs.fullOuterJoin(rhs = rightHS)
     lhs.leftOuterJoin(rhs = rightHS)
@@ -50,10 +51,10 @@ object FixJoinNames {
   }
 
   def example(lhs: SCollection[(Int, String)], right: SCollection[String]): Unit = {
-    def hashLeftJoin(lhs: SCollection[(Int, String)]
-    ): SCollection[(Int, (String, Option[String]))]  =  {
+    def hashLeftJoin(
+      lhs: SCollection[(Int, String)]
+    ): SCollection[(Int, (String, Option[String]))] =
       lhs.hashLeftOuterJoin(rhs = right.map(a => (a.length, a)))
-    }
 
     def sparseOuterJoin(a: String): Int =
       a.length

--- a/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -8,7 +8,6 @@ object FixJoinNames {
     lhs: SCollection[(Int, String)],
     rhs: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
-    lhs.leftOuterJoin(rhs)
     lhs.hashLeftOuterJoin(rhs)
     lhs.sparseFullOuterJoin(rhs, 3)
     lhs.skewedLeftOuterJoin(rhs)
@@ -26,17 +25,14 @@ object FixJoinNames {
   }
 
   def example(): Unit = {
-    def hashLeftJoin(a: String): Int =  {
+    def hashLeftJoin(a: String): Int =
       a.length
-    }
 
-    def sparseOuterJoin(a: String): Int = {
+    def sparseOuterJoin(a: String): Int =
       a.length
-    }
 
-    def skewedLeftJoin(that: String): Int = {
+    def skewedLeftJoin(that: String): Int =
       that.length
-    }
 
     hashLeftJoin("test")
     sparseOuterJoin("test")

--- a/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -13,15 +13,13 @@ object FixJoinNames {
     lhs.skewedLeftOuterJoin(rhs)
   }
 
-  def changeNamesAndArgs(
-    lhs: SCollection[(Int, String)],
-    rhs: SCollection[(Int, String)]
+  def changeNamesAndArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
-    lhs.leftOuterJoin(that = rhs)
-    lhs.hashLeftOuterJoin(right = rhs)
-    lhs.sparseFullOuterJoin(right = rhs, 3)
-    lhs.sparseFullOuterJoin(right = rhs, thatNumKeys = 3)
-    lhs.skewedLeftOuterJoin(right = rhs)
+    lhs.leftOuterJoin(that = rightHS)
+    lhs.hashLeftOuterJoin(rhs = rightHS)
+    lhs.sparseFullOuterJoin(rhs = rightHS, 3)
+    lhs.sparseFullOuterJoin(rhs = rightHS, rhsNumKeys = 3)
+    lhs.skewedLeftOuterJoin(rhs = rightHS)
   }
 
   def example(): Unit = {

--- a/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -24,4 +24,22 @@ object FixJoinNames {
     lhs.sparseFullOuterJoin(right = rhs, thatNumKeys = 3)
     lhs.skewedLeftOuterJoin(right = rhs)
   }
+
+  def example(): Unit = {
+    def hashLeftJoin(a: String): Int =  {
+      a.length
+    }
+
+    def sparseOuterJoin(a: String): Int = {
+      a.length
+    }
+
+    def skewedLeftJoin(that: String): Int = {
+      that.length
+    }
+
+    hashLeftJoin("test")
+    sparseOuterJoin("test")
+    skewedLeftJoin("test")
+  }
 }

--- a/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -15,16 +15,45 @@ object FixJoinNames {
 
   def changeNamesAndArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
-    lhs.leftOuterJoin(that = rightHS)
     lhs.hashLeftOuterJoin(rhs = rightHS)
     lhs.sparseFullOuterJoin(rhs = rightHS, 3)
     lhs.sparseFullOuterJoin(rhs = rightHS, rhsNumKeys = 3)
     lhs.skewedLeftOuterJoin(rhs = rightHS)
   }
 
-  def example(): Unit = {
-    def hashLeftJoin(a: String): Int =
-      a.length
+  def changeArgs(lhs: SCollection[(Int, String)], rightHS: SCollection[(Int, String)]
+  ): Unit = {
+    lhs.join(rhs = rightHS)
+    lhs.fullOuterJoin(rhs = rightHS)
+    lhs.leftOuterJoin(rhs = rightHS)
+    lhs.rightOuterJoin(rhs = rightHS)
+    lhs.sparseFullOuterJoin(rhs = rightHS, rhsNumKeys = 4L, fpProb = 0.01)
+    lhs.sparseLeftOuterJoin(rhs = rightHS, rhsNumKeys = 4)
+    lhs.sparseRightOuterJoin(rhs = rightHS, rhsNumKeys = 2)
+    lhs.cogroup(rhs = rightHS)
+    lhs.cogroup(rhs1 = rightHS, rhs2 = rightHS)
+    lhs.cogroup(rhs1 = rightHS, rhs2 = rightHS, rhs3 = rightHS)
+    lhs.groupWith(rhs = rightHS)
+    lhs.groupWith(rhs1 = rightHS, rhs2 = rightHS)
+    lhs.groupWith(rhs1 = rightHS, rhs2 = rightHS, rhs3 = rightHS)
+    lhs.sparseLookup(rhs = rightHS, thisNumKeys = 1)
+    lhs.sparseLookup(rhs1 = rightHS, rhs2 = rightHS, 3)
+
+    lhs.skewedJoin(rhs = rightHS)
+    lhs.skewedLeftOuterJoin(rhs = rightHS)
+    lhs.skewedFullOuterJoin(rhs = rightHS)
+
+    lhs.hashJoin(rhs = rightHS)
+    lhs.hashFullOuterJoin(rhs = rightHS)
+    lhs.hashLeftOuterJoin(rhs = rightHS)
+    lhs.hashIntersectByKey(rhs = rightHS.map(a => a._1))
+  }
+
+  def example(lhs: SCollection[(Int, String)], right: SCollection[String]): Unit = {
+    def hashLeftJoin(lhs: SCollection[(Int, String)]
+    ): SCollection[(Int, (String, Option[String]))]  =  {
+      lhs.hashLeftOuterJoin(rhs = right.map(a => (a.length, a)))
+    }
 
     def sparseOuterJoin(a: String): Int =
       a.length
@@ -32,7 +61,7 @@ object FixJoinNames {
     def skewedLeftJoin(that: String): Int =
       that.length
 
-    hashLeftJoin("test")
+    hashLeftJoin(lhs)
     sparseOuterJoin("test")
     skewedLeftJoin("test")
   }

--- a/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -4,7 +4,9 @@ import com.spotify.scio.values.SCollection
 
 object FixJoinNames {
 
-  def changeJoinNames(lhs: SCollection[(Int, String)], rhs: SCollection[(Int, String)]
+  def changeJoinNames(
+    lhs: SCollection[(Int, String)],
+    rhs: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
     lhs.hashLeftOuterJoin(rhs)
     lhs.sparseFullOuterJoin(rhs, 3)
@@ -12,17 +14,14 @@ object FixJoinNames {
   }
 
   def example(): Unit = {
-    def hashLeftJoin(a: String): Int =  {
+    def hashLeftJoin(a: String): Int =
       a.length
-    }
 
-    def sparseOuterJoin(a: String): Int = {
+    def sparseOuterJoin(a: String): Int =
       a.length
-    }
 
-    def skewedLeftJoin(that: String): Int = {
+    def skewedLeftJoin(that: String): Int =
       that.length
-    }
 
     hashLeftJoin("test")
     sparseOuterJoin("test")

--- a/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
+++ b/scalafix/output-0_8/src/main/scala/fix/FixJoinNames.scala
@@ -8,23 +8,20 @@ object FixJoinNames {
     lhs: SCollection[(Int, String)],
     rhs: SCollection[(Int, String)]
   ): SCollection[(Int, (String, Option[String]))] = {
+    lhs.leftOuterJoin(rhs)
     lhs.hashLeftOuterJoin(rhs)
     lhs.sparseFullOuterJoin(rhs, 3)
     lhs.skewedLeftOuterJoin(rhs)
   }
 
-  def example(): Unit = {
-    def hashLeftJoin(a: String): Int =
-      a.length
-
-    def sparseOuterJoin(a: String): Int =
-      a.length
-
-    def skewedLeftJoin(that: String): Int =
-      that.length
-
-    hashLeftJoin("test")
-    sparseOuterJoin("test")
-    skewedLeftJoin("test")
+  def changeNamesAndArgs(
+    lhs: SCollection[(Int, String)],
+    rhs: SCollection[(Int, String)]
+  ): SCollection[(Int, (String, Option[String]))] = {
+    lhs.leftOuterJoin(that = rhs)
+    lhs.hashLeftOuterJoin(right = rhs)
+    lhs.sparseFullOuterJoin(right = rhs, 3)
+    lhs.sparseFullOuterJoin(right = rhs, thatNumKeys = 3)
+    lhs.skewedLeftOuterJoin(right = rhs)
   }
 }

--- a/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
+++ b/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
@@ -193,7 +193,7 @@ final class ConsistenceJoinNames extends SemanticRule("ConsistenceJoinNames") {
       case _ => false
     }
 
-  private def renameNamedArgs(args: List[Term]): Patch = {
+  private def renameNamedArgs(args: List[Term]): Patch =
     args.collect {
       case Term.Assign(lhs, _) =>
         lhs match {
@@ -208,5 +208,4 @@ final class ConsistenceJoinNames extends SemanticRule("ConsistenceJoinNames") {
         }
       case _ => Patch.empty
     }.asPatch
-  }
 }

--- a/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
+++ b/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
@@ -166,6 +166,23 @@ final class ConsistenceJoinNames extends SemanticRule("ConsistenceJoinNames") {
                 Patch.replaceTree(t, "skewedLeftOuterJoin") + renameNamedArgs(args)
               case t @ Term.Name("sparseOuterJoin") if (expectedType(qual, pairedScol)) =>
                 Patch.replaceTree(t, "sparseFullOuterJoin") + renameNamedArgs(args)
+              case _ @ (Term.Name("join") |
+                   Term.Name("fullOuterJoin") |
+                   Term.Name("leftOuterJoin") |
+                   Term.Name("rightOuterJoin") |
+                   Term.Name("sparseLeftOuterJoin") |
+                   Term.Name("sparseRightOuterJoin") |
+                   Term.Name("cogroup") |
+                   Term.Name("groupWith") |
+                   Term.Name("sparseLookup")) if (expectedType(qual, pairedScol)) =>
+                renameNamedArgs(args)
+              case _ @ (Term.Name("skewedJoin") |
+                   Term.Name("skewedFullOuterJoin")) if (expectedType(qual, pairedSkewedScol)) =>
+                renameNamedArgs(args)
+              case _ @ (Term.Name("hashJoin") |
+                   Term.Name("hashFullOuterJoin") |
+                   Term.Name("hashIntersectByKey")) if (expectedType(qual, pairedHashScol)) =>
+                renameNamedArgs(args)
               case _ => Patch.empty
             }
           case _ => Patch.empty
@@ -202,7 +219,9 @@ final class ConsistenceJoinNames extends SemanticRule("ConsistenceJoinNames") {
          case t2 @ Term.Name("that2") => Patch.replaceTree(t2, "rhs2")
          case t2 @ Term.Name("that3") => Patch.replaceTree(t2, "rhs3")
          case t2 @ Term.Name("thatNumKeys") => Patch.replaceTree(t2, "rhsNumKeys")
-         case _ => Patch.empty
+         case s =>
+           println(s)
+           Patch.empty
        }
      case _ => Patch.empty
    }.asPatch

--- a/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
+++ b/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
@@ -155,17 +155,17 @@ final class ConsistenceJoinNames extends SemanticRule("ConsistenceJoinNames") {
   private val pairedScol = "com/spotify/scio/values/PairSCollectionFunctions#"
 
   override def fix(implicit doc: SemanticDocument): Patch = {
-    doc.tree.collect {
+    doc.tree.collect{
       case Term.Apply(fun, args) =>
         fun match {
           case Term.Select(qual, name) =>
             name match {
-              case t @ Term.Name("hashLeftJoin") if (expectedType(qual, pairedHashScol)) =>
+              case t @ Term.Name("hashLeftJoin") if(expectedType(qual, pairedHashScol)) =>
                 Patch.replaceTree(t, "hashLeftOuterJoin") + renameNamedArgs(args)
-              case t @ Term.Name("skewedLeftJoin") if (expectedType(qual, pairedSkewedScol)) =>
+              case t @ Term.Name("skewedLeftJoin") if(expectedType(qual, pairedSkewedScol))=>
                 Patch.replaceTree(t, "skewedLeftOuterJoin") + renameNamedArgs(args)
               case t @ Term.Name("sparseOuterJoin") if (expectedType(qual, pairedScol)) =>
-                Patch.replaceTree(t, "sparseFullOuterJoin")
+                Patch.replaceTree(t, "sparseFullOuterJoin") + renameNamedArgs(args)
               case _ => Patch.empty
             }
           case _ => Patch.empty
@@ -192,13 +192,19 @@ final class ConsistenceJoinNames extends SemanticRule("ConsistenceJoinNames") {
       case _ => false
     }
 
-  private def renameNamedArgs(args: List[Term]): Patch =
-    args.collect {
-      case Term.Assign(lhs, rhs) =>
-        lhs match {
-          case t2 @ Term.Name("that") => Patch.replaceTree(t2, "right")
-          case _                      => Patch.empty
-        }
-      case _ => Patch.empty
-    }.asPatch
+
+  private def renameNamedArgs(args: List[Term]): Patch = {
+   args.collect{
+     case Term.Assign(lhs, _) =>
+       lhs match {
+         case t2 @ Term.Name("that") => Patch.replaceTree(t2, "rhs")
+         case t2 @ Term.Name("that1") => Patch.replaceTree(t2, "rhs1")
+         case t2 @ Term.Name("that2") => Patch.replaceTree(t2, "rhs2")
+         case t2 @ Term.Name("that3") => Patch.replaceTree(t2, "rhs3")
+         case t2 @ Term.Name("thatNumKeys") => Patch.replaceTree(t2, "rhsNumKeys")
+         case _ => Patch.empty
+       }
+     case _ => Patch.empty
+   }.asPatch
+  }
 }

--- a/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
+++ b/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
@@ -156,16 +156,16 @@ final class ConsistenceJoinNames extends SemanticRule("ConsistenceJoinNames") {
 
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
-      case t @ Term.Apply(fun, args) =>
+      case Term.Apply(fun, args) =>
         fun match {
-          case t2 @ Term.Select(qual, name) =>
+          case Term.Select(qual, name) =>
             name match {
-              case t3 @ Term.Name("hashLeftJoin") if (expectedType(qual, pairedHashScol)) =>
-                Patch.replaceTree(t3, "hashLeftOuterJoin") + renameNamedArgs(args)
-              case t3 @ Term.Name("skewedLeftJoin") if (expectedType(qual, pairedSkewedScol)) =>
-                Patch.replaceTree(t3, "skewedLeftOuterJoin") + renameNamedArgs(args)
-              case t3 @ Term.Name("sparseOuterJoin") if (expectedType(qual, pairedScol)) =>
-                Patch.replaceTree(t3, "sparseFullOuterJoin") + renameNamedArgs(args)
+              case t @ Term.Name("hashLeftJoin") if (expectedType(qual, pairedHashScol)) =>
+                Patch.replaceTree(t, "hashLeftOuterJoin") + renameNamedArgs(args)
+              case t @ Term.Name("skewedLeftJoin") if (expectedType(qual, pairedSkewedScol)) =>
+                Patch.replaceTree(t, "skewedLeftOuterJoin") + renameNamedArgs(args)
+              case t @ Term.Name("sparseOuterJoin") if (expectedType(qual, pairedScol)) =>
+                Patch.replaceTree(t, "sparseFullOuterJoin") + renameNamedArgs(args)
               case _ => Patch.empty
             }
           case _ => Patch.empty
@@ -189,10 +189,7 @@ final class ConsistenceJoinNames extends SemanticRule("ConsistenceJoinNames") {
         typ == Symbol(typStr)
       case ValueSignature(AnnotatedType(_, TypeRef(_, typ, _))) =>
         typ == Symbol(typStr)
-      case str =>
-        println(s"typStr: [$typStr]")
-        println(s"Str: [${str.structure}]")
-        false
+      case _ => false
     }
 
   private def renameNamedArgs(args: List[Term]): Patch =

--- a/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
+++ b/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
@@ -165,7 +165,7 @@ final class ConsistenceJoinNames extends SemanticRule("ConsistenceJoinNames") {
               case t @ Term.Name("skewedLeftJoin") if (expectedType(qual, pairedSkewedScol)) =>
                 Patch.replaceTree(t, "skewedLeftOuterJoin") + renameNamedArgs(args)
               case t @ Term.Name("sparseOuterJoin") if (expectedType(qual, pairedScol)) =>
-                Patch.replaceTree(t, "sparseFullOuterJoin") + renameNamedArgs(args)
+                Patch.replaceTree(t, "sparseFullOuterJoin")
               case _ => Patch.empty
             }
           case _ => Patch.empty

--- a/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
+++ b/scalafix/rules/src/main/scala/fix/MigrateV0_8.scala
@@ -150,23 +150,50 @@ final class FixBigQueryDeprecations extends SemanticRule("FixBigQueryDeprecation
 }
 
 final class ConsistenceJoinNames extends SemanticRule("ConsistenceJoinNames") {
-  override def fix(implicit doc: _root_.scalafix.v1.SemanticDocument): Patch = {
+  private val pairedHashScol = "com/spotify/scio/values/PairHashSCollectionFunctions#"
+  private val pairedSkewedScol = "com/spotify/scio/values/PairSkewedSCollectionFunctions#"
+  private val pairedScol = "com/spotify/scio/values/PairSCollectionFunctions#"
+
+  override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
       case t @ Term.Apply(fun, args) =>
         fun match {
           case t2 @ Term.Select(qual, name) =>
             name match {
-              case t3 @ Term.Name("hashLeftJoin") =>
+              case t3 @ Term.Name("hashLeftJoin") if (expectedType(qual, pairedHashScol)) =>
                 Patch.replaceTree(t3, "hashLeftOuterJoin") + renameNamedArgs(args)
-              case t3 @ Term.Name("skewedLeftJoin") =>
+              case t3 @ Term.Name("skewedLeftJoin") if (expectedType(qual, pairedSkewedScol)) =>
                 Patch.replaceTree(t3, "skewedLeftOuterJoin") + renameNamedArgs(args)
-              case t3 @ Term.Name("sparseOuterJoin") =>
+              case t3 @ Term.Name("sparseOuterJoin") if (expectedType(qual, pairedScol)) =>
                 Patch.replaceTree(t3, "sparseFullOuterJoin") + renameNamedArgs(args)
               case _ => Patch.empty
             }
+          case _ => Patch.empty
         }
     }
   }.asPatch
+
+  private def renameNamedArgs(args: List[Term]): Patch =
+    args.collect {
+      case Term.Assign(lhs, rhs) =>
+        lhs match {
+          case t2 @ Term.Name("that") => Patch.replaceTree(t2, "right")
+          case _                      => Patch.empty
+        }
+      case _ => Patch.empty
+    }.asPatch
+
+  private def expectedType(qual: Term, typStr: String)(implicit doc: SemanticDocument): Boolean =
+    qual.symbol.info.get.signature match {
+      case MethodSignature(_, _, TypeRef(_, typ, _)) =>
+        typ == Symbol(typStr)
+      case ValueSignature(AnnotatedType(_, TypeRef(_, typ, _))) =>
+        typ == Symbol(typStr)
+      case str =>
+        println(s"typStr: [$typStr]")
+        println(s"Str: [${str.structure}]")
+        false
+    }
 
   private def renameNamedArgs(args: List[Term]): Patch =
     args.collect {


### PR DESCRIPTION
Scala fix rule to handle
-  `that` -> `rhs` 
- `that1` -> `rhs1`
- `that2` -> `rhs2`
- `that3` -> `rhs3`
- `thatNumKeys` -> `rhsNumKeys` 
