### PR TITLE
Add schema cache support in BigQueryType

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -601,6 +601,8 @@ lazy val `scio-bigquery`: Project = project
   .settings(
     description := "Scio add-on for Google BigQuery",
     libraryDependencies ++= Seq(
+      //this dep seems to be required only when compilling with 2.11
+      "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion % "provided",
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
       "com.twitter" %% "chill" % chillVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -27,21 +27,35 @@ import org.joda.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 
 import scala.collection.JavaConverters._
 import scala.reflect.runtime.universe._
+import com.spotify.scio.util.Cache
 
 private[types] object SchemaProvider {
-  def avroSchemaOf[T: TypeTag]: Schema =
-    BigQueryUtils.toGenericAvroSchema(typeTag[T].tpe.toString, schemaOf[T].getFields)
 
-  def schemaOf[T: TypeTag]: TableSchema = {
-    val fields = typeOf[T].erasure match {
-      case t if isCaseClass(t) => toFields(t)
-      case t                   => throw new RuntimeException(s"Unsupported type $t")
-    }
-    val r = new TableSchema().setFields(fields.toList.asJava)
-    debug(s"SchemaProvider.schemaOf[${typeOf[T]}]:")
-    debug(r)
-    r
-  }
+  private val avroSchemaCache =
+    Cache.concurrentHashMap[String, Schema]
+
+  def avroSchemaOf[T: TypeTag]: Schema =
+    avroSchemaCache.get(
+      typeTag[T].tpe.toString,
+      BigQueryUtils.toGenericAvroSchema(typeTag[T].tpe.toString, schemaOf[T].getFields)
+    )
+
+  private val tableSchemaCache =
+    Cache.concurrentHashMap[Type, TableSchema]
+
+  def schemaOf[T: TypeTag]: TableSchema =
+    tableSchemaCache.get(
+      typeOf[T].erasure, {
+        val fields = typeOf[T].erasure match {
+          case t if isCaseClass(t) => toFields(t)
+          case t                   => throw new RuntimeException(s"Unsupported type $t")
+        }
+        val r = new TableSchema().setFields(fields.toList.asJava)
+        debug(s"SchemaProvider.schemaOf[${typeOf[T]}]:")
+        debug(r)
+        r
+      }
+    )
 
   private def field(
     mode: String,

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -30,21 +30,17 @@ import scala.reflect.runtime.universe._
 import com.spotify.scio.util.Cache
 
 private[types] object SchemaProvider {
-
-  private val avroSchemaCache =
-    Cache.concurrentHashMap[String, Schema]
+  private[this] val AvroSchemaCache = Cache.concurrentHashMap[String, Schema]
+  private[this] val TableSchemaCache = Cache.concurrentHashMap[Type, TableSchema]
 
   def avroSchemaOf[T: TypeTag]: Schema =
-    avroSchemaCache.get(
+    AvroSchemaCache.get(
       typeTag[T].tpe.toString,
       BigQueryUtils.toGenericAvroSchema(typeTag[T].tpe.toString, schemaOf[T].getFields)
     )
 
-  private val tableSchemaCache =
-    Cache.concurrentHashMap[Type, TableSchema]
-
   def schemaOf[T: TypeTag]: TableSchema =
-    tableSchemaCache.get(
+    TableSchemaCache.get(
       typeOf[T].erasure, {
         val fields = typeOf[T].erasure match {
           case t if isCaseClass(t) => toFields(t)


### PR DESCRIPTION
https://github.com/spotify/scio/pull/2714#pullrequestreview-370710821

### no cache
```
[info] Benchmark                         Mode  Cnt      Score       Error  Units
[info] BigQueryAvroBenchmark.convert     avgt   10  47635.637 ± 1167.784  ns/op
```

### cache
```
[info] Benchmark                         Mode  Cnt     Score     Error  Units
[info] BigQueryAvroBenchmark.convert     avgt   10  2350.097 ± 9.759  ns/op
```

```
 BigQueryType.fromAvro[FooBar](BigQueryType.toAvro[FooBar](FooBar(...)))
```
