### PR TITLE
Don't write SMB metadata if prior steps fail (fix #2895)

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -115,7 +115,7 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
     @SuppressWarnings("deprecation")
     final Reshuffle.ViaRandomKey<Integer> reshuffle = Reshuffle.viaRandomKey();
 
-    final PCollectionTuple tuple =
+    return WriteResult.fromTuple(
         begin
             .getPipeline()
             .apply("CreateBuckets", createBuckets)
@@ -135,9 +135,7 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
             .apply(
                 "FinalizeTempFiles",
                 new SortedBucketSink.RenameBuckets<>(
-                    filenamePolicy.forDestination(), bucketMetadata, fileOperations));
-
-    return WriteResult.fromTuple(begin.getPipeline(), tuple);
+                    filenamePolicy.forDestination(), bucketMetadata, fileOperations)));
   }
 
   @FunctionalInterface


### PR DESCRIPTION
I moved the metadata write to the final Rename step, before moving the buckets from their temp to their final destinations. Since metadata is just one file, I think it's still a pretty atomic operation despite no longer being written to temp storage first; if the metadata write fails, it will be cleaned up and the bucket rename won't happen.

Also simplified the graph a bit by removing redundant composite transforms

before:
![Screen Shot 2020-04-21 at 1 58 50 PM](https://user-images.githubusercontent.com/1360529/79897842-4874a500-83d8-11ea-882f-826d4518b127.png)

after:
![Screen Shot 2020-04-21 at 2 10 42 PM](https://user-images.githubusercontent.com/1360529/79898869-f3399300-83d9-11ea-8ccd-e2e95e02ee69.png)
