### PR TITLE
Use a sampled subset of files to compute estimated SMB source size

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -442,7 +442,7 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
    * @param <V> the type of the values in a bucket
    */
   public static class BucketedInput<K, V> implements Serializable {
-    private static int samplingNumFilesThreshold = 1000;
+    private static int SAMPLING_NUM_FILES_THRESHOLD = 1000;
 
     private TupleTag<V> tupleTag;
     private String filenameSuffix;
@@ -509,8 +509,8 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
           });
 
       double sampleFraction;
-      if (totalNumFiles.get() > samplingNumFilesThreshold) {
-        sampleFraction = samplingNumFilesThreshold / (totalNumFiles.get() * 1.0);
+      if (totalNumFiles.get() > SAMPLING_NUM_FILES_THRESHOLD) {
+        sampleFraction = SAMPLING_NUM_FILES_THRESHOLD / (totalNumFiles.get() * 1.0);
       } else {
         sampleFraction = 1.0;
       }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -199,7 +199,7 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
               .mapToLong(source -> source.getOrSampleByteSize(bucketOffsetId, effectiveParallelism))
               .sum();
 
-      LOG.error("Estimated byte size is " + estimatedSizeBytes);
+      LOG.info("Estimated byte size is " + estimatedSizeBytes);
     }
 
     return estimatedSizeBytes;

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -142,14 +142,14 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
       int bucketOffsetId,
       int effectiveParallelism,
       String metricsKey) {
-    this.finalKeyClass = finalKeyClass;
-    this.sources = sources;
-    this.targetParallelism = targetParallelism;
-    this.bucketOffsetId = bucketOffsetId;
-    this.effectiveParallelism = effectiveParallelism;
-    this.metricsKey = metricsKey;
-    this.keyGroupSize =
-        Metrics.distribution(SortedBucketSource.class, metricsKey + "-KeyGroupSize");
+    this(
+        finalKeyClass,
+        sources,
+        targetParallelism,
+        bucketOffsetId,
+        effectiveParallelism,
+        metricsKey,
+        null);
   }
 
   private SortedBucketSource(
@@ -159,14 +159,15 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
       int bucketOffsetId,
       int effectiveParallelism,
       String metricsKey,
-      long estimatedSizeBytes) {
-    this(
-        finalKeyClass,
-        sources,
-        targetParallelism,
-        bucketOffsetId,
-        effectiveParallelism,
-        metricsKey);
+      Long estimatedSizeBytes) {
+    this.finalKeyClass = finalKeyClass;
+    this.sources = sources;
+    this.targetParallelism = targetParallelism;
+    this.bucketOffsetId = bucketOffsetId;
+    this.effectiveParallelism = effectiveParallelism;
+    this.metricsKey = metricsKey;
+    this.keyGroupSize =
+        Metrics.distribution(SortedBucketSource.class, metricsKey + "-KeyGroupSize");
     this.estimatedSizeBytes = estimatedSizeBytes;
   }
 
@@ -253,9 +254,9 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
     }
 
     final int effectiveParallelism = parallelism;
+    LOG.info("Parallelism was adjusted to " + effectiveParallelism);
+
     long estSplitSize = getOrComputeSizeBytes() / effectiveParallelism;
-    LOG.info(
-        "Parallelism was adjusted to " + effectiveParallelism + " split size = " + estSplitSize);
 
     return IntStream.range(0, effectiveParallelism)
         .boxed()

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -422,6 +422,8 @@ public class SortedBucketSourceTest {
     final SortedBucketSource source =
         new SortedBucketSource(String.class, inputs, TargetParallelism.auto());
 
+    Assert.assertEquals(180, source.getEstimatedSizeBytes(PipelineOptionsFactory.create()));
+
     final List<SortedBucketSource<String>> splitSources =
         source.split(
             (long) (50 / DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR), PipelineOptionsFactory.create());


### PR DESCRIPTION
For sources with a very very high # of files, computing the estimated byte size of the SMB BoundedSource couldn't be done in memory as it materialized a list of every file in the Source (for the initial split(), the BoundedSource must estimate the byte size of every file in every bucket). This change introduces sampling of the total file set--it will only read the metadata of up to 1000 randomly selected files, and use that info to extrapolate the total byte size.

Tested on an internal use case with ~1.6 million unique files. `gsutil du` computes their total byte size to be ~4.57 TB. The sampling algorithm in this PR, using only 1000 files as a sample, resulted in an estimate of ~4.54 TB--so it seems fairly accurate, given the relatively small sample size. (Also, before this change, that computation ran out of memory and couldn't complete at all.)

