### PR TITLE
Update beam to 2.18

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ import bloop.integrations.sbt.BloopDefaults
 
 ThisBuild / turbo := true
 
-val beamVersion = "2.17.0"
+val beamVersion = "2.18.0"
 
 val algebirdVersion = "0.13.6"
 val annoy4sVersion = "0.9.0"
@@ -81,8 +81,8 @@ val caffeineVersion = "2.8.1"
 val bigtableClientVersion = "1.8.0"
 val generatedGrpcGaVersion = "1.43.0"
 val generatedGrpcBetaVersion = "0.44.0"
-val googleClientsVersion = "1.27.0"
-val googleApiServicesBigQuery = s"v2-rev20181104-$googleClientsVersion"
+val googleClientsVersion = "1.28.0"
+val googleApiServicesBigQuery = s"v2-rev20181221-$googleClientsVersion"
 val bigdataossVersion = "1.9.16"
 val gaxVersion = "1.38.0"
 val googleAuthVersion = "0.12.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,6 +17,7 @@ addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.6.8")
 addSbtPlugin("io.github.jonas" % "sbt-paradox-material-theme" % "0.6.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.5")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.1.1")
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.12")
 
 libraryDependencies ++= Seq(
   "com.github.os72" % "protoc-jar" % "3.11.1"

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -697,11 +697,11 @@ object BigQueryTyped {
         }
     }
 
-    def apply[T: Schema: Coder](table: STable): BeamSchema[T] =
+    def apply[T: Schema: Coder: ClassTag](table: STable): BeamSchema[T] =
       new BeamSchema(table, defaultParseFn)
   }
 
