### PR TITLE
Support multiple input partitions in scio-smb

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1038,6 +1038,7 @@ lazy val `scio-smb`: Project = project
       (Compile / sourceManaged).value.mkdirs()
       Seq("-s", (Compile / sourceManaged).value.getAbsolutePath)
     },
+    testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a")),
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
   )
   .configs(

--- a/scio-smb/src/it/java/org/apache/beam/sdk/extensions/smb/SmbPublicAPITest.java
+++ b/scio-smb/src/it/java/org/apache/beam/sdk/extensions/smb/SmbPublicAPITest.java
@@ -63,7 +63,9 @@ public class SmbPublicAPITest {
         Collections.singletonList(
             new BucketedInput<>(
                 new TupleTag<>(),
-                FileSystems.matchSingleFileSpec("in").resourceId(),
+                Collections.singletonList(
+                    FileSystems.matchSingleFileSpec("in").resourceId()
+                ),
                 ".avro",
                 new MyFileOperation())));
   }

--- a/scio-smb/src/it/java/org/apache/beam/sdk/extensions/smb/SmbPublicAPITest.java
+++ b/scio-smb/src/it/java/org/apache/beam/sdk/extensions/smb/SmbPublicAPITest.java
@@ -75,6 +75,11 @@ public class SmbPublicAPITest {
     }
 
     @Override
+    public boolean isSameSourceCompatible(BucketMetadata other) {
+      return true;
+    }
+
+    @Override
     public String extractKey(String value) {
       return null;
     }

--- a/scio-smb/src/it/java/org/apache/beam/sdk/extensions/smb/SmbPublicAPITest.java
+++ b/scio-smb/src/it/java/org/apache/beam/sdk/extensions/smb/SmbPublicAPITest.java
@@ -77,7 +77,7 @@ public class SmbPublicAPITest {
     }
 
     @Override
-    public boolean isSameSourceCompatible(BucketMetadata other) {
+    public boolean isPartitionCompatible(BucketMetadata other) {
       return true;
     }
 

--- a/scio-smb/src/it/scala/com/spotify/scio/smb/SortMergeBucketParityIT.scala
+++ b/scio-smb/src/it/scala/com/spotify/scio/smb/SortMergeBucketParityIT.scala
@@ -85,11 +85,15 @@ class SortMergeBucketParityIT extends AnyFlatSpec with Matchers {
           SCollection.unionAll(
             List(
               sc.avroFile(s"${inputs(0)}/*.avro", schema),
-              sc.avroFile(s"${inputs(1)}/*.avro", schema))),
+              sc.avroFile(s"${inputs(1)}/*.avro", schema)
+            )
+          ),
           SCollection.unionAll(
             List(
               sc.avroFile(s"${inputs(2)}/*.avro", schema),
-              sc.avroFile(s"${inputs(3)}/*.avro", schema)))
+              sc.avroFile(s"${inputs(3)}/*.avro", schema)
+            )
+          )
         )
 
         lhs.keyBy(keyFn).cogroup(rhs.keyBy(keyFn))

--- a/scio-smb/src/it/scala/com/spotify/scio/smb/SortMergeBucketParityIT.scala
+++ b/scio-smb/src/it/scala/com/spotify/scio/smb/SortMergeBucketParityIT.scala
@@ -68,6 +68,34 @@ class SortMergeBucketParityIT extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "have parity with a 2-way CoGroup across multiple input partitions" in
+    withNumSources(4) { inputs =>
+      compareResults(
+        _.sortMergeCoGroup(
+          classOf[Integer],
+          AvroSortedBucketIO
+            .read(new TupleTag[GenericRecord]("lhs"), schema)
+            .from(inputs(0).toString, inputs(1).toString),
+          AvroSortedBucketIO
+            .read(new TupleTag[GenericRecord]("rhs"), schema)
+            .from(inputs(2).toString, inputs(3).toString)
+        )
+      ) { sc =>
+        val (lhs, rhs) = (
+          SCollection.unionAll(
+            List(
+              sc.avroFile(s"${inputs(0)}/*.avro", schema),
+              sc.avroFile(s"${inputs(1)}/*.avro", schema))),
+          SCollection.unionAll(
+            List(
+              sc.avroFile(s"${inputs(2)}/*.avro", schema),
+              sc.avroFile(s"${inputs(3)}/*.avro", schema)))
+        )
+
+        lhs.keyBy(keyFn).cogroup(rhs.keyBy(keyFn))
+      }
+    }
+
   it should "have parity with a 3-way CoGroup" in withNumSources(3) { inputs =>
     compareResults(
       _.sortMergeCoGroup(classOf[Integer], mkRead(inputs(0)), mkRead(inputs(1)), mkRead(inputs(2)))
@@ -147,7 +175,7 @@ class SortMergeBucketParityIT extends AnyFlatSpec with Matchers {
           AvroSortedBucketIO
             .write(classOf[Integer], "key", schema)
             .to(outputPath.toString)
-            .withNumBuckets(2)
+            .withNumBuckets(Math.pow(2.0, 1.0 * n).toInt)
             .withNumShards(2)
         )
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -103,7 +103,7 @@ class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetadata<K, V
       return false;
     }
     AvroBucketMetadata<?, ?> that = (AvroBucketMetadata<?, ?>) o;
-    return Objects.equals(keyField, that.keyField) &&
+    return getKeyClass() == that.getKeyClass() && keyField.equals(that.keyField) &&
         Arrays.equals(keyPath, that.keyPath);
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -26,7 +26,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
@@ -93,6 +95,16 @@ class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetadata<K, V
   public void populateDisplayData(Builder builder) {
     super.populateDisplayData(builder);
     builder.add(DisplayData.item("keyField", keyField));
+  }
+
+  @Override
+  public boolean isSameSourceCompatible(BucketMetadata o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AvroBucketMetadata<?, ?> that = (AvroBucketMetadata<?, ?>) o;
+    return Objects.equals(keyField, that.keyField) &&
+        Arrays.equals(keyPath, that.keyPath);
   }
 
   // Coders for types commonly used as keys in Avro

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -98,7 +98,7 @@ class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetadata<K, V
   }
 
   @Override
