### PR TITLE
Don't require a List for Bigtable admin operations.

### DIFF
--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/TableAdmin.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/TableAdmin.scala
@@ -80,7 +80,7 @@ object TableAdmin {
    */
   def ensureTables(
     bigtableOptions: BigtableOptions,
-    tablesAndColumnFamilies: Map[String, List[String]]
+    tablesAndColumnFamilies: Map[String, Iterable[String]]
   ): Unit = {
     val tcf = tablesAndColumnFamilies.iterator.map {
       case (k, l) => k -> l.map(_ -> None)
@@ -93,17 +93,17 @@ object TableAdmin {
    * Checks for existence of tables or creates them if they do not exist.  Also checks for
    * existence of column families within each table and creates them if they do not exist.
    *
-   * @param tablesAndColumnFamiliesWithExpiration A map of tables and column families.
-   *                                              Keys are table names. Values are a
-   *                                              list of column family names along with
-   *                                              the desired cell expiration. Cell
-   *                                              expiration is the duration before which
-   *                                              garbage collection of a cell may occur.
-   *                                              Note: minimum granularity is second.
+   * @param tablesAndColumnFamilies A map of tables and column families.
+   *                                Keys are table names. Values are a
+   *                                list of column family names along with
+   *                                the desired cell expiration. Cell
+   *                                expiration is the duration before which
+   *                                garbage collection of a cell may occur.
+   *                                Note: minimum granularity is one second.
    */
   def ensureTablesWithExpiration(
     bigtableOptions: BigtableOptions,
-    tablesAndColumnFamilies: Map[String, List[(String, Option[Duration])]]
+    tablesAndColumnFamilies: Map[String, Iterable[(String, Option[Duration])]]
   ): Unit = {
     // Convert Duration to GcRule
     val x = tablesAndColumnFamilies.iterator.map {
@@ -127,7 +127,7 @@ object TableAdmin {
    */
   def ensureTablesWithGcRules(
     bigtableOptions: BigtableOptions,
-    tablesAndColumnFamilies: Map[String, List[(String, Option[GcRule])]]
+    tablesAndColumnFamilies: Map[String, Iterable[(String, Option[GcRule])]]
   ): Unit =
     ensureTablesImpl(bigtableOptions, tablesAndColumnFamilies).get
 
@@ -141,7 +141,7 @@ object TableAdmin {
    */
   private def ensureTablesImpl(
     bigtableOptions: BigtableOptions,
-    tablesAndColumnFamilies: Map[String, List[(String, Option[GcRule])]]
+    tablesAndColumnFamilies: Map[String, Iterable[(String, Option[GcRule])]]
   ): Try[Unit] = {
     val project = bigtableOptions.getProjectId
     val instance = bigtableOptions.getInstanceId
@@ -185,7 +185,7 @@ object TableAdmin {
   private def ensureColumnFamilies(
     client: BigtableTableAdminClient,
     tablePath: String,
-    columnFamilies: List[(String, Option[GcRule])]
+    columnFamilies: Iterable[(String, Option[GcRule])]
   ): Unit = {
     val tableInfo =
       client.getTable(GetTableRequest.newBuilder().setName(tablePath).build)

--- a/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/syntax/ScioContextSyntax.scala
+++ b/scio-bigtable/src/main/scala/com/spotify/scio/bigtable/syntax/ScioContextSyntax.scala
@@ -129,7 +129,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   def ensureTables(
     projectId: String,
     instanceId: String,
-    tablesAndColumnFamilies: Map[String, List[String]]
+    tablesAndColumnFamilies: Map[String, Iterable[String]]
   ): Unit =
     if (!self.isTest) {
       val bigtableOptions = BigtableOptions
@@ -150,7 +150,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
    */
   def ensureTables(
     bigtableOptions: BigtableOptions,
-    tablesAndColumnFamilies: Map[String, List[String]]
+    tablesAndColumnFamilies: Map[String, Iterable[String]]
   ): Unit =
     if (!self.isTest) {
       TableAdmin.ensureTables(bigtableOptions, tablesAndColumnFamilies)
@@ -172,7 +172,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   def ensureTablesWithExpiration(
     projectId: String,
     instanceId: String,
-    tablesAndColumnFamiliesWithExpiration: Map[String, List[(String, Option[Duration])]]
+    tablesAndColumnFamiliesWithExpiration: Map[String, Iterable[(String, Option[Duration])]]
   ): Unit =
     if (!self.isTest) {
       val bigtableOptions = BigtableOptions
@@ -201,7 +201,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
    */
   def ensureTablesWithExpiration(
     bigtableOptions: BigtableOptions,
-    tablesAndColumnFamiliesWithExpiration: Map[String, List[(String, Option[Duration])]]
+    tablesAndColumnFamiliesWithExpiration: Map[String, Iterable[(String, Option[Duration])]]
   ): Unit =
     if (!self.isTest) {
       TableAdmin.ensureTablesWithExpiration(
@@ -222,7 +222,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   def ensureTablesWithGcRules(
     projectId: String,
     instanceId: String,
-    tablesAndColumnFamiliesWithGcRules: Map[String, List[(String, Option[GcRule])]]
+    tablesAndColumnFamiliesWithGcRules: Map[String, Iterable[(String, Option[GcRule])]]
   ): Unit =
     if (!self.isTest) {
       val bigtableOptions = BigtableOptions
@@ -251,7 +251,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
    */
   def ensureTablesWithGcRules(
     bigtableOptions: BigtableOptions,
-    tablesAndColumnFamiliesWithGcRule: Map[String, List[(String, Option[GcRule])]]
+    tablesAndColumnFamiliesWithGcRule: Map[String, Iterable[(String, Option[GcRule])]]
   ): Unit =
     if (!self.isTest) {
       TableAdmin.ensureTablesWithGcRules(


### PR DESCRIPTION
This PR fixes a super small Scala annoyance - our Bigtable Admin API interface requires a `List[T]` in many of its APIs, when technically we just iterate over the `List` - so it could be any `Iterable[T]` instead. This change should be fully backwards compatible and will allow us to pass `Set[T]`, etc.

Tagging @regadas and @brianmartin randomly as GitHub suggested.