### PR TITLE
Fix typo in Usage comments

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/DebuggingWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/DebuggingWordCount.scala
@@ -18,7 +18,7 @@
 // Example: Word Count Example with Assertions
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.DebuggingWordCount
+// `sbt "runMain com.spotify.scio.examples.DebuggingWordCount
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/MinimalWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/MinimalWordCount.scala
@@ -18,7 +18,7 @@
 // Example: Minimal Word Count Example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.MinimalWordCount
+// `sbt "runMain com.spotify.scio.examples.MinimalWordCount
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/minimal_wordcount"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/MinimalWordCountTypedArguments.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/MinimalWordCountTypedArguments.scala
@@ -18,7 +18,7 @@
 // Example: Minimal Word Count Example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.MinimalWordCount
+// `sbt "runMain com.spotify.scio.examples.MinimalWordCount
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/minimal_wordcount"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/WindowedWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/WindowedWordCount.scala
@@ -18,7 +18,7 @@
 // Example: Word Count Example with Windowing
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.WindowedWordCount
+// `sbt "runMain com.spotify.scio.examples.WindowedWordCount
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/WordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/WordCount.scala
@@ -18,7 +18,7 @@
 // Example: Word Count Example with Metrics
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.WordCount
+// `sbt "runMain com.spotify.scio.examples.WordCount
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/AutoComplete.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/AutoComplete.scala
@@ -18,7 +18,7 @@
 // Example: AutoComplete lines of text
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.complete.AutoComplete
+// `sbt "runMain com.spotify.scio.examples.complete.AutoComplete
 // --project=[PROJECT] --runner=DataflowPRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --outputToBigqueryTable=true --outputToDatastore=false --output=[DATASET].auto_complete"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/StreamingWordExtract.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/StreamingWordExtract.scala
@@ -18,7 +18,7 @@
 // Example: Streaming Word Extract
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.complete.StreamingWordExtract
+// `sbt "runMain com.spotify.scio.examples.complete.StreamingWordExtract
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=[DATASET].streaming_word_extract"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TfIdf.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TfIdf.scala
@@ -18,7 +18,7 @@
 // Example: Compute TF-IDF from a Text Corpus
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.complete.TfIdf
+// `sbt "runMain com.spotify.scio.examples.complete.TfIdf
 // --project=[PROJECT] --runner=DataflowPRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/?*.txt
 // --output=gs://[BUCKET]/[PATH]/tf_idf"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TopWikipediaSessions.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TopWikipediaSessions.scala
@@ -18,7 +18,7 @@
 // Example: Top Wikipedia Sessions
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.complete.TopWikipediaSessions
+// `sbt "runMain com.spotify.scio.examples.complete.TopWikipediaSessions
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/wikipedia_edits/wiki_data-*.json
 // --output=gs://[BUCKET]/[PATH]/top_wikipedia_sessions"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficMaxLaneFlow.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficMaxLaneFlow.scala
@@ -18,7 +18,7 @@
 // Example: Traffic max lane flow computation from sensor data
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.complete.TrafficMaxLaneFlow
+// `sbt "runMain com.spotify.scio.examples.complete.TrafficMaxLaneFlow
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/traffic_sensor/Freeways-5Minaa2010-01-01_to_2010-02-15_test2.csv
 // --output=[DATASET].traffic_max_lane_flow"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficRoutes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficRoutes.scala
@@ -18,7 +18,7 @@
 // Example: Traffic routes based on traffic sensor data
 // Usage
 
-// `sbt runMain "com.spotify.scio.examples.complete.TrafficRoutes
+// `sbt "runMain com.spotify.scio.examples.complete.TrafficRoutes
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/traffic_sensor/Freeways-5Minaa2010-01-01_to_2010-02-15_test2.csv
 // --output=[DATASET].traffic_routes"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/GameStats.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/GameStats.scala
