### PR TITLE
Correct deprecation documentation

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -47,7 +47,7 @@ final class SCollectionTableRowOps[T <: TableRow](private val self: SCollection[
    * Save this SCollection as a BigQuery table. Note that elements must be of type
    * [[com.google.api.services.bigquery.model.TableRow TableRow]].
    */
-  @deprecated("this method will be removed; use saveAsBigQuery(Table.Ref(table)) instead", "0.8.0")
+  @deprecated("this method will be removed; use saveAsBigQueryTable(Table.Ref(table)) instead", "0.8.0")
   def saveAsBigQuery(
     table: TableReference,
     schema: TableSchema,
@@ -71,7 +71,7 @@ final class SCollectionTableRowOps[T <: TableRow](private val self: SCollection[
    * Save this SCollection as a BigQuery table. Note that elements must be of type
    * [[com.google.api.services.bigquery.model.TableRow TableRow]].
    */
-  @deprecated("this method will be removed; use saveAsBigQuery(Table.Ref(table)) instead", "0.8.0")
+  @deprecated("this method will be removed; use saveAsBigQueryTable(Table.Ref(table)) instead", "0.8.0")
   def saveAsBigQuery(
     tableSpec: String,
     schema: TableSchema = BigQueryTable.WriteParam.DefaultSchema,
@@ -161,7 +161,7 @@ final class SCollectionTypedOps[T <: HasAnnotation](private val self: SCollectio
    * Save this SCollection as a BigQuery table. Note that element type `T` must be a case class
    * annotated with [[com.spotify.scio.bigquery.types.BigQueryType.toTable BigQueryType.toTable]].
    */
-  @deprecated("this method will be removed; use saveAsBigQuery(Table.Ref(table)) instead", "0.8.0")
+  @deprecated("this method will be removed; use saveAsBigQueryTable(Table.Ref(table)) instead", "0.8.0")
   def saveAsTypedBigQuery(
     table: TableReference,
     writeDisposition: WriteDisposition,
@@ -202,7 +202,7 @@ final class SCollectionTypedOps[T <: HasAnnotation](private val self: SCollectio
    *   .saveAsTypedBigQuery("myproject:samples.gsod")
    * }}}
    */
-  @deprecated("this method will be removed; use saveAsBigQuery(Table.Ref(table)) instead", "0.8.0")
+  @deprecated("this method will be removed; use saveAsBigQueryTable(Table.Ref(table)) instead", "0.8.0")
   def saveAsTypedBigQuery(
     tableSpec: String,
     writeDisposition: WriteDisposition = TableWriteParam.DefaultWriteDisposition,


### PR DESCRIPTION
Corrects 0.8 deprecation documentation to suggest `saveAsBigQueryTable` rather than `saveAsBigQuery`