### PR TITLE
Use BigQuery client project consistently

### DIFF
--- a/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/types/StorageIT.scala
+++ b/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/types/StorageIT.scala
@@ -316,6 +316,9 @@ object StorageIT {
   @BigQueryType.fromStorage("data-integration-test:partition_a.table_%s", List("$LATEST"))
   class StorageLatest
 
+  @BigQueryType.fromStorage("partition_a.table_%s", List("$LATEST"))
+  class StorageEnvProject
+
   @BigQueryType.fromTable("data-integration-test:storage.required")
   class FromTable
 

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryPartitionUtil.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryPartitionUtil.scala
@@ -58,7 +58,7 @@ private[bigquery] object BigQueryPartitionUtil {
   private def getPartitions(bq: BigQuery, tableRef: TableReference): Set[String] = {
     val prefix = tableRef.getTableId.split('$')(0)
     bq.tables
-      .tableReferences(tableRef.getProjectId, tableRef.getDatasetId)
+      .tableReferences(tableRef)
       .filter(_.getTableId.startsWith(prefix))
       .map(_.getTableId.substring(prefix.length))
       .toSet

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryPartitionUtil.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryPartitionUtil.scala
@@ -58,7 +58,7 @@ private[bigquery] object BigQueryPartitionUtil {
   private def getPartitions(bq: BigQuery, tableRef: TableReference): Set[String] = {
     val prefix = tableRef.getTableId.split('$')(0)
     bq.tables
-      .tableReferences(Option(tableRef.getProjectId()), tableRef.getDatasetId())
+      .tableReferences(tableRef.getProjectId(), tableRef.getDatasetId())
       .filter(_.getTableId.startsWith(prefix))
       .map(_.getTableId.substring(prefix.length))
       .toSet

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryPartitionUtil.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryPartitionUtil.scala
@@ -58,7 +58,7 @@ private[bigquery] object BigQueryPartitionUtil {
   private def getPartitions(bq: BigQuery, tableRef: TableReference): Set[String] = {
     val prefix = tableRef.getTableId.split('$')(0)
     bq.tables
-      .tableReferences(tableRef)
+      .tableReferences(Option(tableRef.getProjectId()), tableRef.getDatasetId())
       .filter(_.getTableId.startsWith(prefix))
       .map(_.getTableId.substring(prefix.length))
       .toSet

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryPartitionUtil.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryPartitionUtil.scala
@@ -58,7 +58,7 @@ private[bigquery] object BigQueryPartitionUtil {
   private def getPartitions(bq: BigQuery, tableRef: TableReference): Set[String] = {
     val prefix = tableRef.getTableId.split('$')(0)
     bq.tables
-      .tableReferences(tableRef.getProjectId(), tableRef.getDatasetId())
+      .tableReferences(tableRef.getProjectId, tableRef.getDatasetId)
       .filter(_.getTableId.startsWith(prefix))
       .map(_.getTableId.substring(prefix.length))
       .toSet

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
@@ -41,7 +41,6 @@ import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 import scala.util.control.NonFatal
-import com.spotify.scio.bigquery.BigQuerySysProps
 
 private[client] object TableOps {
   private val Logger = LoggerFactory.getLogger(this.getClass)

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
@@ -163,16 +163,13 @@ final private[client] class TableOps(client: Client) {
   }
 
   /** Get list of tables in a dataset. */
-  def tableReferences(tableRef: TableReference): Seq[TableReference] =
-    tableReferences(
-      Option(tableRef.getProjectId).getOrElse(client.project),
-      tableRef.getDatasetId()
-    )
+  def tableReferences(projectId: String, datasetId: String): Seq[TableReference] =
+    tableReferences(Option(projectId), datasetId)
 
   /** Get list of tables in a dataset. */
-  def tableReferences(projectId: String, datasetId: String): Seq[TableReference] = {
+  def tableReferences(projectId: Option[String], datasetId: String): Seq[TableReference] = {
     val b = Seq.newBuilder[TableReference]
-    val req = client.underlying.tables().list(projectId, datasetId)
+    val req = client.underlying.tables().list(projectId.getOrElse(client.project), datasetId)
     var rep = req.execute()
     Option(rep.getTables).foreach(_.asScala.foreach(b += _.getTableReference))
     while (rep.getNextPageToken != null) {


### PR DESCRIPTION
Fixes #2994
Fixes #2928, It will allow compilation without `projectId` in the spec. However, it must be defined either through `-Dbigquery.project`, env or `.config/gcloud`