### PR TITLE
Add -release 8 scalac option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -168,6 +168,7 @@ val commonSettings = Sonatype.sonatypeSettings ++ assemblySettings ++ Seq(
       Seq()
     }
   },
+  Compile / doc / scalacOptions --= Seq("-release", "8"),
   scalacOptions in (Compile, doc) ++= Scalac.compileDocOptions.value,
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
   javacOptions in (Compile, doc) := Seq("-source", "1.8"),
@@ -1073,6 +1074,7 @@ lazy val `scio-repl`: Project = project
   .settings(commonSettings)
   .settings(macroSettings)
   .settings(
+    scalacOptions --= Seq("-release", "8"),
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-runners-direct-java" % beamVersion,

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -20,6 +20,8 @@ import sbt._, Keys._
 object Scalac {
   // see: https://tpolecat.github.io/2017/04/25/scalac-flags.html
   val baseOptions = List(
+    "-release",
+    "8",
     "-target:jvm-1.8",
     "-deprecation", // Emit warning and location for usages of deprecated APIs.
     "-feature", // Emit warning and location for usages of features that should be imported explicitly.
@@ -57,9 +59,7 @@ object Scalac {
     // "-Ywarn-unused:privates", // Warn if a private member is unused.
     "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
     "-Xmacro-settings:show-coder-fallback=true",
-    "-Ydelambdafy:inline", // Set the strategy used for translating lambdas into JVM code to "inline"
-    "-Ybackend-parallelism",
-    "8"
+    "-Ydelambdafy:inline" // Set the strategy used for translating lambdas into JVM code to "inline"
   )
 
   def scala212settings = Def.setting {

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -59,7 +59,9 @@ object Scalac {
     // "-Ywarn-unused:privates", // Warn if a private member is unused.
     "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
     "-Xmacro-settings:show-coder-fallback=true",
-    "-Ydelambdafy:inline" // Set the strategy used for translating lambdas into JVM code to "inline"
+    "-Ydelambdafy:inline", // Set the strategy used for translating lambdas into JVM code to "inline"
+    "-Ybackend-parallelism",
+    "8"
   )
 
   def scala212settings = Def.setting {


### PR DESCRIPTION
Fixes #3000

This flag will force scala to target 8 to avoid the mentioned issue when compiling/publishing with jdk11. It doesn't play well in some other situations (read [thread](https://github.com/scala/scala-dev/issues/139)) and in our case I had to disabled it in `scio-repl` (ClassLoader issues) and while doing `doc` generation. In both these cases it's not really important that this flag is enabled.