### PR TITLE
remove implicit Coder requirement for .saveAsSortedBucket

### DIFF
--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketSCollectionSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketSCollectionSyntax.scala
@@ -18,7 +18,6 @@
 package com.spotify.scio.smb.syntax
 
 import com.spotify.scio.annotations.experimental
-import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.{ClosedTap, EmptyTap}
 import com.spotify.scio.values._
 import org.apache.beam.sdk.extensions.smb.SortedBucketSink
@@ -26,12 +25,12 @@ import org.apache.beam.sdk.transforms.PTransform
 import org.apache.beam.sdk.values.PCollection
 
 trait SortMergeBucketSCollectionSyntax {
-  implicit def toSortMergeBucketSCollection[T: Coder](
+  implicit def toSortMergeBucketSCollection[T](
     data: SCollection[T]
   ): SortedBucketSCollection[T] = new SortedBucketSCollection(data)
 }
 
-final class SortedBucketSCollection[T: Coder](private val self: SCollection[T]) {
+final class SortedBucketSCollection[T](private val self: SCollection[T]) {
   type Write = PTransform[PCollection[T], SortedBucketSink.WriteResult]
 
   /**


### PR DESCRIPTION
it isn't required to apply the write transform fn -- and makes it harder to work with data types where we may want to apply a coder explicitly, i.e. for GenericRecord