### PR TITLE
New method mapKeys for PairScollection

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -898,6 +898,14 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     self.map(_._1)
 
   /**
+   * Pass each key in the key-value pair SCollection through a `map` function without changing
+   * the values.
+   * @group transform
+   */
+  def mapKeys[U: Coder](f: K => U)(implicit koder: Coder[K], voder: Coder[V]): SCollection[(U, V)] =
+    self.map(kv => (f(kv._1), kv._2))
+
+  /**
    * Pass each value in the key-value pair SCollection through a `map` function without changing
    * the keys.
    * @group transform

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -902,7 +902,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * the values.
    * @group transform
    */
-  def mapKeys[U: Coder](f: K => U)(implicit koder: Coder[K], voder: Coder[V]): SCollection[(U, V)] =
+  def mapKeys[U: Coder](f: K => U)(implicit voder: Coder[V]): SCollection[(U, V)] =
     self.map(kv => (f(kv._1), kv._2))
 
   /**

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -435,6 +435,13 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
+  it should "support mapKeys()" in {
+    runWithContext { sc =>
+      val p = sc.parallelize(Seq((1, "a"), (2, "b"))).mapKeys(_ + 10.0)
+      p should containInAnyOrder(Seq((11.0, "a"), (12.0, "b")))
+    }
+  }
+
   it should "support mapValues()" in {
     runWithContext { sc =>
       val p = sc.parallelize(Seq(("a", 1), ("b", 2))).mapValues(_ + 10.0)


### PR DESCRIPTION
Mapping keys seems to be as useful as mapping values. 

Example use case for stripping part of the key for next aggregations:

```
scolByCompositeKey.mapKeys { (k1, _) => k1 }
```