-  final case class BeamSchema[T: Schema: Coder](
+  final case class BeamSchema[T: Schema: Coder: ClassTag](
     table: STable,
     parseFn: SchemaAndRecord => T
   ) extends BigQueryIO[T] {

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -138,7 +138,7 @@ final class SCollectionTableRowOps[T <: TableRow](private val self: SCollection[
   }
 }
 
-final class SCollectionBeamSchemaOps[T](private val self: SCollection[T]) extends AnyVal {
+final class SCollectionBeamSchemaOps[T: ClassTag](private val self: SCollection[T]) {
   def saveAsBigQuery(
     table: Table,
     writeDisposition: WriteDisposition = TypedWriteParam.DefaultWriteDisposition,
@@ -272,7 +272,7 @@ trait SCollectionSyntax {
   ): SCollectionTableRowOps[T] =
     new SCollectionTableRowOps[T](sc)
 
-  implicit def bigQuerySCollectionBeamSchemaOps[T](
+  implicit def bigQuerySCollectionBeamSchemaOps[T: ClassTag](
     sc: SCollection[T]
   ): SCollectionBeamSchemaOps[T] =
     new SCollectionBeamSchemaOps[T](sc)

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
@@ -202,10 +202,10 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
     }
   }
 
-  def typedBigQueryTable[T: Schema: Coder](table: Table): SCollection[T] =
+  def typedBigQueryTable[T: Schema: Coder: ClassTag](table: Table): SCollection[T] =
     self.read(BigQueryTyped.BeamSchema(table))
 
-  def typedBigQueryTable[T: Schema: Coder](
+  def typedBigQueryTable[T: Schema: Coder: ClassTag](
     table: Table,
     parseFn: SchemaAndRecord => T
   ): SCollection[T] =

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
@@ -28,6 +28,7 @@ import com.spotify.scio.transforms.BaseAsyncLookupDoFn
 import com.spotify.scio.util.ScioUtil
 import org.apache.beam.sdk.coders.{Coder => _, _}
 import org.apache.beam.sdk.schemas.SchemaCoder
+import org.apache.beam.sdk.values.TypeDescriptor
 import org.apache.beam.sdk.{coders => bcoders}
 
 import scala.reflect.ClassTag
@@ -116,7 +117,8 @@ trait JavaCoders extends JavaBeanCoders {
 trait JavaBeanCoders {
   implicit def javaBeanCoder[T: IsJavaBean: ClassTag]: Coder[T] = {
     val rec = Schema.javaBeanSchema[T]
-    Coder.beam(SchemaCoder.of(rec.schema, rec.toRow, rec.fromRow))
+    val td = TypeDescriptor.of(ScioUtil.classOf[T])
+    Coder.beam(SchemaCoder.of(rec.schema, td, rec.toRow, rec.fromRow))
   }
 }
 

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
@@ -267,12 +267,8 @@ private[scio] trait SchemaMacroHelpers {
     }
   }
 
-  def inferClassTag(t: ctx.Type): ctx.Expr[ClassTag[_]] = {
-    val tp = ctx.typecheck(tq"_root_.scala.reflect.ClassTag[$t]", ctx.TYPEmode).tpe
-    val typedTree = ctx.inferImplicitValue(tp, silent = false)
-    val untypedTree = ctx.untypecheck(typedTree.duplicate)
-    ctx.Expr[ClassTag[_]](untypedTree)
-  }
+  def inferClassTag(t: ctx.Type): ctx.Expr[ClassTag[_]] =
+    ctx.Expr[ClassTag[_]](q"implicitly[_root_.scala.reflect.ClassTag[$t]]")
 
   implicit def liftTupleTag[A: ctx.WeakTypeTag]: Liftable[TupleTag[A]] = Liftable[TupleTag[A]] {
     x =>

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
@@ -267,6 +267,13 @@ private[scio] trait SchemaMacroHelpers {
     }
   }
 
+  def inferClassTag(t: ctx.Type): ctx.Expr[ClassTag[_]] = {
+    val tp = ctx.typecheck(tq"_root_.scala.reflect.ClassTag[$t]", ctx.TYPEmode).tpe
+    val typedTree = ctx.inferImplicitValue(tp, silent = false)
+    val untypedTree = ctx.untypecheck(typedTree.duplicate)
+    ctx.Expr[ClassTag[_]](untypedTree)
+  }
+
   implicit def liftTupleTag[A: ctx.WeakTypeTag]: Liftable[TupleTag[A]] = Liftable[TupleTag[A]] {
     x =>
       q"new _root_.org.apache.beam.sdk.values.TupleTag[${weakTypeOf[A]}](${x.getId()})"

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -133,10 +133,11 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   def setCoder(coder: org.apache.beam.sdk.coders.Coder[T]): SCollection[T] =
     context.wrap(internal.setCoder(coder))
 
-  def setSchema(schema: Schema[T]): SCollection[T] =
+  def setSchema(schema: Schema[T])(implicit ct: ClassTag[T]): SCollection[T] =
     if (!internal.hasSchema) {
       val (s, to, from) = SchemaMaterializer.materialize(schema)
-      context.wrap(internal.setSchema(s, to, from))
+      val td = TypeDescriptor.of(ScioUtil.classOf[T])
+      context.wrap(internal.setSchema(s, td, to, from))
     } else this
 
   private def ensureSerializable[A](coder: BCoder[A]): Either[Throwable, BCoder[A]] =

--- a/scio-examples/src/main/java/org/apache/beam/examples/BeamSqlExample.java
+++ b/scio-examples/src/main/java/org/apache/beam/examples/BeamSqlExample.java
@@ -32,6 +32,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TypeDescriptors;
 
 /**
  * This is a quick example, which uses Beam SQL DSL to create a data pipeline.
@@ -63,7 +64,7 @@ class BeamSqlExample {
 
     // create a source PCollection with Create.of();
     PCollection<Row> inputTable = PBegin.in(p).apply(Create.of(row1, row2, row3).withSchema(type,
-        SerializableFunctions.identity(), SerializableFunctions.identity()));
+        TypeDescriptors.rows(), SerializableFunctions.identity(), SerializableFunctions.identity()));
 
     // Case 1. run a simple SQL query over input PCollection with
     // BeamSql.simpleQuery;

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/BeamSqlInterpolatorWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/BeamSqlInterpolatorWordCount.scala
@@ -30,23 +30,22 @@ import com.spotify.scio.sql._
 import com.spotify.scio.examples.common.ExampleData
 
 object BeamSqlInterpolatorWordCount {
-  def main(cmdlineArgs: Array[String]): Unit = {
-    val (sc, args) = ContextAndArgs(cmdlineArgs)
-    val coll = sc
-      .textFile(args.getOrElse("input", ExampleData.KING_LEAR))
-      // Split input lines, filter out empty tokens and expand into a collection of tokens
-      .flatMap(_.split("[^a-zA-Z']+").filter(_.nonEmpty))
-
-    // Count distinct string's
-    tsql"select distinct(`value`), count(*) from $coll group by `value`"
-      .as[(String, Long)]
-      // Map `(String, Long)` tuples into strings
-      .map(t => t._1 + ": " + t._2)
-      // Save result as text files under the output path
-      .saveAsTextFile(args("output"))
-
-    // Execute the pipeline
-    sc.run()
+  def main(cmdlineArgs: Array[String]): Unit =
+//    val (sc, args) = ContextAndArgs(cmdlineArgs)
+//    val coll = sc
+//      .textFile(args.getOrElse("input", ExampleData.KING_LEAR))
+//      // Split input lines, filter out empty tokens and expand into a collection of tokens
+//      .flatMap(_.split("[^a-zA-Z']+").filter(_.nonEmpty))
+//
+//    // Count distinct string's
+//    tsql"select distinct(`value`), count(*) from $coll group by `value`"
+//      .as[(String, Long)]
+//      // Map `(String, Long)` tuples into strings
+//      .map(t => t._1 + ": " + t._2)
+//      // Save result as text files under the output path
+//      .saveAsTextFile(args("output"))
+//
+//    // Execute the pipeline
+//    sc.run()
     ()
-  }
 }

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/BeamSqlInterpolatorWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/BeamSqlInterpolatorWordCount.scala
@@ -30,22 +30,23 @@ import com.spotify.scio.sql._
 import com.spotify.scio.examples.common.ExampleData
 
 object BeamSqlInterpolatorWordCount {
-  def main(cmdlineArgs: Array[String]): Unit =
-//    val (sc, args) = ContextAndArgs(cmdlineArgs)
-//    val coll = sc
-//      .textFile(args.getOrElse("input", ExampleData.KING_LEAR))
-//      // Split input lines, filter out empty tokens and expand into a collection of tokens
-//      .flatMap(_.split("[^a-zA-Z']+").filter(_.nonEmpty))
-//
-//    // Count distinct string's
-//    tsql"select distinct(`value`), count(*) from $coll group by `value`"
-//      .as[(String, Long)]
-//      // Map `(String, Long)` tuples into strings
-//      .map(t => t._1 + ": " + t._2)
-//      // Save result as text files under the output path
-//      .saveAsTextFile(args("output"))
-//
-//    // Execute the pipeline
-//    sc.run()
+  def main(cmdlineArgs: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(cmdlineArgs)
+    val coll = sc
+      .textFile(args.getOrElse("input", ExampleData.KING_LEAR))
+      // Split input lines, filter out empty tokens and expand into a collection of tokens
+      .flatMap(_.split("[^a-zA-Z']+").filter(_.nonEmpty))
+
+    // Count distinct string's
+    tsql"select distinct(`value`), count(*) from $coll group by `value`"
+      .as[(String, Long)]
+      // Map `(String, Long)` tuples into strings
+      .map(t => t._1 + ": " + t._2)
+      // Save result as text files under the output path
+      .saveAsTextFile(args("output"))
+
+    // Execute the pipeline
+    sc.run()
     ()
+  }
 }

--- a/scio-jmh/src/test/scala/com/spotify/scio/jmh/CoderBenchmark.scala
+++ b/scio-jmh/src/test/scala/com/spotify/scio/jmh/CoderBenchmark.scala
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.coders.{
 }
 import org.apache.beam.sdk.util.CoderUtils
 import org.apache.beam.sdk.schemas.SchemaCoder
+import org.apache.beam.sdk.values.TypeDescriptor
 import org.openjdk.jmh.annotations._
 
 final case class UserId(bytes: Array[Byte])
@@ -209,7 +210,12 @@ class CoderBenchmark {
     )
 
   val specializedSchemaCoder: BCoder[SpecializedUserForDerived] =
-    SchemaCoder.of(specializedUserSchema, specializedTo, specializedFrom)
+    SchemaCoder.of(
+      specializedUserSchema,
+      TypeDescriptor.of(classOf[SpecializedUserForDerived]),
+      specializedTo,
+      specializedFrom
+    )
 
   @Benchmark
   def schemaCoderEncode(o: SerializedOutputSize): Array[Byte] =
@@ -231,7 +237,7 @@ class CoderBenchmark {
     )
 
   val javaSchemaCoder: BCoder[j.User] =
-    SchemaCoder.of(javaUserSchema, javaTo, javaFrom)
+    SchemaCoder.of(javaUserSchema, TypeDescriptor.of(classOf[j.User]), javaTo, javaFrom)
 
   @Benchmark
   def javaSchemaCoderEncode(o: SerializedOutputSize): Array[Byte] =

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query1.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query1.scala
@@ -24,6 +24,7 @@ import org.apache.beam.sdk.extensions.sql.impl.ParseException
 import org.apache.beam.sdk.values._
 
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 final case class Query1[A, B](
   query: String,
@@ -91,7 +92,7 @@ object Query1 {
   }
 }
 
-final class SqlSCollection1[A: Schema](sc: SCollection[A]) {
+final class SqlSCollection1[A: Schema: ClassTag](sc: SCollection[A]) {
   def query(q: String, udfs: Udf*): SCollection[Row] =
     query(Query1[A, Row](q, Sql.defaultTag, udfs = udfs.toList))
 
@@ -106,10 +107,10 @@ final class SqlSCollection1[A: Schema](sc: SCollection[A]) {
       scWithSchema.applyInternal(sqlTransform)
     }
 
-  def queryAs[R: Schema](q: String, udfs: Udf*): SCollection[R] =
+  def queryAs[R: Schema: ClassTag](q: String, udfs: Udf*): SCollection[R] =
     queryAs(Query1[A, R](q, Sql.defaultTag, udfs = udfs.toList))
 
-  def queryAs[R: Schema](q: Query1[A, R]): SCollection[R] =
+  def queryAs[R: Schema: ClassTag](q: Query1[A, R]): SCollection[R] =
     try {
       query(Query1[A, Row](q.query, q.tag, q.udfs)).to(To.unchecked((_, i) => i))
     } catch {

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query10.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query10.scala
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.extensions.sql.impl.ParseException
 import org.apache.beam.sdk.values._
 
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 final case class Query10[A, B, C, D, E, F, G, H, I, J, R](
   query: String,
@@ -226,26 +227,26 @@ object Query10 {
       schemas10,
       schemas11
     ).fold(
-      err => c.abort(c.enclosingPosition, err),
-      _ =>
-        c.Expr[Query10[A, B, C, D, E, F, G, H, I, J, R]](
-          q"_root_.com.spotify.scio.sql.Query10($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag, $iTag, $jTag)"
-        )
-    )
+        err => c.abort(c.enclosingPosition, err),
+        _ =>
+          c.Expr[Query10[A, B, C, D, E, F, G, H, I, J, R]](
+            q"_root_.com.spotify.scio.sql.Query10($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag, $iTag, $jTag)"
+          )
+      )
   }
 }
 
 final class SqlSCollection10[
-  A: Schema,
-  B: Schema,
-  C: Schema,
-  D: Schema,
-  E: Schema,
-  F: Schema,
-  G: Schema,
-  H: Schema,
-  I: Schema,
-  J: Schema
+  A: Schema: ClassTag,
+  B: Schema: ClassTag,
+  C: Schema: ClassTag,
+  D: Schema: ClassTag,
+  E: Schema: ClassTag,
+  F: Schema: ClassTag,
+  G: Schema: ClassTag,
+  H: Schema: ClassTag,
+  I: Schema: ClassTag,
+  J: Schema: ClassTag
 ](
   a: SCollection[A],
   b: SCollection[B],
@@ -307,7 +308,7 @@ final class SqlSCollection10[
 
     }
 
-  def queryAs[R: Schema](
+  def queryAs[R: Schema: ClassTag](
     q: String,
     aTag: TupleTag[A],
     bTag: TupleTag[B],
@@ -323,7 +324,7 @@ final class SqlSCollection10[
   ): SCollection[R] =
     queryAs(Query10(q, aTag, bTag, cTag, dTag, eTag, fTag, gTag, hTag, iTag, jTag, udfs.toList))
 
-  def queryAs[R: Schema](q: Query10[A, B, C, D, E, F, G, H, I, J, R]): SCollection[R] =
+  def queryAs[R: Schema: ClassTag](q: Query10[A, B, C, D, E, F, G, H, I, J, R]): SCollection[R] =
     try {
       query(
         q.query,

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query10.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query10.scala
@@ -227,12 +227,12 @@ object Query10 {
       schemas10,
       schemas11
     ).fold(
-        err => c.abort(c.enclosingPosition, err),
-        _ =>
-          c.Expr[Query10[A, B, C, D, E, F, G, H, I, J, R]](
-            q"_root_.com.spotify.scio.sql.Query10($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag, $iTag, $jTag)"
-          )
-      )
+      err => c.abort(c.enclosingPosition, err),
+      _ =>
+        c.Expr[Query10[A, B, C, D, E, F, G, H, I, J, R]](
+          q"_root_.com.spotify.scio.sql.Query10($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag, $iTag, $jTag)"
+        )
+    )
   }
 }
 

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query2.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query2.scala
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.extensions.sql.impl.ParseException
 import org.apache.beam.sdk.values._
 
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 final case class Query2[A, B, R](
   query: String,
@@ -95,7 +96,10 @@ object Query2 {
   }
 }
 
-final class SqlSCollection2[A: Schema, B: Schema](a: SCollection[A], b: SCollection[B]) {
+final class SqlSCollection2[A: Schema: ClassTag, B: Schema: ClassTag](
+  a: SCollection[A],
+  b: SCollection[B]
+) {
 
   def query(q: String, aTag: TupleTag[A], bTag: TupleTag[B], udfs: Udf*): SCollection[Row] =
     query(Query2(q, aTag, bTag, udfs.toList))
@@ -113,7 +117,7 @@ final class SqlSCollection2[A: Schema, B: Schema](a: SCollection[A], b: SCollect
 
     }
 
-  def queryAs[R: Schema](
+  def queryAs[R: Schema: ClassTag](
     q: String,
     aTag: TupleTag[A],
     bTag: TupleTag[B],
@@ -121,7 +125,7 @@ final class SqlSCollection2[A: Schema, B: Schema](a: SCollection[A], b: SCollect
   ): SCollection[R] =
     queryAs(Query2(q, aTag, bTag, udfs.toList))
 
-  def queryAs[R: Schema](q: Query2[A, B, R]): SCollection[R] =
+  def queryAs[R: Schema: ClassTag](q: Query2[A, B, R]): SCollection[R] =
     try {
       query(q.query, q.aTag, q.bTag, q.udfs: _*).to(To.unchecked((_, i) => i))
     } catch {

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query3.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query3.scala
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.extensions.sql.impl.ParseException
 import org.apache.beam.sdk.values._
 
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 final case class Query3[A, B, C, R](
   query: String,
@@ -109,7 +110,7 @@ object Query3 {
   }
 }
 
-final class SqlSCollection3[A: Schema, B: Schema, C: Schema](
+final class SqlSCollection3[A: Schema: ClassTag, B: Schema: ClassTag, C: Schema: ClassTag](
   a: SCollection[A],
   b: SCollection[B],
   c: SCollection[C]
@@ -139,7 +140,7 @@ final class SqlSCollection3[A: Schema, B: Schema, C: Schema](
 
     }
 
-  def queryAs[R: Schema](
+  def queryAs[R: Schema: ClassTag](
     q: String,
     aTag: TupleTag[A],
     bTag: TupleTag[B],
@@ -148,7 +149,7 @@ final class SqlSCollection3[A: Schema, B: Schema, C: Schema](
   ): SCollection[R] =
     queryAs(Query3(q, aTag, bTag, cTag, udfs.toList))
 
-  def queryAs[R: Schema](q: Query3[A, B, C, R]): SCollection[R] =
+  def queryAs[R: Schema: ClassTag](q: Query3[A, B, C, R]): SCollection[R] =
     try {
       query(q.query, q.aTag, q.bTag, q.cTag, q.udfs: _*).to(To.unchecked((_, i) => i))
     } catch {

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query4.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query4.scala
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.extensions.sql.impl.ParseException
 import org.apache.beam.sdk.values._
 
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 final case class Query4[A, B, C, D, R](
   query: String,
@@ -124,12 +125,12 @@ object Query4 {
   }
 }
 
-final class SqlSCollection4[A: Schema, B: Schema, C: Schema, D: Schema](
-  a: SCollection[A],
-  b: SCollection[B],
-  c: SCollection[C],
-  d: SCollection[D]
-) {
+final class SqlSCollection4[
+  A: Schema: ClassTag,
+  B: Schema: ClassTag,
+  C: Schema: ClassTag,
+  D: Schema: ClassTag
+](a: SCollection[A], b: SCollection[B], c: SCollection[C], d: SCollection[D]) {
 
   def query(
     q: String,
@@ -161,7 +162,7 @@ final class SqlSCollection4[A: Schema, B: Schema, C: Schema, D: Schema](
 
     }
 
-  def queryAs[R: Schema](
+  def queryAs[R: Schema: ClassTag](
     q: String,
     aTag: TupleTag[A],
     bTag: TupleTag[B],
@@ -171,7 +172,7 @@ final class SqlSCollection4[A: Schema, B: Schema, C: Schema, D: Schema](
   ): SCollection[R] =
     queryAs(Query4(q, aTag, bTag, cTag, dTag, udfs.toList))
 
-  def queryAs[R: Schema](q: Query4[A, B, C, D, R]): SCollection[R] =
+  def queryAs[R: Schema: ClassTag](q: Query4[A, B, C, D, R]): SCollection[R] =
     try {
       query(q.query, q.aTag, q.bTag, q.cTag, q.dTag, q.udfs: _*).to(To.unchecked((_, i) => i))
     } catch {

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query5.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query5.scala
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.extensions.sql.impl.ParseException
 import org.apache.beam.sdk.values._
 
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 final case class Query5[A, B, C, D, E, R](
   query: String,
@@ -132,13 +133,13 @@ object Query5 {
   }
 }
 
-final class SqlSCollection5[A: Schema, B: Schema, C: Schema, D: Schema, E: Schema](
-  a: SCollection[A],
-  b: SCollection[B],
-  c: SCollection[C],
-  d: SCollection[D],
-  e: SCollection[E]
-) {
+final class SqlSCollection5[
+  A: Schema: ClassTag,
+  B: Schema: ClassTag,
+  C: Schema: ClassTag,
+  D: Schema: ClassTag,
+  E: Schema: ClassTag
+](a: SCollection[A], b: SCollection[B], c: SCollection[C], d: SCollection[D], e: SCollection[E]) {
 
   def query(
     q: String,
@@ -173,7 +174,7 @@ final class SqlSCollection5[A: Schema, B: Schema, C: Schema, D: Schema, E: Schem
 
     }
 
-  def queryAs[R: Schema](
+  def queryAs[R: Schema: ClassTag](
     q: String,
     aTag: TupleTag[A],
     bTag: TupleTag[B],
@@ -184,7 +185,7 @@ final class SqlSCollection5[A: Schema, B: Schema, C: Schema, D: Schema, E: Schem
   ): SCollection[R] =
     queryAs(Query5(q, aTag, bTag, cTag, dTag, eTag, udfs.toList))
 
-  def queryAs[R: Schema](q: Query5[A, B, C, D, E, R]): SCollection[R] =
+  def queryAs[R: Schema: ClassTag](q: Query5[A, B, C, D, E, R]): SCollection[R] =
     try {
       query(q.query, q.aTag, q.bTag, q.cTag, q.dTag, q.eTag, q.udfs: _*)
         .to(To.unchecked((_, i) => i))

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query6.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query6.scala
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.extensions.sql.impl.ParseException
 import org.apache.beam.sdk.values._
 
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 final case class Query6[A, B, C, D, E, F, R](
   query: String,
@@ -142,7 +143,14 @@ object Query6 {
   }
 }
 
-final class SqlSCollection6[A: Schema, B: Schema, C: Schema, D: Schema, E: Schema, F: Schema](
+final class SqlSCollection6[
+  A: Schema: ClassTag,
+  B: Schema: ClassTag,
+  C: Schema: ClassTag,
+  D: Schema: ClassTag,
+  E: Schema: ClassTag,
+  F: Schema: ClassTag
+](
   a: SCollection[A],
   b: SCollection[B],
   c: SCollection[C],
@@ -187,7 +195,7 @@ final class SqlSCollection6[A: Schema, B: Schema, C: Schema, D: Schema, E: Schem
 
     }
 
-  def queryAs[R: Schema](
+  def queryAs[R: Schema: ClassTag](
     q: String,
     aTag: TupleTag[A],
     bTag: TupleTag[B],
@@ -199,7 +207,7 @@ final class SqlSCollection6[A: Schema, B: Schema, C: Schema, D: Schema, E: Schem
   ): SCollection[R] =
     queryAs(Query6(q, aTag, bTag, cTag, dTag, eTag, fTag, udfs.toList))
 
-  def queryAs[R: Schema](q: Query6[A, B, C, D, E, F, R]): SCollection[R] =
+  def queryAs[R: Schema: ClassTag](q: Query6[A, B, C, D, E, F, R]): SCollection[R] =
     try {
       query(q.query, q.aTag, q.bTag, q.cTag, q.dTag, q.eTag, q.fTag, q.udfs: _*)
         .to(To.unchecked((_, i) => i))

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query7.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query7.scala
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.extensions.sql.impl.ParseException
 import org.apache.beam.sdk.values._
 
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 final case class Query7[A, B, C, D, E, F, G, R](
   query: String,
@@ -158,13 +159,13 @@ object Query7 {
 }
 
 final class SqlSCollection7[
-  A: Schema,
-  B: Schema,
-  C: Schema,
-  D: Schema,
-  E: Schema,
-  F: Schema,
-  G: Schema
+  A: Schema: ClassTag,
+  B: Schema: ClassTag,
+  C: Schema: ClassTag,
+  D: Schema: ClassTag,
+  E: Schema: ClassTag,
+  F: Schema: ClassTag,
+  G: Schema: ClassTag
 ](
   a: SCollection[A],
   b: SCollection[B],
@@ -214,7 +215,7 @@ final class SqlSCollection7[
 
     }
 
-  def queryAs[R: Schema](
+  def queryAs[R: Schema: ClassTag](
     q: String,
     aTag: TupleTag[A],
     bTag: TupleTag[B],
@@ -227,7 +228,7 @@ final class SqlSCollection7[
   ): SCollection[R] =
     queryAs(Query7(q, aTag, bTag, cTag, dTag, eTag, fTag, gTag, udfs.toList))
 
-  def queryAs[R: Schema](q: Query7[A, B, C, D, E, F, G, R]): SCollection[R] =
+  def queryAs[R: Schema: ClassTag](q: Query7[A, B, C, D, E, F, G, R]): SCollection[R] =
     try {
       query(q.query, q.aTag, q.bTag, q.cTag, q.dTag, q.eTag, q.fTag, q.gTag, q.udfs: _*)
         .to(To.unchecked((_, i) => i))

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query8.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query8.scala
@@ -187,12 +187,12 @@ object Query8 {
       schemas8,
       schemas9
     ).fold(
-        err => c.abort(c.enclosingPosition, err),
-        _ =>
-          c.Expr[Query8[A, B, C, D, E, F, G, H, R]](
-            q"_root_.com.spotify.scio.sql.Query8($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag)"
-          )
-      )
+      err => c.abort(c.enclosingPosition, err),
+      _ =>
+        c.Expr[Query8[A, B, C, D, E, F, G, H, R]](
+          q"_root_.com.spotify.scio.sql.Query8($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag)"
+        )
+    )
   }
 }
 

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query8.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query8.scala
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.extensions.sql.impl.ParseException
 import org.apache.beam.sdk.values._
 
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 final case class Query8[A, B, C, D, E, F, G, H, R](
   query: String,
@@ -186,24 +187,24 @@ object Query8 {
       schemas8,
       schemas9
     ).fold(
-      err => c.abort(c.enclosingPosition, err),
-      _ =>
-        c.Expr[Query8[A, B, C, D, E, F, G, H, R]](
-          q"_root_.com.spotify.scio.sql.Query8($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag)"
-        )
-    )
+        err => c.abort(c.enclosingPosition, err),
+        _ =>
+          c.Expr[Query8[A, B, C, D, E, F, G, H, R]](
+            q"_root_.com.spotify.scio.sql.Query8($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag)"
+          )
+      )
   }
 }
 
 final class SqlSCollection8[
-  A: Schema,
-  B: Schema,
-  C: Schema,
-  D: Schema,
-  E: Schema,
-  F: Schema,
-  G: Schema,
-  H: Schema
+  A: Schema: ClassTag,
+  B: Schema: ClassTag,
+  C: Schema: ClassTag,
+  D: Schema: ClassTag,
+  E: Schema: ClassTag,
+  F: Schema: ClassTag,
+  G: Schema: ClassTag,
+  H: Schema: ClassTag
 ](
   a: SCollection[A],
   b: SCollection[B],
@@ -257,7 +258,7 @@ final class SqlSCollection8[
 
     }
 
-  def queryAs[R: Schema](
+  def queryAs[R: Schema: ClassTag](
     q: String,
     aTag: TupleTag[A],
     bTag: TupleTag[B],
@@ -271,7 +272,7 @@ final class SqlSCollection8[
   ): SCollection[R] =
     queryAs(Query8(q, aTag, bTag, cTag, dTag, eTag, fTag, gTag, hTag, udfs.toList))
 
-  def queryAs[R: Schema](q: Query8[A, B, C, D, E, F, G, H, R]): SCollection[R] =
+  def queryAs[R: Schema: ClassTag](q: Query8[A, B, C, D, E, F, G, H, R]): SCollection[R] =
     try {
       query(q.query, q.aTag, q.bTag, q.cTag, q.dTag, q.eTag, q.fTag, q.gTag, q.hTag, q.udfs: _*)
         .to(To.unchecked((_, i) => i))

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query9.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query9.scala
@@ -212,12 +212,12 @@ object Query9 {
       schemas9,
       schemas10
     ).fold(
-        err => c.abort(c.enclosingPosition, err),
-        _ =>
-          c.Expr[Query9[A, B, C, D, E, F, G, H, I, R]](
-            q"_root_.com.spotify.scio.sql.Query9($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag, $iTag)"
-          )
-      )
+      err => c.abort(c.enclosingPosition, err),
+      _ =>
+        c.Expr[Query9[A, B, C, D, E, F, G, H, I, R]](
+          q"_root_.com.spotify.scio.sql.Query9($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag, $iTag)"
+        )
+    )
   }
 }
 

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Query9.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Query9.scala
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.extensions.sql.impl.ParseException
 import org.apache.beam.sdk.values._
 
 import scala.language.experimental.macros
+import scala.reflect.ClassTag
 
 final case class Query9[A, B, C, D, E, F, G, H, I, R](
   query: String,
@@ -211,25 +212,25 @@ object Query9 {
       schemas9,
       schemas10
     ).fold(
-      err => c.abort(c.enclosingPosition, err),
-      _ =>
-        c.Expr[Query9[A, B, C, D, E, F, G, H, I, R]](
-          q"_root_.com.spotify.scio.sql.Query9($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag, $iTag)"
-        )
-    )
+        err => c.abort(c.enclosingPosition, err),
+        _ =>
+          c.Expr[Query9[A, B, C, D, E, F, G, H, I, R]](
+            q"_root_.com.spotify.scio.sql.Query9($query, $aTag, $bTag, $cTag, $dTag, $eTag, $fTag, $gTag, $hTag, $iTag)"
+          )
+      )
   }
 }
 
 final class SqlSCollection9[
-  A: Schema,
-  B: Schema,
-  C: Schema,
-  D: Schema,
-  E: Schema,
-  F: Schema,
-  G: Schema,
-  H: Schema,
-  I: Schema
+  A: Schema: ClassTag,
+  B: Schema: ClassTag,
+  C: Schema: ClassTag,
+  D: Schema: ClassTag,
+  E: Schema: ClassTag,
+  F: Schema: ClassTag,
+  G: Schema: ClassTag,
+  H: Schema: ClassTag,
+  I: Schema: ClassTag
 ](
   a: SCollection[A],
   b: SCollection[B],
@@ -287,7 +288,7 @@ final class SqlSCollection9[
 
     }
 
-  def queryAs[R: Schema](
+  def queryAs[R: Schema: ClassTag](
     q: String,
     aTag: TupleTag[A],
     bTag: TupleTag[B],
@@ -302,7 +303,7 @@ final class SqlSCollection9[
   ): SCollection[R] =
     queryAs(Query9(q, aTag, bTag, cTag, dTag, eTag, fTag, gTag, hTag, iTag, udfs.toList))
 
-  def queryAs[R: Schema](q: Query9[A, B, C, D, E, F, G, H, I, R]): SCollection[R] =
+  def queryAs[R: Schema: ClassTag](q: Query9[A, B, C, D, E, F, G, H, I, R]): SCollection[R] =
     try {
       query(
         q.query,

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/SQLBuilders.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/SQLBuilders.scala
@@ -24,22 +24,23 @@ package com.spotify.scio.sql
 
 import com.spotify.scio.schemas.Schema
 import org.apache.beam.sdk.values.TupleTag
+import scala.reflect._
 
 object SQLBuilders {
 
-  private[sql] def from[A](
+  private[sql] def from[A: ClassTag](
     q: String,
     refA: SCollectionRef[A],
     aTag: TupleTag[A],
     udfs: List[Udf]
   ): SQLBuilder = new SQLBuilder {
-    def as[R: Schema] =
+    def as[R: Schema: ClassTag] =
       Sql
-        .from(refA.coll)(refA.schema)
+        .from(refA.coll)(refA.schema, classTag[A])
         .queryAs(new Query1[refA._A, R](q, aTag, udfs))
   }
 
-  private[sql] def from[A, B](
+  private[sql] def from[A: ClassTag, B: ClassTag](
     q: String,
     refA: SCollectionRef[A],
     refB: SCollectionRef[B],
@@ -47,13 +48,13 @@ object SQLBuilders {
     bTag: TupleTag[B],
     udfs: List[Udf]
   ): SQLBuilder = new SQLBuilder {
-    def as[R: Schema] =
+    def as[R: Schema: ClassTag] =
       Sql
-        .from(refA.coll, refB.coll)(refA.schema, refB.schema)
+        .from(refA.coll, refB.coll)(refA.schema, classTag[A], refB.schema, classTag[B])
         .queryAs(new Query2[refA._A, refB._A, R](q, aTag, bTag, udfs))
   }
 
-  private[sql] def from[A, B, C](
+  private[sql] def from[A: ClassTag, B: ClassTag, C: ClassTag](
     q: String,
     refA: SCollectionRef[A],
     refB: SCollectionRef[B],
@@ -63,13 +64,20 @@ object SQLBuilders {
     cTag: TupleTag[C],
     udfs: List[Udf]
   ): SQLBuilder = new SQLBuilder {
-    def as[R: Schema] =
+    def as[R: Schema: ClassTag] =
       Sql
-        .from(refA.coll, refB.coll, refC.coll)(refA.schema, refB.schema, refC.schema)
+        .from(refA.coll, refB.coll, refC.coll)(
+          refA.schema,
+          classTag[A],
+          refB.schema,
+          classTag[B],
+          refC.schema,
+          classTag[C]
+        )
         .queryAs(new Query3[refA._A, refB._A, refC._A, R](q, aTag, bTag, cTag, udfs))
   }
 
-  private[sql] def from[A, B, C, D](
+  private[sql] def from[A: ClassTag, B: ClassTag, C: ClassTag, D: ClassTag](
     q: String,
     refA: SCollectionRef[A],
     refB: SCollectionRef[B],
@@ -81,18 +89,22 @@ object SQLBuilders {
     dTag: TupleTag[D],
     udfs: List[Udf]
   ): SQLBuilder = new SQLBuilder {
-    def as[R: Schema] =
+    def as[R: Schema: ClassTag] =
       Sql
         .from(refA.coll, refB.coll, refC.coll, refD.coll)(
           refA.schema,
+          classTag[A],
           refB.schema,
+          classTag[B],
           refC.schema,
-          refD.schema
+          classTag[C],
+          refD.schema,
+          classTag[D]
         )
         .queryAs(new Query4[refA._A, refB._A, refC._A, refD._A, R](q, aTag, bTag, cTag, dTag, udfs))
   }
 
-  private[sql] def from[A, B, C, D, E](
+  private[sql] def from[A: ClassTag, B: ClassTag, C: ClassTag, D: ClassTag, E: ClassTag](
     q: String,
     refA: SCollectionRef[A],
     refB: SCollectionRef[B],
@@ -106,14 +118,19 @@ object SQLBuilders {
     eTag: TupleTag[E],
     udfs: List[Udf]
   ): SQLBuilder = new SQLBuilder {
-    def as[R: Schema] =
+    def as[R: Schema: ClassTag] =
       Sql
         .from(refA.coll, refB.coll, refC.coll, refD.coll, refE.coll)(
           refA.schema,
+          classTag[A],
           refB.schema,
+          classTag[B],
           refC.schema,
+          classTag[C],
           refD.schema,
-          refE.schema
+          classTag[D],
+          refE.schema,
+          classTag[E]
         )
         .queryAs(
           new Query5[refA._A, refB._A, refC._A, refD._A, refE._A, R](
@@ -128,7 +145,14 @@ object SQLBuilders {
         )
   }
 
-  private[sql] def from[A, B, C, D, E, F](
+  private[sql] def from[
+    A: ClassTag,
+    B: ClassTag,
+    C: ClassTag,
+    D: ClassTag,
+    E: ClassTag,
+    F: ClassTag
+  ](
     q: String,
     refA: SCollectionRef[A],
     refB: SCollectionRef[B],
@@ -144,15 +168,21 @@ object SQLBuilders {
     fTag: TupleTag[F],
     udfs: List[Udf]
   ): SQLBuilder = new SQLBuilder {
-    def as[R: Schema] =
+    def as[R: Schema: ClassTag] =
       Sql
         .from(refA.coll, refB.coll, refC.coll, refD.coll, refE.coll, refF.coll)(
           refA.schema,
+          classTag[A],
           refB.schema,
+          classTag[B],
           refC.schema,
+          classTag[C],
           refD.schema,
+          classTag[D],
           refE.schema,
-          refF.schema
+          classTag[E],
+          refF.schema,
+          classTag[F]
         )
         .queryAs(
           new Query6[refA._A, refB._A, refC._A, refD._A, refE._A, refF._A, R](
@@ -168,7 +198,15 @@ object SQLBuilders {
         )
   }
 
-  private[sql] def from[A, B, C, D, E, F, G](
+  private[sql] def from[
+    A: ClassTag,
+    B: ClassTag,
+    C: ClassTag,
+    D: ClassTag,
+    E: ClassTag,
+    F: ClassTag,
+    G: ClassTag
+  ](
     q: String,
     refA: SCollectionRef[A],
     refB: SCollectionRef[B],
@@ -186,16 +224,23 @@ object SQLBuilders {
     gTag: TupleTag[G],
     udfs: List[Udf]
   ): SQLBuilder = new SQLBuilder {
-    def as[R: Schema] =
+    def as[R: Schema: ClassTag] =
       Sql
         .from(refA.coll, refB.coll, refC.coll, refD.coll, refE.coll, refF.coll, refG.coll)(
           refA.schema,
+          classTag[A],
           refB.schema,
+          classTag[B],
           refC.schema,
+          classTag[C],
           refD.schema,
+          classTag[D],
           refE.schema,
+          classTag[E],
           refF.schema,
-          refG.schema
+          classTag[F],
+          refG.schema,
+          classTag[G]
         )
         .queryAs(
           new Query7[refA._A, refB._A, refC._A, refD._A, refE._A, refF._A, refG._A, R](
@@ -212,7 +257,16 @@ object SQLBuilders {
         )
   }
 
-  private[sql] def from[A, B, C, D, E, F, G, H](
+  private[sql] def from[
+    A: ClassTag,
+    B: ClassTag,
+    C: ClassTag,
+    D: ClassTag,
+    E: ClassTag,
+    F: ClassTag,
+    G: ClassTag,
+    H: ClassTag
+  ](
     q: String,
     refA: SCollectionRef[A],
     refB: SCollectionRef[B],
@@ -232,7 +286,7 @@ object SQLBuilders {
     hTag: TupleTag[H],
     udfs: List[Udf]
   ): SQLBuilder = new SQLBuilder {
-    def as[R: Schema] =
+    def as[R: Schema: ClassTag] =
       Sql
         .from(
           refA.coll,
@@ -245,13 +299,21 @@ object SQLBuilders {
           refH.coll
         )(
           refA.schema,
+          classTag[A],
           refB.schema,
+          classTag[B],
           refC.schema,
+          classTag[C],
           refD.schema,
+          classTag[D],
           refE.schema,
+          classTag[E],
           refF.schema,
+          classTag[F],
           refG.schema,
-          refH.schema
+          classTag[G],
+          refH.schema,
+          classTag[H]
         )
         .queryAs(
           new Query8[refA._A, refB._A, refC._A, refD._A, refE._A, refF._A, refG._A, refH._A, R](
@@ -269,7 +331,17 @@ object SQLBuilders {
         )
   }
 
-  private[sql] def from[A, B, C, D, E, F, G, H, I](
+  private[sql] def from[
+    A: ClassTag,
+    B: ClassTag,
+    C: ClassTag,
+    D: ClassTag,
+    E: ClassTag,
+    F: ClassTag,
+    G: ClassTag,
+    H: ClassTag,
+    I: ClassTag
+  ](
     q: String,
     refA: SCollectionRef[A],
     refB: SCollectionRef[B],
@@ -291,7 +363,7 @@ object SQLBuilders {
     iTag: TupleTag[I],
     udfs: List[Udf]
   ): SQLBuilder = new SQLBuilder {
-    def as[R: Schema] =
+    def as[R: Schema: ClassTag] =
       Sql
         .from(
           refA.coll,
@@ -305,14 +377,23 @@ object SQLBuilders {
           refI.coll
         )(
           refA.schema,
+          classTag[A],
           refB.schema,
+          classTag[B],
           refC.schema,
+          classTag[C],
           refD.schema,
+          classTag[D],
           refE.schema,
+          classTag[E],
           refF.schema,
+          classTag[F],
           refG.schema,
+          classTag[G],
           refH.schema,
-          refI.schema
+          classTag[H],
+          refI.schema,
+          classTag[I]
         )
         .queryAs(
           new Query9[
@@ -330,7 +411,18 @@ object SQLBuilders {
         )
   }
 
-  private[sql] def from[A, B, C, D, E, F, G, H, I, J](
+  private[sql] def from[
+    A: ClassTag,
+    B: ClassTag,
+    C: ClassTag,
+    D: ClassTag,
+    E: ClassTag,
+    F: ClassTag,
+    G: ClassTag,
+    H: ClassTag,
+    I: ClassTag,
+    J: ClassTag
+  ](
     q: String,
     refA: SCollectionRef[A],
     refB: SCollectionRef[B],
@@ -354,7 +446,7 @@ object SQLBuilders {
     jTag: TupleTag[J],
     udfs: List[Udf]
   ): SQLBuilder = new SQLBuilder {
-    def as[R: Schema] =
+    def as[R: Schema: ClassTag] =
       Sql
         .from(
           refA.coll,
@@ -369,15 +461,25 @@ object SQLBuilders {
           refJ.coll
         )(
           refA.schema,
+          classTag[A],
           refB.schema,
+          classTag[B],
           refC.schema,
+          classTag[C],
           refD.schema,
+          classTag[D],
           refE.schema,
+          classTag[E],
           refF.schema,
+          classTag[F],
           refG.schema,
+          classTag[G],
           refH.schema,
+          classTag[H],
           refI.schema,
-          refJ.schema
+          classTag[I],
+          refJ.schema,
+          classTag[J]
         )
         .queryAs(
           new Query10[

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/Sql.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/Sql.scala
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.values._
 import org.apache.commons.lang3.exception.ExceptionUtils
 
 import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
 import scala.util.Try
 
 object Sql extends SqlSCollections {
@@ -59,10 +60,11 @@ object Sql extends SqlSCollections {
     new ReadOnlyTableProvider(SCollectionTypeName, Collections.singletonMap(tag.getId, table))
   }
 
-  private[sql] def setSchema[T: Schema](c: SCollection[T]): SCollection[T] =
+  private[sql] def setSchema[T: Schema: ClassTag](c: SCollection[T]): SCollection[T] =
     c.transform { x =>
       val (schema, to, from) = SchemaMaterializer.materialize(Schema[T])
-      x.map(identity)(Coder.beam(SchemaCoder.of(schema, to, from)))
+      val td = TypeDescriptor.of(ScioUtil.classOf[T])
+      x.map(identity)(Coder.beam(SchemaCoder.of(schema, td, to, from)))
     }
 }
 

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/SqlInterpolator.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/SqlInterpolator.scala
@@ -25,15 +25,17 @@ import scala.language.experimental.macros
 import scala.reflect.macros.{blackbox, whitebox}
 import com.spotify.scio.schemas.SchemaMacroHelpers
 
+import scala.reflect._
+
 trait SQLBuilder {
-  def as[B: Schema]: SCollection[B]
+  def as[B: Schema: ClassTag]: SCollection[B]
 }
 
 sealed trait SqlParam
 
 final case class SCollectionRef[A: Schema](coll: SCollection[A]) extends SqlParam {
   type _A = A
-  val schema = Schema[A]
+  val schema: Schema[A] = Schema[A]
 }
 
 final case class UdfRef(udf: Udf) extends SqlParam
@@ -156,16 +158,17 @@ object SqlInterpolatorMacro {
         {
           import _root_.com.spotify.scio.values.SCollection
           import _root_.com.spotify.scio.schemas.Schema
+          import _root_.scala.reflect.ClassTag
 
           sealed trait $fakeName  extends _root_.com.spotify.scio.sql.SQLBuilder {
-            def as[B: Schema]: SCollection[B] = ???
+            def as[B: Schema: ClassTag]: SCollection[B] = ???
           }
 
           final class $className extends $fakeName {
             import scala.language.experimental.macros
 
             @_root_.com.spotify.scio.sql.SqlInterpolatorMacro.SqlParts(List(..$parts),..$ps)
-            override def as[B: Schema]: SCollection[B] =
+            override def as[B: Schema: ClassTag]: SCollection[B] =
               macro _root_.com.spotify.scio.sql.SqlInterpolatorMacro.expand[B]
           }
           new $className
@@ -177,7 +180,7 @@ object SqlInterpolatorMacro {
 
   def expand[B: c.WeakTypeTag](
     c: blackbox.Context
-  )(schB: c.Expr[Schema[B]]): c.Expr[SCollection[B]] = {
+  )(schB: c.Expr[Schema[B]], classTag: c.Expr[ClassTag[B]]): c.Expr[SCollection[B]] = {
     import c.universe._
 
     val annotationParams =
@@ -202,12 +205,14 @@ object SqlInterpolatorMacro {
           )
       }
 
-    tsqlImpl[B](c)(parts, ps: _*)
+    tsqlImpl[B](c)(parts, ps: _*)(classTag)
   }
 
   def tsqlImpl[B: c.WeakTypeTag](
     c: blackbox.Context
-  )(parts: List[c.Tree], ps: c.Expr[Any]*): c.Expr[SCollection[B]] = {
+  )(parts: List[c.Tree], ps: c.Expr[Any]*)(
+    ct: c.Expr[ClassTag[B]]
+  ): c.Expr[SCollection[B]] = {
     val h = new { val ctx: c.type = c } with SqlInterpolatorMacroHelpers with SchemaMacroHelpers
     import h._
     import c.universe._
@@ -243,14 +248,19 @@ object SqlInterpolatorMacro {
         val tags = list.map(x => tagFor(x._2, toSCollectionName(x._1)))
         val sql = buildSQLString(parts, scs.map(x => toSCollectionName(x._1)))
         val implOut = inferImplicitSchema[B]
-        val implIn = types.map(inferImplicitSchema)
+        val implIn =
+          types
+            .map(inferImplicitSchema)
+            .map(List(_))
+            .zipAll(types.map(inferClassTag).map(List(_)), Nil, Nil)
+            .flatMap { case (a, b) => a ++ b }
 
         val queryTree = c.parse(s"_root_.com.spotify.scio.sql.Query${types.size}")
         val q = q"$queryTree.typed[..${types :+ weakTypeOf[B]}]($sql, ..$tags)"
         c.Expr[SCollection[B]](q"""
             _root_.com.spotify.scio.sql.Sql
                 .from(..$colls)(..$implIn)
-                .queryAs($q)($implOut)""")
+                .queryAs($q)($implOut, $ct)""")
       case d =>
         val ns = d.map(_._1).mkString(", ")
         c.abort(

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/SqlInterpolator.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/SqlInterpolator.scala
@@ -248,12 +248,9 @@ object SqlInterpolatorMacro {
         val tags = list.map(x => tagFor(x._2, toSCollectionName(x._1)))
         val sql = buildSQLString(parts, scs.map(x => toSCollectionName(x._1)))
         val implOut = inferImplicitSchema[B]
-        val implIn =
-          types
-            .map(inferImplicitSchema)
-            .map(List(_))
-            .zipAll(types.map(inferClassTag).map(List(_)), Nil, Nil)
-            .flatMap { case (a, b) => a ++ b }
+        val implIn = types.flatMap { t =>
+          Seq(inferImplicitSchema(t), inferClassTag(t))
+        }
 
         val queryTree = c.parse(s"_root_.com.spotify.scio.sql.Query${types.size}")
         val q = q"$queryTree.typed[..${types :+ weakTypeOf[B]}]($sql, ..$tags)"

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/SqlSCollections.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/SqlSCollections.scala
@@ -25,29 +25,46 @@ package com.spotify.scio.sql
 import com.spotify.scio.schemas._
 import com.spotify.scio.values.SCollection
 
+import scala.reflect.ClassTag
+
 trait SqlSCollections {
-  def from[A: Schema](a: SCollection[A]): SqlSCollection1[A] = new SqlSCollection1(a)
-  def from[A: Schema, B: Schema](a: SCollection[A], b: SCollection[B]): SqlSCollection2[A, B] =
-    new SqlSCollection2(a, b)
-  def from[A: Schema, B: Schema, C: Schema](
+  def from[A: Schema: ClassTag](a: SCollection[A]): SqlSCollection1[A] = new SqlSCollection1(a)
+  def from[A: Schema: ClassTag, B: Schema: ClassTag](
+    a: SCollection[A],
+    b: SCollection[B]
+  ): SqlSCollection2[A, B] = new SqlSCollection2(a, b)
+  def from[A: Schema: ClassTag, B: Schema: ClassTag, C: Schema: ClassTag](
     a: SCollection[A],
     b: SCollection[B],
     c: SCollection[C]
   ): SqlSCollection3[A, B, C] = new SqlSCollection3(a, b, c)
-  def from[A: Schema, B: Schema, C: Schema, D: Schema](
+  def from[A: Schema: ClassTag, B: Schema: ClassTag, C: Schema: ClassTag, D: Schema: ClassTag](
     a: SCollection[A],
     b: SCollection[B],
     c: SCollection[C],
     d: SCollection[D]
   ): SqlSCollection4[A, B, C, D] = new SqlSCollection4(a, b, c, d)
-  def from[A: Schema, B: Schema, C: Schema, D: Schema, E: Schema](
+  def from[
+    A: Schema: ClassTag,
+    B: Schema: ClassTag,
+    C: Schema: ClassTag,
+    D: Schema: ClassTag,
+    E: Schema: ClassTag
+  ](
     a: SCollection[A],
     b: SCollection[B],
     c: SCollection[C],
     d: SCollection[D],
     e: SCollection[E]
   ): SqlSCollection5[A, B, C, D, E] = new SqlSCollection5(a, b, c, d, e)
-  def from[A: Schema, B: Schema, C: Schema, D: Schema, E: Schema, F: Schema](
+  def from[
+    A: Schema: ClassTag,
+    B: Schema: ClassTag,
+    C: Schema: ClassTag,
+    D: Schema: ClassTag,
+    E: Schema: ClassTag,
+    F: Schema: ClassTag
+  ](
     a: SCollection[A],
     b: SCollection[B],
     c: SCollection[C],
@@ -55,7 +72,15 @@ trait SqlSCollections {
     e: SCollection[E],
     f: SCollection[F]
   ): SqlSCollection6[A, B, C, D, E, F] = new SqlSCollection6(a, b, c, d, e, f)
-  def from[A: Schema, B: Schema, C: Schema, D: Schema, E: Schema, F: Schema, G: Schema](
+  def from[
+    A: Schema: ClassTag,
+    B: Schema: ClassTag,
+    C: Schema: ClassTag,
+    D: Schema: ClassTag,
+    E: Schema: ClassTag,
+    F: Schema: ClassTag,
+    G: Schema: ClassTag
+  ](
     a: SCollection[A],
     b: SCollection[B],
     c: SCollection[C],
@@ -64,7 +89,16 @@ trait SqlSCollections {
     f: SCollection[F],
     g: SCollection[G]
   ): SqlSCollection7[A, B, C, D, E, F, G] = new SqlSCollection7(a, b, c, d, e, f, g)
-  def from[A: Schema, B: Schema, C: Schema, D: Schema, E: Schema, F: Schema, G: Schema, H: Schema](
+  def from[
+    A: Schema: ClassTag,
+    B: Schema: ClassTag,
+    C: Schema: ClassTag,
+    D: Schema: ClassTag,
+    E: Schema: ClassTag,
+    F: Schema: ClassTag,
+    G: Schema: ClassTag,
+    H: Schema: ClassTag
+  ](
     a: SCollection[A],
     b: SCollection[B],
     c: SCollection[C],
@@ -75,15 +109,15 @@ trait SqlSCollections {
     h: SCollection[H]
   ): SqlSCollection8[A, B, C, D, E, F, G, H] = new SqlSCollection8(a, b, c, d, e, f, g, h)
   def from[
-    A: Schema,
-    B: Schema,
-    C: Schema,
-    D: Schema,
-    E: Schema,
-    F: Schema,
-    G: Schema,
-    H: Schema,
-    I: Schema
+    A: Schema: ClassTag,
+    B: Schema: ClassTag,
+    C: Schema: ClassTag,
+    D: Schema: ClassTag,
+    E: Schema: ClassTag,
+    F: Schema: ClassTag,
+    G: Schema: ClassTag,
+    H: Schema: ClassTag,
+    I: Schema: ClassTag
   ](
     a: SCollection[A],
     b: SCollection[B],
@@ -96,16 +130,16 @@ trait SqlSCollections {
     i: SCollection[I]
   ): SqlSCollection9[A, B, C, D, E, F, G, H, I] = new SqlSCollection9(a, b, c, d, e, f, g, h, i)
   def from[
-    A: Schema,
-    B: Schema,
-    C: Schema,
-    D: Schema,
-    E: Schema,
-    F: Schema,
-    G: Schema,
-    H: Schema,
-    I: Schema,
-    J: Schema
+    A: Schema: ClassTag,
+    B: Schema: ClassTag,
+    C: Schema: ClassTag,
+    D: Schema: ClassTag,
+    E: Schema: ClassTag,
+    F: Schema: ClassTag,
+    G: Schema: ClassTag,
+    H: Schema: ClassTag,
+    I: Schema: ClassTag,
+    J: Schema: ClassTag
   ](
     a: SCollection[A],
     b: SCollection[B],

--- a/scio-sql/src/main/scala/com/spotify/scio/sql/syntax/SCollectionSyntax.scala
+++ b/scio-sql/src/main/scala/com/spotify/scio/sql/syntax/SCollectionSyntax.scala
@@ -20,6 +20,9 @@ import com.spotify.scio.values.SCollection
 import com.spotify.scio.schemas.Schema
 import com.spotify.scio.sql.{Sql, SqlSCollection1}
 
+import scala.reflect.ClassTag
+
 trait SCollectionSyntax {
-  implicit def sqlSCollectionOps[A: Schema](sc: SCollection[A]): SqlSCollection1[A] = Sql.from(sc)
+  implicit def sqlSCollectionOps[A: Schema: ClassTag](sc: SCollection[A]): SqlSCollection1[A] =
+    Sql.from(sc)
 }

--- a/scio-test/src/test/scala/com/spotify/scio/testing/SCollectionMatchersTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/SCollectionMatchersTest.scala
@@ -24,11 +24,13 @@ import org.apache.beam.sdk.Pipeline.PipelineExecutionException
 import org.apache.beam.sdk.transforms.windowing.{
   AfterProcessingTime,
   AfterWatermark,
-  IntervalWindow
+  IntervalWindow,
+  Repeatedly
 }
 import org.apache.beam.sdk.values.TimestampedValue
 import org.joda.time.{Duration, Instant}
 import java.io.ObjectOutputStream
+
 import scala.util.Try
 import java.io.ObjectInputStream
 import java.io.IOException
@@ -506,17 +508,20 @@ class SCollectionMatchersTest extends PipelineSpec {
         .withFixedWindows(
           teamWindowDuration,
           options = WindowOptions(
-            trigger = AfterWatermark
-              .pastEndOfWindow()
-              .withEarlyFirings(
-                AfterProcessingTime
-                  .pastFirstElementInPane()
-                  .plusDelayOf(Duration.standardMinutes(5))
-              )
-              .withLateFirings(
-                AfterProcessingTime
-                  .pastFirstElementInPane()
-                  .plusDelayOf(Duration.standardMinutes(10))
+            trigger = Repeatedly
+              .forever(
+                AfterWatermark
+                  .pastEndOfWindow()
+                  .withEarlyFirings(
+                    AfterProcessingTime
+                      .pastFirstElementInPane()
+                      .plusDelayOf(Duration.standardMinutes(5))
+                  )
+                  .withLateFirings(
+                    AfterProcessingTime
+                      .pastFirstElementInPane()
+                      .plusDelayOf(Duration.standardMinutes(10))
+                  )
               ),
             accumulationMode = ACCUMULATING_FIRED_PANES,
             allowedLateness = allowedLateness
@@ -559,13 +564,15 @@ class SCollectionMatchersTest extends PipelineSpec {
         )
         .withGlobalWindow(
           options = WindowOptions(
-            trigger = AfterWatermark
-              .pastEndOfWindow()
-              .withEarlyFirings(
-                AfterProcessingTime
-                  .pastFirstElementInPane()
-                  .plusDelayOf(Duration.standardMinutes(5))
-              ),
+            trigger = Repeatedly.forever(
+              AfterWatermark
+                .pastEndOfWindow()
+                .withEarlyFirings(
+                  AfterProcessingTime
+                    .pastFirstElementInPane()
+                    .plusDelayOf(Duration.standardMinutes(5))
+                )
+            ),
             accumulationMode = ACCUMULATING_FIRED_PANES,
             allowedLateness = allowedLateness
           )


### PR DESCRIPTION
Interesting nugget about windows and that might be a user pitfall: https://docs.google.com/document/d/1sr8Y8jgk8TPToJerWgcdmfaRSoTzPCQPnuW9F73yTpE/edit#heading=h.k6vgpjglhg2k

with beam 2.18 top level `GroupBykey` will not allow windows that finish.