### PR TITLE
implement SMB "least bucket replication" for SortedBucketSource

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
@@ -35,6 +35,7 @@ import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.{JsonProperties, Schema}
 import org.apache.beam.sdk.extensions.smb.AvroSortedBucketIO
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType
+import org.apache.beam.sdk.extensions.smb.SortedBucketSource.TargetParallelism
 import org.apache.beam.sdk.values.TupleTag
 
 import scala.collection.JavaConverters._
@@ -137,7 +138,8 @@ object SortMergeBucketJoinExample {
           .from(args("lhsInput")),
         AvroSortedBucketIO
           .read(new TupleTag[Account]("rhs"), classOf[Account])
-          .from(args("rhsInput"))
+          .from(args("rhsInput")),
+        TargetParallelism.max()
       )
       .map(mapFn) // Apply mapping function
       .saveAsTextFile(args("output"))

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
@@ -35,7 +35,7 @@ import org.apache.avro.generic.{GenericData, GenericRecord}
 import org.apache.avro.{JsonProperties, Schema}
 import org.apache.beam.sdk.extensions.smb.AvroSortedBucketIO
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType
-import org.apache.beam.sdk.extensions.smb.SortedBucketSource.TargetParallelism
+import org.apache.beam.sdk.extensions.smb.TargetParallelism
 import org.apache.beam.sdk.values.TupleTag
 
 import scala.collection.JavaConverters._

--- a/scio-smb/src/it/scala/com/spotify/scio/smb/SortMergeBucketParityIT.scala
+++ b/scio-smb/src/it/scala/com/spotify/scio/smb/SortMergeBucketParityIT.scala
@@ -26,8 +26,7 @@ import com.spotify.scio.values.SCollection
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Field
 import org.apache.avro.generic.{GenericData, GenericRecord}
-import org.apache.beam.sdk.extensions.smb.SortedBucketSource.TargetParallelism
-import org.apache.beam.sdk.extensions.smb.{AvroSortedBucketIO, SortedBucketIO}
+import org.apache.beam.sdk.extensions.smb.{AvroSortedBucketIO, SortedBucketIO, TargetParallelism}
 import org.apache.beam.sdk.values.TupleTag
 import org.apache.commons.io.FileUtils
 import org.scalatest.Assertion

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -202,8 +203,9 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
     return Math.abs(hashFunction.hashBytes(keyBytes).asInt()) % numBuckets;
   }
 
