### PR TITLE
Add Avro BigQuery logical types conversion

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableRow.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableRow.scala
@@ -26,6 +26,7 @@ import com.spotify.scio.extra.bigquery.Implicits.AvroConversionException
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericFixed, IndexedRecord}
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.BaseEncoding
+import org.joda.time.{DateTime, LocalDate, LocalTime}
 
 import scala.collection.JavaConverters._
 
@@ -62,6 +63,9 @@ trait ToTableRow {
       case x: util.Map[_, _]        => toTableRowFromMap(x.asScala, field)
       case x: java.lang.Iterable[_] => toTableRowFromIterable(x.asScala, field)
       case x: IndexedRecord         => toTableRow(x)
+      case x: LocalDate             => x
+      case x: LocalTime             => x
+      case x: DateTime              => x
       case _ =>
         throw AvroConversionException(
           s"ToTableRow conversion failed:" +

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableRow.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableRow.scala
@@ -69,7 +69,7 @@ trait ToTableRow {
     fieldValue match {
       case x: CharSequence          => x.toString
       case x: Enum[_]               => x.name()
-      case x: JBigDecimal           => x.unscaledValue().toString
+      case x: JBigDecimal           => x.toString
       case x: Number                => x
       case x: Boolean               => x
       case x: GenericFixed          => encodeByteArray(x.bytes(), field.schema())

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableRow.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableRow.scala
@@ -17,6 +17,7 @@
 
 package com.spotify.scio.extra.bigquery
 
+import java.math.{BigDecimal => JBigDecimal}
 import java.nio.ByteBuffer
 import java.util
 
@@ -68,6 +69,7 @@ trait ToTableRow {
     fieldValue match {
       case x: CharSequence          => x.toString
       case x: Enum[_]               => x.name()
+      case x: JBigDecimal           => x.unscaledValue().toString
       case x: Number                => x
       case x: Boolean               => x
       case x: GenericFixed          => encodeByteArray(x.bytes(), field.schema())

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableSchema.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableSchema.scala
@@ -161,6 +161,7 @@ trait ToTableSchema {
   }
 
   import org.apache.avro.LogicalTypes._
+
   /**
    * This uses avro logical type to Converted BigQuery mapping in the following table
    * https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#logical_types
@@ -174,6 +175,6 @@ trait ToTableSchema {
     case _: TimeMicros      => "INTEGER"
     case _: TimestampMillis => "TIMESTAMP"
     case _: TimestampMicros => "INTEGER"
-    case _  => throw new IllegalStateException(s"Unknown Logical Type: [${logicalType.getName}]")
+    case _                  => throw new IllegalStateException(s"Unknown Logical Type: [${logicalType.getName}]")
   }
 }

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableSchema.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableSchema.scala
@@ -161,13 +161,19 @@ trait ToTableSchema {
   }
 
   import org.apache.avro.LogicalTypes._
+  /**
+   * This uses avro logical type to Converted BigQuery mapping in the following table
+   * https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#logical_types
+   * Joda time library doesn't support microsecond level precision, therefore
+   * time-micros map to 'INTEGER' instead of 'TIME', for the same reason
+   * timestamp-micros map to 'INTEGER' instead of 'TIMESTAMP'
+   */
   private def typeFromLogicalType(logicalType: LogicalType): String = logicalType match {
     case _: Date            => "DATE"
     case _: TimeMillis      => "TIME"
-    case _: TimeMicros      => "TIME"
+    case _: TimeMicros      => "INTEGER"
     case _: TimestampMillis => "TIMESTAMP"
-    case _: TimestampMicros => "TIMESTAMP"
-    case _  => throw new IllegalStateException(s"Uknown Logical Type: ${logicalType.getName}")
+    case _: TimestampMicros => "INTEGER"
+    case _  => throw new IllegalStateException(s"Unknown Logical Type: [${logicalType.getName}]")
   }
-
 }

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableSchema.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableSchema.scala
@@ -175,6 +175,7 @@ trait ToTableSchema {
     case _: TimeMicros      => "INTEGER"
     case _: TimestampMillis => "TIMESTAMP"
     case _: TimestampMicros => "INTEGER"
+    case _: Decimal         => "NUMERIC"
     case _                  => throw new IllegalStateException(s"Unknown Logical Type: [${logicalType.getName}]")
   }
 }

--- a/scio-extra/src/test/avro/scio-avro-logical-type-example.avsc
+++ b/scio-extra/src/test/avro/scio-avro-logical-type-example.avsc
@@ -1,0 +1,19 @@
+{
+  "type": "record",
+  "namespace": "com.spotify.scio.extra.bigquery",
+  "name": "AvroExampleWithLogicalType",
+  "fields": [
+    {"name": "intField", "type": "int"},
+    {"name": "stringField", "type": "string"},
+    {"name": "booleanField", "type": "boolean"},
+    {"name": "longField", "type": "long"},
+    {"name": "doubleField", "type": "double"},
+    {"name": "floatField", "type": "float"},
+    {"name": "bytesField", "type": "bytes"},
+    {"name": "dateField", "type": { "type":  "int", "logicalType":  "date" }},
+    {"name": "timeMillisField", "type":{ "type":  "int", "logicalType":  "time-millis"}},
+    {"name": "timeMicrosField", "type": { "type":  "long", "logicalType":  "time-micros"}},
+    {"name": "timestampMillisField", "type": { "type":  "long", "logicalType":  "timestamp-millis"}},
+    {"name": "timestampMicrosField", "type": { "type":  "long", "logicalType":  "timestamp-micros"}}
+  ]
+}

--- a/scio-extra/src/test/avro/scio-avro-logical-type-example.avsc
+++ b/scio-extra/src/test/avro/scio-avro-logical-type-example.avsc
@@ -10,6 +10,7 @@
     {"name": "doubleField", "type": "double"},
     {"name": "floatField", "type": "float"},
     {"name": "bytesField", "type": "bytes"},
+    {"name":  "decimalField", "type": {"type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 2}},
     {"name": "dateField", "type": { "type":  "int", "logicalType":  "date" }},
     {"name": "timeMillisField", "type":{ "type":  "int", "logicalType":  "time-millis"}},
     {"name": "timeMicrosField", "type": { "type":  "long", "logicalType":  "time-micros"}},

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableRowTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableRowTest.scala
@@ -95,24 +95,24 @@ class ToTableRowTest extends AnyFlatSpec with Matchers with ToTableRow {
     toTableRow(genericRecord) shouldEqual expectedOutput
   }
 
-  val date = LocalDate.now()
-  val timeMillis: LocalTime = LocalTime.now()
+  val date = LocalDate.parse("2019-10-29")
+  val timeMillis: LocalTime = LocalTime.parse("01:24:52.211")
   val timeMicros = 1234L
-  val timestampMillis: DateTime = DateTime.now()
+  val timestampMillis: DateTime = DateTime.parse("2019-10-29T05:24:52.215")
   val timestampMicros = 4325L
 
   val expectedLogicalTypeOutput = new TableRow()
-    .set("booleanField", true)
     .set("intField", 1)
     .set("stringField", "someString")
+    .set("booleanField", true)
     .set("longField", 1L)
     .set("doubleField", 1.0)
     .set("floatField", 1f)
     .set("bytesField", BaseEncoding.base64Url().encode("someBytes".getBytes))
-    .set("dateField", date)
-    .set("timeMillisField", timeMillis)
+    .set("dateField", "2019-10-29")
+    .set("timeMillisField", "01:24:52.211000")
     .set("timeMicrosField", timeMicros)
-    .set("timestampMillisField", timestampMillis)
+    .set("timestampMillisField", "2019-10-29T05:24:52.215000")
     .set("timestampMicrosField", timestampMicros)
 
   "ToTableRowWithLogicalType" should "convert a SpecificRecord with Logical Types to TableRow" in {

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableRowTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableRowTest.scala
@@ -100,6 +100,8 @@ class ToTableRowTest extends AnyFlatSpec with Matchers with ToTableRow {
   val timeMicros = 1234L
   val timestampMillis: DateTime = DateTime.parse("2019-10-29T05:24:52.215")
   val timestampMicros = 4325L
+  import java.math.{BigDecimal => JBigDecimal}
+  val decimal = new JBigDecimal("3.14")
 
   val expectedLogicalTypeOutput = new TableRow()
     .set("intField", 1)
@@ -110,6 +112,7 @@ class ToTableRowTest extends AnyFlatSpec with Matchers with ToTableRow {
     .set("floatField", 1f)
     .set("bytesField", BaseEncoding.base64Url().encode("someBytes".getBytes))
     .set("dateField", "2019-10-29")
+    .set("decimalField", decimal.unscaledValue().toString)
     .set("timeMillisField", "01:24:52.211000")
     .set("timeMicrosField", timeMicros)
     .set("timestampMillisField", "2019-10-29T05:24:52.215000")
@@ -130,6 +133,7 @@ class ToTableRowTest extends AnyFlatSpec with Matchers with ToTableRow {
       .setTimeMicrosField(timeMicros)
       .setTimestampMillisField(timestampMillis)
       .setTimestampMicrosField(timestampMicros)
+      .setDecimalField(decimal)
       .build()
 
     toTableRow(specificRecord) shouldEqual expectedLogicalTypeOutput

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableRowTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableRowTest.scala
@@ -112,7 +112,7 @@ class ToTableRowTest extends AnyFlatSpec with Matchers with ToTableRow {
     .set("floatField", 1f)
     .set("bytesField", BaseEncoding.base64Url().encode("someBytes".getBytes))
     .set("dateField", "2019-10-29")
-    .set("decimalField", decimal.unscaledValue().toString)
+    .set("decimalField", decimal.toString)
     .set("timeMillisField", "01:24:52.211000")
     .set("timeMicrosField", timeMicros)
     .set("timestampMillisField", "2019-10-29T05:24:52.215000")

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableRowTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableRowTest.scala
@@ -17,6 +17,7 @@
 
 package com.spotify.scio.extra.bigquery
 
+import java.math.{BigDecimal => JBigDecimal}
 import java.nio.ByteBuffer
 
 import com.google.protobuf.ByteString
@@ -24,8 +25,8 @@ import com.spotify.scio.bigquery.TableRow
 import org.apache.avro.generic.GenericData
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.BaseEncoding
 import org.joda.time.{DateTime, LocalDate, LocalTime}
-import org.scalatest.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.JavaConverters._
 
@@ -100,7 +101,6 @@ class ToTableRowTest extends AnyFlatSpec with Matchers with ToTableRow {
   val timeMicros = 1234L
   val timestampMillis: DateTime = DateTime.parse("2019-10-29T05:24:52.215")
   val timestampMicros = 4325L
-  import java.math.{BigDecimal => JBigDecimal}
   val decimal = new JBigDecimal("3.14")
 
   val expectedLogicalTypeOutput = new TableRow()

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableRowTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableRowTest.scala
@@ -23,8 +23,9 @@ import com.google.protobuf.ByteString
 import com.spotify.scio.bigquery.TableRow
 import org.apache.avro.generic.GenericData
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.BaseEncoding
+import org.joda.time.{DateTime, LocalDate, LocalTime}
+import org.scalatest.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
 
 import scala.collection.JavaConverters._
 
@@ -92,5 +93,45 @@ class ToTableRowTest extends AnyFlatSpec with Matchers with ToTableRow {
     genericRecord.put("fixedField", new fixedType("1234567890123456".getBytes()))
 
     toTableRow(genericRecord) shouldEqual expectedOutput
+  }
+
+  val date = LocalDate.now()
+  val timeMillis: LocalTime = LocalTime.now()
+  val timeMicros = 1234L
+  val timestampMillis: DateTime = DateTime.now()
+  val timestampMicros = 4325L
+
+  val expectedLogicalTypeOutput = new TableRow()
+    .set("booleanField", true)
+    .set("intField", 1)
+    .set("stringField", "someString")
+    .set("longField", 1L)
+    .set("doubleField", 1.0)
+    .set("floatField", 1f)
+    .set("bytesField", BaseEncoding.base64Url().encode("someBytes".getBytes))
+    .set("dateField", date)
+    .set("timeMillisField", timeMillis)
+    .set("timeMicrosField", timeMicros)
+    .set("timestampMillisField", timestampMillis)
+    .set("timestampMicrosField", timestampMicros)
+
+  "ToTableRowWithLogicalType" should "convert a SpecificRecord with Logical Types to TableRow" in {
+    val specificRecord = AvroExampleWithLogicalType
+      .newBuilder()
+      .setBooleanField(true)
+      .setStringField("someString")
+      .setDoubleField(1.0)
+      .setLongField(1L)
+      .setIntField(1)
+      .setFloatField(1f)
+      .setBytesField(ByteBuffer.wrap(ByteString.copyFromUtf8("someBytes").toByteArray))
+      .setDateField(date)
+      .setTimeMillisField(timeMillis)
+      .setTimeMicrosField(timeMicros)
+      .setTimestampMillisField(timestampMillis)
+      .setTimestampMicrosField(timestampMicros)
+      .build()
+
+    toTableRow(specificRecord) shouldEqual expectedLogicalTypeOutput
   }
 }

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableSchemaTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableSchemaTest.scala
@@ -100,4 +100,60 @@ class ToTableSchemaTest extends AnyFlatSpec with Matchers with ToTableSchema {
         ).asJava
       )
   }
+
+  "toTableSchema" should "convert an Avro Schema with Logical Types to a BigQuery TableSchema" in {
+    toTableSchema(AvroExampleWithLogicalType.SCHEMA$) shouldEqual
+      new TableSchema().setFields(
+        List(
+          new TableFieldSchema()
+            .setName("intField")
+            .setType("INTEGER")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
+            .setName("stringField")
+            .setType("STRING")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
+            .setName("booleanField")
+            .setType("BOOLEAN")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
+            .setName("longField")
+            .setType("INTEGER")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
+            .setName("doubleField")
+            .setType("FLOAT")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
+            .setName("floatField")
+            .setType("FLOAT")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
+            .setName("bytesField")
+            .setType("BYTES")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
+            .setName("dateField")
+            .setType("DATE")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
+            .setName("timeMillisField")
+            .setType("TIME")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
+            .setName("timeMicrosField")
+            .setType("TIME")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
+            .setName("timestampMillisField")
+            .setType("TIMESTAMP")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
+            .setName("timestampMicrosField")
+            .setType("TIMESTAMP")
+            .setMode("REQUIRED")
+        ).asJava
+      )
+  }
 }

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableSchemaTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableSchemaTest.scala
@@ -134,6 +134,10 @@ class ToTableSchemaTest extends AnyFlatSpec with Matchers with ToTableSchema {
             .setType("BYTES")
             .setMode("REQUIRED"),
           new TableFieldSchema()
+            .setName("decimalField")
+            .setType("NUMERIC")
+            .setMode("REQUIRED"),
+          new TableFieldSchema()
             .setName("dateField")
             .setType("DATE")
             .setMode("REQUIRED"),

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableSchemaTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/bigquery/ToTableSchemaTest.scala
@@ -143,7 +143,7 @@ class ToTableSchemaTest extends AnyFlatSpec with Matchers with ToTableSchema {
             .setMode("REQUIRED"),
           new TableFieldSchema()
             .setName("timeMicrosField")
-            .setType("TIME")
+            .setType("INTEGER")
             .setMode("REQUIRED"),
           new TableFieldSchema()
             .setName("timestampMillisField")
@@ -151,7 +151,7 @@ class ToTableSchemaTest extends AnyFlatSpec with Matchers with ToTableSchema {
             .setMode("REQUIRED"),
           new TableFieldSchema()
             .setName("timestampMicrosField")
-            .setType("TIMESTAMP")
+            .setType("INTEGER")
             .setMode("REQUIRED")
         ).asJava
       )


### PR DESCRIPTION
Add Avro date, time and decimal logical type conversion support for scio-extra Avro -> BQ.
fixes #1880 