### PR TITLE
Better support for alternative runners in tests

### DIFF
--- a/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
@@ -294,21 +294,21 @@ object JobTest {
       val metricsFn = (result: ScioResult) => {
         state.counters.foreach {
           case a: SingleMetricAssertion[beam.Counter, Long] =>
-            a.assert(result.counter(a.metric).committed.get)
+            a.assert(result.counter(a.metric).attempted)
           case a: AllMetricsAssertion[beam.Counter, Long] =>
-            a.assert(result.allCounters.map(c => c._1 -> c._2.committed.get))
+            a.assert(result.allCounters.map(c => c._1 -> c._2.attempted))
         }
         state.gauges.foreach {
           case a: SingleMetricAssertion[beam.Gauge, beam.GaugeResult] =>
-            a.assert(result.gauge(a.metric).committed.get)
+            a.assert(result.gauge(a.metric).attempted)
           case a: AllMetricsAssertion[beam.Gauge, beam.GaugeResult] =>
-            a.assert(result.allGauges.map(c => c._1 -> c._2.committed.get))
+            a.assert(result.allGauges.map(c => c._1 -> c._2.attempted))
         }
         state.distributions.foreach {
           case a: SingleMetricAssertion[beam.Distribution, beam.DistributionResult] =>
-            a.assert(result.distribution(a.metric).committed.get)
+            a.assert(result.distribution(a.metric).attempted)
           case a: AllMetricsAssertion[beam.Distribution, beam.DistributionResult] =>
-            a.assert(result.allDistributions.map(c => c._1 -> c._2.committed.get))
+            a.assert(result.allDistributions.map(c => c._1 -> c._2.attempted))
         }
       }
       TestDataManager.tearDown(testId, metricsFn)

--- a/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -41,14 +41,18 @@ class ScioContextTest extends PipelineSpec {
   }
 
   it should "have temp location for default runner" in {
-    val opts = ScioContext().options
+    val sc = ScioContext()
+    sc.prepare()
+    val opts = sc.options
     opts.getTempLocation should not be null
   }
 
   it should "have temp location for DirectRunner" in {
     val opts = PipelineOptionsFactory.create()
     opts.setRunner(classOf[DirectRunner])
-    ScioContext(opts).options.getTempLocation should not be null
+    val sc = ScioContext(opts)
+    sc.prepare()
+    sc.options.getTempLocation should not be null
   }
 
   it should "support user defined temp location" in {


### PR DESCRIPTION
This PR makes it possible to run test with a different runner (tested with `FlinkRunner`) and fixes #2876, #2864 and #2865 
