### PR TITLE
Add GenericJson coder

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/BeamTypeCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/BeamTypeCoders.scala
@@ -60,7 +60,7 @@ trait BeamTypeCoders {
 
   implicit def genericJsonCoder[T <: GenericJson: ClassTag]: Coder[T] =
     Coder.xmap(Coder[String])(
-      str => DefaultDsonObjectParser.parseAndClose(new StringReader(str), ScioUtil.classOf[T]),
+      str => DefaultJsonObjectParser.parseAndClose(new StringReader(str), ScioUtil.classOf[T]),
       (s: T) => {
         s.setFactory(new JacksonFactory)
         s.toString
@@ -69,5 +69,5 @@ trait BeamTypeCoders {
 }
 
 private[coders] object BeamTypeCoders extends BeamTypeCoders {
-  private lazy val DefaultDsonObjectParser = new JsonObjectParser(new JacksonFactory)
+  private lazy val DefaultJsonObjectParser = new JsonObjectParser(new JacksonFactory)
 }

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/BeamTypeCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/BeamTypeCoders.scala
@@ -17,19 +17,27 @@
 
 package com.spotify.scio.coders.instances
 
+import com.google.api.client.json.GenericJson
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.JsonObjectParser
 import com.google.api.services.bigquery.model.TableRow
 import com.spotify.scio.coders.Coder
+import com.spotify.scio.util.ScioUtil
+import java.io.StringReader
 import org.apache.beam.sdk.coders.RowCoder
 import org.apache.beam.sdk.io.FileIO.ReadableFile
-import org.apache.beam.sdk.io.ReadableFileCoder
 import org.apache.beam.sdk.io.fs.{MatchResult, MetadataCoderV2}
 import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder
 import org.apache.beam.sdk.io.gcp.pubsub.{PubsubMessage, PubsubMessageWithAttributesCoder}
+import org.apache.beam.sdk.io.ReadableFileCoder
 import org.apache.beam.sdk.schemas.{Schema => BSchema}
 import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, IntervalWindow, PaneInfo}
 import org.apache.beam.sdk.values.{KV, Row}
+import scala.reflect.ClassTag
 
 trait BeamTypeCoders {
+  import BeamTypeCoders._
+
   implicit def intervalWindowCoder: Coder[IntervalWindow] = Coder.beam(IntervalWindow.getCoder)
 
   implicit def boundedWindowCoder: Coder[BoundedWindow] = Coder.kryo[BoundedWindow]
@@ -49,6 +57,17 @@ trait BeamTypeCoders {
 
   implicit def matchResultMetadataCoder: Coder[MatchResult.Metadata] =
     Coder.beam(MetadataCoderV2.of())
+
+  implicit def genericJsonCoder[T <: GenericJson: ClassTag]: Coder[T] =
+    Coder.xmap(Coder[String])(
+      str => DefaultDsonObjectParser.parseAndClose(new StringReader(str), ScioUtil.classOf[T]),
+      (s: T) => {
+        s.setFactory(new JacksonFactory)
+        s.toString
+      }
+    )
 }
 
-private[coders] object BeamTypeCoders extends BeamTypeCoders
+private[coders] object BeamTypeCoders extends BeamTypeCoders {
+  private lazy val DefaultDsonObjectParser = new JsonObjectParser(new JacksonFactory)
+}

--- a/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
-object ScioUtil {
+private[scio] object ScioUtil {
   // Try.toEither does not exists in Scala 2.11
   def toEither[T](t: Try[T]): Either[Throwable, T] =
     t match {

--- a/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
-private[scio] object ScioUtil {
+object ScioUtil {
   // Try.toEither does not exists in Scala 2.11
   def toEither[T](t: Try[T]): Either[Throwable, T] =
     t match {

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -32,7 +32,7 @@ import scala.collection.JavaConverters._
 import scala.collection.{mutable => mut}
 import java.io.ByteArrayInputStream
 import org.apache.beam.sdk.testing.CoderProperties
-import com.google.api.services.bigquery.model.{TableSchema, TableFieldSchema}
+import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
 
 final case class UserId(bytes: Seq[Byte])
 final case class User(id: UserId, username: String, email: String)

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -32,6 +32,7 @@ import scala.collection.JavaConverters._
 import scala.collection.{mutable => mut}
 import java.io.ByteArrayInputStream
 import org.apache.beam.sdk.testing.CoderProperties
+import com.google.api.services.bigquery.model.{TableSchema, TableFieldSchema}
 
 final case class UserId(bytes: Seq[Byte])
 final case class User(id: UserId, username: String, email: String)
@@ -563,6 +564,19 @@ final class CoderTest extends AnyFlatSpec with Matchers {
       val coder = Coder[Set[Int]]
       materialize(coder).verifyDeterministic()
     }
+  }
+
+  it should "support GenericJson types" in {
+    coderIsSerializable[TableSchema]
+
+    val tableSchema = new TableSchema().setFields(
+      List(
+        new TableFieldSchema().setName("word").setType("STRING").setMode("NULLABLE"),
+        new TableFieldSchema().setName("word_count").setType("INTEGER").setMode("NULLABLE")
+      ).asJava
+    )
+
+    tableSchema coderShould roundtrip()
   }
 
 }


### PR DESCRIPTION
There are a lot of types that inherit from `GenericJson` I think it's worth adding a coder since any attempt to serialize one of these will end up using our `javaBeanCoder`.

Fixes #2741