### PR TITLE
Update scala to 2.13.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
       - image: circleci/openjdk:8-jdk
     environment:
       <<: *env
-      SCALA_VERSION: 2.13.1
+      SCALA_VERSION: 2.13.2
 
   scala_212_jdk11:
     <<: [*scala_212]

--- a/build.sbt
+++ b/build.sbt
@@ -1385,7 +1385,7 @@ ThisBuild / dependencyOverrides ++= Seq(
   "org.hamcrest" % "hamcrest-core" % hamcrestVersion,
   "org.objenesis" % "objenesis" % "2.5.1",
   "org.ow2.asm" % "asm" % "5.0.4",
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2",
+  "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
   "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
   "org.scalacheck" %% "scalacheck" % scalacheckVersion,
   "org.scalactic" %% "scalactic" % scalatestVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -167,7 +167,7 @@ lazy val formatSettings = Seq(
 
 val commonSettings = Sonatype.sonatypeSettings ++ assemblySettings ++ Seq(
   organization := "com.spotify",
-  scalaVersion := "2.13.1",
+  scalaVersion := "2.13.2",
   crossScalaVersions := Seq("2.12.11", scalaVersion.value),
   scalacOptions ++= Scalac.commonsOptions.value,
   scalacOptions ++= {


### PR DESCRIPTION
Tooling is here so we can safely update now.