### PR TITLE
Add support to allow static bq execution in traditional template

### DIFF
--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/taps.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/taps.scala
@@ -74,19 +74,25 @@ final case class BigQueryTaps(self: Taps) {
   private lazy val bqc = BigQuery.defaultInstance()
 
   /** Get a `Future[Tap[TableRow]]` for BigQuery SELECT query. */
-  def bigQuerySelect(sqlQuery: String, flattenResults: Boolean = false): Future[Tap[TableRow]] =
+  def bigQuerySelect(
+    sqlQuery: String,
+    flattenResults: Boolean = false,
+    templateCompat: Boolean = false
+  ): Future[Tap[TableRow]] =
     mkTap(
       s"BigQuery SELECT: $sqlQuery",
       () => isQueryDone(sqlQuery),
-      () => BigQuerySelect(Query(sqlQuery)).tap(BigQuerySelect.ReadParam(flattenResults))
+      () =>
+        BigQuerySelect(Query(sqlQuery))
+          .tap(BigQuerySelect.ReadParam(flattenResults, templateCompat))
     )
 
   /** Get a `Future[Tap[TableRow]]` for BigQuery table. */
-  def bigQueryTable(table: TableReference): Future[Tap[TableRow]] =
+  def bigQueryTable(table: TableReference, templateCompat: Boolean = false): Future[Tap[TableRow]] =
     mkTap(
       s"BigQuery Table: $table",
       () => bqc.tables.exists(table),
-      () => BigQueryTable(Table.Ref(table)).tap(())
+      () => BigQueryTable(Table.Ref(table)).tap(BigQueryTable.ReadParam(templateCompat))
     )
 
   /** Get a `Future[Tap[TableRow]]` for BigQuery table. */


### PR DESCRIPTION
This is very much a first step. It only allows/fixes current impl to allow static bq execution using the "traditional" template scheme.

Fixes #3036