### PR TITLE
Fix sharded Sparkey side input lookups with missing values.

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -422,13 +422,32 @@ package object sparkey {
 
     def hashKey(str: String): Short = hashKey(str.getBytes)
 
-    override def getAsString(key: String): String = sparkeys(hashKey(key)).getAsString(key)
+    override def getAsString(key: String): String = {
+      val hashed = hashKey(key)
+      if (sparkeys.contains(hashed)) {
+        sparkeys(hashed).getAsString(key)
+      } else {
+        null
+      }
+    }
 
-    override def getAsByteArray(key: Array[Byte]): Array[Byte] =
-      sparkeys(hashKey(key)).getAsByteArray(key)
+    override def getAsByteArray(key: Array[Byte]): Array[Byte] = {
+      val hashed = hashKey(key)
+      if (sparkeys.contains(hashed)) {
+        sparkeys(hashed).getAsByteArray(key)
+      } else {
+        null
+      }
+    }
 
-    override def getAsEntry(key: Array[Byte]): SparkeyReader.Entry =
-      sparkeys(hashKey(key)).getAsEntry(key)
+    override def getAsEntry(key: Array[Byte]): SparkeyReader.Entry = {
+      val hashed = hashKey(key)
+      if (sparkeys.contains(hashed)) {
+        sparkeys(hashed).getAsEntry(key)
+      } else {
+        null
+      }
+    }
 
     override def getIndexHeader: IndexHeader =
       throw new NotImplementedError("ShardedSparkeyReader does not support getIndexHeader.")


### PR DESCRIPTION
`ShardedSparkeySideInput` in 0.8.0 should return `null` for keys not present in the Sparkey file, but - depending on the distribution of keys across the underlying shards - may sometimes throw a `java.util.NoSuchElementException: key not found` instead.

This is due to the fact that:
 - if the hash value of the key passed in to `get*` matches a shard's hash key, `.get*` will be called on the shard and `null` will be returned if the key does not exist.
 - if the hash value of the key passed into `get*` does _not_ match any shard's hash key, the lookup in the `sparkeys` map will throw a `NoSuchElementException`, as the map's `apply` method is called directly.

This PR fixes this issue (and adds a regression test) by checking for the hash key's presence in the map first, before fetching the shard to query from. (This is done via `if/else` rather than `.get(key).map` to avoid an extra `Option` object creation in the hot path of `get` methods on `ShardedSparkeySideInput`.)