### PR TITLE
Assert FileStorage.isDone in MaterializeTap

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
@@ -30,6 +30,7 @@ import org.apache.avro.file.{DataFileReader, SeekableInput}
 import org.apache.avro.generic.GenericDatumReader
 import org.apache.avro.specific.SpecificDatumReader
 import org.apache.beam.sdk.io.FileSystems
+import org.apache.beam.sdk.io.fs.EmptyMatchTreatment
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata
 import org.apache.commons.compress.compressors.CompressorStreamFactory
 import org.apache.commons.io.IOUtils
@@ -43,7 +44,7 @@ private[scio] object FileStorage {
 
 private[scio] final class FileStorage(protected[scio] val path: String) {
   private def listFiles: Seq[Metadata] =
-    FileSystems.`match`(path).metadata().asScala
+    FileSystems.`match`(path, EmptyMatchTreatment.DISALLOW).metadata().asScala
 
   private def getObjectInputStream(meta: Metadata): InputStream =
     Channels.newInputStream(FileSystems.open(meta.resourceId()))

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1142,8 +1142,15 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   // =======================================================================
 
   /**
-   * Extract data from this SCollection as a `Future`. The `Future` will be completed once the
-   * pipeline completes successfully.
+   * Extract data from this SCollection as a closed [[Tap]]. The Tap will be available
+   * once the pipeline completes successfully. `.materialize()` must be called before
+   * the `ScioContext` is closed, as its implementation modifies the current pipeline graph.
+   *
+   * {{{
+   * val closedTap = sc.parallelize(1 to 10).materialize
+   * sc.run().waitUntilDone().tap(closedTap)
+   * }}}
+   *
    * @group output
    */
   def materialize(implicit coder: Coder[T]): ClosedTap[T] =


### PR DESCRIPTION
IMO, since the implementation of `materialize` is pretty opaque to the user, they may not realize it's actually modifying the pipeline graph to add a write operation, and call it after the context is closed (`sc.run().waitUntilDone().tap(data.materialize)`). this adds a check using `FileStorage.isDone` API so the user at least gets a clear error message instead of just an empty tap (actually, the avro file tap implementation has a bug when file list is empty, so user would just get a confusing strack trace)