### PR TITLE
Add specialized coders for Elasticsearch, fix #2626

### DIFF
--- a/scio-elasticsearch/es5/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
+++ b/scio-elasticsearch/es5/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.elasticsearch
+
+import java.io.{InputStream, OutputStream}
+
+import com.spotify.scio.coders._
+import org.apache.beam.sdk.coders.{AtomicCoder, CoderException}
+import org.elasticsearch.action.DocWriteRequest
+import org.elasticsearch.action.delete.DeleteRequest
+import org.elasticsearch.action.index.IndexRequest
+import org.elasticsearch.action.update.UpdateRequest
+import org.elasticsearch.common.io.stream.{InputStreamStreamInput, OutputStreamStreamOutput, Streamable}
+
+trait CoderInstances {
+  private val INDEX_REQ_INDEX = 0
+  private val UPDATE_REQ_INDEX = 1
+  private val DELETE_REQ_INDEX = 2
+  private val KRYO_INDEX = 3
+
+  private lazy val kryoCoder = Coder.kryo[DocWriteRequest[_]]
+  private lazy val kryoBCoder = CoderMaterializer.beamWithDefault(kryoCoder)
+
+  implicit val docWriteRequestCoder: Coder[DocWriteRequest[_]] = Coder.beam[DocWriteRequest[_]](
+    new AtomicCoder[DocWriteRequest[_]] {
+      override def encode(value: DocWriteRequest[_], outStream: OutputStream): Unit = {
+        value match {
+          case i: IndexRequest =>
+            outStream.write(INDEX_REQ_INDEX)
+            indexRequestBCoder.encode(i, outStream)
+          case u: UpdateRequest =>
+            outStream.write(UPDATE_REQ_INDEX)
+            updateRequestBCoder.encode(u, outStream)
+          case d: DeleteRequest =>
+            outStream.write(DELETE_REQ_INDEX)
+            deleteRequestBCoder.encode(d, outStream)
+          case _ =>
+            outStream.write(KRYO_INDEX)
+            kryoBCoder.encode(value, outStream)
+        }
+      }
+
+      override def decode(inStream: InputStream): DocWriteRequest[_] = {
+        val request = inStream.read() match {
+          case INDEX_REQ_INDEX => indexRequestBCoder.decode(inStream)
+          case UPDATE_REQ_INDEX => updateRequestBCoder.decode(inStream)
+          case DELETE_REQ_INDEX => deleteRequestBCoder.decode(inStream)
+          case KRYO_INDEX => kryoBCoder.decode(inStream)
+          case n => throw new CoderException(s"Unknown index $n")
+        }
+
+        request.asInstanceOf[DocWriteRequest[_]]
+      }
+    })
+
+  private def writableBCoder[T <: Streamable](
+                                                              constructor: () => T
+                                                            ): org.apache.beam.sdk.coders.Coder[T] = new AtomicCoder[T] {
+    override def encode(value: T, outStream: OutputStream): Unit =
+      value.writeTo(new OutputStreamStreamOutput(outStream))
+    override def decode(inStream: InputStream): T = {
+      val value = constructor()
+      value.readFrom(new InputStreamStreamInput(inStream))
+      value
+    }
+  }
+
+  private val indexRequestBCoder = writableBCoder[IndexRequest](() => new IndexRequest())
+  implicit val indexRequestCoder: Coder[IndexRequest] =
+    Coder.beam[IndexRequest](indexRequestBCoder)
+
+  private val deleteRequestBCoder = writableBCoder[DeleteRequest](() => new DeleteRequest())
+  implicit val deleteRequestCoder: Coder[DeleteRequest] =
+    Coder.beam[DeleteRequest](deleteRequestBCoder)
+
+  private val updateRequestBCoder = writableBCoder[UpdateRequest](() => new UpdateRequest())
+  implicit val updateRequestCoder: Coder[UpdateRequest] =
+    Coder.beam[UpdateRequest](updateRequestBCoder)
+}

--- a/scio-elasticsearch/es5/src/main/scala/com/spotify/scio/elasticsearch/package.scala
+++ b/scio-elasticsearch/es5/src/main/scala/com/spotify/scio/elasticsearch/package.scala
@@ -34,7 +34,7 @@ import org.joda.time.Duration
  * import com.spotify.scio.elasticsearch._
  * }}}
  */
