### PR TITLE
Add BigQuery Geography support

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -189,7 +189,11 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[LocalDateTime] =>
           q"_root_.com.spotify.scio.bigquery.DateTime.parse($s)"
 
-        case t if isCaseClass(c)(t) =>
+        case t if t =:= typeOf[Geography] =>
+          // different than nested record match below, even though this is a case class
+          q"_root_.com.spotify.scio.bigquery.types.Geography($s)"
+
+        case t if isCaseClass(c)(t) => // nested records
           val fn = TermName("r" + t.typeSymbol.name)
           q"""{
                 val $fn = $tree.asInstanceOf[_root_.java.util.Map[String, AnyRef]]
@@ -289,7 +293,11 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[LocalDateTime] =>
           q"_root_.com.spotify.scio.bigquery.DateTime($tree)"
 
-        case t if isCaseClass(c)(t) =>
+        case t if t =:= typeOf[Geography] =>
+          // different than nested record match below, even though this is a case class
+          q"$tree.wkt"
+
+        case t if isCaseClass(c)(t) => // nested records
           val fn = TermName("r" + t.typeSymbol.name)
           q"""{
                 val $fn = $tree

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -93,6 +93,8 @@ private[types] object ConverterProvider {
           q"_root_.com.spotify.scio.bigquery.Time.parse($tree)"
         case t if t =:= typeOf[LocalDateTime] =>
           q"_root_.com.spotify.scio.bigquery.DateTime.parse($tree.toString)"
+        case t if t =:= typeOf[Geography] =>
+          q"_root_.com.spotify.scio.bigquery.types.Geography($tree.toString)"
 
         case t if isCaseClass(c)(t) =>
           val fn = TermName("r" + t.typeSymbol.name)

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -74,6 +74,7 @@ private[types] object SchemaProvider {
       case t if t =:= typeOf[LocalDate]     => ("DATE", Iterable.empty)
       case t if t =:= typeOf[LocalTime]     => ("TIME", Iterable.empty)
       case t if t =:= typeOf[LocalDateTime] => ("DATETIME", Iterable.empty)
+      case t if t =:= typeOf[Geography]     => ("GEOGRAPHY", Iterable.empty)
 
       case t if isCaseClass(t) => ("RECORD", toFields(t))
       case _                   => throw new RuntimeException(s"Unsupported type: $tpe")

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -187,7 +187,7 @@ private[types] object TypeProvider {
         val traits = (if (fields.size <= 22) Seq(fnTrait) else Seq()) ++ defTblDesc
           .map(_ => tq"${p(c, SType)}.HasTableDescription")
         val taggedFields = fields.map {
-          case q"$m val $n: com.spotify.scio.bigquery.types.Geography = $rhs" =>
+          case q"$m val $n: _root_.com.spotify.scio.bigquery.types.Geography = $rhs" =>
             provider.initializeToTable(c)(m, n, tq"_root_.java.lang.String")
             c.universe.ValDef(
               c.universe.Modifiers(m.flags, m.privateWithin, m.annotations),

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -264,7 +264,7 @@ private[types] object TypeProvider {
         case "DATE"              => (tq"_root_.org.joda.time.LocalDate", Nil)
         case "TIME"              => (tq"_root_.org.joda.time.LocalTime", Nil)
         case "DATETIME"          => (tq"_root_.org.joda.time.LocalDateTime", Nil)
-        case "GEOGRAPHY"         =>
+        case "GEOGRAPHY" =>
           (tq"_root_.com.spotify.scio.bigquery.types.Geography", Nil)
         case "RECORD" | "STRUCT" =>
           val name = NameProvider.getUniqueName(tfs.getName)

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -36,11 +36,11 @@ package object types {
 
   // scalastyle:on class.name
   /**
-    * Case class to serve as raw type for Geography instances to distinguish them from Strings.
-    *
-    * See also https://cloud.google.com/bigquery/docs/gis-data
-    *
-    * @param wkt Well Known Text formatted string that BigQuery displays for Geography
-    */
+   * Case class to serve as raw type for Geography instances to distinguish them from Strings.
+   *
+   * See also https://cloud.google.com/bigquery/docs/gis-data
+   *
+   * @param wkt Well Known Text formatted string that BigQuery displays for Geography
+   */
   case class Geography(wkt: String)
 }

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -33,4 +33,7 @@ package object types {
    * }}}
    */
   final class description(value: String) extends StaticAnnotation with Serializable
+
+  // scalastyle:on class.name
+  case class Geography(wkt: String)
 }

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -35,5 +35,12 @@ package object types {
   final class description(value: String) extends StaticAnnotation with Serializable
 
   // scalastyle:on class.name
+  /**
+    * Case class to serve as raw type for Geography instances to distinguish them from Strings.
+    *
+    * See also https://cloud.google.com/bigquery/docs/gis-data
+    *
+    * @param wkt Well Known Text formatted string that BigQuery displays for Geography
+    */
   case class Geography(wkt: String)
 }

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
@@ -92,6 +92,7 @@ final class ConverterProviderSpec
       o.timeF.isDefined shouldBe r.containsKey("timeF")
       o.datetimeF.isDefined shouldBe r.containsKey("datetimeF")
       o.bigDecimalF.isDefined shouldBe r.containsKey("bigDecimalF")
+      o.geographyF.isDefined shouldBe r.containsKey("geographyF")
     }
   }
 

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -39,9 +39,20 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
       Repeated.fromTableRow(TableRow())
     } should have message """REPEATED field "a" is null"""
   }