@@ -19,7 +19,7 @@
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.complete.game.GameStats
+// `sbt "runMain com.spotify.scio.examples.complete.game.GameStats
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --fixedWindowDuration=60
 // --sessionGap=5

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/HourlyTeamScore.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/HourlyTeamScore.scala
@@ -19,7 +19,7 @@
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.complete.game.HourlyTeamScore
+// `sbt "runMain com.spotify.scio.examples.complete.game.HourlyTeamScore
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --windowDuration=60
 // --startMin=2018-05-13-00-00

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/LeaderBoard.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/LeaderBoard.scala
@@ -19,7 +19,7 @@
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.complete.game.LeaderBoard
+// `sbt "runMain com.spotify.scio.examples.complete.game.LeaderBoard
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --teamWindowDuration=60
 // --allowedLateness=120

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/UserScore.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/UserScore.scala
@@ -19,7 +19,7 @@
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.complete.game.UserScore
+// `sbt "runMain com.spotify.scio.examples.complete.game.UserScore
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=bq://[PROJECT]/[DATASET]/mobile_game_user_score"`
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/BigQueryTornadoes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/BigQueryTornadoes.scala
@@ -18,7 +18,7 @@
 // Example: BigQuery Tornadoes Example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.cookbook.BigQueryTornadoes
+// `sbt "runMain com.spotify.scio.examples.cookbook.BigQueryTornadoes
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=clouddataflow-readonly:samples.weather_stations
 // --output=[DATASET].bigquery_tornadoes"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/CombinePerKeyExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/CombinePerKeyExamples.scala
@@ -18,7 +18,7 @@
 // Example: Combine Per Key Example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.cookbook.CombinePerKeyExamples
+// `sbt "runMain com.spotify.scio.examples.cookbook.CombinePerKeyExamples
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=[DATASET].combine_per_key_examples"`
 package com.spotify.scio.examples.cookbook

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/DistinctByKeyExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/DistinctByKeyExample.scala
@@ -18,7 +18,7 @@
 // Example: Distinct With RepresentativeValue Example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.cookbook.DistinctWithRepresentativeValueFnExample
+// `sbt "runMain com.spotify.scio.examples.cookbook.DistinctWithRepresentativeValueFnExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=[DATASET].distinct_by_key_example"`
 package com.spotify.scio.examples.cookbook

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/DistinctExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/DistinctExample.scala
@@ -18,7 +18,7 @@
 // Example: Distinct Example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.cookbook.DistinctExample
+// `sbt "runMain com.spotify.scio.examples.cookbook.DistinctExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=gs://[BUCKET]/output/path"`
 package com.spotify.scio.examples.cookbook

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/FilterExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/FilterExamples.scala
@@ -18,7 +18,7 @@
 // Example: Filter Example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.cookbook.FilterExamples
+// `sbt "runMain com.spotify.scio.examples.cookbook.FilterExamples
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=[DATASET].filter_examples"`
 package com.spotify.scio.examples.cookbook

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/JoinExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/JoinExamples.scala
@@ -18,7 +18,7 @@
 // Example: Different Types of Joins
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.cookbook.JoinExamples
+// `sbt "runMain com.spotify.scio.examples.cookbook.JoinExamples
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=gs://[BUCKET]/[PATH]/join_examples"`
 package com.spotify.scio.examples.cookbook

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/MaxPerKeyExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/MaxPerKeyExamples.scala
@@ -18,7 +18,7 @@
 // Example: Max Per Key Example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.cookbook.MaxPerKeyExamples
+// `sbt "runMain com.spotify.scio.examples.cookbook.MaxPerKeyExamples
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=[DATASET].max_per_key_examples"`
 package com.spotify.scio.examples.cookbook

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/StorageBigQueryTornadoes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/StorageBigQueryTornadoes.scala
@@ -18,7 +18,7 @@
 // Example: Read using BigQuery Storage Read API.
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.StorageBigQueryTornadoes
+// `sbt "runMain com.spotify.scio.examples.extra.StorageBigQueryTornadoes
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=[PROJECT]:[DATASET].[TABLE]"`
 package com.spotify.scio.examples.cookbook

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/TriggerExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/TriggerExample.scala
@@ -18,7 +18,7 @@
 // Example: Trigger example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.cookbook.TriggerExample