-  int rehashBucket(byte[] keyBytes, int newNumBuckets) {
-    return Math.abs(hashFunction.hashBytes(keyBytes).asInt()) % newNumBuckets;
+  Function<byte[], Boolean> checkRehashedBucketFn(int newNumBuckets, int currentBucket) {
+    return (keyBytes) ->
+        Math.abs(hashFunction.hashBytes(keyBytes).asInt()) % newNumBuckets == currentBucket;
   }
 
   ////////////////////////////////////////

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -39,7 +39,6 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.hash.HashFunction;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.hash.Hashing;
@@ -201,6 +200,10 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
 
   int getBucketId(byte[] keyBytes) {
     return Math.abs(hashFunction.hashBytes(keyBytes).asInt()) % numBuckets;
+  }
+
+  int rehashBucket(byte[] keyBytes, int newNumBuckets) {
+    return Math.abs(hashFunction.hashBytes(keyBytes).asInt()) % newNumBuckets;
   }
 
   ////////////////////////////////////////

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSink.WriteResult;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
-import org.apache.beam.sdk.extensions.smb.SortedBucketSource.TargetParallelism;
+import org.apache.beam.sdk.extensions.smb.TargetParallelism;
 import org.apache.beam.sdk.extensions.smb.SortedBucketTransform.TransformFn;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.PTransform;

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSink.WriteResult;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
+import org.apache.beam.sdk.extensions.smb.SortedBucketSource.TargetParallelism;
 import org.apache.beam.sdk.extensions.smb.SortedBucketTransform.TransformFn;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -47,6 +48,7 @@ public class SortedBucketIO {
   static final int DEFAULT_NUM_SHARDS = 1;
   static final HashType DEFAULT_HASH_TYPE = HashType.MURMUR3_128;
   static final int DEFAULT_SORTER_MEMORY_MB = 128;
+  static final TargetParallelism DEFAULT_PARALLELISM = TargetParallelism.min();
 
   /** Co-groups sorted-bucket sources with the same sort key. */
   public static <FinalKeyT> CoGbkBuilder<FinalKeyT> read(Class<FinalKeyT> finalKeyClass) {
@@ -63,7 +65,7 @@ public class SortedBucketIO {
 
     /** Returns a new {@link CoGbk} with the given first sorted-bucket source in {@link Read}. */
     public CoGbk<K> of(Read<?> read) {
-      return new CoGbk<>(finalKeyClass, Collections.singletonList(read));
+      return new CoGbk<>(finalKeyClass, Collections.singletonList(read), DEFAULT_PARALLELISM);
     }
   }
 
@@ -73,10 +75,12 @@ public class SortedBucketIO {
   public static class CoGbk<K> extends PTransform<PBegin, PCollection<KV<K, CoGbkResult>>> {
     private final Class<K> keyClass;
     private final List<Read<?>> reads;
+    private final TargetParallelism targetParallelism;
 
-    private CoGbk(Class<K> keyClass, List<Read<?>> reads) {
+    private CoGbk(Class<K> keyClass, List<Read<?>> reads, TargetParallelism targetParallelism) {
       this.keyClass = keyClass;
       this.reads = reads;
+      this.targetParallelism = targetParallelism;
     }
 
     /**
@@ -86,7 +90,11 @@ public class SortedBucketIO {
     public CoGbk<K> and(Read<?> read) {
       ImmutableList<Read<?>> newReads =
           ImmutableList.<Read<?>>builder().addAll(reads).add(read).build();
-      return new CoGbk<>(keyClass, newReads);
+      return new CoGbk<>(keyClass, newReads, targetParallelism);
+    }
+
+    public CoGbk<K> withTargetParallelism(TargetParallelism targetParallelism) {
+      return new CoGbk<>(keyClass, reads, targetParallelism);
     }
 
     public <V> CoGbkTransform<K, V> to(SortedBucketIO.Write<K, V> write) {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.nio.channels.Channels;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -31,24 +30,21 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.coders.MapCoder;
 import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
-import org.apache.beam.sdk.extensions.smb.BucketMetadata.BucketMetadataCoder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadataUtil.PartitionMetadata;
 import org.apache.beam.sdk.extensions.smb.BucketMetadataUtil.SourceMetadata;
-import org.apache.beam.sdk.extensions.smb.SMBFilenamePolicy.FileAssignment;
-import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
-import org.apache.beam.sdk.io.fs.ResourceIdCoder;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Metrics;
@@ -96,20 +92,51 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Unsig
 public class SortedBucketSource<FinalKeyT>
     extends PTransform<PBegin, PCollection<KV<FinalKeyT, CoGbkResult>>> {
 
+  public abstract static class TargetParallelism {
+    public static MinParallelism MIN = new MinParallelism();
+    public static MaxParallelism MAX = new MaxParallelism();
+
+    public static CustomParallelism of(int value) {
+      return new CustomParallelism(value);
+    }
+  }
+
+  private static class MaxParallelism extends TargetParallelism {}
+
+  private static class MinParallelism extends TargetParallelism {}
+
+  private static class CustomParallelism extends TargetParallelism {
+    int value;
+
+    CustomParallelism(int value) {
+      this.value = value;
+    }
+  }
+
   private static final Comparator<byte[]> bytesComparator =
       UnsignedBytes.lexicographicalComparator();
 
   private final Class<FinalKeyT> finalKeyClass;
   private final transient List<BucketedInput<?, ?>> sources;
+  private final TargetParallelism targetParallelism;
 
   public SortedBucketSource(Class<FinalKeyT> finalKeyClass, List<BucketedInput<?, ?>> sources) {
+    this(finalKeyClass, sources, TargetParallelism.MIN);
+  }
+
+  public SortedBucketSource(
+      Class<FinalKeyT> finalKeyClass,
+      List<BucketedInput<?, ?>> sources,
+      TargetParallelism targetParallelism) {
     this.finalKeyClass = finalKeyClass;
     this.sources = sources;
+    this.targetParallelism = targetParallelism;
   }
 
   @Override
   public final PCollection<KV<FinalKeyT, CoGbkResult>> expand(PBegin begin) {
     final SourceSpec<FinalKeyT> sourceSpec = getSourceSpec(finalKeyClass, sources);
+    int parallelism = sourceSpec.getParallelism(targetParallelism);
 
     @SuppressWarnings("deprecation")
     final Reshuffle.ViaRandomKey<Integer> reshuffle = Reshuffle.viaRandomKey();
@@ -123,28 +150,47 @@ public class SortedBucketSource<FinalKeyT>
     return begin
         .getPipeline()
         .apply(
-            "CreateBuckets",
-            Create.of(
-                    IntStream.range(0, sourceSpec.leastNumBuckets)
-                        .boxed()
-                        .collect(Collectors.toList()))
+            "CreateWorkers",
+            Create.of(IntStream.range(0, parallelism).boxed().collect(Collectors.toList()))
                 .withCoder(VarIntCoder.of()))
         .apply("ReshuffleKeys", reshuffle)
         .apply(
             "MergeBuckets",
-            ParDo.of(
-                new MergeBuckets<>(
-                    this.getName(), sources, sourceSpec.leastNumBuckets, sourceSpec.keyCoder)))
+            ParDo.of(new MergeBuckets<>(this.getName(), sources, parallelism, sourceSpec)))
         .setCoder(KvCoder.of(sourceSpec.keyCoder, resultCoder));
   }
 
   static class SourceSpec<K> {
     int leastNumBuckets;
+    int greatestNumBuckets;
     Coder<K> keyCoder;
 
-    SourceSpec(int leastNumBuckets, Coder<K> keyCoder) {
+    SourceSpec(int leastNumBuckets, int greatestNumBuckets, Coder<K> keyCoder) {
       this.leastNumBuckets = leastNumBuckets;
+      this.greatestNumBuckets = greatestNumBuckets;
       this.keyCoder = keyCoder;
+    }
+
+    int getParallelism(TargetParallelism targetParallelism) {
+      int parallelism;
+      if (targetParallelism == TargetParallelism.MIN) {
+        return leastNumBuckets;
+      } else if (targetParallelism == TargetParallelism.MAX) {
+        return greatestNumBuckets;
+      } else {
+        parallelism = ((CustomParallelism) targetParallelism).value;
+
+        Preconditions.checkArgument(
+            ((parallelism & parallelism - 1) == 0)
+                && parallelism >= leastNumBuckets
+                && parallelism <= greatestNumBuckets,
+            String.format(
+                "Target parallelism must be a power of 2 between the least (%d) and "
+                    + "greatest (%d) number of buckets in sources. Was: %d",
+                leastNumBuckets, greatestNumBuckets, parallelism));
+
+        return parallelism;
+      }
     }
   }
 
@@ -153,7 +199,6 @@ public class SortedBucketSource<FinalKeyT>
     BucketMetadata<?, ?> first = null;
     Coder<KeyT> finalKeyCoder = null;
 
-    int leastNumBuckets = Integer.MAX_VALUE;
     // Check metadata of each source
     for (BucketedInput<?, ?> source : sources) {
       final BucketMetadata<?, ?> current = source.getMetadata();
@@ -166,8 +211,6 @@ public class SortedBucketSource<FinalKeyT>
             sources.get(0),
             source);
       }
-
-      leastNumBuckets = Math.min(current.getNumBuckets(), leastNumBuckets);
 
       if (current.getKeyClass() == finalKeyClass && finalKeyCoder == null) {
         try {
@@ -182,10 +225,24 @@ public class SortedBucketSource<FinalKeyT>
       }
     }
 
+    int leastNumBuckets =
+        sources.stream()
+            .flatMap(source -> source.getPartitionMetadata().values().stream())
+            .map(PartitionMetadata::getNumBuckets)
+            .min(Integer::compareTo)
+            .get();
+
+    int greatestNumBuckets =
+        sources.stream()
+            .flatMap(source -> source.getPartitionMetadata().values().stream())
+            .map(PartitionMetadata::getNumBuckets)
+            .max(Integer::compareTo)
+            .get();
+
     Preconditions.checkNotNull(
         finalKeyCoder, "Could not infer coder for key class %s", finalKeyClass);
 
-    return new SourceSpec<>(leastNumBuckets, finalKeyCoder);
+    return new SourceSpec<>(leastNumBuckets, greatestNumBuckets, finalKeyCoder);
   }
 
   /** Merge key-value groups in matching buckets. */
@@ -193,6 +250,7 @@ public class SortedBucketSource<FinalKeyT>
     private static final Comparator<Map.Entry<TupleTag, KV<byte[], Iterator<?>>>> keyComparator =
         (o1, o2) -> bytesComparator.compare(o1.getValue().getKey(), o2.getValue().getKey());
 
+    private final Integer targetParallelism;
     private final Integer leastNumBuckets;
     private final Coder<FinalKeyT> keyCoder;
     private final List<BucketedInput<?, ?>> sources;
@@ -203,10 +261,11 @@ public class SortedBucketSource<FinalKeyT>
     MergeBuckets(
         String transformName,
         List<BucketedInput<?, ?>> sources,
-        int leastNumBuckets,
-        Coder<FinalKeyT> keyCoder) {
-      this.leastNumBuckets = leastNumBuckets;
-      this.keyCoder = keyCoder;
+        int targetParallelism,
+        SourceSpec<FinalKeyT> sourceSpec) {
+      this.targetParallelism = targetParallelism;
+      this.leastNumBuckets = sourceSpec.leastNumBuckets;
+      this.keyCoder = sourceSpec.keyCoder;
       this.sources = sources;
 
       elementsRead = Metrics.counter(SortedBucketSource.class, transformName + "-ElementsRead");
@@ -216,10 +275,28 @@ public class SortedBucketSource<FinalKeyT>
 
     @ProcessElement
     public void processElement(ProcessContext c) {
+      int bucketId = c.element();
+
+      final KeyGroupIterator[] iterators;
+      iterators =
+          sources.stream()
+              .map(i -> i.createIterator(bucketId, targetParallelism))
+              .toArray(KeyGroupIterator[]::new);
+
+      Function<byte[], Boolean> keyGroupFilter;
+
+      if (targetParallelism.equals(leastNumBuckets)) {
+        keyGroupFilter = (bytes) -> true;
+      } else {
+        keyGroupFilter =
+            (bytes) ->
+                sources.get(0).getMetadata().rehashBucket(bytes, targetParallelism) == bucketId;
+      }
+
       merge(
-          c.element(),
-          sources,
-          leastNumBuckets,
+          iterators,
+          BucketedInput.schemaOf(sources),
+          keyGroupFilter,
           mergedKeyGroup -> {
             try {
               c.output(
@@ -235,23 +312,15 @@ public class SortedBucketSource<FinalKeyT>
     }
 
     static void merge(
-        int bucketId,
-        List<BucketedInput<?, ?>> sources,
-        int leastNumBuckets,
+        KeyGroupIterator[] iterators,
+        CoGbkResultSchema resultSchema,
+        Function<byte[], Boolean> keyGroupFilter,
         Consumer<KV<byte[], CoGbkResult>> consumer,
         Counter elementsRead,
         Distribution keyGroupSize) {
-      final int numSources = sources.size();
+      final int numSources = iterators.length;
 
-      // Initialize iterators and tuple tags for sources
-      final KeyGroupIterator[] iterators =
-          sources.stream()
-              .map(i -> i.createIterator(bucketId, leastNumBuckets))
-              .toArray(KeyGroupIterator[]::new);
-
-      final CoGbkResultSchema resultSchema = BucketedInput.schemaOf(sources);
       final TupleTagList tupleTags = resultSchema.getTupleTagList();
-
       final Map<TupleTag, KV<byte[], Iterator<?>>> nextKeyGroups = new HashMap<>();
 
       while (true) {
@@ -279,6 +348,8 @@ public class SortedBucketSource<FinalKeyT>
         final Map.Entry<TupleTag, KV<byte[], Iterator<?>>> minKeyEntry =
             nextKeyGroups.entrySet().stream().min(keyComparator).orElse(null);
 
+        final boolean acceptKeyGroup = keyGroupFilter.apply(minKeyEntry.getValue().getKey());
+
         final Iterator<Map.Entry<TupleTag, KV<byte[], Iterator<?>>>> nextKeyGroupsIt =
             nextKeyGroups.entrySet().iterator();
         final List<Iterable<?>> valueMap = new ArrayList<>();
@@ -296,21 +367,24 @@ public class SortedBucketSource<FinalKeyT>
             // TODO: this exhausts everything from the "lazy" iterator and can be expensive.
             // To fix we have to make the underlying Reader range aware so that it's safe to
             // re-iterate or stop without exhausting remaining elements in the value group.
+
             entry.getValue().getValue().forEachRemaining(values::add);
+
             nextKeyGroupsIt.remove();
             keyGroupCount += values.size();
           }
         }
 
-        keyGroupSize.update(keyGroupCount);
-        elementsRead.inc(keyGroupCount);
+        if (acceptKeyGroup) {
+          keyGroupSize.update(keyGroupCount);
+          elementsRead.inc(keyGroupCount);
 
-        final KV<byte[], CoGbkResult> mergedKeyGroup =
-            KV.of(
-                minKeyEntry.getValue().getKey(),
-                CoGbkResultUtil.newCoGbkResult(resultSchema, valueMap));
-
-        consumer.accept(mergedKeyGroup);
+          final KV<byte[], CoGbkResult> mergedKeyGroup =
+              KV.of(
+                  minKeyEntry.getValue().getKey(),
+                  CoGbkResultUtil.newCoGbkResult(resultSchema, valueMap));
+          consumer.accept(mergedKeyGroup);
+        }
 
         if (completedSources == numSources) {
           break;
@@ -374,37 +448,39 @@ public class SortedBucketSource<FinalKeyT>
     }
 
     public BucketMetadata<K, V> getMetadata() {
-      computeMetadataIfAbsent();
-      return sourceMetadata.getCanonicalMetadata();
+      return getOrComputeMetadata().getCanonicalMetadata();
     }
 
-    private void computeMetadataIfAbsent() {
-      if (this.sourceMetadata != null) {
-        return;
+    public Map<ResourceId, PartitionMetadata> getPartitionMetadata() {
+      return getOrComputeMetadata().getPartitionMetadata();
+    }
+
+    private SourceMetadata<K, V> getOrComputeMetadata() {
+      if (sourceMetadata == null) {
+        sourceMetadata =
+            BucketMetadataUtil.get().getSourceMetadata(inputDirectories, filenameSuffix);
       }
-
-      sourceMetadata = BucketMetadataUtil.get().getSourceMetadata(inputDirectories, filenameSuffix);
+      return sourceMetadata;
     }
 
-    KeyGroupIterator<byte[], V> createIterator(int bucketId, int leastNumBuckets) {
+    KeyGroupIterator<byte[], V> createIterator(int workerId, int targetParallelism) {
       final List<Iterator<V>> iterators = new ArrayList<>();
-
       // Create one iterator per shard
-      sourceMetadata
+      getOrComputeMetadata()
           .getPartitionMetadata()
           .forEach(
               (resourceId, partitionMetadata) -> {
-                final int directoryBuckets = partitionMetadata.getNumBuckets();
-                final int directoryShards = partitionMetadata.getNumShards();
+                final int numBuckets = partitionMetadata.getNumBuckets();
+                final int numShards = partitionMetadata.getNumShards();
 
                 // Since all BucketedInputs have a bucket count that's a power of two, we can infer
                 // which buckets should be merged together for the join.
-                for (int i = bucketId; i < directoryBuckets; i += leastNumBuckets) {
-                  for (int j = 0; j < directoryShards; j++) {
+                for (int i = (workerId % numBuckets); i < numBuckets; i += targetParallelism) {
+                  for (int j = 0; j < numShards; j++) {
                     final ResourceId file =
                         partitionMetadata
                             .getFileAssignment()
-                            .forBucket(BucketShardId.of(i, j), directoryBuckets, directoryShards);
+                            .forBucket(BucketShardId.of(i, j), numBuckets, numShards);
                     try {
                       iterators.add(fileOperations.iterator(file));
                     } catch (Exception e) {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TargetParallelism.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TargetParallelism.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.beam.sdk.extensions.smb;
+
+/**
+ * Represents the desired parallelism of an SMB read operation. For a given set of sources,
+ * targetParallelism can be set to any number between the least and greatest numbers of buckets
+ * among sources. This can be dynamically configured using {@link TargetParallelism#min()} or {@link
+ * TargetParallelism#max()}, which at graph construction time will determine the least or greatest
+ * amount of parallelism based on sources. Alternately, {@link TargetParallelism#of(int)} can be
+ * used to statically configure a custom value.
+ *
+ * <p>If no value is specified, SMB read operations will use the minimum parallelism.
+ *
+ * <p>When selecting a target parallelism for your SMB operation, there are tradeoffs to consider:
+ *
+ * <p>- Minimal parallelism means a fewer number of workers merging data from potentially many
+ * buckets. For example, if source A has 4 buckets and source B has 64, a minimally parallel SMB
+ * read would have 4 workers, each one merging 1 bucket from source A and 16 buckets from source B.
+ * This read may have low throughput. - Maximal parallelism means that each bucket is read by at
+ * least one worker. For example, if source A has 4 buckets and source B has 64, a maximally
+ * parallel SMB read would have 64 workers, each one merging 1 bucket from source B and 1 bucket
+ * from source A, replicated 16 times. This may have better throughput than the minimal example, but
+ * more expensive because every key group from the replicated sources must be re-hashed to avoid
+ * emitting duplicate records. - A custom parallelism in the middle of these bounds may be the best
+ * balance of speed and computing cost.
+ */
+public abstract class TargetParallelism {
+
+  public static MinParallelism min() {
+    return MinParallelism.INSTANCE;
+  }
+
+  public static MaxParallelism max() {
+    return MaxParallelism.INSTANCE;
+  }
+
+  public static CustomParallelism of(int value) {
+    return new CustomParallelism(value);
+  }
+
+  boolean isMax() {
+    return this.getClass().equals(MaxParallelism.class);
+  }
+
+  boolean isMin() {
+    return this.getClass().equals(MinParallelism.class);
+  }
+
+  abstract int getValue();
+
+  static class MaxParallelism extends TargetParallelism {
+    static MaxParallelism INSTANCE = new MaxParallelism();
+
+    private MaxParallelism() {}
+
+    @Override
+    int getValue() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  static class MinParallelism extends TargetParallelism {
+    static MinParallelism INSTANCE = new MinParallelism();
+
+    private MinParallelism() {}
+
+    @Override
+    int getValue() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  static class CustomParallelism extends TargetParallelism {
+    private int value;
+
+    CustomParallelism(int value) {
+      this.value = value;
+    }
+
+    @Override
+    int getValue() {
+      return value;
+    }
+  }
+}

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -22,8 +22,7 @@ import com.spotify.scio.annotations.experimental
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.{ClosedTap, EmptyTap}
 import com.spotify.scio.values._
-import org.apache.beam.sdk.extensions.smb.SortedBucketSource.TargetParallelism
-import org.apache.beam.sdk.extensions.smb.{SortedBucketIO, SortedBucketTransform}
+import org.apache.beam.sdk.extensions.smb.{SortedBucketIO, SortedBucketTransform, TargetParallelism}
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.transforms.join.CoGbkResult
 import org.apache.beam.sdk.transforms.{DoFn, ParDo}
@@ -56,6 +55,8 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
    *                 supported yet.
    * @param lhs
    * @param rhs
+   * @param targetParallelism the desired parallelism of the job. See
+   *                 [[org.apache.beam.sdk.extensions.smb.TargetParallelism]] for more information.
    */
   @experimental
   def sortMergeJoin[K: Coder, L: Coder, R: Coder](
@@ -138,6 +139,8 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
    * @param keyClass cogroup key class. Must have a Coder in Beam's default
    *                 [[org.apache.beam.sdk.coders.CoderRegistry]] as custom key coders are not
    *                 supported yet.
+   * @param targetParallelism the desired parallelism of the job. See
+   *                 [[org.apache.beam.sdk.extensions.smb.TargetParallelism]] for more information.
    */
   @experimental
   def sortMergeCoGroup[K: Coder, A: Coder, B: Coder](
@@ -169,6 +172,14 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
       }
   }
 
+  @experimental
+  def sortMergeCoGroup[K: Coder, A: Coder, B: Coder](
+    keyClass: Class[K],
+    a: SortedBucketIO.Read[A],
+    b: SortedBucketIO.Read[B]
+  ): SCollection[(K, (Iterable[A], Iterable[B]))] =
+    sortMergeCoGroup(keyClass, a, b, TargetParallelism.min())
+
   /**
    * For each key K in `a` or `b` or `c`, return a resulting SCollection that contains a tuple
    * with the list of values for that key in `a`, `b` and `c`.
@@ -181,6 +192,8 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
    * @param keyClass cogroup key class. Must have a Coder in Beam's default
    *                 [[org.apache.beam.sdk.coders.CoderRegistry]] as custom key coders are not
    *                 supported yet.
+   * @param targetParallelism the desired parallelism of the job. See
+   *                 [[org.apache.beam.sdk.extensions.smb.TargetParallelism]] for more information.
    */
   @experimental
   def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder](
@@ -220,6 +233,15 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
       }
   }
 
+  @experimental
+  def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder](
+    keyClass: Class[K],
+    a: SortedBucketIO.Read[A],
+    b: SortedBucketIO.Read[B],
+    c: SortedBucketIO.Read[C]
+  ): SCollection[(K, (Iterable[A], Iterable[B], Iterable[C]))] =
+    sortMergeCoGroup(keyClass, a, b, c, TargetParallelism.min())
+
   /**
    * For each key K in `a` or `b` or `c` or `d`, return a resulting SCollection that contains a
    * tuple with the list of values for that key in `a`, `b`, `c` and `d`.
@@ -232,6 +254,8 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
    * @param keyClass cogroup key class. Must have a Coder in Beam's default
    *                 [[org.apache.beam.sdk.coders.CoderRegistry]] as custom key coders are not
    *                 supported yet.
+   * @param targetParallelism the desired parallelism of the job. See
+   *                 [[org.apache.beam.sdk.extensions.smb.TargetParallelism]] for more information.
    */
   @experimental
   def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder, D: Coder](
@@ -274,6 +298,15 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
         )
       }
   }
+  @experimental
+  def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder, D: Coder](
+    keyClass: Class[K],
+    a: SortedBucketIO.Read[A],
+    b: SortedBucketIO.Read[B],
+    c: SortedBucketIO.Read[C],
+    d: SortedBucketIO.Read[D]
+  ): SCollection[(K, (Iterable[A], Iterable[B], Iterable[C], Iterable[D]))] =
+    sortMergeCoGroup(keyClass, a, b, c, d, TargetParallelism.min())
 
   /**
    * Perform a [[SortedBucketScioContext.sortMergeGroupByKey()]] operation, then immediately apply

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -22,6 +22,7 @@ import com.spotify.scio.annotations.experimental
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.{ClosedTap, EmptyTap}
 import com.spotify.scio.values._
+import org.apache.beam.sdk.extensions.smb.SortedBucketSource.TargetParallelism
 import org.apache.beam.sdk.extensions.smb.{SortedBucketIO, SortedBucketTransform}
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.transforms.join.CoGbkResult
@@ -60,9 +61,10 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
   def sortMergeJoin[K: Coder, L: Coder, R: Coder](
     keyClass: Class[K],
     lhs: SortedBucketIO.Read[L],
-    rhs: SortedBucketIO.Read[R]
+    rhs: SortedBucketIO.Read[R],
+    targetParallelism: TargetParallelism = TargetParallelism.min()
   ): SCollection[(K, (L, R))] = {
-    val t = SortedBucketIO.read(keyClass).of(lhs).and(rhs)
+    val t = SortedBucketIO.read(keyClass).of(lhs).and(rhs).withTargetParallelism(targetParallelism)
     val (tupleTagA, tupleTagB) = (lhs.getTupleTag, rhs.getTupleTag)
     val tfName = self.tfName
 
@@ -141,9 +143,10 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
   def sortMergeCoGroup[K: Coder, A: Coder, B: Coder](
     keyClass: Class[K],
     a: SortedBucketIO.Read[A],
-    b: SortedBucketIO.Read[B]
+    b: SortedBucketIO.Read[B],
+    targetParallelism: TargetParallelism
   ): SCollection[(K, (Iterable[A], Iterable[B]))] = {
-    val t = SortedBucketIO.read(keyClass).of(a).and(b)
+    val t = SortedBucketIO.read(keyClass).of(a).and(b).withTargetParallelism(targetParallelism)
     val (tupleTagA, tupleTagB) = (
       a.getTupleTag,
       b.getTupleTag
@@ -184,9 +187,15 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     keyClass: Class[K],
     a: SortedBucketIO.Read[A],
     b: SortedBucketIO.Read[B],
-    c: SortedBucketIO.Read[C]
+    c: SortedBucketIO.Read[C],
+    targetParallelism: TargetParallelism
   ): SCollection[(K, (Iterable[A], Iterable[B], Iterable[C]))] = {
-    val t = SortedBucketIO.read(keyClass).of(a).and(b).and(c)
+    val t = SortedBucketIO
+      .read(keyClass)
+      .of(a)
+      .and(b)
+      .and(c)
+      .withTargetParallelism(targetParallelism)
     val (tupleTagA, tupleTagB, tupleTagC) = (
       a.getTupleTag,
       b.getTupleTag,
@@ -230,9 +239,16 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     a: SortedBucketIO.Read[A],
     b: SortedBucketIO.Read[B],
     c: SortedBucketIO.Read[C],
-    d: SortedBucketIO.Read[D]
+    d: SortedBucketIO.Read[D],
+    targetParallelism: TargetParallelism
   ): SCollection[(K, (Iterable[A], Iterable[B], Iterable[C], Iterable[D]))] = {
-    val t = SortedBucketIO.read(keyClass).of(a).and(b).and(c).and(d)
+    val t = SortedBucketIO
+      .read(keyClass)
+      .of(a)
+      .and(b)
+      .and(c)
+      .and(d)
+      .withTargetParallelism(targetParallelism)
     val (tupleTagA, tupleTagB, tupleTagC, tupleTagD) = (
       a.getTupleTag,
       b.getTupleTag,

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -426,11 +426,9 @@ public class SortedBucketSourceTest {
     List<ResourceId> lhsPaths = new ArrayList<>();
     Map<BucketShardId, List<String>> allLhsValues = new HashMap<>();
 
-    int maxNumBuckets = Integer.MIN_VALUE;
     for (Map<BucketShardId, List<String>> input : lhsInputs) {
       int numBuckets = maxId(input.keySet(), BucketShardId::getBucketId) + 1;
       int numShards = maxId(input.keySet(), BucketShardId::getShardId) + 1;
-      maxNumBuckets = Math.max(maxNumBuckets, numBuckets);
       TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
       ResourceId destination =
           LocalResources.fromFile(
@@ -452,11 +450,9 @@ public class SortedBucketSourceTest {
 
     List<ResourceId> rhsPaths = new ArrayList<>();
     Map<BucketShardId, List<String>> allRhsValues = new HashMap<>();
-
     for (Map<BucketShardId, List<String>> input : rhsInputs) {
       int numBuckets = maxId(input.keySet(), BucketShardId::getBucketId) + 1;
       int numShards = maxId(input.keySet(), BucketShardId::getShardId) + 1;
-      maxNumBuckets = Math.max(maxNumBuckets, numBuckets);
       TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
       ResourceId destination =
           LocalResources.fromFile(

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -321,7 +321,7 @@ public class SortedBucketSourceTest {
             ImmutableMap.of(
                 BucketShardId.of(0, 0), Lists.newArrayList("w7", "w8"),
                 BucketShardId.of(1, 0), Lists.newArrayList("c7", "c8"))),
-        TargetParallelism.MAX);
+        TargetParallelism.max());
   }
 
   @Test
@@ -338,7 +338,7 @@ public class SortedBucketSourceTest {
             BucketShardId.of(0, 1), Lists.newArrayList("m4", "m4"),
             BucketShardId.of(1, 0), Lists.newArrayList("t3", "t3"),
             BucketShardId.of(1, 1), Lists.newArrayList("h4", "h4")),
-        TargetParallelism.MAX);
+        TargetParallelism.max());
   }
 
   @Test
@@ -359,7 +359,7 @@ public class SortedBucketSourceTest {
   private void test(
       Map<BucketShardId, List<String>> lhsInput, Map<BucketShardId, List<String>> rhsInput)
       throws Exception {
-    test(lhsInput, rhsInput, TargetParallelism.MIN);
+    test(lhsInput, rhsInput, TargetParallelism.min());
   }
 
   private void test(
@@ -414,7 +414,7 @@ public class SortedBucketSourceTest {
       List<Map<BucketShardId, List<String>>> lhsInputs,
       List<Map<BucketShardId, List<String>>> rhsInputs)
       throws Exception {
-    testPartitioned(lhsInputs, rhsInputs, TargetParallelism.MIN);
+    testPartitioned(lhsInputs, rhsInputs, TargetParallelism.min());
   }
 
   private void testPartitioned(

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -38,6 +38,7 @@ import java.util.stream.StreamSupport;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.extensions.smb.FileOperations.Writer;
 import org.apache.beam.sdk.extensions.smb.SMBFilenamePolicy.FileAssignment;
+import org.apache.beam.sdk.extensions.smb.SortedBucketSource.TargetParallelism;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.LocalResources;
 import org.apache.beam.sdk.io.fs.ResourceId;
@@ -304,8 +305,67 @@ public class SortedBucketSourceTest {
                 BucketShardId.of(1, 0), Lists.newArrayList("c7", "c8"))));
   }
 
+  // For custom parallelism, test input keys *must* hash to their corresponding bucket IDs,
+  // since a rehash is required in the merge step
+  @Test
+  @Category(NeedsRunner.class)
+  public void testPartitionedInputsMixedBucketsMaxParallelism() throws Exception {
+    testPartitioned(
+        ImmutableList.of(
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("w1", "w2"),
+                BucketShardId.of(1, 0), Lists.newArrayList("c1", "c2")),
+            ImmutableMap.of(BucketShardId.of(0, 0), Lists.newArrayList("w3", "w4"))),
+        ImmutableList.of(
+            ImmutableMap.of(BucketShardId.of(0, 0), Lists.newArrayList("w5", "w6")),
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("w7", "w8"),
+                BucketShardId.of(1, 0), Lists.newArrayList("c7", "c8"))),
+        TargetParallelism.MAX);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testMixedBucketsMixedShardMaxParallelism() throws Exception {
+    test(
+        ImmutableMap.of(
+            BucketShardId.of(0, 0), Lists.newArrayList("e1", "e2"),
+            BucketShardId.of(1, 0), Lists.newArrayList("c1", "c2", "c3"),
+            BucketShardId.of(2, 0), Lists.newArrayList("i1", "i2", "i1", "i2"),
+            BucketShardId.of(3, 0), Lists.newArrayList("k1", "k2", "k1", "k2")),
+        ImmutableMap.of(
+            BucketShardId.of(0, 0), Lists.newArrayList("e3", "e3"),
+            BucketShardId.of(0, 1), Lists.newArrayList("m4", "m4"),
+            BucketShardId.of(1, 0), Lists.newArrayList("t3", "t3"),
+            BucketShardId.of(1, 1), Lists.newArrayList("h4", "h4")),
+        TargetParallelism.MAX);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testMixedBucketsMixedShardCustomParallelism() throws Exception {
+    test(
+        ImmutableMap.of(
+            BucketShardId.of(0, 0), Lists.newArrayList("e1", "e2"),
+            BucketShardId.of(1, 0), Lists.newArrayList("c1", "c2", "c3"),
+            BucketShardId.of(2, 0), Lists.newArrayList("i1", "i2", "i1", "i2"),
+            BucketShardId.of(3, 0), Lists.newArrayList("k1", "k2", "k1", "k2")),
+        ImmutableMap.of(
+            BucketShardId.of(0, 0), Lists.newArrayList("e3", "e3"),
+            BucketShardId.of(0, 1), Lists.newArrayList("m4", "m4")),
+        TargetParallelism.of(2));
+  }
+
   private void test(
       Map<BucketShardId, List<String>> lhsInput, Map<BucketShardId, List<String>> rhsInput)
+      throws Exception {
+    test(lhsInput, rhsInput, TargetParallelism.MIN);
+  }
+
+  private void test(
+      Map<BucketShardId, List<String>> lhsInput,
+      Map<BucketShardId, List<String>> rhsInput,
+      TargetParallelism targetParallelism)
       throws Exception {
     int lhsNumBuckets = maxId(lhsInput.keySet(), BucketShardId::getBucketId) + 1;
     int lhsNumShards = maxId(lhsInput.keySet(), BucketShardId::getShardId) + 1;
@@ -324,7 +384,8 @@ public class SortedBucketSourceTest {
         Collections.singletonList(fromFolder(lhsFolder)),
         Collections.singletonList(fromFolder(rhsFolder)),
         lhsInput,
-        rhsInput);
+        rhsInput,
+        targetParallelism);
 
     final PipelineResult result = pipeline.run();
 
@@ -353,13 +414,23 @@ public class SortedBucketSourceTest {
       List<Map<BucketShardId, List<String>>> lhsInputs,
       List<Map<BucketShardId, List<String>>> rhsInputs)
       throws Exception {
+    testPartitioned(lhsInputs, rhsInputs, TargetParallelism.MIN);
+  }
+
+  private void testPartitioned(
+      List<Map<BucketShardId, List<String>>> lhsInputs,
+      List<Map<BucketShardId, List<String>>> rhsInputs,
+      TargetParallelism targetParallelism)
+      throws Exception {
 
     List<ResourceId> lhsPaths = new ArrayList<>();
     Map<BucketShardId, List<String>> allLhsValues = new HashMap<>();
 
+    int maxNumBuckets = Integer.MIN_VALUE;
     for (Map<BucketShardId, List<String>> input : lhsInputs) {
       int numBuckets = maxId(input.keySet(), BucketShardId::getBucketId) + 1;
       int numShards = maxId(input.keySet(), BucketShardId::getShardId) + 1;
+      maxNumBuckets = Math.max(maxNumBuckets, numBuckets);
       TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
       ResourceId destination =
           LocalResources.fromFile(
@@ -381,9 +452,11 @@ public class SortedBucketSourceTest {
 
     List<ResourceId> rhsPaths = new ArrayList<>();
     Map<BucketShardId, List<String>> allRhsValues = new HashMap<>();
+
     for (Map<BucketShardId, List<String>> input : rhsInputs) {
       int numBuckets = maxId(input.keySet(), BucketShardId::getBucketId) + 1;
       int numShards = maxId(input.keySet(), BucketShardId::getShardId) + 1;
+      maxNumBuckets = Math.max(maxNumBuckets, numBuckets);
       TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
       ResourceId destination =
           LocalResources.fromFile(
@@ -403,7 +476,7 @@ public class SortedBucketSourceTest {
                   }));
     }
 
-    checkJoin(pipeline, lhsPaths, rhsPaths, allLhsValues, allRhsValues);
+    checkJoin(pipeline, lhsPaths, rhsPaths, allLhsValues, allRhsValues, targetParallelism);
     pipeline.run();
   }
 
@@ -412,7 +485,8 @@ public class SortedBucketSourceTest {
       List<ResourceId> lhsPaths,
       List<ResourceId> rhsPaths,
       Map<BucketShardId, List<String>> lhsValues,
-      Map<BucketShardId, List<String>> rhsValues)
+      Map<BucketShardId, List<String>> rhsValues,
+      TargetParallelism targetParallelism)
       throws Exception {
     final TupleTag<String> lhsTag = new TupleTag<>("LHS");
     final TupleTag<String> rhsTag = new TupleTag<>("RHS");
@@ -423,7 +497,7 @@ public class SortedBucketSourceTest {
             new BucketedInput<>(rhsTag, rhsPaths, ".txt", fileOperations));
 
     PCollection<KV<String, CoGbkResult>> output =
-        pipeline.apply(new SortedBucketSource<>(String.class, inputs));
+        pipeline.apply(new SortedBucketSource<>(String.class, inputs, targetParallelism));
 
     Function<String, String> extractKeyFn = TestBucketMetadata.of(2, 1)::extractKey;
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -38,7 +38,6 @@ import java.util.stream.StreamSupport;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.extensions.smb.FileOperations.Writer;
 import org.apache.beam.sdk.extensions.smb.SMBFilenamePolicy.FileAssignment;
-import org.apache.beam.sdk.extensions.smb.SortedBucketSource.TargetParallelism;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.LocalResources;
 import org.apache.beam.sdk.io.fs.ResourceId;


### PR DESCRIPTION
(fix #2652) 

I haven't implemented it for SortedBucketTransform, can follow up with another PR or release Scio with just this and let users try it out.