### PR TITLE
Fix needs to be java.math.BigDecimal

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -381,7 +381,7 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[String]              => tree
 
         case t if t =:= typeOf[BigDecimal] =>
-          q"_root_.com.spotify.scio.bigquery.Numeric($tree).toString"
+          q"_root_.com.spotify.scio.bigquery.Numeric($tree.bigDecimal).toString"
         case t if t =:= typeOf[ByteString] =>
           q"_root_.com.google.common.io.BaseEncoding.base64().encode($tree.toByteArray)"
         case t if t =:= typeOf[Array[Byte]] =>


### PR DESCRIPTION
beam sdk verifies that it's an instanceof java.math.BigDecimal
was getting the following error:

```
Caused by: java.lang.IllegalArgumentException: For field name fees and type DECIMAL found incorrect class type class scala.math.BigDecimal
	at org.apache.beam.sdk.values.Row$Builder.verifyPrimitiveType(Row.java:816)
	at org.apache.beam.sdk.values.Row$Builder.verify(Row.java:654)
	at org.apache.beam.sdk.values.Row$Builder.verify(Row.java:635)
	at org.apache.beam.sdk.values.Row$Builder.build(Row.java:840)
	at com.spotify.scio.schemas.SchemaMaterializer$.com$spotify$scio$schemas$SchemaMaterializer$$encode(SchemaMaterializer.scala:144)
	at com.spotify.scio.schemas.SchemaMaterializer$$anonfun$com$spotify$scio$schemas$SchemaMaterializer$$dispatchEncode$1.apply(SchemaMaterializer.scala:121)
	at com.spotify.scio.schemas.SchemaMaterializer$$anonfun$com$spotify$scio$schemas$SchemaMaterializer$$dispatchEncode$1.apply(SchemaMaterializer.scala:121)
	at com.spotify.scio.schemas.SchemaMaterializer$.com$spotify$scio$schemas$SchemaMaterializer$$encode(SchemaMaterializer.scala:140)
	at com.spotify.scio.schemas.SchemaMaterializer$$anon$4.apply(SchemaMaterializer.scala:204)
	at com.spotify.scio.schemas.SchemaMaterializer$$anon$4.apply(SchemaMaterializer.scala:202)
	at org.apache.beam.sdk.schemas.SchemaCoder.encode(SchemaCoder.java:166)
```