### PR TITLE
Revert "delete unused schema in scio-avro"

### DIFF
--- a/scio-avro/src/test/avro/scio-avro-test.avsc
+++ b/scio-avro/src/test/avro/scio-avro-test.avsc
@@ -1,0 +1,7 @@
+{
+  "type": "record",
+  "name": "Test",
+  "fields": [
+    {"name": "test", "type": "int"}
+  ]
+}


### PR DESCRIPTION
Reverts spotify/scio#2870

The file is used in an integration test.