### PR TITLE
add small SMB sink optimizations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1148,7 +1148,7 @@ lazy val `scio-smb`: Project = project
       "joda-time" % "joda-time" % jodaTimeVersion,
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
-      "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion
+      "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion % "provided"
     ),
     beamSDKIODependencies,
     javacOptions ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -1147,7 +1147,8 @@ lazy val `scio-smb`: Project = project
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
-      "org.slf4j" % "slf4j-api" % slf4jVersion
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
+      "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion
     ),
     beamSDKIODependencies,
     javacOptions ++= {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
@@ -85,6 +85,7 @@ public class AvroSortedBucketIO {
         .setSorterMemoryMb(SortedBucketIO.DEFAULT_SORTER_MEMORY_MB)
         .setKeyClass(keyClass)
         .setKeyField(keyField)
+        .setKeyCacheSize(0)
         .setFilenameSuffix(DEFAULT_SUFFIX)
         .setCodec(DEFAULT_CODEC);
   }
@@ -218,6 +219,8 @@ public class AvroSortedBucketIO {
 
       abstract Builder<K, T> setCodec(CodecFactory codec);
 
+      abstract Builder<K, T> setKeyCacheSize(int cacheSize);
+
       abstract Write<K, T> build();
     }
 
@@ -277,6 +280,11 @@ public class AvroSortedBucketIO {
     /** Specifies the sorter memory in MB. */
     public Write<K, T> withSorterMemoryMb(int sorterMemoryMb) {
       return toBuilder().setSorterMemoryMb(sorterMemoryMb).build();
+    }
+
+    /** Specifies the size of an optional key-to-hash cache in the ExtractKeys transform. */
+    public Write<K, T> withKeyCacheOfSize(int keyCacheSize) {
+      return toBuilder().setKeyCacheSize(keyCacheSize).build();
     }
 
     /** Specifies the output file {@link CodecFactory}. */

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -178,8 +178,10 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
   /* Business logic */
 
   byte[] getKeyBytes(V value) {
-    final K key = extractKey(value);
+    return encodeKeyBytes(extractKey(value));
+  }
 
+  byte[] encodeKeyBytes(K key) {
     if (key == null) {
       return null;
     }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
@@ -54,6 +54,7 @@ public class JsonSortedBucketIO {
         .setSorterMemoryMb(SortedBucketIO.DEFAULT_SORTER_MEMORY_MB)
         .setKeyClass(keyClass)
         .setKeyField(keyField)
+        .setKeyCacheSize(0)
         .setFilenameSuffix(DEFAULT_SUFFIX)
         .setCompression(Compression.UNCOMPRESSED)
         .build();
@@ -151,6 +152,8 @@ public class JsonSortedBucketIO {
 
       abstract Builder<K> setSorterMemoryMb(int sorterMemoryMb);
 
+      abstract Builder<K> setKeyCacheSize(int cacheSize);
+
       // JSON specific
       abstract Builder<K> setKeyField(String keyField);
 
@@ -196,6 +199,11 @@ public class JsonSortedBucketIO {
     /** Specifies the sorter memory in MB. */
     public Write<K> withSorterMemoryMb(int sorterMemoryMb) {
       return toBuilder().setSorterMemoryMb(sorterMemoryMb).build();
+    }
+
+    /** Specifies the size of an optional key-to-hash cache in the ExtractKeys transform. */
+    public Write<K> withKeyCacheOfSize(int keyCacheSize) {
+      return toBuilder().setKeyCacheSize(keyCacheSize).build();
     }
 
     /** Specifies the output file {@link Compression}. */

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -203,8 +203,8 @@ public class SortedBucketIO {
 
     abstract int getKeyCacheSize();
 
-    public PreKeyedWrite<K, V> onKeyedCollection(Coder<V> valueCoder) {
-      return new PreKeyedWrite<>(this, valueCoder);
+    public PreKeyedWrite<K, V> onKeyedCollection(Coder<V> valueCoder, boolean verifyKeyExtraction) {
+      return new PreKeyedWrite<>(this, valueCoder, verifyKeyExtraction);
     }
 
     @SuppressWarnings("unchecked")
@@ -232,10 +232,12 @@ public class SortedBucketIO {
   public static class PreKeyedWrite<K, V> extends PTransform<PCollection<KV<K, V>>, WriteResult> {
     private final Write<K, V> write;
     private final Coder<V> valueCoder;
+    private final boolean verifyKeyExtraction;
 
-    public PreKeyedWrite(Write<K, V> write, Coder<V> valueCoder) {
+    public PreKeyedWrite(Write<K, V> write, Coder<V> valueCoder, boolean verifyKeyExtraction) {
       this.write = write;
       this.valueCoder = valueCoder;
+      this.verifyKeyExtraction = verifyKeyExtraction;
     }
 
     @SuppressWarnings("unchecked")
@@ -257,6 +259,7 @@ public class SortedBucketIO {
               write.getFileOperations(),
               write.getSorterMemoryMb(),
               valueCoder,
+              verifyKeyExtraction,
               write.getKeyCacheSize()));
     }
   }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -21,7 +21,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
+import org.apache.beam.sdk.extensions.smb.SortedBucketSink.SortedBucketPreKeyedSink;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSink.WriteResult;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
 import org.apache.beam.sdk.extensions.smb.SortedBucketTransform.TransformFn;
@@ -199,6 +201,13 @@ public class SortedBucketIO {
 
     abstract BucketMetadata<K, V> getBucketMetadata();
 
+    abstract int getKeyCacheSize();
+
+    public PreKeyedWrite<K, V> onKeyedCollection(Coder<V> valueCoder) {
+      return new PreKeyedWrite<>(this, valueCoder);
+    }
+
+    @SuppressWarnings("unchecked")
     @Override
     public WriteResult expand(PCollection<V> input) {
       Preconditions.checkNotNull(getOutputDirectory(), "outputDirectory is not set");
@@ -208,7 +217,6 @@ public class SortedBucketIO {
       if (tempDirectory == null) {
         tempDirectory = outputDirectory;
       }
-
       return input.apply(
           new SortedBucketSink<>(
               getBucketMetadata(),
@@ -216,7 +224,40 @@ public class SortedBucketIO {
               tempDirectory,
               getFilenameSuffix(),
               getFileOperations(),
-              getSorterMemoryMb()));
+              getSorterMemoryMb(),
+              getKeyCacheSize()));
+    }
+  }
+
+  public static class PreKeyedWrite<K, V> extends PTransform<PCollection<KV<K, V>>, WriteResult> {
+    private final Write<K, V> write;
+    private final Coder<V> valueCoder;
+
+    public PreKeyedWrite(Write<K, V> write, Coder<V> valueCoder) {
+      this.write = write;
+      this.valueCoder = valueCoder;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public WriteResult expand(PCollection<KV<K, V>> input) {
+      Preconditions.checkNotNull(write.getOutputDirectory(), "outputDirectory is not set");
+
+      final ResourceId outputDirectory = write.getOutputDirectory();
+      ResourceId tempDirectory = write.getTempDirectory();
+      if (tempDirectory == null) {
+        tempDirectory = outputDirectory;
+      }
+      return input.apply(
+          new SortedBucketPreKeyedSink<>(
+              write.getBucketMetadata(),
+              outputDirectory,
+              tempDirectory,
+              write.getFilenameSuffix(),
+              write.getFileOperations(),
+              write.getSorterMemoryMb(),
+              valueCoder,
+              write.getKeyCacheSize()));
     }
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSink.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSink.java
@@ -320,7 +320,7 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
 
     @Override
     public ResourceType getResourceType() {
-      return ResourceType.PER_CLASS;
+      return ResourceType.PER_INSTANCE;
     }
 
     @Override

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSink.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSink.java
@@ -17,6 +17,9 @@
 
 package org.apache.beam.sdk.extensions.smb;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.spotify.scio.transforms.DoFnWithResource;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.channels.Channels;
@@ -31,6 +34,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.DelegateCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.extensions.smb.BucketShardId.BucketShardIdCoder;
@@ -45,14 +49,16 @@ import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.fs.ResourceIdCoder;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
-import org.apache.beam.sdk.schemas.transforms.Group;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.Create.Values;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Sample;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.values.KV;
@@ -86,7 +92,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>{@link SortedBucketSink} re-uses existing {@link PTransform}s to map over each element,
  * extract a {@code byte[]} representation of its sorting key using {@link
- * BucketMetadata#getKeyBytes(Object)}, and assign it to an Integer bucket using {@link
+ * BucketMetadata#extractKey(Object)} (Object)}, and assign it to an Integer bucket using {@link
  * BucketMetadata#getBucketId(byte[])}. Next, a {@link GroupByKey} transform is applied to create a
  * {@link PCollection} of {@code N} elements, where {@code N} is the number of buckets specified by
  * {@link BucketMetadata#getNumBuckets()}, then a {@link SortValues} transform is used to sort
@@ -118,6 +124,7 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
   private final ResourceId tempDirectory;
   private final FileOperations<V> fileOperations;
   private final int sorterMemoryMb;
+  private final int keyCacheSize;
 
   public SortedBucketSink(
       BucketMetadata<K, V> bucketMetadata,
@@ -126,11 +133,30 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
       String filenameSuffix,
       FileOperations<V> fileOperations,
       int sorterMemoryMb) {
+    this(
+        bucketMetadata,
+        outputDirectory,
+        tempDirectory,
+        filenameSuffix,
+        fileOperations,
+        sorterMemoryMb,
+        0);
+  }
+
+  public SortedBucketSink(
+      BucketMetadata<K, V> bucketMetadata,
+      ResourceId outputDirectory,
+      ResourceId tempDirectory,
+      String filenameSuffix,
+      FileOperations<V> fileOperations,
+      int sorterMemoryMb,
+      int keyCacheSize) {
     this.bucketMetadata = bucketMetadata;
     this.filenamePolicy = new SMBFilenamePolicy(outputDirectory, filenameSuffix);
     this.tempDirectory = tempDirectory;
     this.fileOperations = fileOperations;
     this.sorterMemoryMb = sorterMemoryMb;
+    this.keyCacheSize = keyCacheSize;
   }
 
   @Override
@@ -139,9 +165,36 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
     Preconditions.checkArgument(
         input.isBounded() == IsBounded.BOUNDED,
         "SortedBucketSink cannot be applied to a non-bounded PCollection");
-    final Coder<V> valueCoder = input.getCoder();
-    return input
-        .apply("ExtractKeys", ParDo.of(new ExtractKeys<>(this.bucketMetadata, valueCoder)))
+    final Coder<V> inputCoder = input.getCoder();
+
+    final PCollection<KV<BucketShardId, KV<byte[], byte[]>>> bucketedInput =
+        input.apply(
+            "ExtractKeys",
+            ParDo.of(
+                ExtractKeys.of(
+                    bucketMetadata, bucketMetadata::extractKey, inputCoder, keyCacheSize)));
+
+    return sink(
+        bucketedInput,
+        getName(),
+        inputCoder,
+        sorterMemoryMb,
+        filenamePolicy,
+        fileOperations,
+        bucketMetadata,
+        tempDirectory);
+  }
+
+  public static <KeyT, ValueT> WriteResult sink(
+      PCollection<KV<BucketShardId, KV<byte[], byte[]>>> bucketedInput,
+      String transformName,
+      Coder<ValueT> valueCoder,
+      int sorterMemoryMb,
+      SMBFilenamePolicy filenamePolicy,
+      FileOperations<ValueT> fileOperations,
+      BucketMetadata<KeyT, ValueT> bucketMetadata,
+      ResourceId tempDirectory) {
+    return bucketedInput
         .setCoder(
             KvCoder.of(
                 BucketShardIdCoder.of(), KvCoder.of(ByteArrayCoder.of(), ByteArrayCoder.of())))
@@ -150,7 +203,7 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
             "SortValues",
             ParDo.of(
                 new SortBytesDoFn<>(
-                    getName(),
+                    transformName,
                     BufferedExternalSorter.options()
                         .withExternalSorterType(ExternalSorter.Options.SorterType.NATIVE)
                         .withMemoryMB(sorterMemoryMb))))
@@ -164,15 +217,31 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
   private static class ExtractKeys<K, V> extends DoFn<V, KV<BucketShardId, KV<byte[], byte[]>>> {
     // Substitute null keys in the output KV<byte[], V> so that they survive serialization
     private static final byte[] NULL_SORT_KEY = new byte[0];
+    private final SerializableFunction<V, K> extractKeyFn;
+    private final Coder<V> valueCoder;
+    private final BucketMetadata<K, ?> bucketMetadata;
+    private transient int shardId;
 
-    ExtractKeys(BucketMetadata<K, V> bucketMetadata, Coder<V> valueCoder) {
-      this.bucketMetadata = bucketMetadata;
-      this.valueCoder = valueCoder;
+    static <KeyT, ValueT> DoFn<ValueT, KV<BucketShardId, KV<byte[], byte[]>>> of(
+        BucketMetadata<KeyT, ?> bucketMetadata,
+        SerializableFunction<ValueT, KeyT> extractKeyFn,
+        Coder<ValueT> valueCoder,
+        int keyCacheSize) {
+      if (keyCacheSize == 0) {
+        return new ExtractKeys<>(bucketMetadata, extractKeyFn, valueCoder);
+      } else {
+        return new ExtractKeysWithCache<>(bucketMetadata, extractKeyFn, valueCoder, keyCacheSize);
+      }
     }
 
-    private final BucketMetadata<K, V> bucketMetadata;
-    private final Coder<V> valueCoder;
-    private transient int shardId;
+    private ExtractKeys(
+        BucketMetadata<K, ?> bucketMetadata,
+        SerializableFunction<V, K> extractKeyFn,
+        Coder<V> valueCoder) {
+      this.bucketMetadata = bucketMetadata;
+      this.extractKeyFn = extractKeyFn;
+      this.valueCoder = valueCoder;
+    }
 
     // From Combine.PerKeyWithHotKeyFanout.
     @StartBundle
@@ -186,29 +255,109 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
           ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE) % bucketMetadata.getNumShards();
     }
 
+    static <KeyT> KV<BucketShardId, byte[]> processKey(
+        KeyT key, BucketMetadata<KeyT, ?> metadata, int shardId) {
+      final byte[] keyBytes = metadata.encodeKeyBytes(key);
+
+      return (keyBytes != null)
+          ? KV.of(BucketShardId.of(metadata.getBucketId(keyBytes), shardId), keyBytes)
+          : KV.of(BucketShardId.ofNullKey(shardId), NULL_SORT_KEY);
+    }
+
+    static <ValueT> byte[] getValueBytes(Coder<ValueT> coder, ValueT value) {
+      try {
+        return CoderUtils.encodeToByteArray(coder, value);
+      } catch (CoderException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
     @ProcessElement
     public void processElement(ProcessContext c) {
       final V record = c.element();
-      final byte[] keyBytes = bucketMetadata.getKeyBytes(record);
+      final KV<BucketShardId, byte[]> bucketAndSortKey =
+          processKey(extractKeyFn.apply(record), bucketMetadata, shardId);
 
-      final BucketShardId bucketShardId =
-          keyBytes != null
-              ? BucketShardId.of(bucketMetadata.getBucketId(keyBytes), shardId)
-              : BucketShardId.ofNullKey(shardId);
-
-      final byte[] sortKey = keyBytes != null ? keyBytes : NULL_SORT_KEY;
-      try {
-        final byte[] valueBytes = CoderUtils.encodeToByteArray(valueCoder, record);
-        c.output(KV.of(bucketShardId, KV.of(sortKey, valueBytes)));
-      } catch (CoderException e) {
-        throw new RuntimeException("Caught coder exception: " + e);
-      }
+      c.output(
+          KV.of(
+              bucketAndSortKey.getKey(),
+              KV.of(bucketAndSortKey.getValue(), getValueBytes(valueCoder, record))));
     }
 
     @Override
     public void populateDisplayData(Builder builder) {
       super.populateDisplayData(builder);
       builder.delegate(bucketMetadata);
+    }
+  }
+
+  /** Extract bucket and shard id for grouping, and key bytes for sorting. */
+  private static class ExtractKeysWithCache<K, V>
+      extends DoFnWithResource<
+          V, KV<BucketShardId, KV<byte[], byte[]>>, Cache<K, KV<BucketShardId, byte[]>>> {
+    // Substitute null keys in the output KV<byte[], V> so that they survive serialization
+    private final SerializableFunction<V, K> extractKeyFn;
+    private final Coder<V> valueCoder;
+    private final BucketMetadata<K, ?> bucketMetadata;
+    private final int cacheSize;
+    private transient int shardId;
+    private Counter cacheHits;
+    private Counter cacheMisses;
+
+    ExtractKeysWithCache(
+        BucketMetadata<K, ?> bucketMetadata,
+        SerializableFunction<V, K> extractKeyFn,
+        Coder<V> valueCoder,
+        int cacheSize) {
+      this.bucketMetadata = bucketMetadata;
+      this.extractKeyFn = extractKeyFn;
+      this.valueCoder = valueCoder;
+      this.cacheSize = cacheSize;
+      cacheHits = Metrics.counter(SortedBucketSink.class, "cacheHits");
+      cacheMisses = Metrics.counter(SortedBucketSink.class, "cacheMisses");
+    }
+
+    @Override
+    public ResourceType getResourceType() {
+      return ResourceType.PER_CLASS;
+    }
+
+    @Override
+    public Cache<K, KV<BucketShardId, byte[]>> createResource() {
+      return Caffeine.newBuilder().maximumSize(cacheSize).build();
+    }
+
+    @StartBundle
+    public void startBundle() {
+      shardId =
+          ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE) % bucketMetadata.getNumShards();
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      final V record = c.element();
+      final K key = extractKeyFn.apply(record);
+
+      KV<BucketShardId, byte[]> bucketIdAndSortBytes = getResource().getIfPresent(key);
+      if (bucketIdAndSortBytes == null) {
+        bucketIdAndSortBytes = ExtractKeys.processKey(key, bucketMetadata, shardId);
+        cacheMisses.inc();
+        getResource().put(key, bucketIdAndSortBytes);
+      } else {
+        cacheHits.inc();
+      }
+      c.output(
+          KV.of(
+              bucketIdAndSortBytes.getKey(),
+              KV.of(
+                  bucketIdAndSortBytes.getValue(), ExtractKeys.getValueBytes(valueCoder, record))));
+    }
+
+    @Override
+    public void populateDisplayData(Builder builder) {
+      super.populateDisplayData(builder);
+      builder.delegate(bucketMetadata);
+      builder.add(DisplayData.item("keyCacheSize", cacheSize));
     }
   }
 
@@ -515,6 +664,100 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
       FileSystems.delete(files, MoveOptions.StandardMoveOptions.IGNORE_MISSING_FILES);
     } catch (IOException e) {
       cause.addSuppressed(e);
+    }
+  }
+
+  public static class SortedBucketPreKeyedSink<K, V>
+      extends PTransform<PCollection<KV<K, V>>, WriteResult> {
+
+    private final BucketMetadata<K, V> bucketMetadata;
+    private final SMBFilenamePolicy filenamePolicy;
+    private final ResourceId tempDirectory;
+    private final FileOperations<V> fileOperations;
+    private final int sorterMemoryMb;
+    private final int keyCacheSize;
+    private final Coder<V> valueCoder;
+
+    public SortedBucketPreKeyedSink(
+        BucketMetadata<K, V> bucketMetadata,
+        ResourceId outputDirectory,
+        ResourceId tempDirectory,
+        String filenameSuffix,
+        FileOperations<V> fileOperations,
+        int sorterMemoryMb,
+        Coder<V> valueCoder) {
+      this(
+          bucketMetadata,
+          outputDirectory,
+          tempDirectory,
+          filenameSuffix,
+          fileOperations,
+          sorterMemoryMb,
+          valueCoder,
+          0);
+    }
+
+    public SortedBucketPreKeyedSink(
+        BucketMetadata<K, V> bucketMetadata,
+        ResourceId outputDirectory,
+        ResourceId tempDirectory,
+        String filenameSuffix,
+        FileOperations<V> fileOperations,
+        int sorterMemoryMb,
+        Coder<V> valueCoder,
+        int keyCacheSize) {
+      this.bucketMetadata = bucketMetadata;
+      this.filenamePolicy = new SMBFilenamePolicy(outputDirectory, filenameSuffix);
+      this.tempDirectory = tempDirectory;
+      this.fileOperations = fileOperations;
+      this.sorterMemoryMb = sorterMemoryMb;
+      this.keyCacheSize = keyCacheSize;
+      this.valueCoder = valueCoder;
+    }
+
+    @Override
+    public final WriteResult expand(PCollection<KV<K, V>> input) {
+      // @Todo: should we allow windowed writes?
+      Preconditions.checkArgument(
+          input.isBounded() == IsBounded.BOUNDED,
+          "SortedBucketSink cannot be applied to a non-bounded PCollection");
+
+      final PCollection<KV<BucketShardId, KV<byte[], byte[]>>> bucketedInput =
+          input.apply(
+              "ExtractKeys",
+              ParDo.of(
+                  ExtractKeys.of(
+                      bucketMetadata,
+                      KV::getKey,
+                      DelegateCoder.of(valueCoder, KV::getValue, null),
+                      keyCacheSize)));
+
+      input
+          .apply("VerifySample", Sample.any(100))
+          .apply(
+              "VerifyKeyFn",
+              ParDo.of(
+                  new DoFn<KV<K, V>, Void>() {
+                    @ProcessElement
+                    public void processElement(ProcessContext c) {
+                      if (!bucketMetadata
+                          .extractKey(c.element().getValue())
+                          .equals(c.element().getKey())) {
+                        throw new RuntimeException(
+                            "BucketMetadata's extractKey fn did not match pre-keyed PCollection");
+                      }
+                    }
+                  }));
+
+      return SortedBucketSink.sink(
+          bucketedInput,
+          getName(),
+          valueCoder,
+          sorterMemoryMb,
+          filenamePolicy,
+          fileOperations,
+          bucketMetadata,
+          tempDirectory);
     }
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
@@ -62,6 +62,7 @@ public class TensorFlowBucketIO {
         .setSorterMemoryMb(SortedBucketIO.DEFAULT_SORTER_MEMORY_MB)
         .setKeyClass(keyClass)
         .setKeyField(keyField)
+        .setKeyCacheSize(0)
         .setFilenameSuffix(DEFAULT_SUFFIX)
         .setCompression(Compression.UNCOMPRESSED)
         .build();
@@ -168,6 +169,8 @@ public class TensorFlowBucketIO {
 
       abstract Builder<K> setCompression(Compression compression);
 
+      abstract Builder<K> setKeyCacheSize(int cacheSize);
+
       abstract Write<K> build();
     }
 
@@ -208,6 +211,11 @@ public class TensorFlowBucketIO {
     /** Specifies the sorter memory in MB. */
     public Write<K> withSorterMemoryMb(int sorterMemoryMb) {
       return toBuilder().setSorterMemoryMb(sorterMemoryMb).build();
+    }
+
+    /** Specifies the size of an optional key-to-hash cache in the ExtractKeys transform. */
+    public Write<K> withKeyCacheOfSize(int keyCacheSize) {
+      return toBuilder().setKeyCacheSize(keyCacheSize).build();
     }
 
     /** Specifies the output file {@link Compression}. */

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketSCollectionSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketSCollectionSyntax.scala
@@ -18,20 +18,25 @@
 package com.spotify.scio.smb.syntax
 
 import com.spotify.scio.annotations.experimental
+import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.io.{ClosedTap, EmptyTap}
 import com.spotify.scio.values._
-import org.apache.beam.sdk.extensions.smb.SortedBucketSink
+import org.apache.beam.sdk.extensions.smb.SortedBucketIO.PreKeyedWrite
+import org.apache.beam.sdk.extensions.smb.{SortedBucketIO, SortedBucketSink}
 import org.apache.beam.sdk.transforms.PTransform
-import org.apache.beam.sdk.values.PCollection
+import org.apache.beam.sdk.values.{KV, PCollection}
 
 trait SortMergeBucketSCollectionSyntax {
+  implicit def toSortMergeBucketKeyedSCollection[K, V: Coder](
+    data: SCollection[KV[K, V]]
+  ): SortedBucketPairSCollection[K, V] = new SortedBucketPairSCollection(data)
+
   implicit def toSortMergeBucketSCollection[T](
     data: SCollection[T]
   ): SortedBucketSCollection[T] = new SortedBucketSCollection(data)
 }
 
 final class SortedBucketSCollection[T](private val self: SCollection[T]) {
-  type Write = PTransform[PCollection[T], SortedBucketSink.WriteResult]
 
   /**
    * Save an `SCollection[T]` to a filesystem, where each file represents a bucket
@@ -43,8 +48,29 @@ final class SortedBucketSCollection[T](private val self: SCollection[T]) {
    *              data. It contains information about key function, bucket and shard size, etc.
    */
   @experimental
-  def saveAsSortedBucket(write: Write): ClosedTap[Nothing] = {
+  def saveAsSortedBucket(write: SortedBucketIO.Write[_, T]): ClosedTap[Nothing] = {
     self.applyInternal(write)
+
+    // @Todo: Implement taps for metadata/bucket elements
+    ClosedTap[Nothing](EmptyTap)
+  }
+}
+
+final class SortedBucketPairSCollection[K, V: Coder](private val self: SCollection[KV[K, V]]) {
+
+  /**
+   * Save an `SCollection[(K, V)]` to a filesystem, where each file represents a bucket
+   * whose records are lexicographically sorted by some key specified in the
+   * [[org.apache.beam.sdk.extensions.smb.BucketMetadata]] corresponding to the provided
+   * [[SortedBucketSink]] transform and to the key K of each KV pair in the `SCollection`.
+   *
+   * @param write the [[PTransform]] that applies a [[SortedBucketSink]] transform to the input
+   *              data. It contains information about key function, bucket and shard size, etc.
+   */
+  @experimental
+  def saveAsPreKeyedSortedBucket(write: SortedBucketIO.Write[K, V]): ClosedTap[Nothing] = {
+    val vCoder = CoderMaterializer.beam(self.context, Coder[V])
+    self.applyInternal(write.onKeyedCollection(vCoder))
 
     // @Todo: Implement taps for metadata/bucket elements
     ClosedTap[Nothing](EmptyTap)

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSinkTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSinkTest.java
@@ -24,6 +24,9 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.nio.channels.Channels;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,6 +38,7 @@ import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.extensions.smb.SMBFilenamePolicy.FileAssignment;
+import org.apache.beam.sdk.extensions.smb.SortedBucketSink.SortedBucketPreKeyedSink;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSink.WriteResult;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.FileIO.Sink;
@@ -51,8 +55,6 @@ import org.apache.beam.sdk.util.MimeTypes;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TupleTag;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.CharStreams;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -82,96 +84,43 @@ public class SortedBucketSinkTest {
   @Test
   @Category(NeedsRunner.class)
   public void testOneBucketOneShard() throws Exception {
-    test(
-        1,
-        1,
-        m -> {
-          Assert.assertEquals(1, m.size());
-          BucketShardId id = BucketShardId.of(0, 0);
-          List<String> actual = m.get(id);
-          MatcherAssert.assertThat(actual, Matchers.containsInAnyOrder(input));
-        });
+    test(1, 1, false);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testOneBucketOneShardWithKeyCache() throws Exception {
+    test(1, 1, true);
   }
 
   @Test
   @Category(NeedsRunner.class)
   public void testMultiBucketOneShard() throws Exception {
-    test(
-        2,
-        1,
-        m -> {
-          Assert.assertEquals(2, m.size());
-          BucketShardId id1 = BucketShardId.of(0, 0);
-          BucketShardId id2 = BucketShardId.of(1, 0);
-          List<String> actual1 = m.get(id1);
-          List<String> actual2 = m.get(id2);
-          MatcherAssert.assertThat(
-              Iterables.concat(actual1, actual2), Matchers.containsInAnyOrder(input));
-
-          // Keys in each bucket do not overlap
-          Set<String> key1 = getKeys(actual1);
-          Set<String> key2 = getKeys(actual2);
-          Assert.assertTrue(Sets.intersection(key1, key2).isEmpty());
-        });
+    test(2, 1, false);
   }
 
   @Test
   @Category(NeedsRunner.class)
   public void testOneBucketMultiShard() throws Exception {
-    test(
-        1,
-        2,
-        m -> {
-          Assert.assertEquals(2, m.size());
-          BucketShardId id1 = BucketShardId.of(0, 0);
-          BucketShardId id2 = BucketShardId.of(0, 1);
-          List<String> actual1 = m.get(id1);
-          List<String> actual2 = m.get(id2);
-          MatcherAssert.assertThat(
-              Iterables.concat(actual1, actual2), Matchers.containsInAnyOrder(input));
-
-          // Keys in each shard can overlap
-          Set<String> key1 = getKeys(actual1);
-          Set<String> key2 = getKeys(actual2);
-          Assert.assertFalse(Sets.intersection(key1, key2).isEmpty());
-        });
+    test(1, 2, false);
   }
 
   @Test
   @Category(NeedsRunner.class)
   public void testMultiBucketMultiShard() throws Exception {
-    test(
-        2,
-        2,
-        m -> {
-          Assert.assertEquals(4, m.size());
-          BucketShardId id1a = BucketShardId.of(0, 0);
-          BucketShardId id1b = BucketShardId.of(0, 1);
-          BucketShardId id2a = BucketShardId.of(1, 0);
-          BucketShardId id2b = BucketShardId.of(1, 1);
-          List<String> actual1a = m.get(id1a);
-          List<String> actual1b = m.get(id1b);
-          List<String> actual2a = m.get(id2a);
-          List<String> actual2b = m.get(id2b);
-          MatcherAssert.assertThat(
-              Iterables.concat(actual1a, actual1b, actual2a, actual2b),
-              Matchers.containsInAnyOrder(input));
+    test(2, 2, false);
+  }
 
-          Set<String> key1a = getKeys(actual1a);
-          Set<String> key1b = getKeys(actual1b);
-          Set<String> key2a = getKeys(actual2a);
-          Set<String> key2b = getKeys(actual2b);
+  @Test
+  @Category(NeedsRunner.class)
+  public void testOneBucketOneShardKeyedPCollectionWithKeyCache() throws Exception {
+    testKeyedCollection(1, 1, true);
+  }
 
-          // Keys in each bucket do not overlap
-          Assert.assertTrue(Sets.intersection(key1a, key2a).isEmpty());
-          Assert.assertTrue(Sets.intersection(key1a, key2b).isEmpty());
-          Assert.assertTrue(Sets.intersection(key1b, key2a).isEmpty());
-          Assert.assertTrue(Sets.intersection(key1b, key2b).isEmpty());
-
-          // Keys in each shard can overlap
-          Assert.assertFalse(Sets.intersection(key1a, key1b).isEmpty());
-          Assert.assertFalse(Sets.intersection(key2a, key2b).isEmpty());
-        });
+  @Test
+  @Category(NeedsRunner.class)
+  public void testMultiBucketMultiShardKeyedPCollection() throws Exception {
+    testKeyedCollection(2, 2, false);
   }
 
   @Test
@@ -229,24 +178,71 @@ public class SortedBucketSinkTest {
     Assert.assertEquals(0, output.getRoot().listFiles().length);
   }
 
-  private void test(
-      int numBuckets, int numShards, SerializableConsumer<Map<BucketShardId, List<String>>> checkFn)
-      throws Exception {
+  private void test(int numBuckets, int numShards, boolean useKeyCache) throws Exception {
     final TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
-
+    final int keyCacheSize = useKeyCache ? 100 : 0;
     final SortedBucketSink<String, String> sink =
         new SortedBucketSink<>(
-            metadata, fromFolder(output), fromFolder(temp), ".txt", new TestFileOperations(), 1);
+            metadata,
+            fromFolder(output),
+            fromFolder(temp),
+            ".txt",
+            new TestFileOperations(),
+            1,
+            keyCacheSize);
 
     @SuppressWarnings("deprecation")
     final Reshuffle.ViaRandomKey<String> reshuffle = Reshuffle.viaRandomKey();
 
-    final WriteResult writeResult =
+    check(
         pipeline
             .apply(Create.of(Stream.of(input).collect(Collectors.toList())))
             .apply(reshuffle)
-            .apply(sink);
+            .apply(sink),
+        metadata,
+        assertValidSmbFormat(metadata));
 
+    pipeline.run();
+  }
+
+  private void testKeyedCollection(int numBuckets, int numShards, boolean useKeyCache)
+      throws Exception {
+    final TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
+    final int keyCacheSize = useKeyCache ? 100 : 0;
+
+    final SortedBucketPreKeyedSink<String, String> sink =
+        new SortedBucketPreKeyedSink<>(
+            metadata,
+            fromFolder(output),
+            fromFolder(temp),
+            ".txt",
+            new TestFileOperations(),
+            1,
+            StringUtf8Coder.of(),
+            keyCacheSize);
+
+    @SuppressWarnings("deprecation")
+    final Reshuffle.ViaRandomKey<KV<String, String>> reshuffle = Reshuffle.viaRandomKey();
+
+    check(
+        pipeline
+            .apply(
+                Create.of(
+                    Stream.of(input)
+                        .map(s -> KV.of(metadata.extractKey(s), s))
+                        .collect(Collectors.toList())))
+            .apply(reshuffle)
+            .apply(sink),
+        metadata,
+        assertValidSmbFormat(metadata));
+
+    pipeline.run();
+  }
+
+  private static void check(
+      WriteResult writeResult,
+      TestBucketMetadata metadata,
+      Consumer<Map<BucketShardId, List<String>>> checkFn) {
     @SuppressWarnings("unchecked")
     final PCollection<ResourceId> writtenMetadata =
         (PCollection<ResourceId>) writeResult.expand().get(new TupleTag<>("WrittenMetadata"));
@@ -265,15 +261,13 @@ public class SortedBucketSinkTest {
 
     PAssert.thatMap(writtenFiles)
         .satisfies(
-            m -> {
+            (m) -> {
               final Map<BucketShardId, List<String>> data =
                   m.entrySet().stream()
                       .collect(Collectors.toMap(Map.Entry::getKey, e -> readFile(e.getValue())));
               checkFn.accept(data);
               return null;
             });
-
-    pipeline.run();
   }
 
   private static BucketMetadata<String, String> readMetadata(ResourceId file) {
@@ -294,12 +288,6 @@ public class SortedBucketSinkTest {
     }
   }
 
-  private static Set<String> getKeys(List<String> content) {
-    return content.stream().map(s -> s.substring(0, 1)).collect(Collectors.toSet());
-  }
-
-  private interface SerializableConsumer<T> extends Consumer<T>, Serializable {}
-
   static class ExceptionThrowingFileOperations extends FileOperations<String> {
     ExceptionThrowingFileOperations() {
       super(Compression.UNCOMPRESSED, MimeTypes.TEXT);
@@ -319,5 +307,63 @@ public class SortedBucketSinkTest {
     public Coder<String> getCoder() {
       return StringUtf8Coder.of();
     }
+  }
+
+  private interface SerializableConsumer<T> extends Consumer<T>, Serializable {}
+
+  private SerializableConsumer<Map<BucketShardId, List<String>>> assertValidSmbFormat(
+      TestBucketMetadata metadata) {
+    return writtenBuckets -> {
+      final Map<String, Integer> keysToBuckets = new HashMap<>();
+      final List<String> seenItems = new ArrayList<>();
+
+      writtenBuckets.forEach(
+          (bucketShardId, writtenRecords) -> {
+            String prevKey = null;
+            final Integer bucketId = bucketShardId.getBucketId();
+            for (String record : writtenRecords) {
+              seenItems.add(record);
+
+              if (prevKey == null) {
+                prevKey = metadata.extractKey(record);
+                keysToBuckets.put(prevKey, bucketId);
+                continue;
+              }
+
+              final String currKey = metadata.extractKey(record);
+              Assert.assertEquals(
+                  "Record " + record + " was not written to correct bucket",
+                  bucketShardId.getBucketId(),
+                  metadata.getBucketId(metadata.getKeyBytes(record)));
+
+              Assert.assertTrue(
+                  "Keys in " + bucketShardId + " are not in sorted order.",
+                  prevKey.compareTo(currKey) <= 0);
+
+              final Integer existingKeyBucket = keysToBuckets.get(currKey);
+              Assert.assertTrue(
+                  "Key in " + bucketShardId + " overlaps with bucket " + existingKeyBucket,
+                  existingKeyBucket == null || existingKeyBucket.equals(bucketId));
+
+              keysToBuckets.put(currKey, bucketId);
+            }
+          });
+
+      MatcherAssert.assertThat(
+          "Written items do not match PCollection input",
+          seenItems,
+          Matchers.containsInAnyOrder(input));
+
+      final Set<BucketShardId> allBucketShardIds = new HashSet<>();
+      for (int bucketId = 0; bucketId < metadata.getNumBuckets(); bucketId++) {
+        for (int shardId = 0; shardId < metadata.getNumShards(); shardId++) {
+          allBucketShardIds.add(BucketShardId.of(bucketId, shardId));
+        }
+      }
+      Assert.assertEquals(
+          "Written bucketShardIds did not match metadata",
+          allBucketShardIds,
+          writtenBuckets.keySet());
+    };
   }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSinkTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSinkTest.java
@@ -219,6 +219,7 @@ public class SortedBucketSinkTest {
             new TestFileOperations(),
             1,
             StringUtf8Coder.of(),
+            true,
             keyCacheSize);
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
adds some opt-in features that may benefit certain pipelines -- both are pretty small/targeted improvements, but do work for specific pipeline cases

1) key cache -- if the SCollection is expected to contain many repeating keys, the user can configure a cache of configurable size mapping `K key --> (byte[], bucketId)`.
2) SMB write on pre-keyed collection. If key extraction is expensive/requires type conversion, and the user's pipeline already has a `map` operation before the SMB sink operation where the key is materialized, they can just modify the `map` operation to emit a `KV` tuple of (key, record):

```scala
// before
data.map(id => MyAvroRecord.newBuilder().setId(id).build()).saveAsSortedBucket(...)

// after
data.map(id => (id, MyAvroRecord.newBuilder().setId(id).build())).saveAsPreKeyedSortedBucket(...)
```