-  public boolean isSameSourceCompatible(BucketMetadata o) {
+  public boolean isPartitionCompatible(BucketMetadata o) {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
@@ -135,10 +135,8 @@ public class AvroSortedBucketIO {
     }
 
     /** Reads from the given input directory. */
-    public Read<T> from(String inputDirectory) {
-      return toBuilder()
-          .setInputDirectories(FileSystems.matchNewResource(inputDirectory, true))
-          .build();
+    public Read<T> from(String... inputDirectories) {
+      return from(Arrays.asList(inputDirectories));
     }
 
     /** Reads from the given input directories. */

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -194,6 +194,9 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
     return baos.toByteArray();
   }
 
+  // Checks for complete equality between BucketMetadatas originating from the same BucketedInput
+  public abstract boolean isSameSourceCompatible(BucketMetadata other);
+
   public abstract K extractKey(V value);
 
   int getBucketId(byte[] keyBytes) {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -195,7 +195,7 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
   }
 
   // Checks for complete equality between BucketMetadatas originating from the same BucketedInput
-  public abstract boolean isSameSourceCompatible(BucketMetadata other);
+  public abstract boolean isPartitionCompatible(BucketMetadata other);
 
   public abstract K extractKey(V value);
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
@@ -86,7 +86,7 @@ class JsonBucketMetadata<K> extends BucketMetadata<K, TableRow> {
       return false;
     }
     JsonBucketMetadata<?> that = (JsonBucketMetadata<?>) o;
-    return Objects.equals(keyField, that.keyField) &&
+    return getKeyClass() == that.getKeyClass() && keyField.equals(that.keyField) &&
         Arrays.equals(keyPath, that.keyPath);
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.api.services.bigquery.model.TableRow;
+import java.util.Arrays;
+import java.util.Objects;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
@@ -76,5 +78,15 @@ class JsonBucketMetadata<K> extends BucketMetadata<K, TableRow> {
   public void populateDisplayData(Builder builder) {
     super.populateDisplayData(builder);
     builder.add(DisplayData.item("keyField", keyField));
+  }
+
+  @Override
+  public boolean isSameSourceCompatible(BucketMetadata o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    JsonBucketMetadata<?> that = (JsonBucketMetadata<?>) o;
+    return Objects.equals(keyField, that.keyField) &&
+        Arrays.equals(keyPath, that.keyPath);
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
@@ -81,7 +81,7 @@ class JsonBucketMetadata<K> extends BucketMetadata<K, TableRow> {
   }
 
   @Override
-  public boolean isSameSourceCompatible(BucketMetadata o) {
+  public boolean isPartitionCompatible(BucketMetadata o) {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.auto.value.AutoValue;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -33,6 +34,7 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
 /** API for reading and writing BigQuery {@link TableRow} JSON sorted-bucket files. */
 public class JsonSortedBucketIO {
@@ -72,7 +74,7 @@ public class JsonSortedBucketIO {
   @AutoValue
   public abstract static class Read extends SortedBucketIO.Read<TableRow> {
     @Nullable
-    abstract ResourceId getInputDirectory();
+    abstract ImmutableList<ResourceId> getInputDirectories();
 
     abstract String getFilenameSuffix();
 
@@ -84,7 +86,9 @@ public class JsonSortedBucketIO {
     abstract static class Builder {
       abstract Builder setTupleTag(TupleTag<TableRow> tupleTag);
 
-      abstract Builder setInputDirectory(ResourceId inputDirectory);
+      abstract Builder setInputDirectories(ResourceId... inputDirectories);
+
+      abstract Builder setInputDirectories(List<ResourceId> inputDirectories);
 
       abstract Builder setFilenameSuffix(String filenameSuffix);
 
@@ -96,7 +100,7 @@ public class JsonSortedBucketIO {
     /** Reads from the given input directory. */
     public Read from(String inputDirectory) {
       return toBuilder()
-          .setInputDirectory(FileSystems.matchNewResource(inputDirectory, true))
+          .setInputDirectories(FileSystems.matchNewResource(inputDirectory, true))
           .build();
     }
 
@@ -109,7 +113,7 @@ public class JsonSortedBucketIO {
     protected BucketedInput<?, TableRow> toBucketedInput() {
       return new BucketedInput<>(
           getTupleTag(),
-          getInputDirectory(),
+          getInputDirectories(),
           getFilenameSuffix(),
           JsonFileOperations.of(getCompression()));
     }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -17,7 +17,6 @@
 
 package org.apache.beam.sdk.extensions.smb;
 
-import com.google.common.collect.Lists;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -115,7 +114,7 @@ public class SortedBucketSource<FinalKeyT>
     int leastNumBuckets = Integer.MAX_VALUE;
     // Check metadata of each source
     for (BucketedInput<?, ?> source : sources) {
-      source.validateSourcesCompatibility();
+      source.validateIntraSourceCompatibility();
       final BucketMetadata<?, ?> current = source.getCanonicalMetadata();
       if (first == null) {
         first = current;
@@ -413,7 +412,8 @@ public class SortedBucketSource<FinalKeyT>
       return fileOperations.getCoder();
     }
 
-    void validateSourcesCompatibility() {
+    // Validates that all the inputDirectories in this source contain compatible metadata
+    void validateIntraSourceCompatibility() {
       if (getMetadata().size() == 1) {
         return;
       }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -345,6 +345,15 @@ public class SortedBucketSource<FinalKeyT>
 
     public BucketedInput(
         TupleTag<V> tupleTag,
+        ResourceId inputDirectory,
+        String filenameSuffix,
+        FileOperations<V> fileOperations
+    ) {
+      this(tupleTag, Collections.singletonList(inputDirectory), filenameSuffix, fileOperations);
+    }
+
+    public BucketedInput(
+        TupleTag<V> tupleTag,
         List<ResourceId> inputDirectories,
         String filenameSuffix,
         FileOperations<V> fileOperations

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -412,7 +412,7 @@ public class SortedBucketSource<FinalKeyT>
 
         Preconditions.checkState(
             metadata.isCompatibleWith(this.canonicalMetadata) &&
-                metadata.isSameSourceCompatible(this.canonicalMetadata),
+                metadata.isPartitionCompatible(this.canonicalMetadata),
             "%s cannot be read as a single input source. Metadata in directory "
                 + "%s is incompatible with metadata in directory %s. %s != %s",
             this, dir, canonicalMetadataDir, metadata, canonicalMetadata);

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -327,7 +327,6 @@ public class SortedBucketSource<FinalKeyT>
     private final TupleTag<V> tupleTag;
     private final String filenameSuffix;
     private final FileOperations<V> fileOperations;
-    private final List<ResourceId> inputDirectories;
 
     private transient Map<ResourceId, FileAssignment> fileAssignments;
     private transient Map<ResourceId, BucketMetadata<K, V>> metadata;
@@ -348,17 +347,15 @@ public class SortedBucketSource<FinalKeyT>
         String filenameSuffix,
         FileOperations<V> fileOperations
     ) {
-      this.tupleTag = tupleTag;
-      this.inputDirectories = inputDirectories;
-      this.filenameSuffix = filenameSuffix;
-      this.fileOperations = fileOperations;
-
       this.fileAssignments = inputDirectories.stream().collect(
-          Collectors.toMap(
+        Collectors.toMap(
             (ResourceId dir) -> dir,
             (ResourceId dir) -> new SMBFilenamePolicy(dir, filenameSuffix).forDestination()
-          )
-      ) ;
+        )
+      );
+      this.tupleTag = tupleTag;
+      this.filenameSuffix = filenameSuffix;
+      this.fileOperations = fileOperations;
     }
 
     private BucketedInput(
@@ -473,6 +470,7 @@ public class SortedBucketSource<FinalKeyT>
 
     @Override
     public String toString() {
+      final List<ResourceId> inputDirectories = new ArrayList<>(getMetadata().keySet());
       return String.format(
           "BucketedInput[tupleTag=%s, inputDirectories=[%s], metadata=%s]",
           tupleTag.getId(),
@@ -485,8 +483,6 @@ public class SortedBucketSource<FinalKeyT>
     private static class BucketedInputCoder<K, V> extends AtomicCoder<BucketedInput<K, V>> {
       private static SerializableCoder<TupleTag> tupleTagCoder =
           SerializableCoder.of(TupleTag.class);
-      private static ListCoder<ResourceId> inputDirectoriesCoder =
-          ListCoder.of(ResourceIdCoder.of());
       private static StringUtf8Coder stringCoder = StringUtf8Coder.of();
       private static SerializableCoder<FileOperations> fileOpCoder =
           SerializableCoder.of(FileOperations.class);
@@ -500,7 +496,6 @@ public class SortedBucketSource<FinalKeyT>
       @Override
       public void encode(BucketedInput<K, V> value, OutputStream outStream) throws IOException {
         tupleTagCoder.encode(value.tupleTag, outStream);
-        inputDirectoriesCoder.encode(value.inputDirectories, outStream);
         stringCoder.encode(value.filenameSuffix, outStream);
         fileOpCoder.encode(value.fileOperations, outStream);
         metadataMapCoder.encode(value.getMetadata(), outStream);
@@ -510,13 +505,16 @@ public class SortedBucketSource<FinalKeyT>
       public BucketedInput<K, V> decode(InputStream inStream) throws IOException {
         @SuppressWarnings("unchecked")
         TupleTag<V> tupleTag = (TupleTag<V>) tupleTagCoder.decode(inStream);
-        List<ResourceId> inputDirectories = inputDirectoriesCoder.decode(inStream);
         String filenameSuffix = stringCoder.decode(inStream);
         @SuppressWarnings("unchecked")
         FileOperations<V> fileOperations = fileOpCoder.decode(inStream);
         Map<ResourceId, BucketMetadata<K, V>> metadata = metadataMapCoder.decode(inStream);
         return new BucketedInput<>(
-            tupleTag, inputDirectories, filenameSuffix, fileOperations, metadata);
+            tupleTag,
+            new ArrayList<>(metadata.keySet()),
+            filenameSuffix,
+            fileOperations,
+            metadata);
       }
     }
   }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.extensions.smb;
 
 import com.google.auto.value.AutoValue;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -31,6 +32,7 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.tensorflow.example.Example;
 
 /**
@@ -80,7 +82,7 @@ public class TensorFlowBucketIO {
   @AutoValue
   public abstract static class Read extends SortedBucketIO.Read<Example> {
     @Nullable
-    abstract ResourceId getInputDirectory();
+    abstract ImmutableList<ResourceId> getInputDirectories();
 
     abstract String getFilenameSuffix();
 
@@ -92,7 +94,9 @@ public class TensorFlowBucketIO {
     abstract static class Builder {
       abstract Builder setTupleTag(TupleTag<Example> tupleTag);
 
-      abstract Builder setInputDirectory(ResourceId inputDirectory);
+      abstract Builder setInputDirectories(ResourceId... inputDirectories);
+
+      abstract Builder setInputDirectories(List<ResourceId> inputDirectories);
 
       abstract Builder setFilenameSuffix(String filenameSuffix);
 
@@ -104,7 +108,7 @@ public class TensorFlowBucketIO {
     /** Reads from the given input directory. */
     public Read from(String inputDirectory) {
       return toBuilder()
-          .setInputDirectory(FileSystems.matchNewResource(inputDirectory, true))
+          .setInputDirectories(FileSystems.matchNewResource(inputDirectory, true))
           .build();
     }
 
@@ -117,7 +121,7 @@ public class TensorFlowBucketIO {
     protected BucketedInput<?, Example> toBucketedInput() {
       return new BucketedInput<>(
           getTupleTag(),
-          getInputDirectory(),
+          getInputDirectories(),
           getFilenameSuffix(),
           TensorFlowFileOperations.of(getCompression()));
     }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
@@ -91,6 +91,6 @@ class TensorFlowBucketMetadata<K> extends BucketMetadata<K, Example> {
       return false;
     }
     TensorFlowBucketMetadata<?> that = (TensorFlowBucketMetadata<?>) o;
-    return Objects.equals(keyField, that.keyField);
+    return getKeyClass() == that.getKeyClass() && keyField.equals(that.keyField);
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.extensions.smb;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -82,5 +83,14 @@ class TensorFlowBucketMetadata<K> extends BucketMetadata<K, Example> {
   public void populateDisplayData(Builder builder) {
     super.populateDisplayData(builder);
     builder.add(DisplayData.item("keyField", keyField));
+  }
+
+  @Override
+  public boolean isSameSourceCompatible(BucketMetadata o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TensorFlowBucketMetadata<?> that = (TensorFlowBucketMetadata<?>) o;
+    return Objects.equals(keyField, that.keyField);
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
@@ -86,7 +86,7 @@ class TensorFlowBucketMetadata<K> extends BucketMetadata<K, Example> {
   }
 
   @Override
-  public boolean isSameSourceCompatible(BucketMetadata o) {
+  public boolean isPartitionCompatible(BucketMetadata o) {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 import org.apache.beam.sdk.io.AvroGeneratedUser;
@@ -141,5 +143,24 @@ public class AvroBucketMetadataTest {
     MatcherAssert.assertThat(
         displayData, hasDisplayItem("hashType", HashType.MURMUR3_32.toString()));
     MatcherAssert.assertThat(displayData, hasDisplayItem("keyCoder", StringUtf8Coder.class));
+  }
+
+  @Test
+  public void testSameSourceCompatibility() throws Exception {
+    final AvroBucketMetadata<String, GenericRecord> metadata1 =
+        new AvroBucketMetadata<>(2, 1, String.class, HashType.MURMUR3_32, "favorite_country");
+
+    final AvroBucketMetadata<String, GenericRecord> metadata2 =
+        new AvroBucketMetadata<>(2, 1, String.class, HashType.MURMUR3_32, "favorite_color");
+
+    final AvroBucketMetadata<String, GenericRecord> metadata3 =
+        new AvroBucketMetadata<>(4, 1, String.class, HashType.MURMUR3_32, "favorite_color");
+
+    final AvroBucketMetadata<Long, GenericRecord> metadata4 =
+        new AvroBucketMetadata<>(4, 1, Long.class, HashType.MURMUR3_32, "favorite_color");
+
+    Assert.assertFalse(metadata1.isSameSourceCompatible(metadata2));
+    Assert.assertTrue(metadata2.isSameSourceCompatible(metadata3));
+    Assert.assertFalse(metadata3.isSameSourceCompatible(metadata4));
   }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
@@ -24,8 +24,6 @@ import java.util.Collections;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
-import org.apache.beam.sdk.coders.CannotProvideCoderException;
-import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 import org.apache.beam.sdk.io.AvroGeneratedUser;
@@ -159,8 +157,8 @@ public class AvroBucketMetadataTest {
     final AvroBucketMetadata<Long, GenericRecord> metadata4 =
         new AvroBucketMetadata<>(4, 1, Long.class, HashType.MURMUR3_32, "favorite_color");
 
-    Assert.assertFalse(metadata1.isSameSourceCompatible(metadata2));
-    Assert.assertTrue(metadata2.isSameSourceCompatible(metadata3));
-    Assert.assertFalse(metadata3.isSameSourceCompatible(metadata4));
+    Assert.assertFalse(metadata1.isPartitionCompatible(metadata2));
+    Assert.assertTrue(metadata2.isPartitionCompatible(metadata3));
+    Assert.assertFalse(metadata3.isPartitionCompatible(metadata4));
   }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
@@ -57,6 +57,10 @@ public class BucketMetadataTest {
               public Object extractKey(Object value) {
                 return null;
               }
+              @Override
+              public boolean isSameSourceCompatible(BucketMetadata other) {
+                return false;
+              }
             });
   }
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
@@ -58,7 +58,7 @@ public class BucketMetadataTest {
                 return null;
               }
               @Override
-              public boolean isSameSourceCompatible(BucketMetadata other) {
+              public boolean isPartitionCompatible(BucketMetadata other) {
                 return false;
               }
             });

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
@@ -99,4 +99,23 @@ public class JsonBucketMetadataTest {
         displayData, hasDisplayItem("hashType", HashType.MURMUR3_32.toString()));
     MatcherAssert.assertThat(displayData, hasDisplayItem("keyCoder", StringUtf8Coder.class));
   }
+
+  @Test
+  public void testSameSourceCompatibility() throws Exception {
+    final JsonBucketMetadata<String> metadata1 =
+        new JsonBucketMetadata<>(2, 1, String.class, HashType.MURMUR3_32, "favorite_country");
+
+    final JsonBucketMetadata<String> metadata2 =
+        new JsonBucketMetadata<>(2, 1, String.class, HashType.MURMUR3_32, "favorite_color");
+
+    final JsonBucketMetadata<String> metadata3 =
+        new JsonBucketMetadata<>(4, 1, String.class, HashType.MURMUR3_32, "favorite_color");
+
+    final JsonBucketMetadata<Long> metadata4 =
+        new JsonBucketMetadata<>(4, 1, Long.class, HashType.MURMUR3_32, "favorite_color");
+
+    Assert.assertFalse(metadata1.isSameSourceCompatible(metadata2));
+    Assert.assertTrue(metadata2.isSameSourceCompatible(metadata3));
+    Assert.assertFalse(metadata3.isSameSourceCompatible(metadata4));
+  }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
@@ -114,8 +114,8 @@ public class JsonBucketMetadataTest {
     final JsonBucketMetadata<Long> metadata4 =
         new JsonBucketMetadata<>(4, 1, Long.class, HashType.MURMUR3_32, "favorite_color");
 
-    Assert.assertFalse(metadata1.isSameSourceCompatible(metadata2));
-    Assert.assertTrue(metadata2.isSameSourceCompatible(metadata3));
-    Assert.assertFalse(metadata3.isSameSourceCompatible(metadata4));
+    Assert.assertFalse(metadata1.isPartitionCompatible(metadata2));
+    Assert.assertTrue(metadata2.isPartitionCompatible(metadata3));
+    Assert.assertFalse(metadata3.isPartitionCompatible(metadata4));
   }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -105,7 +105,7 @@ public class SortedBucketSourceTest {
     // Metadata aren't same-source compatible
     Assert.assertThrows(
         IllegalStateException.class,
-        bucketedInput::validateSourcesCompatibility);
+        bucketedInput::validateIntraSourceCompatibility);
   }
 
   @Test

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -242,8 +242,8 @@ public class SortedBucketSourceTest {
 
     final TupleTag<String> tag = new TupleTag<>("GBK");
     final TestFileOperations fileOperations = new TestFileOperations();
-    final BucketedInput<?, ?> bucketedInput =
-        new BucketedInput<>(tag, fromFolder(lhsFolder), ".txt", fileOperations);
+    final BucketedInput<?, ?> bucketedInput = new BucketedInput<>(
+        tag, fromFolder(lhsFolder), ".txt", fileOperations);
 
     PCollection<KV<String, CoGbkResult>> output = pipeline.apply(
         new SortedBucketSource<>(String.class, Collections.singletonList(bucketedInput)));

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -21,8 +21,10 @@ import static org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInpu
 import static org.apache.beam.sdk.extensions.smb.TestUtils.fromFolder;
 
 import java.nio.channels.Channels;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +36,8 @@ import java.util.stream.StreamSupport;
 import org.apache.beam.sdk.extensions.smb.FileOperations.Writer;
 import org.apache.beam.sdk.extensions.smb.SMBFilenamePolicy.FileAssignment;
 import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.LocalResources;
+import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -41,6 +45,7 @@ import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
@@ -56,6 +61,7 @@ public class SortedBucketSourceTest {
   @Rule public final TestPipeline pipeline = TestPipeline.create();
   @Rule public final TemporaryFolder lhsFolder = new TemporaryFolder();
   @Rule public final TemporaryFolder rhsFolder = new TemporaryFolder();
+  @Rule public final TemporaryFolder partitionedInputFolder = new TemporaryFolder();
 
   private SMBFilenamePolicy lhsPolicy;
   private SMBFilenamePolicy rhsPolicy;
@@ -178,8 +184,8 @@ public class SortedBucketSourceTest {
   @Category(NeedsRunner.class)
   public void testSingleSourceGbk() throws Exception {
     Map<BucketShardId, List<String>> input = ImmutableMap.of(
-      BucketShardId.of(0, 0), Lists.newArrayList("a1", "a2", "b1", "b2"),
-      BucketShardId.of(1, 0), Lists.newArrayList("x1", "x2", "y1", "y2"));
+        BucketShardId.of(0, 0), Lists.newArrayList("a1", "a2", "b1", "b2"),
+        BucketShardId.of(1, 0), Lists.newArrayList("x1", "x2", "y1", "y2"));
 
     int numBuckets = maxId(input.keySet(), BucketShardId::getBucketId) + 1;
     int numShards = maxId(input.keySet(), BucketShardId::getShardId) + 1;
@@ -216,6 +222,48 @@ public class SortedBucketSourceTest {
     pipeline.run();
   }
 
+  @Test
+  @Category(NeedsRunner.class)
+  public void testPartitionedInputsMixedBuckets() throws Exception {
+    testPartitioned(
+        ImmutableList.of(
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("x1", "x2"),
+                BucketShardId.of(1, 0), Lists.newArrayList("c1", "c2")),
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("x3", "x4"))
+        ),
+        ImmutableList.of(
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("x5", "x6")),
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("x7", "x8"),
+                BucketShardId.of(1, 0), Lists.newArrayList("c7", "c8")))
+    );
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testPartitionedInputsUniformBuckets() throws Exception {
+    testPartitioned(
+        ImmutableList.of(
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("x1", "x2"),
+                BucketShardId.of(1, 0), Lists.newArrayList("c1", "c2")),
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("x3", "x4"),
+                BucketShardId.of(1, 0), Lists.newArrayList("c3", "c4"))
+        ),
+        ImmutableList.of(
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("x5", "x6"),
+                BucketShardId.of(1, 0), Lists.newArrayList("c5", "c6")),
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("x7", "x8"),
+                BucketShardId.of(1, 0), Lists.newArrayList("c7", "c8")))
+    );
+  }
+
   private void test(
       Map<BucketShardId, List<String>> lhsInput, Map<BucketShardId, List<String>> rhsInput)
       throws Exception {
@@ -231,20 +279,89 @@ public class SortedBucketSourceTest {
     write(lhsPolicy.forDestination(), lhsMetadata, lhsInput);
     write(rhsPolicy.forDestination(), rhsMetadata, rhsInput);
 
+    checkJoin(
+        pipeline,
+        Collections.singletonList(fromFolder(lhsFolder)),
+        Collections.singletonList(fromFolder(rhsFolder)),
+        lhsInput, rhsInput);
+
+    pipeline.run();
+  }
+
+  private void testPartitioned(
+      List<Map<BucketShardId, List<String>>> lhsInputs,
+      List<Map<BucketShardId, List<String>>> rhsInputs)
+      throws Exception {
+
+    List<ResourceId> lhsPaths = new ArrayList<>();
+    Map<BucketShardId, List<String>> allLhsValues = new HashMap<>();
+
+    for (Map<BucketShardId, List<String>> input : lhsInputs) {
+      int numBuckets = maxId(input.keySet(), BucketShardId::getBucketId) + 1;
+      int numShards = maxId(input.keySet(), BucketShardId::getShardId) + 1;
+      TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
+      ResourceId destination = LocalResources.fromFile(
+        partitionedInputFolder.newFolder("lhs" + lhsInputs.indexOf(input)),
+        true
+      );
+      FileAssignment fileAssignment =
+          new SMBFilenamePolicy(destination,".txt").forDestination();
+      write(fileAssignment, metadata, input);
+      lhsPaths.add(destination);
+      input.forEach((k, v) -> allLhsValues.merge(k, v, (v1, v2) -> {
+        List<String> newList = new LinkedList<>(v1);
+        newList.addAll(v2);
+        return newList;
+      }));
+    }
+
+    List<ResourceId> rhsPaths = new ArrayList<>();
+    Map<BucketShardId, List<String>> allRhsValues = new HashMap<>();
+    for (Map<BucketShardId, List<String>> input : rhsInputs) {
+      int numBuckets = maxId(input.keySet(), BucketShardId::getBucketId) + 1;
+      int numShards = maxId(input.keySet(), BucketShardId::getShardId) + 1;
+      TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
+      ResourceId destination = LocalResources.fromFile(
+          partitionedInputFolder.newFolder("rhs" + rhsInputs.indexOf(input)),
+          true
+      );
+      FileAssignment fileAssignment =
+          new SMBFilenamePolicy(destination,".txt").forDestination();
+      write(fileAssignment, metadata, input);
+      rhsPaths.add(destination);
+      input.forEach((k, v) -> allRhsValues.merge(k, v, (v1, v2) -> {
+        List<String> newList = new LinkedList<>(v1);
+        newList.addAll(v2);
+        return newList;
+      }));
+    }
+
+    checkJoin(pipeline, lhsPaths, rhsPaths, allLhsValues, allRhsValues);
+    pipeline.run();
+  }
+
+  private static void checkJoin(
+      TestPipeline pipeline,
+      List<ResourceId> lhsPaths, List<ResourceId> rhsPaths,
+      Map<BucketShardId, List<String>> lhsValues, Map<BucketShardId, List<String>> rhsValues
+  ) throws Exception {
     final TupleTag<String> lhsTag = new TupleTag<>("LHS");
     final TupleTag<String> rhsTag = new TupleTag<>("RHS");
     final TestFileOperations fileOperations = new TestFileOperations();
     final List<BucketedInput<?, ?>> inputs =
         Lists.newArrayList(
-            new BucketedInput<>(lhsTag, fromFolder(lhsFolder), ".txt", fileOperations),
-            new BucketedInput<>(rhsTag, fromFolder(rhsFolder), ".txt", fileOperations));
+            new BucketedInput<>(lhsTag, lhsPaths, ".txt", fileOperations),
+            new BucketedInput<>(rhsTag, rhsPaths, ".txt", fileOperations));
 
     PCollection<KV<String, CoGbkResult>> output =
         pipeline.apply(new SortedBucketSource<>(String.class, inputs));
 
+    Function<String, String> extractKeyFn = TestBucketMetadata.of(2, 1)::extractKey;
+
     // CoGroupByKey inputs as expected result
-    final Map<String, List<String>> lhs = groupByKey(lhsInput, lhsMetadata::extractKey);
-    final Map<String, List<String>> rhs = groupByKey(rhsInput, rhsMetadata::extractKey);
+    final Map<String, List<String>> lhs = groupByKey(lhsValues, extractKeyFn);
+    final Map<String, List<String>> rhs = groupByKey(rhsValues, extractKeyFn);
+
     final Map<String, KV<List<String>, List<String>>> expected = new HashMap<>();
     for (String k : Sets.union(lhs.keySet(), rhs.keySet())) {
       List<String> l = lhs.getOrDefault(k, Collections.emptyList());
@@ -270,8 +387,6 @@ public class SortedBucketSourceTest {
               Assert.assertEquals(expected, actual);
               return null;
             });
-
-    pipeline.run();
   }
 
   private static void write(

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
@@ -104,4 +104,24 @@ public class TensorFlowBucketMetadataTest {
         displayData, hasDisplayItem("hashType", HashType.MURMUR3_32.toString()));
     MatcherAssert.assertThat(displayData, hasDisplayItem("keyCoder", ByteArrayCoder.class));
   }
+
+
+  @Test
+  public void testSameSourceCompatibility() throws Exception {
+    final TensorFlowBucketMetadata<byte[]> metadata1 =
+        new TensorFlowBucketMetadata<>(2, 1, byte[].class, HashType.MURMUR3_32, "foo");
+
+    final TensorFlowBucketMetadata<byte[]> metadata2 =
+        new TensorFlowBucketMetadata<>(2, 1, byte[].class, HashType.MURMUR3_32, "bar");;
+
+    final TensorFlowBucketMetadata<byte[]> metadata3 =
+        new TensorFlowBucketMetadata<>(4, 1, byte[].class, HashType.MURMUR3_32, "bar");
+
+    final TensorFlowBucketMetadata<String> metadata4 =
+        new TensorFlowBucketMetadata<>(4, 1, String.class, HashType.MURMUR3_32, "bar");
+
+    Assert.assertFalse(metadata1.isSameSourceCompatible(metadata2));
+    Assert.assertTrue(metadata2.isSameSourceCompatible(metadata3));
+    Assert.assertFalse(metadata3.isSameSourceCompatible(metadata4));
+  }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
@@ -120,8 +120,8 @@ public class TensorFlowBucketMetadataTest {
     final TensorFlowBucketMetadata<String> metadata4 =
         new TensorFlowBucketMetadata<>(4, 1, String.class, HashType.MURMUR3_32, "bar");
 
-    Assert.assertFalse(metadata1.isSameSourceCompatible(metadata2));
-    Assert.assertTrue(metadata2.isSameSourceCompatible(metadata3));
-    Assert.assertFalse(metadata3.isSameSourceCompatible(metadata4));
+    Assert.assertFalse(metadata1.isPartitionCompatible(metadata2));
+    Assert.assertTrue(metadata2.isPartitionCompatible(metadata3));
+    Assert.assertFalse(metadata3.isPartitionCompatible(metadata4));
   }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TestBucketMetadata.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TestBucketMetadata.java
@@ -48,6 +48,11 @@ class TestBucketMetadata extends BucketMetadata<String, String> {
   }
 
   @Override
+  public boolean isSameSourceCompatible(BucketMetadata other) {
+    return true;
+  }
+
+  @Override
   public String extractKey(String value) {
     try {
       return value.substring(0, 1);

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TestBucketMetadata.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TestBucketMetadata.java
@@ -23,10 +23,17 @@ import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 
 class TestBucketMetadata extends BucketMetadata<String, String> {
+  @JsonProperty("keyIndex")
+  private Integer keyIndex = 0;
 
   static TestBucketMetadata of(int numBuckets, int numShards)
       throws CannotProvideCoderException, NonDeterministicException {
     return new TestBucketMetadata(numBuckets, numShards, HashType.MURMUR3_32);
+  }
+
+  TestBucketMetadata withKeyIndex(int keyIndex) {
+    this.keyIndex = keyIndex;
+    return this;
   }
 
   TestBucketMetadata(
@@ -49,13 +56,13 @@ class TestBucketMetadata extends BucketMetadata<String, String> {
 
   @Override
   public boolean isSameSourceCompatible(BucketMetadata other) {
-    return true;
+    return keyIndex.equals(((TestBucketMetadata) other).keyIndex);
   }
 
   @Override
   public String extractKey(String value) {
     try {
-      return value.substring(0, 1);
+      return value.substring(keyIndex, 1);
     } catch (StringIndexOutOfBoundsException e) {
       return null;
     }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TestBucketMetadata.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TestBucketMetadata.java
@@ -55,7 +55,7 @@ class TestBucketMetadata extends BucketMetadata<String, String> {
   }
 
   @Override
-  public boolean isSameSourceCompatible(BucketMetadata other) {
+  public boolean isPartitionCompatible(BucketMetadata other) {
     return keyIndex.equals(((TestBucketMetadata) other).keyIndex);
   }
 


### PR DESCRIPTION
use case: user wants to read and join the last 30 days of input data. In the existing implementation they'd have to do a 30-way SMB cogroup.

I modified the FileAssignment interfaces to be different for source and sink use cases. For the sink, it's unchanged--`forBucket()` still returns a single `ResourceId`. However, for source, the `forBucket()` return signature is now `List<ResourceId>`s and can be overridden by the user to return the resource Ids representing all partitions of the input.

I guess another approach might be to create a new abstract class extending `ResourceId`, i.e. `PartitionedResourceId`, that manages multiple partitioned directories for an input. That way fileAssignment API wouldn't have to change. Need to think about it. But it would also have to support different FileSystems, so idk.

todos: benchmarks/tests