-package object elasticsearch {
+package object elasticsearch extends CoderInstances {
   final case class ElasticsearchOptions(clusterName: String, servers: Seq[InetSocketAddress])
 
   implicit class ElasticsearchSCollection[T](@transient private val self: SCollection[T])

--- a/scio-elasticsearch/es5/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
+++ b/scio-elasticsearch/es5/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
@@ -35,9 +35,9 @@ class CoderInstancesTest extends AnyFlatSpec with Matchers with CoderInstances {
 
   val indexRequest = new IndexRequest("index1", "type1", "id1")
   val deleteRequest = new DeleteRequest("index2", "type2", "id2").version(2)
-  val updateRequest = new UpdateRequest("index3", "type3", "id3").doc(
-    Map("key" -> 4).asJava, XContentType.JSON)
-  val fooRequest = FooDocWriteRequest("index3","id3")
+  val updateRequest =
+    new UpdateRequest("index3", "type3", "id3").doc(Map("key" -> 4).asJava, XContentType.JSON)
+  val fooRequest = FooDocWriteRequest("index3", "id3")
 
   // DocWriteRequests don't have a well-defined equals method it seems
   implicit def indexRequestEq[T <: DocWriteRequest[_]]: Equality[T] = new Equality[T] {

--- a/scio-elasticsearch/es5/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
+++ b/scio-elasticsearch/es5/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.elasticsearch
+
+import org.elasticsearch.action.DocWriteRequest
+import org.elasticsearch.action.delete.DeleteRequest
+import org.elasticsearch.action.index.IndexRequest
+import org.elasticsearch.action.support.IndicesOptions
+import org.elasticsearch.action.update.UpdateRequest
+import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.index.VersionType
+import org.scalactic.Equality
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
+
+class CoderInstancesTest extends AnyFlatSpec with Matchers with CoderInstances {
+  import com.spotify.scio.testing.CoderAssertions._
+
+  val indexRequest = new IndexRequest("index1", "type1", "id1")
+  val deleteRequest = new DeleteRequest("index2", "type2", "id2").version(2)
+  val updateRequest = new UpdateRequest("index3", "type3", "id3").doc(
+    Map("key" -> 4).asJava, XContentType.JSON)
+  val fooRequest = FooDocWriteRequest("index3","id3")
+
+  // DocWriteRequests don't have a well-defined equals method it seems
+  implicit def indexRequestEq[T <: DocWriteRequest[_]]: Equality[T] = new Equality[T] {
+    override def areEqual(a: T, b: Any): Boolean = (a, b) match {
+      case (a: IndexRequest, b: IndexRequest) =>
+        a.id() == b.id() && a.index() == b.index()
+      case (a: UpdateRequest, b: UpdateRequest) =>
+        a.id() == b.id() && a.doc().source() == b.doc().source() && a.index() == b.index()
+      case (a: DeleteRequest, b: DeleteRequest) =>
+        a.id() == b.id() && a.index() == b.index()
+      case (a: FooDocWriteRequest, b: FooDocWriteRequest) =>
+        a.id == b.id && a._index == b._index
+      case _ => false
+    }
+  }
+
+  "IndexRequest coders" should "work" in {
+    indexRequest coderShould roundtrip()
+  }
+
+  "DeleteRequest coders" should "work" in {
+    deleteRequest coderShould roundtrip()
+  }
+
+  "UpdateRequest coders" should "work" in {
+    updateRequest coderShould roundtrip()
+  }
+
+  "FooDocWriteRequest coders" should "work" in {
+    fooRequest coderShould roundtrip()
+  }
+}
+
+case class FooDocWriteRequest(_index: String, id: String) extends DocWriteRequest[String] {
+  override def index(): String = _index
+
+  override def `type`(): String = "type"
+
+  override def indicesOptions(): IndicesOptions = null
+
+  override def routing(routing: String): String = routing
+
+  override def routing(): String = "routing"
+
+  override def version(): Long = 1
+
+  override def version(version: Long): String = "1"
+
+  override def versionType(): VersionType = VersionType.INTERNAL
+
+  override def versionType(versionType: VersionType): String = versionType.toString
+
+  override def opType(): DocWriteRequest.OpType = DocWriteRequest.OpType.CREATE
+
+  override def indices(): Array[String] = Array("foo")
+
+  override def parent(): String = "parent"
+}

--- a/scio-elasticsearch/es6/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
+++ b/scio-elasticsearch/es6/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.elasticsearch
+
+import java.io.{InputStream, OutputStream}
+
+import com.spotify.scio.coders._
+import org.apache.beam.sdk.coders.{AtomicCoder, CoderException}
+import org.elasticsearch.action.DocWriteRequest
+import org.elasticsearch.action.delete.DeleteRequest
+import org.elasticsearch.action.index.IndexRequest
+import org.elasticsearch.action.update.UpdateRequest
+import org.elasticsearch.common.io.stream.{InputStreamStreamInput, OutputStreamStreamOutput, Streamable, Writeable}
+
+trait CoderInstances {
+  private val INDEX_REQ_INDEX = 0
+  private val UPDATE_REQ_INDEX = 1
+  private val DELETE_REQ_INDEX = 2
+  private val KRYO_INDEX = 3
+
+  private lazy val kryoCoder = Coder.kryo[DocWriteRequest[_]]
+  private lazy val kryoBCoder = CoderMaterializer.beamWithDefault(kryoCoder)
+
+  implicit val docWriteRequestCoder: Coder[DocWriteRequest[_]] = Coder.beam[DocWriteRequest[_]](
+    new AtomicCoder[DocWriteRequest[_]] {
+      override def encode(value: DocWriteRequest[_], outStream: OutputStream): Unit = {
+        value match {
+          case i: IndexRequest =>
+            outStream.write(INDEX_REQ_INDEX)
+            indexRequestBCoder.encode(i, outStream)
+          case u: UpdateRequest =>
+            outStream.write(UPDATE_REQ_INDEX)
+            updateRequestBCoder.encode(u, outStream)
+          case d: DeleteRequest =>
+            outStream.write(DELETE_REQ_INDEX)
+            deleteRequestBCoder.encode(d, outStream)
+          case _ =>
+            outStream.write(KRYO_INDEX)
+            kryoBCoder.encode(value, outStream)
+        }
+      }
+
+      override def decode(inStream: InputStream): DocWriteRequest[_] = {
+        val request = inStream.read() match {
+          case INDEX_REQ_INDEX => indexRequestBCoder.decode(inStream)
+          case UPDATE_REQ_INDEX => updateRequestBCoder.decode(inStream)
+          case DELETE_REQ_INDEX => deleteRequestBCoder.decode(inStream)
+          case KRYO_INDEX => kryoBCoder.decode(inStream)
+          case n => throw new CoderException(s"Unknown index $n")
+        }
+
+        request.asInstanceOf[DocWriteRequest[_]]
+      }
+    })
+
+  private def writableBCoder[T <: Writeable with Streamable](
+                                              constructor: () => T
+                                            ): org.apache.beam.sdk.coders.Coder[T] = new AtomicCoder[T] {
+    override def encode(value: T, outStream: OutputStream): Unit =
+      value.writeTo(new OutputStreamStreamOutput(outStream))
+    override def decode(inStream: InputStream): T = {
+      val value = constructor()
+      value.readFrom(new InputStreamStreamInput(inStream))
+      value
+    }
+  }
+
+  private val indexRequestBCoder = writableBCoder[IndexRequest](() => new IndexRequest())
+  implicit val indexRequestCoder: Coder[IndexRequest] =
+    Coder.beam[IndexRequest](indexRequestBCoder)
+
+  private val deleteRequestBCoder = writableBCoder[DeleteRequest](() => new DeleteRequest())
+  implicit val deleteRequestCoder: Coder[DeleteRequest] =
+    Coder.beam[DeleteRequest](deleteRequestBCoder)
+
+  private val updateRequestBCoder = writableBCoder[UpdateRequest](() => new UpdateRequest())
+  implicit val updateRequestCoder: Coder[UpdateRequest] =
+    Coder.beam[UpdateRequest](updateRequestBCoder)
+}

--- a/scio-elasticsearch/es6/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
+++ b/scio-elasticsearch/es6/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
@@ -25,7 +25,12 @@ import org.elasticsearch.action.DocWriteRequest
 import org.elasticsearch.action.delete.DeleteRequest
 import org.elasticsearch.action.index.IndexRequest
 import org.elasticsearch.action.update.UpdateRequest
-import org.elasticsearch.common.io.stream.{InputStreamStreamInput, OutputStreamStreamOutput, Streamable, Writeable}
+import org.elasticsearch.common.io.stream.{
+  InputStreamStreamInput,
+  OutputStreamStreamOutput,
+  Streamable,
+  Writeable
+}
 
 trait CoderInstances {
   private val INDEX_REQ_INDEX = 0
@@ -36,9 +41,9 @@ trait CoderInstances {
   private lazy val kryoCoder = Coder.kryo[DocWriteRequest[_]]
   private lazy val kryoBCoder = CoderMaterializer.beamWithDefault(kryoCoder)
 
-  implicit val docWriteRequestCoder: Coder[DocWriteRequest[_]] = Coder.beam[DocWriteRequest[_]](
-    new AtomicCoder[DocWriteRequest[_]] {
-      override def encode(value: DocWriteRequest[_], outStream: OutputStream): Unit = {
+  implicit val docWriteRequestCoder: Coder[DocWriteRequest[_]] =
+    Coder.beam[DocWriteRequest[_]](new AtomicCoder[DocWriteRequest[_]] {
+      override def encode(value: DocWriteRequest[_], outStream: OutputStream): Unit =
         value match {
           case i: IndexRequest =>
             outStream.write(INDEX_REQ_INDEX)
@@ -53,15 +58,14 @@ trait CoderInstances {
             outStream.write(KRYO_INDEX)
             kryoBCoder.encode(value, outStream)
         }
-      }
 
       override def decode(inStream: InputStream): DocWriteRequest[_] = {
         val request = inStream.read() match {
-          case INDEX_REQ_INDEX => indexRequestBCoder.decode(inStream)
+          case INDEX_REQ_INDEX  => indexRequestBCoder.decode(inStream)
           case UPDATE_REQ_INDEX => updateRequestBCoder.decode(inStream)
           case DELETE_REQ_INDEX => deleteRequestBCoder.decode(inStream)
-          case KRYO_INDEX => kryoBCoder.decode(inStream)
-          case n => throw new CoderException(s"Unknown index $n")
+          case KRYO_INDEX       => kryoBCoder.decode(inStream)
+          case n                => throw new CoderException(s"Unknown index $n")
         }
 
         request.asInstanceOf[DocWriteRequest[_]]
@@ -69,8 +73,8 @@ trait CoderInstances {
     })
 
   private def writableBCoder[T <: Writeable with Streamable](
-                                              constructor: () => T
-                                            ): org.apache.beam.sdk.coders.Coder[T] = new AtomicCoder[T] {
+    constructor: () => T
+  ): org.apache.beam.sdk.coders.Coder[T] = new AtomicCoder[T] {
     override def encode(value: T, outStream: OutputStream): Unit =
       value.writeTo(new OutputStreamStreamOutput(outStream))
     override def decode(inStream: InputStream): T = {

--- a/scio-elasticsearch/es6/src/main/scala/com/spotify/scio/elasticsearch/package.scala
+++ b/scio-elasticsearch/es6/src/main/scala/com/spotify/scio/elasticsearch/package.scala
@@ -34,7 +34,7 @@ import org.joda.time.Duration
  * import com.spotify.scio.elasticsearch._
  * }}}
  */
-package object elasticsearch {
+package object elasticsearch extends CoderInstances {
   final case class ElasticsearchOptions(clusterName: String, servers: Seq[InetSocketAddress])
 
   implicit class ElasticsearchSCollection[T](@transient private val self: SCollection[T])

--- a/scio-elasticsearch/es6/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
+++ b/scio-elasticsearch/es6/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.elasticsearch
+
+import org.elasticsearch.action.DocWriteRequest
+import org.elasticsearch.action.delete.DeleteRequest
+import org.elasticsearch.action.index.IndexRequest
+import org.elasticsearch.action.support.IndicesOptions
+import org.elasticsearch.action.update.UpdateRequest
+import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.index.VersionType
+import org.scalactic.Equality
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
+
+class CoderInstancesTest extends AnyFlatSpec with Matchers with CoderInstances {
+  import com.spotify.scio.testing.CoderAssertions._
+
+  val indexRequest = new IndexRequest("index1", "type1", "id1")
+  val deleteRequest = new DeleteRequest("index2", "type2", "id2").version(2)
+  val updateRequest = new UpdateRequest("index3", "type3", "id3").doc(
+    Map("key" -> 4).asJava, XContentType.JSON)
+  val fooRequest = FooDocWriteRequest("index3","id3")
+
+  // DocWriteRequests don't have a well-defined equals method it seems
+  implicit def indexRequestEq[T <: DocWriteRequest[_]]: Equality[T] = new Equality[T] {
+    override def areEqual(a: T, b: Any): Boolean = (a, b) match {
+      case (a: IndexRequest, b: IndexRequest) =>
+        a.id() == b.id() && a.index() == b.index()
+      case (a: UpdateRequest, b: UpdateRequest) =>
+        a.id() == b.id() && a.doc().source() == b.doc().source() && a.index() == b.index()
+      case (a: DeleteRequest, b: DeleteRequest) =>
+        a.id() == b.id() && a.index() == b.index()
+      case (a: FooDocWriteRequest, b: FooDocWriteRequest) =>
+        a.id == b.id && a._index == b._index
+      case _ => false
+    }
+  }
+
+  "IndexRequest coders" should "work" in {
+    indexRequest coderShould roundtrip()
+  }
+
+  "DeleteRequest coders" should "work" in {
+    deleteRequest coderShould roundtrip()
+  }
+
+  "UpdateRequest coders" should "work" in {
+    updateRequest coderShould roundtrip()
+  }
+
+  "FooDocWriteRequest coders" should "work" in {
+    fooRequest coderShould roundtrip()
+  }
+}
+
+case class FooDocWriteRequest(_index: String, id: String) extends DocWriteRequest[String] {
+  override def index(index: String): String = index
+
+  override def index(): String = _index
+
+  override def `type`(`type`: String): String = `type`
+
+  override def `type`(): String = "type"
+
+  override def indicesOptions(): IndicesOptions = null
+
+  override def routing(routing: String): String = routing
+
+  override def routing(): String = "routing"
+
+  override def version(): Long = 1
+
+  override def version(version: Long): String = "1"
+
+  override def versionType(): VersionType = VersionType.INTERNAL
+
+  override def versionType(versionType: VersionType): String = versionType.toString
+
+  override def setIfSeqNo(seqNo: Long): String = "true"
+
+  override def setIfPrimaryTerm(term: Long): String = "true"
+
+  override def ifSeqNo(): Long = 2L
+
+  override def ifPrimaryTerm(): Long = 3L
+
+  override def opType(): DocWriteRequest.OpType = DocWriteRequest.OpType.CREATE
+
+  override def indices(): Array[String] = Array("foo")
+
+  override def parent(): String = "parent"
+}

--- a/scio-elasticsearch/es6/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
+++ b/scio-elasticsearch/es6/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
@@ -35,9 +35,9 @@ class CoderInstancesTest extends AnyFlatSpec with Matchers with CoderInstances {
 
   val indexRequest = new IndexRequest("index1", "type1", "id1")
   val deleteRequest = new DeleteRequest("index2", "type2", "id2").version(2)
-  val updateRequest = new UpdateRequest("index3", "type3", "id3").doc(
-    Map("key" -> 4).asJava, XContentType.JSON)
-  val fooRequest = FooDocWriteRequest("index3","id3")
+  val updateRequest =
+    new UpdateRequest("index3", "type3", "id3").doc(Map("key" -> 4).asJava, XContentType.JSON)
+  val fooRequest = FooDocWriteRequest("index3", "id3")
 
   // DocWriteRequests don't have a well-defined equals method it seems
   implicit def indexRequestEq[T <: DocWriteRequest[_]]: Equality[T] = new Equality[T] {

--- a/scio-elasticsearch/es7/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
+++ b/scio-elasticsearch/es7/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
@@ -20,7 +20,7 @@ package com.spotify.scio.elasticsearch
 import java.io.{InputStream, OutputStream}
 
 import com.spotify.scio.coders._
-import org.apache.beam.sdk.coders.AtomicCoder
+import org.apache.beam.sdk.coders.{AtomicCoder, CoderException}
 import org.elasticsearch.action.DocWriteRequest
 import org.elasticsearch.action.delete.DeleteRequest
 import org.elasticsearch.action.index.IndexRequest
@@ -60,7 +60,8 @@ trait CoderInstances {
           case INDEX_REQ_INDEX => indexRequestBCoder.decode(inStream)
           case UPDATE_REQ_INDEX => updateRequestBCoder.decode(inStream)
           case DELETE_REQ_INDEX => deleteRequestBCoder.decode(inStream)
-          case _ => kryoBCoder.decode(inStream)
+          case KRYO_INDEX => kryoBCoder.decode(inStream)
+          case n => throw new CoderException(s"Unknown index $n")
         }
 
         request.asInstanceOf[DocWriteRequest[_]]
@@ -73,7 +74,7 @@ trait CoderInstances {
     override def encode(value: T, outStream: OutputStream): Unit =
       value.writeTo(new OutputStreamStreamOutput(outStream))
     override def decode(inStream: InputStream): T =
-      constructor.apply(new InputStreamStreamInput(inStream))
+      constructor(new InputStreamStreamInput(inStream))
   }
 
   private val indexRequestBCoder = writableBCoder[IndexRequest](new IndexRequest(_))

--- a/scio-elasticsearch/es7/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
+++ b/scio-elasticsearch/es7/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.elasticsearch
+
+import java.io.{InputStream, OutputStream}
+
+import com.spotify.scio.coders._
+import org.apache.beam.sdk.coders.AtomicCoder
+import org.elasticsearch.action.DocWriteRequest
+import org.elasticsearch.action.delete.DeleteRequest
+import org.elasticsearch.action.index.IndexRequest
+import org.elasticsearch.action.update.UpdateRequest
+import org.elasticsearch.common.io.stream.{InputStreamStreamInput, OutputStreamStreamOutput, StreamInput, Writeable}
+
+trait CoderInstances {
+  private val INDEX_REQ_INDEX = 0
+  private val UPDATE_REQ_INDEX = 1
+  private val DELETE_REQ_INDEX = 2
+  private val KRYO_INDEX = 3
+
+  private lazy val kryoCoder = Coder.kryo[DocWriteRequest[_]]
+  private lazy val kryoBCoder = CoderMaterializer.beamWithDefault(kryoCoder)
+
+  implicit val docWriteRequestCoder: Coder[DocWriteRequest[_]] = Coder.beam[DocWriteRequest[_]](
+    new AtomicCoder[DocWriteRequest[_]] {
+      override def encode(value: DocWriteRequest[_], outStream: OutputStream): Unit = {
+        value match {
+          case i: IndexRequest =>
+            outStream.write(INDEX_REQ_INDEX)
+            indexRequestBCoder.encode(i, outStream)
+          case u: UpdateRequest =>
+            outStream.write(UPDATE_REQ_INDEX)
+            updateRequestBCoder.encode(u, outStream)
+          case d: DeleteRequest =>
+            outStream.write(DELETE_REQ_INDEX)
+            deleteRequestBCoder.encode(d, outStream)
+          case _ =>
+            outStream.write(KRYO_INDEX)
+            kryoBCoder.encode(value, outStream)
+        }
+      }
+
+      override def decode(inStream: InputStream): DocWriteRequest[_] = {
+        val request = inStream.read() match {
+          case INDEX_REQ_INDEX => indexRequestBCoder.decode(inStream)
+          case UPDATE_REQ_INDEX => updateRequestBCoder.decode(inStream)
+          case DELETE_REQ_INDEX => deleteRequestBCoder.decode(inStream)
+          case _ => kryoBCoder.decode(inStream)
+        }
+
+        request.asInstanceOf[DocWriteRequest[_]]
+      }
+    })
+
+  private def writableBCoder[T <: Writeable](
+    constructor: StreamInput => T
+  ): org.apache.beam.sdk.coders.Coder[T] = new AtomicCoder[T] {
+    override def encode(value: T, outStream: OutputStream): Unit =
+      value.writeTo(new OutputStreamStreamOutput(outStream))
+    override def decode(inStream: InputStream): T =
+      constructor.apply(new InputStreamStreamInput(inStream))
+  }
+
+  private val indexRequestBCoder = writableBCoder[IndexRequest](new IndexRequest(_))
+  implicit val indexRequestCoder: Coder[IndexRequest] =
+    Coder.beam[IndexRequest](indexRequestBCoder)
+
+  private val deleteRequestBCoder = writableBCoder[DeleteRequest](new DeleteRequest(_))
+  implicit val deleteRequestCoder: Coder[DeleteRequest] =
+    Coder.beam[DeleteRequest](deleteRequestBCoder)
+
+  private val updateRequestBCoder = writableBCoder[UpdateRequest](new UpdateRequest(_))
+  implicit val updateRequestCoder: Coder[UpdateRequest] =
+    Coder.beam[UpdateRequest](updateRequestBCoder)
+}

--- a/scio-elasticsearch/es7/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
+++ b/scio-elasticsearch/es7/src/main/scala/com/spotify/scio/elasticsearch/CoderInstances.scala
@@ -25,7 +25,12 @@ import org.elasticsearch.action.DocWriteRequest
 import org.elasticsearch.action.delete.DeleteRequest
 import org.elasticsearch.action.index.IndexRequest
 import org.elasticsearch.action.update.UpdateRequest
-import org.elasticsearch.common.io.stream.{InputStreamStreamInput, OutputStreamStreamOutput, StreamInput, Writeable}
+import org.elasticsearch.common.io.stream.{
+  InputStreamStreamInput,
+  OutputStreamStreamOutput,
+  StreamInput,
+  Writeable
+}
 
 trait CoderInstances {
   private val INDEX_REQ_INDEX = 0
@@ -36,9 +41,9 @@ trait CoderInstances {
   private lazy val kryoCoder = Coder.kryo[DocWriteRequest[_]]
   private lazy val kryoBCoder = CoderMaterializer.beamWithDefault(kryoCoder)
 
-  implicit val docWriteRequestCoder: Coder[DocWriteRequest[_]] = Coder.beam[DocWriteRequest[_]](
-    new AtomicCoder[DocWriteRequest[_]] {
-      override def encode(value: DocWriteRequest[_], outStream: OutputStream): Unit = {
+  implicit val docWriteRequestCoder: Coder[DocWriteRequest[_]] =
+    Coder.beam[DocWriteRequest[_]](new AtomicCoder[DocWriteRequest[_]] {
+      override def encode(value: DocWriteRequest[_], outStream: OutputStream): Unit =
         value match {
           case i: IndexRequest =>
             outStream.write(INDEX_REQ_INDEX)
@@ -53,15 +58,14 @@ trait CoderInstances {
             outStream.write(KRYO_INDEX)
             kryoBCoder.encode(value, outStream)
         }
-      }
 
       override def decode(inStream: InputStream): DocWriteRequest[_] = {
         val request = inStream.read() match {
-          case INDEX_REQ_INDEX => indexRequestBCoder.decode(inStream)
+          case INDEX_REQ_INDEX  => indexRequestBCoder.decode(inStream)
           case UPDATE_REQ_INDEX => updateRequestBCoder.decode(inStream)
           case DELETE_REQ_INDEX => deleteRequestBCoder.decode(inStream)
-          case KRYO_INDEX => kryoBCoder.decode(inStream)
-          case n => throw new CoderException(s"Unknown index $n")
+          case KRYO_INDEX       => kryoBCoder.decode(inStream)
+          case n                => throw new CoderException(s"Unknown index $n")
         }
 
         request.asInstanceOf[DocWriteRequest[_]]

--- a/scio-elasticsearch/es7/src/main/scala/com/spotify/scio/elasticsearch/package.scala
+++ b/scio-elasticsearch/es7/src/main/scala/com/spotify/scio/elasticsearch/package.scala
@@ -33,7 +33,7 @@ import org.joda.time.Duration
  * import com.spotify.scio.elasticsearch._
  * }}}
  */
-package object elasticsearch {
+package object elasticsearch extends CoderInstances {
   final case class ElasticsearchOptions(nodes: Seq[HttpHost])
 
   implicit class ElasticsearchSCollection[T](@transient private val self: SCollection[T])

--- a/scio-elasticsearch/es7/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
+++ b/scio-elasticsearch/es7/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
@@ -34,9 +34,9 @@ class CoderInstancesTest extends AnyFlatSpec with Matchers with CoderInstances {
   import com.spotify.scio.testing.CoderAssertions._
 
   val indexRequest = new IndexRequest("index").id("id").`type`("type")
-  val deleteRequest = new DeleteRequest("index2","id2").version(2)
-  val updateRequest = new UpdateRequest("index3","id3").doc(
-    Map("key" -> 4).asJava, XContentType.JSON)
+  val deleteRequest = new DeleteRequest("index2", "id2").version(2)
+  val updateRequest =
+    new UpdateRequest("index3", "id3").doc(Map("key" -> 4).asJava, XContentType.JSON)
   val fooRequest = FooDocWriteRequest("index3", "id3")
 
   // DocWriteRequests don't have a well-defined equals method it seems

--- a/scio-elasticsearch/es7/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
+++ b/scio-elasticsearch/es7/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
@@ -30,8 +30,7 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.collection.JavaConverters._
 
-
-class ESCoderInstancesTest extends AnyFlatSpec with Matchers with CoderInstances {
+class CoderInstancesTest extends AnyFlatSpec with Matchers with CoderInstances {
   import com.spotify.scio.testing.CoderAssertions._
 
   val indexRequest = new IndexRequest("index").id("id").`type`("type")

--- a/scio-elasticsearch/es7/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
+++ b/scio-elasticsearch/es7/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
@@ -34,10 +34,10 @@ class CoderInstancesTest extends AnyFlatSpec with Matchers with CoderInstances {
   import com.spotify.scio.testing.CoderAssertions._
 
   val indexRequest = new IndexRequest("index").id("id").`type`("type")
-  val deleteRequest = new DeleteRequest("index2").id("id2").version(2)
+  val deleteRequest = new DeleteRequest("index2","id2").version(2)
   val updateRequest = new UpdateRequest("index3","id3").doc(
     Map("key" -> 4).asJava, XContentType.JSON)
-  val fooRequest = FooDocWriteRequest("index3","id3")
+  val fooRequest = FooDocWriteRequest("index3", "id3")
 
   // DocWriteRequests don't have a well-defined equals method it seems
   implicit def indexRequestEq[T <: DocWriteRequest[_]]: Equality[T] = new Equality[T] {

--- a/scio-elasticsearch/es7/src/test/scala/com/spotify/scio/elasticsearch/ESCoderInstancesTest.scala
+++ b/scio-elasticsearch/es7/src/test/scala/com/spotify/scio/elasticsearch/ESCoderInstancesTest.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.elasticsearch
+
+import org.elasticsearch.action.DocWriteRequest
+import org.elasticsearch.action.delete.DeleteRequest
+import org.elasticsearch.action.index.IndexRequest
+import org.elasticsearch.action.support.IndicesOptions
+import org.elasticsearch.action.update.UpdateRequest
+import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.index.VersionType
+import org.scalactic.Equality
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
+
+
+class ESCoderInstancesTest extends AnyFlatSpec with Matchers with CoderInstances {
+  import com.spotify.scio.testing.CoderAssertions._
+
+  val indexRequest = new IndexRequest("index").id("id").`type`("type")
+  val deleteRequest = new DeleteRequest("index2").id("id2").version(2)
+  val updateRequest = new UpdateRequest("index3","id3").doc(
+    Map("key" -> 4).asJava, XContentType.JSON)
+  val fooRequest = FooDocWriteRequest("index3","id3")
+
+  // DocWriteRequests don't have a well-defined equals method it seems
+  implicit def indexRequestEq[T <: DocWriteRequest[_]]: Equality[T] = new Equality[T] {
+    override def areEqual(a: T, b: Any): Boolean = (a, b) match {
+      case (a: IndexRequest, b: IndexRequest) =>
+        a.id() == b.id() && a.index() == b.index()
+      case (a: UpdateRequest, b: UpdateRequest) =>
+        a.id() == b.id() && a.doc().source() == b.doc().source() && a.index() == b.index()
+      case (a: DeleteRequest, b: DeleteRequest) =>
+        a.id() == b.id() && a.index() == b.index()
+      case (a: FooDocWriteRequest, b: FooDocWriteRequest) =>
+        a.id == b.id && a._index == b._index
+      case _ => false
+    }
+  }
+
+  "IndexRequest coders" should "work" in {
+    indexRequest coderShould roundtrip()
+  }
+
+  "DeleteRequest coders" should "work" in {
+    deleteRequest coderShould roundtrip()
+  }
+
+  "UpdateRequest coders" should "work" in {
+    updateRequest coderShould roundtrip()
+  }
+
+  "FooDocWriteRequest coders" should "work" in {
+    fooRequest coderShould roundtrip()
+  }
+}
+
+case class FooDocWriteRequest(_index: String, id: String) extends DocWriteRequest[String] {
+  override def index(index: String): String = index
+
+  override def index(): String = _index
+
+  override def `type`(`type`: String): String = `type`
+
+  override def `type`(): String = "type"
+
+  override def defaultTypeIfNull(defaultType: String): String = defaultType
+
+  override def indicesOptions(): IndicesOptions = null
+
+  override def routing(routing: String): String = routing
+
+  override def routing(): String = "routing"
+
+  override def version(): Long = 1
+
+  override def version(version: Long): String = "1"
+
+  override def versionType(): VersionType = VersionType.INTERNAL
+
+  override def versionType(versionType: VersionType): String = versionType.toString
+
+  override def setIfSeqNo(seqNo: Long): String = "true"
+
+  override def setIfPrimaryTerm(term: Long): String = "true"
+
+  override def ifSeqNo(): Long = 2L
+
+  override def ifPrimaryTerm(): Long = 3L
+
+  override def opType(): DocWriteRequest.OpType = DocWriteRequest.OpType.CREATE
+
+  override def indices(): Array[String] = Array("foo")
+}


### PR DESCRIPTION
Only covering ES5,6,7 here since ES2 support is deprecated.