### PR TITLE
Add BigQuery section to 0.9.0 migration guide

### DIFF
--- a/site/src/paradox/migrations/v0.9.0-Migration-Guide.md
+++ b/site/src/paradox/migrations/v0.9.0-Migration-Guide.md
@@ -50,6 +50,63 @@ val bfCoder: Coder[BloomFilter[String]] = BloomFilter.filterCoder
 
 ## IO's
 
+### BigQuery
+
+In `scio` `0.8.0` we introduced some [deprecations](https://spotify.github.io/scio/migrations/v0.8.0-Migration-Guide.html#bigquery) and with this version, we are enforcing them. What this means is that all `BigQuery` operations should expect a `Table` type that can be created either from a table reference of spec:
+
+```scala
+def tableSpecString: String = ???
+
+def table: Table = Table.Spec(tableSpecString)
+```
+
+or
+
+```scala
+def tableReference: TableReference = ???
+
+def table: Table = Table.Ref(tableReference)
+```
+
+Bellow are some of the affected methods and suggestion on how you can migrate:
+
+```diff
+- typedBigQuery(table: TableReference, ...)
++ typedBigQueryTable(table: Table.Ref(tableReference), ...)
+
+- typedBigQuery(tableSpec: String, ...)
++ typedBigQueryTable(tableSpec: Table.Spec(tableSpec), ...)
+
+- saveAsBigQuery(table: TableReference, ...)
++ saveAsBigQueryTable(table: Table.Ref(tableReference), ...)
+
+- saveAsBigQuery(tableSpec: String, ...)
++ saveAsBigQueryTable(tableSpec: Table.Spec(tableSpec), ...)
+
+- saveAsTypedBigQuery(table: TableReference, ...)
++ saveAsTypedBigQueryTable(table: Table.Ref(tableReference), ...)
+
+- saveAsTypedBigQuery(tableSpec: String, ...)
++ saveAsTypedBigQueryTable(tableSpec: Table.Spec(tableSpec), ...)
+```
+
+Methods with only argument type change:
+
+```diff
+- bigQuerySelect(query: String, ...)
++ bigQuerySelect(query: Query(sql), ...)
+
+- saveAsTypedBigQuery(table: TableReference, ...)
++ saveAsTypedBigQuery(table: Table.Ref(tableReference), ...)
+
+- saveAsTypedBigQuery(tableSpec: String, ...)
++ saveAsTypedBigQuery(tableSpec: Table.Spec(tableSpec), ...)
+```
+
+#### BigQuery deprecations
+
+With `0.9.0` we introduced a new method `queryRaw` method to `BigQueryType` and deprecated the existing one `query`. This is scheduled for removal in the next release.
+
 ### Avro
 
 `ReflectiveRecordIO` was removed in this release and this means that we no longer need to pass a type param when reading `GenericRecord` making things a little bit cleaner. This unfortunately means that you will need to update your code by removing the type param from `avroFile`.

--- a/site/src/paradox/migrations/v0.9.0-Migration-Guide.md
+++ b/site/src/paradox/migrations/v0.9.0-Migration-Guide.md
@@ -105,7 +105,7 @@ Methods with only argument type change:
 
 #### BigQuery deprecations
 
-With `0.9.0` we introduced a new method `queryRaw` method to `BigQueryType` and deprecated the existing one `query`. This is scheduled for removal in the next release.
+With `0.9.0` we introduced a new method `queryRaw` to `BigQueryType.fromQuery` and deprecated the existing one `query`. This is scheduled for removal in the next release.
 
 ### Avro
 


### PR DESCRIPTION
Fixes #2990