### PR TITLE
New inLatePane matcher for SCollection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -579,12 +579,19 @@ lazy val `scio-test`: Project = project
   .configs(
     IntegrationTest
   )
+//  .dependsOn(
+//    `scio-core` % "test->test;compile->compile;it->it",
+//    `scio-schemas` % "test;it",
+//    `scio-avro` % "compile->test;it->it",
+//    `scio-sql` % "compile->test;it->it",
+//    `scio-bigquery` % "compile->test;it->it"
+//  )
   .dependsOn(
-    `scio-core` % "test->test;compile->compile;it->it",
-    `scio-schemas` % "test;it",
-    `scio-avro` % "compile->test;it->it",
-    `scio-sql` % "compile->test;it->it",
-    `scio-bigquery` % "compile->test;it->it"
+    `scio-core` % "compile->compile",
+    `scio-schemas` % "compile->compile",
+    `scio-avro` % "compile->compile",
+    `scio-sql` % "compile->compile",
+    `scio-bigquery` % "compile->compile"
   )
 
 lazy val `scio-macros`: Project = project

--- a/build.sbt
+++ b/build.sbt
@@ -579,19 +579,12 @@ lazy val `scio-test`: Project = project
   .configs(
     IntegrationTest
   )
-//  .dependsOn(
-//    `scio-core` % "test->test;compile->compile;it->it",
-//    `scio-schemas` % "test;it",
-//    `scio-avro` % "compile->test;it->it",
-//    `scio-sql` % "compile->test;it->it",
-//    `scio-bigquery` % "compile->test;it->it"
-//  )
   .dependsOn(
-    `scio-core` % "compile->compile",
-    `scio-schemas` % "compile->compile",
-    `scio-avro` % "compile->compile",
-    `scio-sql` % "compile->compile",
-    `scio-bigquery` % "compile->compile"
+    `scio-core` % "test->test;compile->compile;it->it",
+    `scio-schemas` % "test;it",
+    `scio-avro` % "compile->test;it->it",
+    `scio-sql` % "compile->test;it->it",
+    `scio-bigquery` % "compile->test;it->it"
   )
 
 lazy val `scio-macros`: Project = project

--- a/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
@@ -274,7 +274,7 @@ trait SCollectionMatchers extends EqInstances {
    * running the checker only on the late pane for each key.
    */
   def inLatePane[T: ClassTag, B: ClassTag](
-      window: BoundedWindow
+    window: BoundedWindow
   )(matcher: MatcherBuilder[T]): Matcher[T] =
     matcher match {
       case value: SingleMatcher[T, _] =>

--- a/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
@@ -270,6 +270,20 @@ trait SCollectionMatchers extends EqInstances {
     }
 
   /**
+   * SCollection assertion only applied to the specified window,
+   * running the checker only on the late pane for each key.
+   */
+  def inLatePane[T: ClassTag, B: ClassTag](
+      window: BoundedWindow
+  )(matcher: MatcherBuilder[T]): Matcher[T] =
+    matcher match {
+      case value: SingleMatcher[T, _] =>
+        value.matcher(_.inLatePane(window))
+      case value: IterableMatcher[T, _] =>
+        value.matcher(_.inLatePane(window))
+    }
+
+  /**
    * SCollection assertion only applied to the specified window.
    * The assertion expect outputs to be produced to the provided window exactly once.
    */

--- a/scio-test/src/test/scala/com/spotify/scio/testing/SCollectionMatchersTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/SCollectionMatchersTest.scala
@@ -604,7 +604,7 @@ class SCollectionMatchersTest extends PipelineSpec {
     val windowDuration = Duration.standardMinutes(10)
     val allowedLateness = Duration.standardMinutes(5)
     val stream = testStreamOf[Int]
-      // Start at the epoch
+    // Start at the epoch
       .advanceWatermarkTo(baseTime)
       // On-time element
       .addElements(

--- a/scio-test/src/test/scala/com/spotify/scio/testing/SCollectionMatchersTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/SCollectionMatchersTest.scala
@@ -599,6 +599,53 @@ class SCollectionMatchersTest extends PipelineSpec {
     }
   }
 
+  it should "support late pane windowing" in {
+    val baseTime = new Instant(0)
+    val windowDuration = Duration.standardMinutes(10)
+    val allowedLateness = Duration.standardMinutes(5)
+    val stream = testStreamOf[Int]
+      // Start at the epoch
+      .advanceWatermarkTo(baseTime)
+      // On-time element
+      .addElements(
+        TimestampedValue.of(1, baseTime.plus(Duration.standardMinutes(1)))
+      )
+      // Advance watermark to the end of window
+      .advanceWatermarkTo(baseTime.plus(windowDuration))
+      .addElements(
+        // Late element in allowed lateness
+        TimestampedValue.of(2, baseTime.plus(Duration.standardMinutes(9)))
+      )
+      .advanceWatermarkToInfinity()
+
+    runWithContext { sc =>
+      val windowedStream = sc
+        .testStream(stream)
+        .withFixedWindows(
+          windowDuration,
+          options = WindowOptions(
+            trigger = AfterWatermark
+              .pastEndOfWindow()
+              .withLateFirings(
+                AfterProcessingTime.pastFirstElementInPane()
+              ),
+            accumulationMode = ACCUMULATING_FIRED_PANES,
+            allowedLateness = allowedLateness
+          )
+        )
+        .sum
+
+      val window = new IntervalWindow(baseTime, windowDuration)
+      windowedStream should inOnTimePane(window) {
+        containSingleValue(1)
+      }
+
+      windowedStream should inLatePane(window) {
+        containSingleValue(1 + 2)
+      }
+    }
+  }
+
   it should "customize equality" in {
     val in = 1 to 10
     val out = 2 to 11


### PR DESCRIPTION
Support for [inLatePane](https://beam.apache.org/releases/javadoc/2.20.0/org/apache/beam/sdk/testing/PAssert.IterableAssert.html#inLatePane-org.apache.beam.sdk.transforms.windowing.BoundedWindow-) Beam assertion.

I was unable to provide easy to understand scenario in existing "support windowing" test method, so I added new one - crafted only for the new assertion. But as long as there is also pastEndOfWindow trigger the onTime pane is also verified.