+// `sbt "runMain com.spotify.scio.examples.cookbook.TriggerExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/traffic_sensor/Freeways-5Minaa2010-01-01_to_2010-02-15_test2.csv
 // --output=[DATASET].trigger_example"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AnnoyExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AnnoyExamples.scala
@@ -47,7 +47,7 @@ object AnnoyExamples {
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.AnnoyIndexSaveExample
+// `sbt "runMain com.spotify.scio.examples.extra.AnnoyIndexSaveExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 //--output=gs://[BUCKET]/[PATH]/annoy.tree"`
 object AnnoyIndexSaveExample {
@@ -68,7 +68,7 @@ object AnnoyIndexSaveExample {
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.AnnoySideInputExample
+// `sbt "runMain com.spotify.scio.examples.extra.AnnoySideInputExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://[BUCKET]/[PATH]/annoy.tree
 // --output=gs://[BUCKET]/[PATH]/otuput"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroExample.scala
@@ -18,7 +18,7 @@
 // Example: Read and Write specific and generic Avro records
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.AvroExample
+// `sbt "runMain com.spotify.scio.examples.extra.AvroExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=[INPUT].avro --output=[OUTPUT].avro --method=[METHOD]"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroInOut.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroInOut.scala
@@ -18,7 +18,7 @@
 // Example: Avro Input and Output
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.AvroInOut
+// `sbt "runMain com.spotify.scio.examples.extra.AvroInOut
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=[INPUT].avro --output=[OUTPUT].avro --method=[METHOD]"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BeamExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BeamExample.scala
@@ -18,7 +18,7 @@
 // Example: Mix Beam Java SDK and Scio Code
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.BeamExample
+// `sbt "runMain com.spotify.scio.examples.extra.BeamExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --inputTopic=[TOPIC] --outputTopic=[TOPIC]"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BigtableExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BigtableExample.scala
@@ -54,7 +54,7 @@ object BigtableExample {
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.BigtableWriteExample
+// `sbt "runMain com.spotify.scio.examples.extra.BigtableWriteExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --bigtableProjectId=[BIG_TABLE_PROJECT_ID]
@@ -100,7 +100,7 @@ object BigtableWriteExample {
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.BigtableReadExample
+// `sbt "runMain com.spotify.scio.examples.extra.BigtableReadExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --bigtableProjectId=[BIG_TABLE_PROJECT_ID]
 // --bigtableInstanceId=[BIG_TABLE_INSTANCE_ID]

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/CheckpointExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/CheckpointExample.scala
@@ -18,7 +18,7 @@
 // Example: Use Checkpoints to debug a long workflow
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.CheckpointExample
+// `sbt "runMain com.spotify.scio.examples.extra.CheckpointExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --checkpoint=gs://[CHECKPOINT_FILE] --output=[OUTPUT]"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/DistCacheExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/DistCacheExample.scala
@@ -18,7 +18,7 @@
 // Example: Distributed Cache Example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.DistCacheExample
+// `sbt "runMain com.spotify.scio.examples.extra.DistCacheExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/wikipedia_edits/wiki_data-*.json
 // --output=gs://[BUCKET]/[PATH]/dist_cache_example"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/DoFnExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/DoFnExample.scala
@@ -18,7 +18,7 @@
 // Example: Mix Beam DoFn and Scio
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.DoFnExample
+// `sbt "runMain com.spotify.scio.examples.extra.DoFnExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/do_fn_example"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/JavaConvertersExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/JavaConvertersExample.scala
@@ -18,7 +18,7 @@
 // Example: Java converters for various output formats
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.JavaConvertersExample
+// `sbt "runMain com.spotify.scio.examples.extra.JavaConvertersExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=gs://[OUTPUT] --converter=[CONVERTER]"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyAvroExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyAvroExample.scala
@@ -40,7 +40,7 @@ object MagnolifyAvroExample {
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.MagnolifyAvroWriteExample
+// `sbt "runMain com.spotify.scio.examples.extra.MagnolifyAvroWriteExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount-avro"`
@@ -65,7 +65,7 @@ object MagnolifyAvroWriteExample {
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.MagnolifyAvroReadExample
+// `sbt "runMain com.spotify.scio.examples.extra.MagnolifyAvroReadExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://[BUCKET]/[PATH]/wordcount-avro
 // --output=gs://[BUCKET]/[PATH]/wordcount"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyDatastoreExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyDatastoreExample.scala
@@ -41,7 +41,7 @@ object MagnolifyDatastoreExample {
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.MagnolifyDatastoreWriteExample
+// `sbt "runMain com.spotify.scio.examples.extra.MagnolifyDatastoreWriteExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=[PROJECT]"`
@@ -72,7 +72,7 @@ object MagnolifyDatastoreWriteExample {
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.MagnolifyDatastoreReadExample
+// `sbt "runMain com.spotify.scio.examples.extra.MagnolifyDatastoreReadExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=[PROJECT]
 // --output=gs://[BUCKET]/[PATH]/wordcount"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyTensorFlowExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyTensorFlowExample.scala
@@ -43,7 +43,7 @@ object MagnolifyTensorFlowExample {
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.MagnolifyTensorFlowWriteExample
+// `sbt "runMain com.spotify.scio.examples.extra.MagnolifyTensorFlowWriteExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount-tf"`
@@ -68,7 +68,7 @@ object MagnolifyTensorFlowWriteExample {
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.MagnolifyTensorFlowReadExample
+// `sbt "runMain com.spotify.scio.examples.extra.MagnolifyTensorFlowReadExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://[BUCKET]/[PATH]/wordcount-tf
 // --output=gs://[BUCKET]/[PATH]/wordcount"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MetricsExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MetricsExample.scala
@@ -18,7 +18,7 @@
 // Example: Metrics Example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.MetricsExample
+// `sbt "runMain com.spotify.scio.examples.extra.MetricsExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ProtobufExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ProtobufExample.scala
@@ -18,7 +18,7 @@
 // Example: Protocol Buffer Input and Output
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.ProtobufExample
+// `sbt "runMain com.spotify.scio.examples.extra.ProtobufExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://[INPUT].proto --output=gs://[OUTPUT].avro"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SafeFlatMapExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SafeFlatMapExample.scala
@@ -18,7 +18,7 @@
 // Example: SafeFlatMap usage
 
 // Usage:
-// `sbt runMain "com.spotify.scio.examples.extra.SafeFlatMapExample
+// `sbt "runMain com.spotify.scio.examples.extra.SafeFlatMapExample
 //  --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 //  --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 //  --output=gs://[BUCKET]/[PATH]/safe_flat_map"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SideInOutExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SideInOutExample.scala
@@ -18,7 +18,7 @@
 // Example: Side Input and Output Example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.SideInOutExample
+// `sbt "runMain com.spotify.scio.examples.extra.SideInOutExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --stopWords=[STOP_WORDS_URI]

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SingleGZipFileExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SingleGZipFileExample.scala
@@ -18,7 +18,7 @@
 // Example: Gzip File write
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.SingleGZipFileExample
+// `sbt "runMain com.spotify.scio.examples.extra.SingleGZipFileExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=[INPUT.txt] --output=[OUTPUT]"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/StatefulExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/StatefulExample.scala
@@ -18,7 +18,7 @@
 // Example: Stateful Processing
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.StatefulExample
+// `sbt "runMain com.spotify.scio.examples.extra.StatefulExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TableRowJsonInOut.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TableRowJsonInOut.scala
@@ -18,7 +18,7 @@
 // Example: BigQuery TableRow JSON Input and Output
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.TableRowJsonInOut
+// `sbt "runMain com.spotify.scio.examples.extra.TableRowJsonInOut
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/wikipedia_edits/wiki_data-*.json
 // --output=gs://[BUCKET]/[PATH]/wikipedia"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TapOutputExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TapOutputExample.scala
@@ -25,7 +25,7 @@ import com.spotify.scio._
 
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.TapOutputExample
+// `sbt "runMain com.spotify.scio.examples.extra.TapOutputExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=gs://[OUTPUT] --method=[METHOD]"`
 object TapOutputExample {

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TemplateExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TemplateExample.scala
@@ -21,7 +21,7 @@
 // Usage:
 
 // To upload the template:
-// `sbt runMain "com.spotify.scio.examples.extra.TemplateExample
+// `sbt "runMain com.spotify.scio.examples.extra.TemplateExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --stagingLocation=gs://[BUCKET]/staging --templateLocation=gs://[BUCKET]/TemplateExample"`
 
@@ -31,7 +31,7 @@
 //  outputTopic=projects/[PROJECT]/topics/[TOPIC]`
 
 // To run the job directly:
-// `sbt runMain "com.spotify.scio.examples.extra.TemplateExample
+// `sbt "runMain com.spotify.scio.examples.extra.TemplateExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --inputSub=projects/[PROJECT]/subscriptions/sub
 // --outputTopic=projects/[PROJECT]/topics/[TOPIC]"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TsvExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TsvExample.scala
@@ -25,7 +25,7 @@ import org.apache.beam.sdk.{io => beam}
 // ## Writing TSV data example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.TsvExampleWrite
+// `sbt "runMain com.spotify.scio.examples.extra.TsvExampleWrite
 //   --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 //   --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 //   --output=gs://[BUCKET]/[PATH]/wordcount"`
@@ -70,7 +70,7 @@ object TsvExampleWrite {
 // ## Reading TSV data example
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.TsvExampleRead
+// `sbt "runMain com.spotify.scio.examples.extra.TsvExampleRead
 //   --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 //   --input=gs://[BUCKET]/word_count_data.tsv
 //   --output=gs://[BUCKET]/[PATH]/word_count_sum"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedBigQueryTornadoes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedBigQueryTornadoes.scala
@@ -18,7 +18,7 @@
 // Example: Read and write using typed BigQuery API with annotated case classes
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.TypedBigQueryTornadoes
+// `sbt "runMain com.spotify.scio.examples.extra.TypedBigQueryTornadoes
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=[PROJECT]:[DATASET].[TABLE]"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedStorageBigQueryTornadoes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedStorageBigQueryTornadoes.scala
@@ -18,7 +18,7 @@
 // Example: Read using typed BigQuery Storage API with annotated case classes
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.TypedStorageBigQueryTornadoes
+// `sbt "runMain com.spotify.scio.examples.extra.TypedStorageBigQueryTornadoes
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=[PROJECT]:[DATASET].[TABLE]"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WordCountOrchestration.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WordCountOrchestration.scala
@@ -18,7 +18,7 @@
 // Example: Use Futures and Taps to orchestrate multiple jobs with dependencies
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.WordCountOrchestration
+// `sbt "runMain com.spotify.scio.examples.extra.WordCountOrchestration
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --output=gs://[BUCKET]/[PATH]/wordcount"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WordCountScioIO.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WordCountScioIO.scala
@@ -18,7 +18,7 @@
 // Example: Word Count Example with Metrics and ScioIO read/write
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.WordCountScioIO
+// `sbt "runMain com.spotify.scio.examples.extra.WordCountScioIO
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount"`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
@@ -18,7 +18,7 @@
 // Example: Demonstrates saveAsDynamic* methods
 // Usage:
 
-// `sbt runMain "com.spotify.scio.examples.extra.WriteDynamicExample
+// `sbt "runMain com.spotify.scio.examples.extra.WriteDynamicExample
 // --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[OUTPUT]"`


### PR DESCRIPTION
`runMain` has to be inside the quotation marks, or else sbt throws an error.