### PR TITLE
Remove mdoc annotation for macro-based Parquet.md examples

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1175,7 +1175,7 @@ lazy val siteSettings = Def.settings(
       .withFavicon("images/favicon.ico")
       .withColor("white", "indigo")
       .withLogo("images/logo.png")
-      .withCopyright("Copyright (C) 2019 Spotify AB")
+      .withCopyright("Copyright (C) 2020 Spotify AB")
       .withRepository(uri("https://github.com/spotify/scio"))
       .withSocial(uri("https://github.com/spotify"), uri("https://twitter.com/spotifyeng"))
   }

--- a/site/src/paradox/io/Parquet.md
+++ b/site/src/paradox/io/Parquet.md
@@ -8,7 +8,7 @@ When reading Parquet files, only Avro specific records are supported.
 
 To read a Parquet file with column projections and row predicates:
 
-```scala mdoc:reset:silent
+```scala
 import com.spotify.scio._
 import com.spotify.scio.parquet.avro._
 import com.spotify.scio.avro.TestRecord
@@ -36,7 +36,7 @@ Note that the result `TestRecord`s are not complete Avro objects. Only the proje
 
 Also note that `predicate` logic is only applied when reading actual Parquet files but not in `JobTest`. To retain the filter behavior while using mock input, it's recommend that you do the following.
 
-```scala mdoc:reset:silent
+```scala
 import com.spotify.scio._
 import com.spotify.scio.parquet.avro._
 import com.spotify.scio.avro.TestRecord


### PR DESCRIPTION
mdoc seems to have issues with code snippets that use the scala-reflect api, in this case the implementation for `Predicate` uses `WeakTypeTag` to invoke `getClassSchema()` on SpecificRecords. Maybe something we can dig into in the future, but for now it's blocking site release.