### PR TITLE
reduce randomSplit test flakiness, fix #2502

### DIFF
--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -358,24 +358,25 @@ class SCollectionTest extends PipelineSpec {
 
   it should "support randomSplit()" in {
     runWithContext { sc =>
-      def round(c: Long): Long = math.round(c / 100.0) * 100
-      val p1 = sc.parallelize(0 to 1000).randomSplit(Array(0.3, 0.7))
-      val p2 = sc.parallelize(0 to 1000).randomSplit(Array(0.2, 0.3, 0.5))
+      val total = 5000
+      def round(c: Long): Double = math.round(c * 10.0 / total) / 10.0
+      val p1 = sc.parallelize(0 to total).randomSplit(Array(0.3, 0.7))
+      val p2 = sc.parallelize(0 to total).randomSplit(Array(0.2, 0.3, 0.5))
       p1.length shouldBe 2
       p2.length shouldBe 3
-      p1(0).count.map(round) should containSingleValue(300L)
-      p1(1).count.map(round) should containSingleValue(700L)
-      p2(0).count.map(round) should containSingleValue(200L)
-      p2(1).count.map(round) should containSingleValue(300L)
-      p2(2).count.map(round) should containSingleValue(500L)
+      p1(0).count.map(round) should containSingleValue(0.3)
+      p1(1).count.map(round) should containSingleValue(0.7)
+      p2(0).count.map(round) should containSingleValue(0.2)
+      p2(1).count.map(round) should containSingleValue(0.3)
+      p2(2).count.map(round) should containSingleValue(0.5)
 
-      val (pa, pb) = sc.parallelize(0 to 1000).randomSplit(0.3)
-      val (pc, pd, pe) = sc.parallelize(0 to 1000).randomSplit(0.2, 0.3)
-      pa.count.map(round) should containSingleValue(300L)
-      pb.count.map(round) should containSingleValue(700L)
-      pc.count.map(round) should containSingleValue(200L)
-      pd.count.map(round) should containSingleValue(300L)
-      pe.count.map(round) should containSingleValue(500L)
+      val (pa, pb) = sc.parallelize(0 to 5000).randomSplit(0.3)
+      val (pc, pd, pe) = sc.parallelize(0 to 5000).randomSplit(0.2, 0.3)
+      pa.count.map(round) should containSingleValue(0.3)
+      pb.count.map(round) should containSingleValue(0.7)
+      pc.count.map(round) should containSingleValue(0.2)
+      pd.count.map(round) should containSingleValue(0.3)
+      pe.count.map(round) should containSingleValue(0.5)
     }
   }
 


### PR DESCRIPTION
The test works by splitting 1000 integers into 10% increments and round result count to closest 100, e.g. `sc.parallelize(1 to 1000).randomSplit(0.3, 0.7)` may produce splits of 299 & 701 elements.

It probably failed when a split falls on the other side of the boundary, e.g. 551 for a `0.5` split. Increasing the # of input might reduce that. Otherwise to fix this properly we'll have to introduce a random seed argument.