### PR TITLE
Make SMB source a splittable BoundedSource

### DIFF
--- a/scio-smb/src/it/scala/com/spotify/scio/smb/SortMergeBucketParityIT.scala
+++ b/scio-smb/src/it/scala/com/spotify/scio/smb/SortMergeBucketParityIT.scala
@@ -61,7 +61,7 @@ class SortMergeBucketParityIT extends AnyFlatSpec with Matchers {
         classOf[Integer],
         mkRead(inputs(0)),
         mkRead(inputs(1)),
-        TargetParallelism.min()
+        TargetParallelism.auto()
       )
     ) { sc =>
       val (avroA, avroB) = (
@@ -84,7 +84,7 @@ class SortMergeBucketParityIT extends AnyFlatSpec with Matchers {
           AvroSortedBucketIO
             .read(new TupleTag[GenericRecord]("rhs"), schema)
             .from(inputs(2).toString, inputs(3).toString),
-          TargetParallelism.max()
+          TargetParallelism.auto()
         )
       ) { sc =>
         val (lhs, rhs) = (
@@ -113,7 +113,7 @@ class SortMergeBucketParityIT extends AnyFlatSpec with Matchers {
         mkRead(inputs(0)),
         mkRead(inputs(1)),
         mkRead(inputs(2)),
-        TargetParallelism.min()
+        TargetParallelism.auto()
       )
     ) { sc =>
       val (avroA, avroB, avroC) = (
@@ -134,7 +134,7 @@ class SortMergeBucketParityIT extends AnyFlatSpec with Matchers {
         mkRead(inputs(1)),
         mkRead(inputs(2)),
         mkRead(inputs(3)),
-        TargetParallelism.max()
+        TargetParallelism.auto()
       )
     ) { sc =>
       val (avroA, avroB, avroC, avroD) = (
@@ -156,7 +156,12 @@ class SortMergeBucketParityIT extends AnyFlatSpec with Matchers {
 
   "sortMergeJoin" should "have parity with a 2-way Join" in withNumSources(2) { inputs =>
     compareResults(
-      _.sortMergeJoin(classOf[Integer], mkRead(inputs(0)), mkRead(inputs(1)))
+      _.sortMergeJoin(
+        classOf[Integer],
+        mkRead(inputs(0)),
+        mkRead(inputs(1)),
+        TargetParallelism.auto()
+      )
     ) { sc =>
       val (avroA, avroB) = (
         sc.avroFile(s"${inputs(0)}/*.avro", schema),

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -47,7 +47,7 @@ public class SortedBucketIO {
   static final int DEFAULT_NUM_SHARDS = 1;
   static final HashType DEFAULT_HASH_TYPE = HashType.MURMUR3_128;
   static final int DEFAULT_SORTER_MEMORY_MB = 1024;
-  static final TargetParallelism DEFAULT_PARALLELISM = TargetParallelism.min();
+  static final TargetParallelism DEFAULT_PARALLELISM = TargetParallelism.auto();
 
   /** Co-groups sorted-bucket sources with the same sort key. */
   public static <FinalKeyT> CoGbkBuilder<FinalKeyT> read(Class<FinalKeyT> finalKeyClass) {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSink.WriteResult;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
-import org.apache.beam.sdk.extensions.smb.TargetParallelism;
 import org.apache.beam.sdk.extensions.smb.SortedBucketTransform.TransformFn;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -105,7 +104,9 @@ public class SortedBucketIO {
     public PCollection<KV<K, CoGbkResult>> expand(PBegin input) {
       List<BucketedInput<?, ?>> bucketedInputs =
           reads.stream().map(Read::toBucketedInput).collect(Collectors.toList());
-      return input.apply(new SortedBucketSource<>(keyClass, bucketedInputs, targetParallelism));
+      return input.apply(
+          org.apache.beam.sdk.io.Read.from(
+              new SortedBucketSource<>(keyClass, bucketedInputs, targetParallelism)));
     }
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -112,11 +112,15 @@ public class SortedBucketIO {
 
     @Override
     public PCollection<KV<K, CoGbkResult>> expand(PBegin input) {
-      List<BucketedInput<?, ?>> bucketedInputs =
+      final List<BucketedInput<?, ?>> bucketedInputs =
           reads.stream().map(Read::toBucketedInput).collect(Collectors.toList());
-      return input.apply(
-          org.apache.beam.sdk.io.Read.from(
-              new SortedBucketSource<>(keyClass, bucketedInputs, targetParallelism, metricsKey)));
+      SortedBucketSource<K> source;
+      if (metricsKey == null) {
+        source = new SortedBucketSource<>(keyClass, bucketedInputs, targetParallelism);
+      } else {
+        source = new SortedBucketSource<>(keyClass, bucketedInputs, targetParallelism, metricsKey);
+      }
+      return input.apply(org.apache.beam.sdk.io.Read.from(source));
     }
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -17,6 +17,7 @@
 
 package org.apache.beam.sdk.extensions.smb;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -29,41 +30,37 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
+import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
-import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadataUtil.PartitionMetadata;
 import org.apache.beam.sdk.extensions.smb.BucketMetadataUtil.SourceMetadata;
+import org.apache.beam.sdk.io.BoundedSource;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.io.fs.ResourceId;
-import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Metrics;
-import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.transforms.join.CoGbkResultSchema;
 import org.apache.beam.sdk.transforms.join.UnionCoder;
 import org.apache.beam.sdk.values.KV;
-import org.apache.beam.sdk.values.PBegin;
-import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.UnsignedBytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link PTransform} for co-grouping sources written using compatible {@link SortedBucketSink}
@@ -88,15 +85,25 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Unsig
  *     bucketed using the same {@code byte[]} representation (see: {@link
  *     BucketMetadata#getKeyBytes(Object)}.
  */
-public class SortedBucketSource<FinalKeyT>
-    extends PTransform<PBegin, PCollection<KV<FinalKeyT, CoGbkResult>>> {
+public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, CoGbkResult>> {
+
+  // Dataflow calls split() with a suggested byte size that assumes a higher throughput than
+  // SMB joins have. By adjusting this suggestion we can arrive at a more optimal parallelism.
+  static final Double DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR = 0.33;
 
   private static final Comparator<byte[]> bytesComparator =
       UnsignedBytes.lexicographicalComparator();
 
+  private static final Logger LOG = LoggerFactory.getLogger(SortedBucketSource.class);
+
   private final Class<FinalKeyT> finalKeyClass;
-  private final transient List<BucketedInput<?, ?>> sources;
+  private final List<BucketedInput<?, ?>> sources;
   private final TargetParallelism targetParallelism;
+  private final int effectiveParallelism;
+  private final int bucketOffsetId;
+  private SourceSpec<FinalKeyT> sourceSpec;
+  private final Distribution keyGroupSize;
+  private Long estimatedSizeBytes;
 
   public SortedBucketSource(Class<FinalKeyT> finalKeyClass, List<BucketedInput<?, ?>> sources) {
     this(finalKeyClass, sources, TargetParallelism.min());
@@ -106,201 +113,231 @@ public class SortedBucketSource<FinalKeyT>
       Class<FinalKeyT> finalKeyClass,
       List<BucketedInput<?, ?>> sources,
       TargetParallelism targetParallelism) {
+    // Initialize with absolute minimal parallelism and allow split() to create parallelism
+    this(finalKeyClass, sources, targetParallelism, 0, 1);
+  }
+
+  private SortedBucketSource(
+      Class<FinalKeyT> finalKeyClass,
+      List<BucketedInput<?, ?>> sources,
+      TargetParallelism targetParallelism,
+      int bucketOffsetId,
+      int effectiveParallelism) {
     this.finalKeyClass = finalKeyClass;
     this.sources = sources;
     this.targetParallelism = targetParallelism;
+    this.bucketOffsetId = bucketOffsetId;
+    this.effectiveParallelism = effectiveParallelism;
+    this.keyGroupSize =
+        Metrics.distribution(SortedBucketSource.class, "SortedBucketSource-KeyGroupSize");
+  }
+
+  @VisibleForTesting
+  int getBucketOffset() {
+    return bucketOffsetId;
+  }
+
+  private SourceSpec<FinalKeyT> getOrComputeSourceSpec() {
+    if (this.sourceSpec == null) {
+      this.sourceSpec = SourceSpec.from(finalKeyClass, sources);
+    }
+    return this.sourceSpec;
   }
 
   @Override
-  public final PCollection<KV<FinalKeyT, CoGbkResult>> expand(PBegin begin) {
-    final SourceSpec<FinalKeyT> sourceSpec = getSourceSpec(finalKeyClass, sources);
-    int parallelism = sourceSpec.getParallelism(targetParallelism);
-
-    @SuppressWarnings("deprecation")
-    final Reshuffle.ViaRandomKey<Integer> reshuffle = Reshuffle.viaRandomKey();
-
-    final CoGbkResult.CoGbkResultCoder resultCoder =
+  public Coder<KV<FinalKeyT, CoGbkResult>> getOutputCoder() {
+    return KvCoder.of(
+        getOrComputeSourceSpec().keyCoder,
         CoGbkResult.CoGbkResultCoder.of(
             BucketedInput.schemaOf(sources),
             UnionCoder.of(
-                sources.stream().map(BucketedInput::getCoder).collect(Collectors.toList())));
-
-    return begin
-        .getPipeline()
-        .apply(
-            "CreateBuckets",
-            Create.of(IntStream.range(0, parallelism).boxed().collect(Collectors.toList()))
-                .withCoder(VarIntCoder.of()))
-        .apply("ReshuffleKeys", reshuffle)
-        .apply(
-            "MergeBuckets",
-            ParDo.of(new MergeBuckets<>(this.getName(), sources, parallelism, sourceSpec)))
-        .setCoder(KvCoder.of(sourceSpec.keyCoder, resultCoder));
+                sources.stream().map(BucketedInput::getCoder).collect(Collectors.toList()))));
   }
 
-  static class SourceSpec<K> {
-    int leastNumBuckets;
-    int greatestNumBuckets;
-    Coder<K> keyCoder;
-
-    SourceSpec(int leastNumBuckets, int greatestNumBuckets, Coder<K> keyCoder) {
-      this.leastNumBuckets = leastNumBuckets;
-      this.greatestNumBuckets = greatestNumBuckets;
-      this.keyCoder = keyCoder;
-    }
-
-    int getParallelism(TargetParallelism targetParallelism) {
-      int parallelism;
-
-      if (targetParallelism.isMin()) {
-        return leastNumBuckets;
-      } else if (targetParallelism.isMax()) {
-        return greatestNumBuckets;
-      } else {
-        parallelism = targetParallelism.getValue();
-
-        Preconditions.checkArgument(
-            ((parallelism & parallelism - 1) == 0)
-                && parallelism >= leastNumBuckets
-                && parallelism <= greatestNumBuckets,
-            String.format(
-                "Target parallelism must be a power of 2 between the least (%d) and "
-                    + "greatest (%d) number of buckets in sources. Was: %d",
-                leastNumBuckets, greatestNumBuckets, parallelism));
-
-        return parallelism;
-      }
-    }
+  @Override
+  public void populateDisplayData(Builder builder) {
+    super.populateDisplayData(builder);
+    builder.add(DisplayData.item("targetParallelism", targetParallelism.toString()));
+    builder.add(DisplayData.item("keyClass", finalKeyClass.toString()));
   }
 
-  static <KeyT> SourceSpec<KeyT> getSourceSpec(
-      Class<KeyT> finalKeyClass, List<BucketedInput<?, ?>> sources) {
-    BucketMetadata<?, ?> first = null;
-    Coder<KeyT> finalKeyCoder = null;
-
-    // Check metadata of each source
-    for (BucketedInput<?, ?> source : sources) {
-      final BucketMetadata<?, ?> current = source.getMetadata();
-      if (first == null) {
-        first = current;
-      } else {
-        Preconditions.checkState(
-            first.isCompatibleWith(current),
-            "Source %s is incompatible with source %s",
-            sources.get(0),
-            source);
-      }
-
-      if (current.getKeyClass() == finalKeyClass && finalKeyCoder == null) {
-        try {
-          @SuppressWarnings("unchecked")
-          final Coder<KeyT> coder = (Coder<KeyT>) current.getKeyCoder();
-          finalKeyCoder = coder;
-        } catch (CannotProvideCoderException e) {
-          throw new RuntimeException("Could not provide coder for key class " + finalKeyClass, e);
-        } catch (NonDeterministicException e) {
-          throw new RuntimeException("Non-deterministic coder for key class " + finalKeyClass, e);
-        }
-      }
+  // `getEstimatedSizeBytes` is called frequently by Dataflow, don't recompute every time
+  private long getOrComputeSizeBytes() throws Exception {
+    if (estimatedSizeBytes == null) {
+      estimatedSizeBytes =
+          FileSystems.matchResources(
+                  sources.stream()
+                      .flatMap(
+                          s -> s.listFilesForBucket(bucketOffsetId, effectiveParallelism).stream())
+                      .collect(Collectors.toList()))
+              .stream()
+              .flatMap(
+                  matchResult -> {
+                    try {
+                      return matchResult.metadata().stream().map(Metadata::sizeBytes);
+                    } catch (IOException e) {
+                      throw new RuntimeException(e);
+                    }
+                  })
+              .reduce(0L, Long::sum);
     }
 
-    int leastNumBuckets =
-        sources.stream()
-            .flatMap(source -> source.getPartitionMetadata().values().stream())
-            .map(PartitionMetadata::getNumBuckets)
-            .min(Integer::compareTo)
-            .get();
+    return estimatedSizeBytes;
+  }
 
-    int greatestNumBuckets =
-        sources.stream()
-            .flatMap(source -> source.getPartitionMetadata().values().stream())
-            .map(PartitionMetadata::getNumBuckets)
-            .max(Integer::compareTo)
-            .get();
+  @Override
+  public List<? extends BoundedSource<KV<FinalKeyT, CoGbkResult>>> split(
+      long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
 
-    Preconditions.checkNotNull(
-        finalKeyCoder, "Could not infer coder for key class %s", finalKeyClass);
+    int greatestNumBuckets = getOrComputeSourceSpec().greatestNumBuckets;
 
-    return new SourceSpec<>(leastNumBuckets, greatestNumBuckets, finalKeyCoder);
+    if (effectiveParallelism == greatestNumBuckets) {
+      LOG.info("Parallelism is already maxed, can't split further.");
+      return ImmutableList.of(this);
+    }
+    int parallelism;
+
+    if (!targetParallelism.isAuto()) {
+      parallelism = getOrComputeSourceSpec().getParallelism(targetParallelism);
+    } else {
+      long size = getEstimatedSizeBytes(options);
+      int fanout = (int) (size / (DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR * desiredBundleSizeBytes));
+
+      if (fanout <= 1) {
+        return ImmutableList.of(this);
+      }
+
+      // round up to nearest power of 2, bounded by greatest # of buckets
+      parallelism = Math.min(Integer.highestOneBit(fanout - 1) * 2, greatestNumBuckets);
+    }
+
+    final int effectiveParallelism = parallelism;
+    LOG.info("Parallelism was adjusted to " + effectiveParallelism);
+
+    return IntStream.range(0, effectiveParallelism)
+        .boxed()
+        .map(
+            i ->
+                new SortedBucketSource<>(
+                    finalKeyClass, sources, targetParallelism, i, effectiveParallelism))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public long getEstimatedSizeBytes(PipelineOptions options) throws Exception {
+    return getOrComputeSizeBytes();
+  }
+
+  @Override
+  public BoundedReader<KV<FinalKeyT, CoGbkResult>> createReader(PipelineOptions options)
+      throws IOException {
+    return new MergeBucketsReader<>(
+        sources,
+        bucketOffsetId,
+        effectiveParallelism,
+        getOrComputeSourceSpec(),
+        this,
+        keyGroupSize);
   }
 
   /** Merge key-value groups in matching buckets. */
-  static class MergeBuckets<FinalKeyT> extends DoFn<Integer, KV<FinalKeyT, CoGbkResult>> {
+  static class MergeBucketsReader<FinalKeyT> extends BoundedReader<KV<FinalKeyT, CoGbkResult>> {
     private static final Comparator<Map.Entry<TupleTag, KV<byte[], Iterator<?>>>> keyComparator =
         (o1, o2) -> bytesComparator.compare(o1.getValue().getKey(), o2.getValue().getKey());
 
-    private final Integer parallelism;
     private final Coder<FinalKeyT> keyCoder;
-    private final List<BucketedInput<?, ?>> sources;
-    private final int leastNumBuckets;
-
-    private final Counter elementsRead;
+    private final SortedBucketSource<FinalKeyT> currentSource;
     private final Distribution keyGroupSize;
+    private final int numSources;
+    private final KeyGroupIterator[] iterators;
+    private final Function<byte[], Boolean> keyGroupFilter;
+    private final CoGbkResultSchema resultSchema;
+    private final TupleTagList tupleTags;
 
-    MergeBuckets(
-        String transformName,
+    private Map<TupleTag, KV<byte[], Iterator<?>>> nextKeyGroups;
+    private Map.Entry<TupleTag, KV<byte[], Iterator<?>>> minKeyEntry;
+
+    MergeBucketsReader(
         List<BucketedInput<?, ?>> sources,
-        int targetParallelism,
-        SourceSpec<FinalKeyT> sourceSpec) {
-      this.parallelism = targetParallelism;
+        Integer bucketId,
+        int parallelism,
+        SourceSpec<FinalKeyT> sourceSpec,
+        SortedBucketSource<FinalKeyT> currentSource,
+        Distribution keyGroupSize) {
       this.keyCoder = sourceSpec.keyCoder;
-      this.sources = sources;
-      this.leastNumBuckets = sourceSpec.leastNumBuckets;
+      this.numSources = sources.size();
+      this.currentSource = currentSource;
+      this.keyGroupSize = keyGroupSize;
 
-      elementsRead = Metrics.counter(SortedBucketSource.class, transformName + "-ElementsRead");
-      keyGroupSize =
-          Metrics.distribution(SortedBucketSource.class, transformName + "-KeyGroupSize");
-    }
+      if (parallelism == sourceSpec.leastNumBuckets) {
+        this.keyGroupFilter = (bytes) -> true;
+      } else {
+        this.keyGroupFilter =
+            sources.get(0).getMetadata().checkRehashedBucketFn(parallelism, bucketId);
+      }
 
-    @ProcessElement
-    public void processElement(ProcessContext c) {
-      int bucketId = c.element();
-
-      final KeyGroupIterator[] iterators =
+      iterators =
           sources.stream()
               .map(i -> i.createIterator(bucketId, parallelism))
               .toArray(KeyGroupIterator[]::new);
 
-      Function<byte[], Boolean> keyGroupFilter;
-      if (parallelism.equals(leastNumBuckets)) {
-        keyGroupFilter = (bytes) -> true;
-      } else {
-        keyGroupFilter = sources.get(0).getMetadata().checkRehashedBucketFn(parallelism, bucketId);
-      }
-
-      merge(
-          iterators,
-          BucketedInput.schemaOf(sources),
-          keyGroupFilter,
-          mergedKeyGroup -> {
-            try {
-              c.output(
-                  KV.of(
-                      keyCoder.decode(new ByteArrayInputStream(mergedKeyGroup.getKey())),
-                      mergedKeyGroup.getValue()));
-            } catch (Exception e) {
-              throw new RuntimeException("Failed to decode and merge key group", e);
-            }
-          },
-          elementsRead,
-          keyGroupSize);
+      resultSchema = BucketedInput.schemaOf(sources);
+      tupleTags = resultSchema.getTupleTagList();
     }
 
-    static void merge(
-        KeyGroupIterator[] iterators,
-        CoGbkResultSchema resultSchema,
-        Function<byte[], Boolean> keyGroupFilter,
-        Consumer<KV<byte[], CoGbkResult>> consumer,
-        Counter elementsRead,
-        Distribution keyGroupSize) {
-      final int numSources = iterators.length;
+    @Override
+    public boolean start() throws IOException {
+      nextKeyGroups = new HashMap<>();
+      return advance();
+    }
 
-      final TupleTagList tupleTags = resultSchema.getTupleTagList();
-      final Map<TupleTag, KV<byte[], Iterator<?>>> nextKeyGroups = new HashMap<>();
+    @Override
+    public KV<FinalKeyT, CoGbkResult> getCurrent() throws NoSuchElementException {
+      // Find next key-value groups
+      final Iterator<Map.Entry<TupleTag, KV<byte[], Iterator<?>>>> nextKeyGroupsIt =
+          nextKeyGroups.entrySet().iterator();
+      final List<Iterable<?>> valueMap = new ArrayList<>();
+      for (int i = 0; i < resultSchema.size(); i++) {
+        valueMap.add(new ArrayList<>());
+      }
 
-      while (true) {
-        int completedSources = 0;
-        // Advance key-value groups from each source
+      int keyGroupCount = 0;
+      while (nextKeyGroupsIt.hasNext()) {
+        final Map.Entry<TupleTag, KV<byte[], Iterator<?>>> entry = nextKeyGroupsIt.next();
+        if (keyComparator.compare(entry, minKeyEntry) == 0) {
+          int index = resultSchema.getIndex(entry.getKey());
+          @SuppressWarnings("unchecked")
+          final List<Object> values = (List<Object>) valueMap.get(index);
+          // TODO: this exhausts everything from the "lazy" iterator and can be expensive.
+          // To fix we have to make the underlying Reader range aware so that it's safe to
+          // re-iterate or stop without exhausting remaining elements in the value group.
+          entry.getValue().getValue().forEachRemaining(values::add);
+
+          nextKeyGroupsIt.remove();
+          keyGroupCount += values.size();
+        }
+      }
+
+      keyGroupSize.update(keyGroupCount);
+      final KV<byte[], CoGbkResult> mergedKeyGroup =
+          KV.of(
+              minKeyEntry.getValue().getKey(),
+              CoGbkResultUtil.newCoGbkResult(resultSchema, valueMap));
+      try {
+        return KV.of(
+            keyCoder.decode(new ByteArrayInputStream(mergedKeyGroup.getKey())),
+            mergedKeyGroup.getValue());
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to decode and merge key group", e);
+      }
+    }
+
+    @Override
+    public boolean advance() throws IOException {
+      int completedSources = 0;
+
+      // Advance key-value groups from each source
+      do {
         for (int i = 0; i < numSources; i++) {
           final KeyGroupIterator it = iterators[i];
           if (nextKeyGroups.containsKey(tupleTags.get(i))) {
@@ -316,67 +353,41 @@ public class SortedBucketSource<FinalKeyT>
         }
 
         if (nextKeyGroups.isEmpty()) {
-          break;
+          return false;
         }
+        minKeyEntry = nextKeyGroups.entrySet().stream().min(keyComparator).orElse(null);
 
-        // Find next key-value groups
-        final Map.Entry<TupleTag, KV<byte[], Iterator<?>>> minKeyEntry =
-            nextKeyGroups.entrySet().stream().min(keyComparator).orElse(null);
+        if (keyGroupFilter.apply(minKeyEntry.getValue().getKey())) {
+          return true;
+        } else {
+          // Still have to exhaust iterator
 
-        final boolean acceptKeyGroup = keyGroupFilter.apply(minKeyEntry.getValue().getKey());
+          final Iterator<Map.Entry<TupleTag, KV<byte[], Iterator<?>>>> nextKeyGroupsIt =
+              nextKeyGroups.entrySet().iterator();
+          final List<Iterable<?>> valueMap = new ArrayList<>();
+          for (int i = 0; i < resultSchema.size(); i++) {
+            valueMap.add(new ArrayList<>());
+          }
 
-        final Iterator<Map.Entry<TupleTag, KV<byte[], Iterator<?>>>> nextKeyGroupsIt =
-            nextKeyGroups.entrySet().iterator();
-        final List<Iterable<?>> valueMap = new ArrayList<>();
-        for (int i = 0; i < resultSchema.size(); i++) {
-          valueMap.add(new ArrayList<>());
-        }
-
-        int keyGroupCount = 0;
-        while (nextKeyGroupsIt.hasNext()) {
-          final Map.Entry<TupleTag, KV<byte[], Iterator<?>>> entry = nextKeyGroupsIt.next();
-          if (keyComparator.compare(entry, minKeyEntry) == 0) {
-            if (acceptKeyGroup) {
-              int index = resultSchema.getIndex(entry.getKey());
-              @SuppressWarnings("unchecked")
-              final List<Object> values = (List<Object>) valueMap.get(index);
-              // TODO: this exhausts everything from the "lazy" iterator and can be expensive.
-              // To fix we have to make the underlying Reader range aware so that it's safe to
-              // re-iterate or stop without exhausting remaining elements in the value group.
-              entry.getValue().getValue().forEachRemaining(values::add);
-
-              nextKeyGroupsIt.remove();
-              keyGroupCount += values.size();
-            } else {
-              // Still have to exhaust iterator
+          while (nextKeyGroupsIt.hasNext()) {
+            final Map.Entry<TupleTag, KV<byte[], Iterator<?>>> entry = nextKeyGroupsIt.next();
+            if (keyComparator.compare(entry, minKeyEntry) == 0) {
               entry.getValue().getValue().forEachRemaining(value -> {});
               nextKeyGroupsIt.remove();
             }
           }
         }
+      } while (completedSources != numSources);
 
-        if (acceptKeyGroup) {
-          keyGroupSize.update(keyGroupCount);
-          elementsRead.inc(keyGroupCount);
-
-          final KV<byte[], CoGbkResult> mergedKeyGroup =
-              KV.of(
-                  minKeyEntry.getValue().getKey(),
-                  CoGbkResultUtil.newCoGbkResult(resultSchema, valueMap));
-          consumer.accept(mergedKeyGroup);
-        }
-
-        if (completedSources == numSources) {
-          break;
-        }
-      }
+      return !nextKeyGroups.isEmpty();
     }
 
     @Override
-    public void populateDisplayData(Builder builder) {
-      super.populateDisplayData(builder);
-      builder.add(DisplayData.item("keyCoder", keyCoder.getClass()));
-      builder.add(DisplayData.item("parallelism", parallelism));
+    public void close() throws IOException {}
+
+    @Override
+    public BoundedSource<KV<FinalKeyT, CoGbkResult>> getCurrentSource() {
+      return currentSource;
     }
   }
 
@@ -443,6 +454,30 @@ public class SortedBucketSource<FinalKeyT>
       return sourceMetadata;
     }
 
+    List<ResourceId> listFilesForBucket(int bucketId, int targetParallelism) {
+      final List<ResourceId> files = new ArrayList<>();
+      // Create one iterator per shard
+      getPartitionMetadata()
+          .forEach(
+              (resourceId, partitionMetadata) -> {
+                final int numBuckets = partitionMetadata.getNumBuckets();
+                final int numShards = partitionMetadata.getNumShards();
+
+                // Since all BucketedInputs have a bucket count that's a power of two, we can infer
+                // which buckets should be merged together for the join.
+                for (int i = (bucketId % numBuckets); i < numBuckets; i += targetParallelism) {
+                  for (int j = 0; j < numShards; j++) {
+                    files.add(
+                        partitionMetadata
+                            .getFileAssignment()
+                            .forBucket(BucketShardId.of(i, j), numBuckets, numShards));
+                  }
+                }
+              });
+
+      return files;
+    }
+
     KeyGroupIterator<byte[], V> createIterator(int bucketId, int targetParallelism) {
       final List<Iterator<V>> iterators = new ArrayList<>();
       // Create one iterator per shard
@@ -475,6 +510,9 @@ public class SortedBucketSource<FinalKeyT>
 
     @Override
     public String toString() {
+      List<ResourceId> inputDirectories =
+          new ArrayList<>(getOrComputeMetadata().getPartitionMetadata().keySet());
+
       return String.format(
           "BucketedInput[tupleTag=%s, inputDirectories=[%s], metadata=%s]",
           tupleTag.getId(),

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -118,7 +118,7 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
       List<BucketedInput<?, ?>> sources,
       TargetParallelism targetParallelism) {
     // Initialize with absolute minimal parallelism and allow split() to create parallelism
-    this(finalKeyClass, sources, targetParallelism, 0, 1, null);
+    this(finalKeyClass, sources, targetParallelism, 0, 1, getDefaultMetricsKey());
   }
 
   public SortedBucketSource(
@@ -142,20 +142,20 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
     this.targetParallelism = targetParallelism;
     this.bucketOffsetId = bucketOffsetId;
     this.effectiveParallelism = effectiveParallelism;
-
-    if (metricsKey == null) {
-      final int nextMetricsId = metricsId.getAndAdd(1);
-      if (nextMetricsId != 1) {
-        metricsKey = "SortedBucketSource{" + nextMetricsId + "}";
-      } else {
-        metricsKey = "SortedBucketSource";
-      }
-    }
     this.metricsKey = metricsKey;
 
-    LOG.info("Initializing SortedBucketSource with metrics namespace " + metricsKey);
+    LOG.error("Initializing SortedBucketSource with metrics namespace " + metricsKey);
     this.keyGroupSize =
         Metrics.distribution(SortedBucketSource.class, metricsKey + "-KeyGroupSize");
+  }
+
+  private static String getDefaultMetricsKey() {
+    final int nextMetricsId = metricsId.getAndAdd(1);
+    if (nextMetricsId != 1) {
+      return "SortedBucketSource{" + nextMetricsId + "}";
+    } else {
+      return "SortedBucketSource";
+    }
   }
 
   @VisibleForTesting

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -143,8 +143,6 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
     this.bucketOffsetId = bucketOffsetId;
     this.effectiveParallelism = effectiveParallelism;
     this.metricsKey = metricsKey;
-
-    LOG.error("Initializing SortedBucketSource with metrics namespace " + metricsKey);
     this.keyGroupSize =
         Metrics.distribution(SortedBucketSource.class, metricsKey + "-KeyGroupSize");
   }
@@ -185,6 +183,7 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
     super.populateDisplayData(builder);
     builder.add(DisplayData.item("targetParallelism", targetParallelism.toString()));
     builder.add(DisplayData.item("keyClass", finalKeyClass.toString()));
+    builder.add(DisplayData.item("metricsKey", metricsKey));
   }
 
   // `getEstimatedSizeBytes` is called frequently by Dataflow, don't recompute every time

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -88,7 +88,7 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
 
   // Dataflow calls split() with a suggested byte size that assumes a higher throughput than
   // SMB joins have. By adjusting this suggestion we can arrive at a more optimal parallelism.
-  static final Double DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR = 0.5;
+  static final Double DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR = 0.33;
 
   private static final Comparator<byte[]> bytesComparator =
       UnsignedBytes.lexicographicalComparator();

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -37,7 +37,6 @@ import java.util.stream.IntStream;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.ListCoder;
-import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadataUtil.PartitionMetadata;
@@ -90,7 +89,7 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
 
   // Dataflow calls split() with a suggested byte size that assumes a higher throughput than
   // SMB joins have. By adjusting this suggestion we can arrive at a more optimal parallelism.
-  static final Double DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR = 0.33;
+  static final Double DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR = 0.5;
 
   private static final Comparator<byte[]> bytesComparator =
       UnsignedBytes.lexicographicalComparator();

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SourceSpec.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SourceSpec.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.beam.sdk.extensions.smb;
+
+import java.io.Serializable;
+import java.util.List;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
+import org.apache.beam.sdk.extensions.smb.BucketMetadataUtil.PartitionMetadata;
+import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
+
+class SourceSpec<K> implements Serializable {
+  int leastNumBuckets;
+  int greatestNumBuckets;
+  Coder<K> keyCoder;
+
+  private SourceSpec(int leastNumBuckets, int greatestNumBuckets, Coder<K> keyCoder) {
+    this.leastNumBuckets = leastNumBuckets;
+    this.greatestNumBuckets = greatestNumBuckets;
+    this.keyCoder = keyCoder;
+  }
+
+  static <KeyT> SourceSpec<KeyT> from(
+      Class<KeyT> finalKeyClass, List<BucketedInput<?, ?>> sources) {
+    BucketMetadata<?, ?> first = null;
+    Coder<KeyT> finalKeyCoder = null;
+
+    // Check metadata of each source
+    for (BucketedInput<?, ?> source : sources) {
+      final BucketMetadata<?, ?> current = source.getMetadata();
+      if (first == null) {
+        first = current;
+      } else {
+        Preconditions.checkState(
+            first.isCompatibleWith(current),
+            "Source %s is incompatible with source %s",
+            sources.get(0),
+            source);
+      }
+
+      if (current.getKeyClass() == finalKeyClass && finalKeyCoder == null) {
+        try {
+          @SuppressWarnings("unchecked")
+          final Coder<KeyT> coder = (Coder<KeyT>) current.getKeyCoder();
+          finalKeyCoder = coder;
+        } catch (CannotProvideCoderException e) {
+          throw new RuntimeException("Could not provide coder for key class " + finalKeyClass, e);
+        } catch (NonDeterministicException e) {
+          throw new RuntimeException("Non-deterministic coder for key class " + finalKeyClass, e);
+        }
+      }
+    }
+
+    int leastNumBuckets =
+        sources.stream()
+            .flatMap(source -> source.getPartitionMetadata().values().stream())
+            .map(PartitionMetadata::getNumBuckets)
+            .min(Integer::compareTo)
+            .get();
+
+    int greatestNumBuckets =
+        sources.stream()
+            .flatMap(source -> source.getPartitionMetadata().values().stream())
+            .map(PartitionMetadata::getNumBuckets)
+            .max(Integer::compareTo)
+            .get();
+
+    Preconditions.checkNotNull(
+        finalKeyCoder, "Could not infer coder for key class %s", finalKeyClass);
+
+    return new SourceSpec<>(leastNumBuckets, greatestNumBuckets, finalKeyCoder);
+  }
+
+  int getParallelism(TargetParallelism targetParallelism) {
+    int parallelism;
+
+    if (targetParallelism.isMin()) {
+      return leastNumBuckets;
+    } else if (targetParallelism.isMax()) {
+      return greatestNumBuckets;
+    } else if (targetParallelism.isAuto()) {
+      throw new UnsupportedOperationException("Can't derive a static value for AutoParallelism");
+    } else {
+      parallelism = targetParallelism.getValue();
+
+      Preconditions.checkArgument(
+          ((parallelism & parallelism - 1) == 0)
+              && parallelism >= leastNumBuckets
+              && parallelism <= greatestNumBuckets,
+          String.format(
+              "Target parallelism must be a power of 2 between the least (%d) and "
+                  + "greatest (%d) number of buckets in sources. Was: %d",
+              leastNumBuckets, greatestNumBuckets, parallelism));
+
+      return parallelism;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "SourceSpec{leastNumBuckets="
+        + leastNumBuckets
+        + ", greatestNumBuckets="
+        + greatestNumBuckets
+        + '}';
+  }
+}

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TargetParallelism.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TargetParallelism.java
@@ -17,6 +17,8 @@
 
 package org.apache.beam.sdk.extensions.smb;
 
+import java.io.Serializable;
+
 /**
  * Represents the desired parallelism of an SMB read operation. For a given set of sources,
  * targetParallelism can be set to any number between the least and greatest numbers of buckets
@@ -40,7 +42,7 @@ package org.apache.beam.sdk.extensions.smb;
  * emitting duplicate records. - A custom parallelism in the middle of these bounds may be the best
  * balance of speed and computing cost.
  */
-public abstract class TargetParallelism {
+public abstract class TargetParallelism implements Serializable {
 
   public static MinParallelism min() {
     return MinParallelism.INSTANCE;
@@ -48,6 +50,10 @@ public abstract class TargetParallelism {
 
   public static MaxParallelism max() {
     return MaxParallelism.INSTANCE;
+  }
+
+  public static AutoParallelism auto() {
+    return AutoParallelism.INSTANCE;
   }
 
   public static CustomParallelism of(int value) {
@@ -62,12 +68,25 @@ public abstract class TargetParallelism {
     return this.getClass().equals(MinParallelism.class);
   }
 
+  boolean isCustom() {
+    return this.getClass().equals(CustomParallelism.class);
+  }
+
+  boolean isAuto() {
+    return this.getClass().equals(AutoParallelism.class);
+  }
+
   abstract int getValue();
 
   static class MaxParallelism extends TargetParallelism {
     static MaxParallelism INSTANCE = new MaxParallelism();
 
     private MaxParallelism() {}
+
+    @Override
+    public String toString() {
+      return "MaxParallelism";
+    }
 
     @Override
     int getValue() {
@@ -79,6 +98,11 @@ public abstract class TargetParallelism {
     static MinParallelism INSTANCE = new MinParallelism();
 
     private MinParallelism() {}
+
+    @Override
+    public String toString() {
+      return "MinParallelism";
+    }
 
     @Override
     int getValue() {
@@ -94,8 +118,29 @@ public abstract class TargetParallelism {
     }
 
     @Override
+    public String toString() {
+      return "CustomParallelism (" + value + ")";
+    }
+
+    @Override
     int getValue() {
       return value;
+    }
+  }
+
+  static class AutoParallelism extends TargetParallelism {
+    static AutoParallelism INSTANCE = new AutoParallelism();
+
+    AutoParallelism() {}
+
+    @Override
+    public String toString() {
+      return "AutoParallelism";
+    }
+
+    @Override
+    int getValue() {
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TargetParallelism.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TargetParallelism.java
@@ -25,9 +25,11 @@ import java.io.Serializable;
  * among sources. This can be dynamically configured using {@link TargetParallelism#min()} or {@link
  * TargetParallelism#max()}, which at graph construction time will determine the least or greatest
  * amount of parallelism based on sources. Alternately, {@link TargetParallelism#of(int)} can be
- * used to statically configure a custom value.
+ * used to statically configure a custom value, or {@link TargetParallelism#auto()} can be used to
+ * let the runner decide how to split the SMB read at runtime based on the combined byte size of the
+ * inputs.
  *
- * <p>If no value is specified, SMB read operations will use the minimum parallelism.
+ * <p>If no value is specified, SMB read operations will use Auto parallelism.
  *
  * <p>When selecting a target parallelism for your SMB operation, there are tradeoffs to consider:
  *
@@ -66,10 +68,6 @@ public abstract class TargetParallelism implements Serializable {
 
   boolean isMin() {
     return this.getClass().equals(MinParallelism.class);
-  }
-
-  boolean isCustom() {
-    return this.getClass().equals(CustomParallelism.class);
   }
 
   boolean isAuto() {

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -63,7 +63,7 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     keyClass: Class[K],
     lhs: SortedBucketIO.Read[L],
     rhs: SortedBucketIO.Read[R],
-    targetParallelism: TargetParallelism = TargetParallelism.min()
+    targetParallelism: TargetParallelism = TargetParallelism.auto()
   ): SCollection[(K, (L, R))] = {
     val t = SortedBucketIO.read(keyClass).of(lhs).and(rhs).withTargetParallelism(targetParallelism)
     val (tupleTagA, tupleTagB) = (lhs.getTupleTag, rhs.getTupleTag)
@@ -178,7 +178,7 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     a: SortedBucketIO.Read[A],
     b: SortedBucketIO.Read[B]
   ): SCollection[(K, (Iterable[A], Iterable[B]))] =
-    sortMergeCoGroup(keyClass, a, b, TargetParallelism.min())
+    sortMergeCoGroup(keyClass, a, b, TargetParallelism.auto())
 
   /**
    * For each key K in `a` or `b` or `c`, return a resulting SCollection that contains a tuple
@@ -240,7 +240,7 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     b: SortedBucketIO.Read[B],
     c: SortedBucketIO.Read[C]
   ): SCollection[(K, (Iterable[A], Iterable[B], Iterable[C]))] =
-    sortMergeCoGroup(keyClass, a, b, c, TargetParallelism.min())
+    sortMergeCoGroup(keyClass, a, b, c, TargetParallelism.auto())
 
   /**
    * For each key K in `a` or `b` or `c` or `d`, return a resulting SCollection that contains a
@@ -306,7 +306,7 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     c: SortedBucketIO.Read[C],
     d: SortedBucketIO.Read[D]
   ): SCollection[(K, (Iterable[A], Iterable[B], Iterable[C], Iterable[D]))] =
-    sortMergeCoGroup(keyClass, a, b, c, d, TargetParallelism.min())
+    sortMergeCoGroup(keyClass, a, b, c, d, TargetParallelism.auto())
 
   /**
    * Perform a [[SortedBucketScioContext.sortMergeGroupByKey()]] operation, then immediately apply

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -674,7 +674,9 @@ public class SortedBucketSourceTest {
     final Map<String, DistributionResult> actualDistributions =
         ImmutableList.copyOf(result.metrics().allMetrics().getDistributions().iterator()).stream()
             .collect(
-                Collectors.toMap(metric -> metric.getName().getName(), MetricResult::getCommitted));
+                Collectors.toMap(
+                    metric -> metric.getName().getName().replaceAll("\\{\\d+}", ""),
+                    MetricResult::getCommitted));
 
     Assert.assertEquals(expectedDistributions, actualDistributions);
   }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -217,7 +217,7 @@ public class SortedBucketSourceTest {
 
   @Test
   @Category(NeedsRunner.class)
-  public void testNullKeysTestd() throws Exception {
+  public void testNullKeysIgnored() throws Exception {
     test(
         ImmutableMap.of(
             BucketShardId.ofNullKey(0), Lists.newArrayList(""),
@@ -310,7 +310,7 @@ public class SortedBucketSourceTest {
                 BucketShardId.of(1, 0), Lists.newArrayList("c7", "c8"))));
   }
 
-  // For non-minimum parallelism, test input keys *must* hash to their corresponding bucket IDs,
+  // For non-minimal parallelism, test input keys *must* hash to their corresponding bucket IDs,
   // since a rehash is required in the merge step
   @Test
   @Category(NeedsRunner.class)
@@ -422,25 +422,16 @@ public class SortedBucketSourceTest {
     final SortedBucketSource source =
         new SortedBucketSource(String.class, inputs, TargetParallelism.auto());
 
-    final List<SortedBucketSource<String>> splitSources1 =
-        source.split(
-            (long) (100 / DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR), PipelineOptionsFactory.create());
-    splitSources1.sort(Comparator.comparingInt(SortedBucketSource::getBucketOffset));
-
-    Assert.assertEquals(2, splitSources1.size());
-    Assert.assertEquals(0, splitSources1.get(0).getBucketOffset());
-    Assert.assertEquals(1, splitSources1.get(1).getBucketOffset());
-
-    final List<SortedBucketSource<String>> splitSources2 =
+    final List<SortedBucketSource<String>> splitSources =
         source.split(
             (long) (50 / DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR), PipelineOptionsFactory.create());
-    splitSources2.sort(Comparator.comparingInt(SortedBucketSource::getBucketOffset));
+    splitSources.sort(Comparator.comparingInt(SortedBucketSource::getBucketOffset));
 
-    Assert.assertEquals(4, splitSources2.size());
-    Assert.assertEquals(0, splitSources2.get(0).getBucketOffset());
-    Assert.assertEquals(1, splitSources2.get(1).getBucketOffset());
-    Assert.assertEquals(2, splitSources2.get(2).getBucketOffset());
-    Assert.assertEquals(3, splitSources2.get(3).getBucketOffset());
+    Assert.assertEquals(4, splitSources.size());
+    Assert.assertEquals(0, splitSources.get(0).getBucketOffset());
+    Assert.assertEquals(1, splitSources.get(1).getBucketOffset());
+    Assert.assertEquals(2, splitSources.get(2).getBucketOffset());
+    Assert.assertEquals(3, splitSources.get(3).getBucketOffset());
   }
 
   private void writeSmbSourceWithBytes(

--- a/site/src/paradox/extras/Sort-Merge-Bucket.md
+++ b/site/src/paradox/extras/Sort-Merge-Bucket.md
@@ -115,9 +115,11 @@ desired parallelism of the SMB read operation. For a given set of sources, `targ
 set to any number between the least and greatest numbers of buckets among sources. This can be
 dynamically configured using `TargetParallelism.min()` or `TargetParallelism.max()`, which at graph
 construction time will determine the least or greatest amount of parallelism based on sources.
-Alternately, `TargetParallelism.of(Integer value)` can be used to statically configure a custom value.
+Alternately, `TargetParallelism.of(Integer value)` can be used to statically configure a custom value,
+or {@link TargetParallelism#auto()} can be used to let the runner decide how to split the SMB read
+at runtime based on the combined byte size of the inputs.
 
-If no value is specified, SMB read operations will use the minimum parallelism.
+If no value is specified, SMB read operations will use Auto parallelism.
 
 When selecting a target parallelism for your SMB operation, there are tradeoffs to consider:
 
@@ -132,6 +134,8 @@ When selecting a target parallelism for your SMB operation, there are tradeoffs 
     from the replicated sources must be re-hashed to avoid emitting duplicate records.
   - A custom parallelism in the middle of these bounds may be the best balance of speed and
     computing cost.
+  - Auto parallelism is more likely to pick an ideal value for most use cases. When using this option,
+    you can check the worker logs to find out which value was selected.
 
 ## Testing
 Currently, mocking data for SMB transforms is not supported in the `com.spotify.scio.testing.JobTest` framework. See


### PR DESCRIPTION
Re-implement `SortedBucketSource` as a proper Beam `BoundedSource` splittable by the runner. "Splittable" refers to how many buckets will be processed per worker, and ranges from 1 (all buckets processed by the same worker) to the highest # of buckets among input sources.

It corresponds to a new `TargetParallelism`, `TargetParallelism.auto()`, that's now the default if the user doesn't supply a value.

I noticed that the Dataflow runner, at least, tries to call `split(long desiredBundleSizeBytes)` with too high of a target byte size than is optimal for SMB, probably because of its relatively low throughput compared to other Sources. To offset I introduced a `DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR`, currently set to 0.5, to adjust the target size by. In benchmarks, this seems to result in the most optimal parallelism*.

This is only implemented for `SortedBucketSource`, not `SortedBucketTransform`, which needs to be followed up on at some point.

**\* benchmarks:**
LHS - 33GB/256buckets, RHS - 100GB/2048 buckets

Baseline:
<img width="496" alt="Screen Shot 2020-05-22 at 1 50 35 PM" src="https://user-images.githubusercontent.com/1360529/82702613-50766d80-9c40-11ea-8d6b-c87c55806fb5.png">

BoundedSource implementation, DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR = 0.5
<img width="495" alt="Screen Shot 2020-05-22 at 1 50 22 PM" src="https://user-images.githubusercontent.com/1360529/82702637-5d935c80-9c40-11ea-9331-bba9ae1825a0.png">

BoundedSource implementation, DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR = 0.33
<img width="526" alt="Screen Shot 2020-05-22 at 3 25 11 PM" src="https://user-images.githubusercontent.com/1360529/82703249-8831e500-9c41-11ea-81c0-dadd19f502b2.png">

^ I'm a little conflicted on what value to set `DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR` to--the higher value runs extremely fast but is a bit more resource-intensive, whereas the lower value is a few minutes slower but uses fewer resources. @nevillelyh wdyt?
