### PR TITLE
Fix: eval coder eagerly for sealead traits

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
@@ -25,8 +25,8 @@ object CoderMaterializer {
 
   private[scio] case class CoderOptions(nullableCoders: Boolean, kryo: KryoOptions)
   private[scio] object CoderOptions {
-    def apply(o: PipelineOptions) = {
-      val nullableCoder = o.as(classOf[com.spotify.scio.options.ScioOptions]).getNullableCoders()
+    final def apply(o: PipelineOptions): CoderOptions = {
+      val nullableCoder = o.as(classOf[com.spotify.scio.options.ScioOptions]).getNullableCoders
       new CoderOptions(nullableCoder, KryoOptions(o))
     }
   }
@@ -77,7 +77,6 @@ object CoderMaterializer {
         )
       case Disjunction(typeName, idCoder, id, coders) =>
         WrappedBCoder.create(
-          // `.map(identity) is really needed to make Map serializable.
           DisjunctionCoder(
             typeName,
             beamImpl(o, idCoder),

--- a/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
@@ -77,6 +77,7 @@ object CoderMaterializer {
         )
       case Disjunction(typeName, idCoder, id, coders) =>
         WrappedBCoder.create(
+          // `.map(identity) is really needed to make Map serializable.
           DisjunctionCoder(
             typeName,
             beamImpl(o, idCoder),

--- a/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
@@ -75,7 +75,6 @@ private object Derived extends Serializable {
 
 trait LowPriorityCoderDerivation {
   import magnolia._
-  import com.spotify.scio.coders.CoderMacros
 
   type Typeclass[T] = Coder[T]
 
@@ -84,35 +83,34 @@ trait LowPriorityCoderDerivation {
 
   def dispatch[T](sealedTrait: SealedTrait[Coder, T]): Coder[T] = {
     val typeName = sealedTrait.typeName.full
+    val coder: Coder[T] = {
+      val idx: Map[magnolia.TypeName, Int] =
+        sealedTrait.subtypes.map(_.typeName).zipWithIndex.toMap
+      val coders: Map[Int, Coder[T]] =
+        sealedTrait.subtypes
+          .map(_.typeclass.asInstanceOf[Coder[T]])
+          .zipWithIndex
+          .map { case (c, i) => (i, c) }
+          .toMap
 
-    Ref(
-      typeName, {
-        val idx: Map[magnolia.TypeName, Int] =
-          sealedTrait.subtypes.map(_.typeName).zipWithIndex.toMap
-        val coders: Map[Int, Coder[T]] =
-          sealedTrait.subtypes
-            .map(_.typeclass.asInstanceOf[Coder[T]])
-            .zipWithIndex
-            .map { case (c, i) => (i, c) }
-            .toMap
-
-        if (sealedTrait.subtypes.length <= 2) {
-          val booleanId: Int => Boolean = _ != 0
-          val cs = coders.map { case (key, v) => (booleanId(key), v) }
-          Coder.disjunction[T, Boolean](typeName, cs) { t =>
-            sealedTrait.dispatch(t) { subtype =>
-              booleanId(idx(subtype.typeName))
-            }
+      if (sealedTrait.subtypes.length <= 2) {
+        val booleanId: Int => Boolean = _ != 0
+        val cs = coders.map { case (key, v) => (booleanId(key), v) }
+        Coder.disjunction[T, Boolean](typeName, cs) { t =>
+          sealedTrait.dispatch(t) { subtype =>
+            booleanId(idx(subtype.typeName))
           }
-        } else {
-          Coder.disjunction[T, Int](typeName, coders) { t =>
-            sealedTrait.dispatch(t) { subtype =>
-              idx(subtype.typeName)
-            }
+        }
+      } else {
+        Coder.disjunction[T, Int](typeName, coders) { t =>
+          sealedTrait.dispatch(t) { subtype =>
+            idx(subtype.typeName)
           }
         }
       }
-    )
+    }
+
+    Ref(typeName, coder)
   }
 
   /**

--- a/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
@@ -83,34 +83,30 @@ trait LowPriorityCoderDerivation {
 
   def dispatch[T](sealedTrait: SealedTrait[Coder, T]): Coder[T] = {
     val typeName = sealedTrait.typeName.full
-    val coder: Coder[T] = {
-      val idx: Map[magnolia.TypeName, Int] =
-        sealedTrait.subtypes.map(_.typeName).zipWithIndex.toMap
-      val coders: Map[Int, Coder[T]] =
-        sealedTrait.subtypes
-          .map(_.typeclass.asInstanceOf[Coder[T]])
-          .zipWithIndex
-          .map { case (c, i) => (i, c) }
-          .toMap
+    val idx: Map[magnolia.TypeName, Int] =
+      sealedTrait.subtypes.map(_.typeName).zipWithIndex.toMap
+    val coders: Map[Int, Coder[T]] =
+      sealedTrait.subtypes
+        .map(_.typeclass.asInstanceOf[Coder[T]])
+        .zipWithIndex
+        .map { case (c, i) => (i, c) }
+        .toMap
 
-      if (sealedTrait.subtypes.length <= 2) {
-        val booleanId: Int => Boolean = _ != 0
-        val cs = coders.map { case (key, v) => (booleanId(key), v) }
-        Coder.disjunction[T, Boolean](typeName, cs) { t =>
-          sealedTrait.dispatch(t) { subtype =>
-            booleanId(idx(subtype.typeName))
-          }
+    if (sealedTrait.subtypes.length <= 2) {
+      val booleanId: Int => Boolean = _ != 0
+      val cs = coders.map { case (key, v) => (booleanId(key), v) }
+      Coder.disjunction[T, Boolean](typeName, cs) { t =>
+        sealedTrait.dispatch(t) { subtype =>
+          booleanId(idx(subtype.typeName))
         }
-      } else {
-        Coder.disjunction[T, Int](typeName, coders) { t =>
-          sealedTrait.dispatch(t) { subtype =>
-            idx(subtype.typeName)
-          }
+      }
+    } else {
+      Coder.disjunction[T, Int](typeName, coders) { t =>
+        sealedTrait.dispatch(t) { subtype =>
+          idx(subtype.typeName)
         }
       }
     }
-
-    Ref(typeName, coder)
   }
 
   /**


### PR DESCRIPTION
In some cases a ref to magnolia `SealedTrait` is kept. Having some hard time coming up with a concrete test example.