### PR TITLE
Fix Sharded Sparkey string hashing behaviour for strings longer than one character.

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/instances/ShardedSparkeyReader.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/instances/ShardedSparkeyReader.scala
@@ -18,7 +18,7 @@ class ShardedSparkeyReader(val sparkeys: Map[Short, SparkeyReader], val numShard
     extends SparkeyReader {
   def hashKey(arr: Array[Byte]): Short = (MurmurHash3.bytesHash(arr, 1) % numShards).toShort
 
-  def hashKey(str: String): Short = hashKey(str.getBytes)
+  def hashKey(str: String): Short = (MurmurHash3.stringHash(str, 1) % numShards).toShort
 
   override def getAsString(key: String): String = {
     val hashed = hashKey(key)

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -426,7 +426,8 @@ package object sparkey extends SparkeyReaderInstances {
     def hashKey(arr: Array[Byte]): Short =
       floorMod(MurmurHash3.bytesHash(arr, 1), numShards).toShort
 
-    def hashKey(str: String): Short = hashKey(str.getBytes)
+    def hashKey(str: String): Short =
+      floorMod(MurmurHash3.stringHash(str, 1), numShards).toShort
 
     override def getAsString(key: String): String = {
       val hashed = hashKey(key)


### PR DESCRIPTION
Sharded Sparkey [was added back in Scio 0.8.0](https://github.com/spotify/scio/pull/2336) and had some [bugfixes that landed in 0.8.2](https://github.com/spotify/scio/pull/2667) - here's another one!

It turns out that `MurmurHash3`, which we're using for distributing data across the shards of a sharded Sparkey fileset, uses a different hashing algorithm if passed a `String` object vs when it's passed an `Array[Byte]`. Namely:

```scala
// if (str.length > 1)
MurmurHash3.stringHash(str, seed) != MurmurHash3.bytesHash(str.getBytes, seed) 
```

Unfortunately, Scio was using these methods interchangeably, and used `bytesHash` in one place and `stringHash` in another. This wasn't caught in tests because the tests used single-character keys, and this inconsistency only appears if the strings being hashed are longer than a single character.

This is a known issue [documented on StackOverflow](https://stackoverflow.com/a/46472986/679081):
> `MurmurHash3.bytesHash` and python's `mmh3.hash` pass characters to the hashing mixer in groups of 4, but `MurmurHash3.stringHash` mixes characters in groups of 2. This means that the two hash functions return completely different outputs.

This PR fixes the issue by:
 - using `stringHash` consistently when the input is a `String`
 - altering the tests to use multi-character keys
 - adding additional assertions to the test

Special thanks to @drubinstein for identifying this bug.