### PR TITLE
Revert "Fix: generate tree eagerly before checking for private constructors    (#2846)"

### DIFF
--- a/scio-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
@@ -132,8 +132,7 @@ private[coders] object CoderMacros {
     imp.map(_ => EmptyTree).getOrElse {
       // Magnolia does not support classes with a private constructor.
       // Workaround the limitation by using a fallback in that case
-      val tree = MagnoliaMacros.genWithoutAnnotations[T](c)
-      privateConstructor(c)(wtt).fold(tree) { _ =>
+      privateConstructor(c)(wtt).fold(MagnoliaMacros.genWithoutAnnotations[T](c)) { _ =>
         q"_root_.com.spotify.scio.coders.Coder.fallback[$wtt](null)"
       }
     }

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -77,6 +77,8 @@ object PrivateClass {
   def apply(l: Long): PrivateClass = new PrivateClass(l)
 }
 
+case class UsesPrivateClass(privateClass: PrivateClass)
+
 case class ClassWithProtoEnum(s: String, enum: OuterClassForProto.EnumExample)
 
 @SerialVersionUID(1)
@@ -361,6 +363,11 @@ final class CoderTest extends AnyFlatSpec with Matchers {
   it should "support classes with private constructors" in {
     Coder.gen[PrivateClass]
     PrivateClass(42L) coderShould fallback()
+  }
+
+  it should "support classes that contain classes with private constructors" in {
+    Coder.gen[UsesPrivateClass]
+    UsesPrivateClass(PrivateClass(1L)) coderShould notFallback()
   }
 
   it should "not derive Coders for org.apache.beam.sdk.values.Row" in {


### PR DESCRIPTION
This is reverting what i thought to be a fix but it's not ... Adding a test case now so we (I) don't do the same mistake.