### PR TITLE
 Customize equality in unit tests and better failure message

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -525,7 +525,7 @@ lazy val `scio-test`: Project = project
       "com.spotify.sparkey" % "sparkey" % sparkeyVersion % "test",
       "com.novocode" % "junit-interface" % junitInterfaceVersion,
       "junit" % "junit" % junitVersion % "test",
-      "com.lihaoyi" %% "pprint" % "0.5.9",
+      "com.lihaoyi" %% "pprint" % "0.5.4",
       "com.chuusai" %% "shapeless" % shapelessVersion,
       "com.google.api.grpc" % "proto-google-cloud-bigtable-v2" % generatedGrpcBetaVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -525,6 +525,7 @@ lazy val `scio-test`: Project = project
       "com.spotify.sparkey" % "sparkey" % sparkeyVersion % "test",
       "com.novocode" % "junit-interface" % junitInterfaceVersion,
       "junit" % "junit" % junitVersion % "test",
+      "com.lihaoyi" %% "pprint" % "0.5.9",
       "com.chuusai" %% "shapeless" % shapelessVersion,
       "com.google.api.grpc" % "proto-google-cloud-bigtable-v2" % generatedGrpcBetaVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,

--- a/scio-test/src/main/scala/com/spotify/scio/testing/BigtableMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/BigtableMatchers.scala
@@ -32,6 +32,9 @@ import scala.reflect.ClassTag
  * [[com.spotify.scio.values.SCollection SCollection]]s specific to Bigtable output.
  */
 trait BigtableMatchers extends SCollectionMatchers {
+
+  import EqInstances._
+
   type BTRow = (ByteString, Iterable[Mutation])
   type BTCollection = SCollection[BTRow]
 

--- a/scio-test/src/main/scala/com/spotify/scio/testing/BigtableMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/BigtableMatchers.scala
@@ -33,8 +33,6 @@ import scala.reflect.ClassTag
  */
 trait BigtableMatchers extends SCollectionMatchers {
 
-  import EqInstances._
-
   type BTRow = (ByteString, Iterable[Mutation])
   type BTCollection = SCollection[BTRow]
 

--- a/scio-test/src/main/scala/com/spotify/scio/testing/EqInstances.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/EqInstances.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.testing
+
+import cats.kernel.Eq
+import shapeless.LowPriority
+
+sealed trait FallbackEqInstances {
+  implicit def fallbackEq[A](implicit lp: LowPriority) = new Eq[A] {
+    def eqv(x: A, y: A): Boolean =
+      (x, y) match {
+        case (x: Array[_], y: Array[_]) => x.sameElements(y)
+        case _                          => Eq.fromUniversalEquals[A].eqv(x, y)
+      }
+  }
+}
+
+trait EqInstances extends FallbackEqInstances {
+  // == does not compare arrays for value equality, but for reference equality.
+  implicit def arrayEq[T](implicit eqT: Eq[T]): Eq[Array[T]] =
+    new Eq[Array[T]] {
+      def eqv(xs: Array[T], ys: Array[T]): Boolean =
+        (xs.length == ys.length) &&
+          (xs.zip(ys)).forall { case (x, y) => eqT.eqv(x, y) }
+    }
+}
+
+object EqInstances extends EqInstances

--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineSpec.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineSpec.scala
@@ -41,7 +41,8 @@ trait PipelineSpec
     with Matchers
     with SCollectionMatchers
     with PipelineTestUtils
-    with RunEnforcementJobTest {
+    with RunEnforcementJobTest
+    with EqInstances {
   private val Beam = """beam\.(.*)""".r
 
   private var beamOpts: BeamOptions = _

--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineSpec.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineSpec.scala
@@ -41,8 +41,7 @@ trait PipelineSpec
     with Matchers
     with SCollectionMatchers
     with PipelineTestUtils
-    with RunEnforcementJobTest
-    with EqInstances {
+    with RunEnforcementJobTest {
   private val Beam = """beam\.(.*)""".r
 
   private var beamOpts: BeamOptions = _

--- a/scio-test/src/main/scala/com/spotify/scio/testing/Pretty.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/Pretty.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.spotify.scio.testing
+
+import org.apache.avro.generic.GenericRecord
+import org.apache.avro.specific.SpecificRecordBase
+import scala.collection.JavaConverters._
+
+private[testing] object Pretty {
+  import pprint.Tree
+  import fansi.{Color, Str}
+
+  private def renderFieldName(n: String) =
+    Tree.Lazy(ctx => List(Color.LightBlue(n).toString).iterator)
+
+  private def renderGenericRecord: PartialFunction[GenericRecord, Tree] = {
+    case g =>
+      val renderer =
+        new pprint.Renderer(
+          printer.defaultWidth,
+          printer.colorApplyPrefix,
+          printer.colorLiteral,
+          printer.defaultIndent
+        )
+      def render(tree: Tree): Str =
+        Str.join(renderer.rec(tree, 0, 0).iter.toSeq: _*)
+      Tree.Lazy { ctx =>
+        val fields =
+          for {
+            f <- g.getSchema().getFields().asScala
+          } yield Str.join(
+            render(renderFieldName(f.name)),
+            ": ",
+            render(treeifyAvro(g.get(f.name())))
+          )
+        List(
+          Color.LightGray("{ ").toString +
+            fields.reduce((a, b) => Str.join(a, ", ", b)) +
+            Color.LightGray(" }")
+        ).iterator
+      }
+  }
+
+  private def renderSpecificRecord: PartialFunction[SpecificRecordBase, Tree] = {
+    case x =>
+      val fs =
+        for {
+          f <- x.getSchema().getFields().asScala
+        } yield Tree.Infix(renderFieldName(f.name), "=", treeifyAvro(x.get(f.name())))
+      Tree.Apply(x.getClass().getSimpleName(), fs.toIterator)
+  }
+
+  private def treeifyAvro: PartialFunction[Any, Tree] = {
+    case x: SpecificRecordBase =>
+      renderSpecificRecord(x)
+    case g: GenericRecord =>
+      renderGenericRecord(g)
+    case x =>
+      printer.treeify(x)
+  }
+
+  private val handlers: PartialFunction[Any, Tree] = {
+    case x: GenericRecord => treeifyAvro(x)
+  }
+
+  val printer = pprint.PPrinter(additionalHandlers = handlers)
+}

--- a/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
@@ -40,16 +40,6 @@ import cats.kernel.Eq
 import org.apache.beam.sdk.testing.SerializableMatchers
 import com.spotify.scio.coders.CoderMaterializer
 import com.spotify.scio.ScioContext
-import java.{util => ju}
-import org.apache.beam.sdk.coders.{Coder => BCoder}
-import java.io.Externalizable
-import java.io.ObjectOutput
-import java.io.ObjectInput
-import java.io.ByteArrayOutputStream
-import java.io.ByteArrayInputStream
-import java.io.ObjectOutputStream
-import java.io.ObjectInputStream
-import org.apache.beam.sdk.util.SerializableUtils
 
 final private case class TestWrapper[T: Eq](get: T) {
 
@@ -170,7 +160,7 @@ private object ScioMatchers {
  */
 trait SCollectionMatchers extends EqInstances {
 
-  import ScioMatchers.{makeFn, makeFnSingle}
+  import ScioMatchers.makeFn
 
   sealed trait MatcherBuilder[T] {
     _: Matcher[T] =>

--- a/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
@@ -40,7 +40,7 @@ import org.apache.beam.sdk.testing.SerializableMatchers
 import com.spotify.scio.coders.CoderMaterializer
 import com.spotify.scio.ScioContext
 
-private[testing] case class TestWrapper[T: Eq](value: T) {
+case class TestWrapper[T: Eq](value: T) {
   override def toString: String = Pretty.printer.apply(value).render
   override def equals(other: Any): Boolean =
     other match {

--- a/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
@@ -94,7 +94,7 @@ private object ScioMatchers {
  * Trait with ScalaTest [[org.scalatest.matchers.Matcher Matcher]]s for
  * [[com.spotify.scio.values.SCollection SCollection]]s.
  */
-trait SCollectionMatchers {
+trait SCollectionMatchers extends EqInstances {
 
   sealed trait MatcherBuilder[T] {
     _: Matcher[T] =>


### PR DESCRIPTION
Fixes #2368 

## Pretty printing

### Pretty print common types (based on [lihaoyi/PPrint](https://github.com/lihaoyi/PPrint))
Example from `AutoCompleteTest`:

#### Before:
![Screenshot 2020-03-04 at 11 27 35](https://user-images.githubusercontent.com/197582/75870406-35e3e380-5e0b-11ea-8ccd-553b2cf3c831.png)

#### After:
![Screenshot 2020-03-04 at 11 17 44](https://user-images.githubusercontent.com/197582/75869404-cde0cd80-5e09-11ea-8d7a-8182bf1be3b5.png)

### Pretty print `GenericRecord` instances

#### Before:

![Screenshot 2020-03-04 at 11 43 56](https://user-images.githubusercontent.com/197582/75878177-7cd8d580-5e19-11ea-991b-973da0f8487e.png)


#### After:

![Screenshot 2020-03-04 at 14 06 08](https://user-images.githubusercontent.com/197582/75882384-59198d80-5e21-11ea-9668-412184292e23.png)

### Pretty print `SpecificRecord` instances

Example from `AvroExampleTest`:

#### Before:
![Screenshot 2020-03-03 at 14 30 18](https://user-images.githubusercontent.com/197582/75868758-d7b60100-5e08-11ea-844f-3ed553b2f3c3.png)
#### After:
![Screenshot 2020-03-04 at 14 03 16](https://user-images.githubusercontent.com/197582/75882217-00e28b80-5e21-11ea-93d9-7af5f4f82e83.png)


## Custom `Eq`

See `SCollectionMatchersTest`:

https://github.com/spotify/scio/blob/13b21c92b8a5f723c9146dbb96726b8dca35fc5e/scio-test/src/test/scala/com/spotify/scio/testing/SCollectionMatchersTest.scala#L592-L623