+
+  // scalastyle:on no.whitespace.before.left.bracket
+  it should "handle required geography type" in {
+    val wkt = "POINT (30 10)"
+    RequiredGeo.fromTableRow(TableRow("a" -> wkt)) shouldBe RequiredGeo(Geography(wkt))
+    BigQueryType.toTableRow[RequiredGeo](RequiredGeo(Geography(wkt))) shouldBe TableRow("a" -> wkt)
+  }
 }
 
 object ConverterProviderTest {
+
+  @BigQueryType.toTable
+  case class RequiredGeo(a: Geography)
+
   @BigQueryType.toTable
   case class Required(a: String)
 

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/SchemaProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/SchemaProviderTest.scala
@@ -40,7 +40,8 @@ class SchemaProviderTest extends AnyFlatSpec with Matchers {
        |  {"mode": "$mode", "name": "dateF", "type": "DATE"},
        |  {"mode": "$mode", "name": "timeF", "type": "TIME"},
        |  {"mode": "$mode", "name": "datetimeF", "type": "DATETIME"},
-       |  {"mode": "$mode", "name": "bigDecimalF", "type": "NUMERIC"}
+       |  {"mode": "$mode", "name": "bigDecimalF", "type": "NUMERIC"},
+       |  {"mode": "$mode", "name": "geographyF", "type": "GEOGRAPHY"}
        |]
        |""".stripMargin
 

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/Schemas.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/Schemas.scala
@@ -35,7 +35,8 @@ object Schemas {
     dateF: LocalDate,
     timeF: LocalTime,
     datetimeF: LocalDateTime,
-    bigDecimalF: BigDecimal
+    bigDecimalF: BigDecimal,
+    geographyF: Geography
   )
   case class Optional(
     boolF: Option[Boolean],
@@ -50,7 +51,8 @@ object Schemas {
     dateF: Option[LocalDate],
     timeF: Option[LocalTime],
     datetimeF: Option[LocalDateTime],
-    bigDecimalF: Option[BigDecimal]
+    bigDecimalF: Option[BigDecimal],
+    geographyF: Option[Geography]
   )
   case class Repeated(
     boolF: List[Boolean],
@@ -65,7 +67,8 @@ object Schemas {
     dateF: List[LocalDate],
     timeF: List[LocalTime],
     datetimeF: List[LocalDateTime],
-    bigDecimalF: List[BigDecimal]
+    bigDecimalF: List[BigDecimal],
+    geographyF: List[Geography]
   )
 
   // records

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
@@ -561,4 +561,21 @@ class TypeProviderTest extends AnyFlatSpec with Matchers {
     noException should be thrownBy
       BigQueryType[TypeProviderTest.RefinedClass with BigQueryType.HasAnnotation]
   }
+
+
+  @BigQueryType.fromSchema(
+    """
+      |{"fields": [{"mode": "REQUIRED", "name": "f1", "type": "GEOGRAPHY"}]}
+    """.stripMargin)
+  class GeoRecordFrom
+
+  @BigQueryType.toTable
+  case class GeoRecordTo(f1: Geography)
+
+  it should "#1882: support GEOGRAPHY type" in {
+    val wkt = "POINT (30 10)"
+    val cc = GeoRecordFrom(Geography(wkt))
+    cc.f1 shouldBe Geography(wkt)
+    GeoRecordTo(Geography(wkt))
+  }
 }

--- a/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
+++ b/scio-bigquery/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
@@ -561,10 +561,7 @@ class TypeProviderTest extends AnyFlatSpec with Matchers {
     noException should be thrownBy
       BigQueryType[TypeProviderTest.RefinedClass with BigQueryType.HasAnnotation]
   }
-
-
-  @BigQueryType.fromSchema(
-    """
+  @BigQueryType.fromSchema("""
       |{"fields": [{"mode": "REQUIRED", "name": "f1", "type": "GEOGRAPHY"}]}
     """.stripMargin)
   class GeoRecordFrom


### PR DESCRIPTION
Related to : https://github.com/spotify/scio/pull/2090
Related to Issue : https://github.com/spotify/scio/issues/1882

Continue works done by @anne-decusatis in #2090 PR.

Tested BigQuery read and write steps with Geography types and fix fromAvro conversion step.
This is good to merge.