### PR TITLE
Rename patched Beam classes in scio-smb to avoid classloader issues

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroFileOperations.java
@@ -35,7 +35,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.AvroIO;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.FileIO;
-import org.apache.beam.sdk.io.SerializableAvroCodecFactory;
+import org.apache.beam.sdk.io.PatchedSerializableAvroCodecFactory;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 import org.apache.beam.sdk.util.MimeTypes;
@@ -47,13 +47,13 @@ class AvroFileOperations<ValueT> extends FileOperations<ValueT> {
 
   private final Class<ValueT> recordClass;
   private final SerializableSchemaSupplier schemaSupplier;
-  private final SerializableAvroCodecFactory codec;
+  private final PatchedSerializableAvroCodecFactory codec;
 
   private AvroFileOperations(Class<ValueT> recordClass, Schema schema, CodecFactory codec) {
     super(Compression.UNCOMPRESSED, MimeTypes.BINARY); // Avro has its own compression via codec
     this.recordClass = recordClass;
     this.schemaSupplier = new SerializableSchemaSupplier(schema);
-    this.codec = new SerializableAvroCodecFactory(codec);
+    this.codec = new PatchedSerializableAvroCodecFactory(codec);
   }
 
   public static <V extends GenericRecord> AvroFileOperations<V> of(Schema schema) {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
@@ -28,7 +28,7 @@ import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.FileIO;
 import org.apache.beam.sdk.io.FileIO.ReadableFile;
 import org.apache.beam.sdk.io.FileSystems;
-import org.apache.beam.sdk.io.ReadableFileUtil;
+import org.apache.beam.sdk.io.PatchedReadableFileUtil;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -160,7 +160,7 @@ public abstract class FileOperations<V> implements Serializable, HasDisplayData 
     try {
       final Metadata metadata = FileSystems.matchSingleFileSpec(resourceId.toString());
 
-      return ReadableFileUtil.newReadableFile(
+      return PatchedReadableFileUtil.newReadableFile(
           metadata,
           compression == Compression.AUTO
               ? Compression.detect(resourceId.getFilename())

--- a/scio-smb/src/main/java/org/apache/beam/sdk/io/PatchedReadableFileUtil.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/io/PatchedReadableFileUtil.java
@@ -21,7 +21,7 @@ import com.spotify.scio.smb.annotations.PatchedFromBeam;
 import org.apache.beam.sdk.io.fs.MatchResult;
 
 @PatchedFromBeam(origin="org.apache.beam.sdk.io.FileIO")
-public class ReadableFileUtil {
+public class PatchedReadableFileUtil {
   public static FileIO.ReadableFile newReadableFile(MatchResult.Metadata metadata, Compression compression) {
     return new FileIO.ReadableFile(metadata, compression);
   }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/io/PatchedSerializableAvroCodecFactory.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/io/PatchedSerializableAvroCodecFactory.java
@@ -42,7 +42,7 @@ import com.spotify.scio.smb.annotations.PatchedFromBeam;
  * standard serialization mechanisms.
  */
 @PatchedFromBeam(origin="org.apache.beam.sdk.io.SerializableAvroCodecFactory")
-public class SerializableAvroCodecFactory implements Externalizable {
+public class PatchedSerializableAvroCodecFactory implements Externalizable {
   // Matches Beam 2.16.0
   private static final long serialVersionUID = 7445324844109564303L;
   private static final List<String> noOptAvroCodecs =
@@ -53,9 +53,9 @@ public class SerializableAvroCodecFactory implements Externalizable {
   private @Nullable CodecFactory codecFactory;
 
   // For java.io.Externalizable
-  public SerializableAvroCodecFactory() {}
+  public PatchedSerializableAvroCodecFactory() {}
 
-  public SerializableAvroCodecFactory(CodecFactory codecFactory) {
+  public PatchedSerializableAvroCodecFactory(CodecFactory codecFactory) {
     checkNotNull(codecFactory, "Codec can't be null");
     checkState(checkIsSupportedCodec(codecFactory), "%s is not supported", codecFactory);
     this.codecFactory = codecFactory;


### PR DESCRIPTION
verified by running SMB sink/source operations using a local snapshot in another SBT project