### PR TITLE
Add more info to RateLimiterDoFn javadoc

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/RateLimiterDoFn.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/RateLimiterDoFn.java
@@ -23,7 +23,8 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.
  * DoFn which will rate limit the number of elements processed per second.
  *
  * <p>Used to rate limit throughput for a job writing to a database or making calls to external
- * services.
+ * services. The limit is applied per worker and should be used with a fixed/max num workers.
+ * Having RateLimiterDoFn(1000) and 20 workers means your total rate will be 20000.
  */
 public class RateLimiterDoFn<InputT> extends DoFnWithResource<InputT, InputT, RateLimiter> {
 


### PR DESCRIPTION
This PR adds a bit more details on proper usage of `RateLimiterDoFn`, i.e. it clarifies whether the limit is applied per worker or to a job in general.