### PR TITLE
BigQuery IO: Allow overriding transform names

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -279,7 +279,7 @@ final case class BigQueryTypedTable[T: Coder](
 
   override protected def read(sc: ScioContext, params: ReadP): SCollection[T] = {
     val io = reader.from(table.ref).withCoder(CoderMaterializer.beam(sc, Coder[T]))
-    sc.wrap(sc.pipeline.apply(s"Read BQ table ${table.spec}", io))
+    sc.wrap(sc.applyInternal(io))
   }
 
   override protected def write(data: SCollection[T], params: WriteP): Tap[T] = {


### PR DESCRIPTION
I think it is nice to allow the user to override transform names.
I think it is also very good to have the table name as part of the transform name in the IO.

In the current implementation, I get the following error:
```
Exception in thread "main" java.lang.IllegalArgumentException: requirement failed: withName() has already been used to set '*******' as the name for the next transform.
```
The happens for the following code when going from Scio 0.7.4 -> 0.8.1+
```diff
- val c = sc.withName("xxxx").typedBigQuery[MyCaseClass]("xyz")
+ val c = sc.withName("xxxx").typedBigQuery[MyCaseClass](Table.Spec("xyz"))
```

I think it would be nice to have the name as part of the transform if the user has not specified anything.

Based on feedback, I am happy to modify this to use `ConstNameProvider` defined [here](https://github.com/spotify/scio/blob/master/scio-core/src/main/scala/com/spotify/scio/values/TransformNameable.scala#L33-L51).
with which we can support both (using custom names from IO, as well as allowing the user to override)

