### PR TITLE
Fix BigQuery caching, by using dry-run when extracting tables

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
@@ -141,7 +141,7 @@ final private[client] class QueryOps(client: Client, tableService: TableOps, job
     }
 
   private[scio] def newCachedQueryJob(query: QueryJobConfig): Try[QueryJob] =
-    extractTables(query)
+    extractTables(query.copy(dryRun = true))
       .flatMap { tableRefs =>
         val sourceTimes = tableRefs
           .map { t =>


### PR DESCRIPTION
The `extractTables` method was called with a `QueryJobConfig` not set to
dry-run, thus making a query with `allowLargeResults` set to true, but no
destination table[1]. This combination is invalid, and the BigQuery API would
return a 400, which would get interpreted as a cache miss[2].

This commit ensures that this query is made in dry-run mode, this allowing
caching to work as intended.

[1] https://github.com/spotify/scio/blob/master/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala#L243
[2] https://github.com/spotify/scio/blob/master/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala#L172