### PR TITLE
Standardize transform names on SMB join/cogroup

### DIFF
--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -60,9 +60,11 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) {
   ): SCollection[(K, (L, R))] = {
     val t = SortedBucketIO.read(keyClass).of(lhs).and(rhs)
     val (tupleTagA, tupleTagB) = (lhs.getTupleTag, rhs.getTupleTag)
+    val tfName = self.tfName
 
     self
-      .wrap(self.applyInternal(t))
+      .wrap(self.pipeline.apply(s"SMB CoGroupByKey@$tfName", t))
+      .withName(tfName)
       .applyTransform(ParDo.of(new DoFn[KV[K, CoGbkResult], (K, (L, R))] {
         @ProcessElement
         private[smb] def processElement(
@@ -108,8 +110,11 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) {
       a.getTupleTag,
       b.getTupleTag
     )
+    val tfName = self.tfName
+
     self
-      .wrap(self.applyInternal(t))
+      .wrap(self.pipeline.apply(s"SMB CoGroupByKey@$tfName", t))
+      .withName(tfName)
       .map { kv =>
         val cgbkResult = kv.getValue
 
@@ -148,8 +153,11 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) {
       b.getTupleTag,
       c.getTupleTag
     )
+    val tfName = self.tfName
+
     self
-      .wrap(self.applyInternal(t))
+      .wrap(self.pipeline.apply(s"SMB CoGroupByKey@$tfName", t))
+      .withName(tfName)
       .map { kv =>
         val cgbkResult = kv.getValue
 
@@ -191,8 +199,11 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) {
       c.getTupleTag,
       d.getTupleTag
     )
+    val tfName = self.tfName
+
     self
-      .wrap(self.applyInternal(t))
+      .wrap(self.pipeline.apply(s"SMB CoGroupByKey@$tfName", t))
+      .withName(tfName)
       .map { kv =>
         val cgbkResult = kv.getValue
 


### PR DESCRIPTION
again, this is just to match what the regular `join`/`cogroup` operations do :)

`sc.sortMergeJoin(...)` in Dataflow:
<img width="215" alt="Screen Shot 2019-12-10 at 4 33 40 PM" src="https://user-images.githubusercontent.com/1360529/70570991-f2127280-1b6a-11ea-8416-b68f7d4285df.png">

`sc.withName("customNameJoin").sortMergeJoin(...)` in Dataflow:
<img width="210" alt="Screen Shot 2019-12-10 at 4 33 49 PM" src="https://user-images.githubusercontent.com/1360529/70571019-ffc7f800-1b6a-11ea-960c-88dd396736d9.png">

also verified for `sortMergeCoGroup()` ops 👍 