### PR TITLE
Fix creation of local sharded Sparkey files.

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/ShardedSparkeyUri.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/ShardedSparkeyUri.scala
@@ -50,8 +50,9 @@ trait ShardedSparkeyUri extends SparkeyUri {
 
   val globExpression = s"$basePath/part-*"
 
-  private[sparkey] def basePathsAndCount(emptyMatchTreatment: EmptyMatchTreatment = DISALLOW):
-  (Seq[String], Short) = {
+  private[sparkey] def basePathsAndCount(
+    emptyMatchTreatment: EmptyMatchTreatment = DISALLOW
+  ): (Seq[String], Short) = {
     val matchResult: MatchResult = FileSystems.`match`(globExpression, emptyMatchTreatment)
     val paths = matchResult.metadata().asScala.map(_.resourceId.toString)
 

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
@@ -172,7 +172,7 @@ class SparkeyTest extends PipelineSpec {
     val tmpDir = Files.createTempDirectory("sparkey-test-")
     val basePath = tmpDir.resolve("new-sharded")
     Files.createDirectory(basePath)
-    runWithContext(sc => sc.parallelize(bigSideData).asSparkey(basePath.toString, numShards=2))
+    runWithContext(sc => sc.parallelize(bigSideData).asSparkey(basePath.toString, numShards = 2))
 
     val allSparkeyFiles = FileSystems
       .`match`(s"$basePath/part-*")
@@ -185,7 +185,6 @@ class SparkeyTest extends PipelineSpec {
 
     val readers = basePaths.map(basePath => Sparkey.open(new File(basePath)))
     readers.map(_.toMap.toList.toMap).reduce(_ ++ _) shouldBe bigSideData.toMap
-
 
     for (ext <- allSparkeyFiles) {
       new File(basePath + ext).delete()


### PR DESCRIPTION
Thanks to @codewitch for discovering this - when trying to create a local sharded Sparkey file, Scio calls `LocalShardedSparkeyUri#exists`, which calls `basePathsAndCount` to get the number of shards - but in doing so, `FileSystems#match` is called on an empty local path, which throws an exception. This PR fixes this by adding `EmptyMatchTreatment.ALLOW` when this method is called via `exists`.