### PR TITLE
Prevent sharded-sparkey shards from having negative indices.

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.util.hashing.MurmurHash3
+import scala.math.abs
 
 /**
  * Main package for Sparkey side input APIs. Import all.
@@ -418,7 +419,7 @@ package object sparkey {
    */
   class ShardedSparkeyReader(val sparkeys: Map[Short, SparkeyReader], val numShards: Short)
       extends SparkeyReader {
-    def hashKey(arr: Array[Byte]): Short = (MurmurHash3.bytesHash(arr, 1) % numShards).toShort
+    def hashKey(arr: Array[Byte]): Short = (abs(MurmurHash3.bytesHash(arr, 1)) % numShards).toShort
 
     def hashKey(str: String): Short = hashKey(str.getBytes)
 
@@ -548,7 +549,7 @@ package object sparkey {
     def put(w: SparkeyWriter, key: String, value: String): Unit =
       w.put(key, value)
 
-    def shardHash(key: String): Int = MurmurHash3.stringHash(key, 1)
+    def shardHash(key: String): Int = abs(MurmurHash3.stringHash(key, 1))
   }
 
   implicit val ByteArraySparkeyWritable =
@@ -556,6 +557,6 @@ package object sparkey {
       def put(w: SparkeyWriter, key: Array[Byte], value: Array[Byte]): Unit =
         w.put(key, value)
 
-      def shardHash(key: Array[Byte]): Int = MurmurHash3.bytesHash(key, 1)
+      def shardHash(key: Array[Byte]): Int = abs(MurmurHash3.bytesHash(key, 1))
     }
 }


### PR DESCRIPTION
https://github.com/spotify/scio/pull/2336 introduced sharded Sparkey support and assumed that the Sparkey shards would have non-negative indices (i.e.: if you specify 32 shards, you should get up to 32 files named `part-00001` through `part-00032-of-00032.sp[il]`). However, Scio 0.8.0 and 0.8.1 instead produce both negative and positive shard indices. This means that any code reading the resulting sharded datasets needs to handle the anticipated number of shards.

This PR fixes this inconsistency by wrapping each call to `MurmurHash` with `abs`. **This means that any sharded Sparkey datasets produced before this change will no longer be readable after this change, as the shard allocation will be different.** Luckily, this feature was introduced very recently and anecdotally is mostly used internally within `.asSparkeySideInput`, which produces temporary datasets that are not intended to be read outside the context of each Scio pipeline.