### PR TITLE
[scio-smb] make *FileOperations and *BucketMetadata public

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -43,7 +43,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
 /**
  * {@link org.apache.beam.sdk.extensions.smb.BucketMetadata} for Avro {@link GenericRecord} records.
  */
-class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetadata<K, V> {
+public class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetadata<K, V> {
 
   @JsonProperty private final String keyField;
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroFileOperations.java
@@ -42,7 +42,7 @@ import org.apache.beam.sdk.util.MimeTypes;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Supplier;
 
 /** {@link org.apache.beam.sdk.extensions.smb.FileOperations} implementation for Avro files. */
-class AvroFileOperations<ValueT> extends FileOperations<ValueT> {
+public class AvroFileOperations<ValueT> extends FileOperations<ValueT> {
   private static final CodecFactory DEFAULT_CODEC = CodecFactory.snappyCodec();
 
   private final Class<ValueT> recordClass;

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
@@ -33,7 +33,7 @@ import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
  * {@link org.apache.beam.sdk.extensions.smb.BucketMetadata} for BigQuery {@link TableRow} JSON
  * records.
  */
-class JsonBucketMetadata<K> extends BucketMetadata<K, TableRow> {
+public class JsonBucketMetadata<K> extends BucketMetadata<K, TableRow> {
 
   @JsonProperty private final String keyField;
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonFileOperations.java
@@ -38,7 +38,7 @@ import org.apache.beam.sdk.util.MimeTypes;
  * {@link org.apache.beam.sdk.extensions.smb.FileOperations} implementation for text files with
  * BigQuery {@link TableRow} JSON records.
  */
-class JsonFileOperations extends FileOperations<TableRow> {
+public class JsonFileOperations extends FileOperations<TableRow> {
   private JsonFileOperations(Compression compression) {
     super(compression, compression == Compression.UNCOMPRESSED ? MimeTypes.TEXT : MimeTypes.BINARY);
   }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
@@ -32,7 +32,7 @@ import org.tensorflow.example.FloatList;
 import org.tensorflow.example.Int64List;
 
 /** {@link BucketMetadata} for TensorFlow {@link Example} records. */
-class TensorFlowBucketMetadata<K> extends BucketMetadata<K, Example> {
+public class TensorFlowBucketMetadata<K> extends BucketMetadata<K, Example> {
 
   @JsonProperty private final String keyField;
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowFileOperations.java
@@ -33,7 +33,7 @@ import org.tensorflow.example.Example;
  * {@link org.apache.beam.sdk.extensions.smb.FileOperations} implementation for TensorFlow TFRecord
  * files with TensorFlow {@link Example} records.
  */
-class TensorFlowFileOperations extends FileOperations<Example> {
+public class TensorFlowFileOperations extends FileOperations<Example> {
 
   private TensorFlowFileOperations(Compression compression) {
     super(compression, MimeTypes.BINARY);


### PR DESCRIPTION
right now the access level makes them almost impossible for users to override if need be