### PR TITLE
(scio-smb) fix missing-bucket case when Sink collection is empty

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
@@ -177,7 +177,7 @@ public abstract class FileOperations<V> implements Serializable, HasDisplayData 
               ? Compression.detect(resourceId.getFilename())
               : compression);
     } catch (IOException e) {
-      throw new RuntimeException(String.format("Exception reading bucket file %s", resourceId), e);
+      throw new RuntimeException(String.format("Exception opening bucket file %s", resourceId), e);
     }
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
@@ -177,8 +177,7 @@ public abstract class FileOperations<V> implements Serializable, HasDisplayData 
               ? Compression.detect(resourceId.getFilename())
               : compression);
     } catch (IOException e) {
-      throw new RuntimeException(
-          String.format("Exception fetching metadata for %s", resourceId), e);
+      throw new RuntimeException(String.format("Exception reading bucket file %s", resourceId), e);
     }
   }
 }


### PR DESCRIPTION
the bug: when SortedBucketSink is applied to an empty PCollection, only the metadata file is written. A SMB join requires all bucket files to at least exist with file header. Missing bucket files are already being populated in the case that the input is too small to span all bucket-shard combinations, but this case (empty input) wasn't working.

I fixed it by converting `RenameBuckets` from a `DoFn` to a `PTransform` and using the output of the temp file write as a SideInput to keep track of which bucket-shard IDs have been written to, compared to the entire bucket/shard combination set.