### PR TITLE
refactor SortedBucketTransform into a BoundedSource + reuse merge logic

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
@@ -163,7 +163,8 @@ object SortMergeBucketTransformExample {
         .from(args("lhsInput")),
       AvroSortedBucketIO
         .read(new TupleTag[Account]("rhs"), classOf[Account])
-        .from(args("rhsInput"))
+        .from(args("rhsInput")),
+      TargetParallelism.auto()
     ).to(
       AvroSortedBucketIO
         .transformOutput(classOf[Integer], "userId", classOf[Account])

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
@@ -166,11 +166,8 @@ object SortMergeBucketTransformExample {
         .from(args("rhsInput"))
     ).to(
       AvroSortedBucketIO
-        .write(classOf[Integer], "userId", classOf[Account])
+        .transformOutput(classOf[Integer], "userId", classOf[Account])
         .to(args("output"))
-        .withNumBuckets(2)
-        .withNumShards(1)
-        .withHashType(HashType.MURMUR3_32)
     ).via {
       case (key, (users, accounts), outputCollector) =>
         users.foreach { user =>

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
+import org.apache.beam.sdk.extensions.smb.SortedBucketTransform.NewBucketMetadataFn;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.values.TupleTag;
@@ -87,6 +88,30 @@ public class AvroSortedBucketIO {
         .setKeyField(keyField)
         .setFilenameSuffix(DEFAULT_SUFFIX)
         .setCodec(DEFAULT_CODEC);
+  }
+
+  /** Returns a new {@link TransformOutput} for Avro generic records. */
+  public static <K> TransformOutput<K, org.apache.avro.generic.GenericRecord> transformOutput(
+      Class<K> keyClass, String keyField, Schema schema) {
+    return new AutoValue_AvroSortedBucketIO_TransformOutput.Builder<K, GenericRecord>()
+        .setFilenameSuffix(DEFAULT_SUFFIX)
+        .setCodec(DEFAULT_CODEC)
+        .setKeyField(keyField)
+        .setKeyClass(keyClass)
+        .setSchema(schema)
+        .build();
+  }
+
+  /** Returns a new {@link TransformOutput} for Avro specific records. */
+  public static <K, T extends SpecificRecordBase> TransformOutput<K, T> transformOutput(
+      Class<K> keyClass, String keyField, Class<T> recordClass) {
+    return new AutoValue_AvroSortedBucketIO_TransformOutput.Builder<K, T>()
+        .setFilenameSuffix(DEFAULT_SUFFIX)
+        .setCodec(DEFAULT_CODEC)
+        .setKeyField(keyField)
+        .setKeyClass(keyClass)
+        .setRecordClass(recordClass)
+        .build();
   }
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -282,6 +307,93 @@ public class AvroSortedBucketIO {
     /** Specifies the output file {@link CodecFactory}. */
     public Write<K, T> withCodec(CodecFactory codec) {
       return toBuilder().setCodec(codec).build();
+    }
+  }
+
+  /** Writes to Avro sorted-bucket files using {@link SortedBucketTransform}. */
+  @AutoValue
+  public abstract static class TransformOutput<K, T extends GenericRecord>
+      extends SortedBucketIO.TransformOutput<K, T> {
+    @Nullable
+    abstract String getKeyField();
+
+    @Nullable
+    abstract Schema getSchema();
+
+    @Nullable
+    abstract Class<T> getRecordClass();
+
+    abstract CodecFactory getCodec();
+
+    abstract Builder<K, T> toBuilder();
+
+    @AutoValue.Builder
+    abstract static class Builder<K, T extends GenericRecord> {
+      abstract Builder<K, T> setKeyClass(Class<K> keyClass);
+
+      abstract Builder<K, T> setOutputDirectory(ResourceId outputDirectory);
+
+      abstract Builder<K, T> setTempDirectory(ResourceId tempDirectory);
+
+      abstract Builder<K, T> setFilenameSuffix(String filenameSuffix);
+
+      // Avro specific
+      abstract Builder<K, T> setKeyField(String keyField);
+
+      abstract Builder<K, T> setSchema(Schema schema);
+
+      abstract Builder<K, T> setRecordClass(Class<T> recordClass);
+
+      abstract Builder<K, T> setCodec(CodecFactory codec);
+
+      abstract TransformOutput<K, T> build();
+    }
+
+    /** Writes to the given output directory. */
+    public TransformOutput<K, T> to(String outputDirectory) {
+      return toBuilder()
+          .setOutputDirectory(FileSystems.matchNewResource(outputDirectory, true))
+          .build();
+    }
+
+    /** Specifies the temporary directory for writing. */
+    public TransformOutput<K, T> withTempDirectory(String tempDirectory) {
+      return toBuilder()
+          .setTempDirectory(FileSystems.matchNewResource(tempDirectory, true))
+          .build();
+    }
+
+    /** Specifies the output filename suffix. */
+    public TransformOutput<K, T> withSuffix(String filenameSuffix) {
+      return toBuilder().setFilenameSuffix(filenameSuffix).build();
+    }
+
+    /** Specifies the output file {@link CodecFactory}. */
+    public TransformOutput<K, T> withCodec(CodecFactory codec) {
+      return toBuilder().setCodec(codec).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    FileOperations<T> getFileOperations() {
+      return getRecordClass() == null
+          ? AvroFileOperations.of(getSchema(), getCodec())
+          : (AvroFileOperations<T>)
+              AvroFileOperations.of((Class<SpecificRecordBase>) getRecordClass(), getCodec());
+    }
+
+    @Override
+    NewBucketMetadataFn<K, T> getNewBucketMetadataFn() {
+      final String keyField = getKeyField();
+      final Class<K> keyClass = getKeyClass();
+
+      return (numBuckets, numShards, hashType) -> {
+        try {
+          return new AvroBucketMetadata<>(numBuckets, numShards, keyClass, hashType, keyField);
+        } catch (CannotProvideCoderException | Coder.NonDeterministicException e) {
+          throw new IllegalStateException(e);
+        }
+      };
     }
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -29,7 +29,6 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
-import java.util.function.Function;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -203,9 +202,8 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
     return Math.abs(hashFunction.hashBytes(keyBytes).asInt()) % numBuckets;
   }
 
-  Function<byte[], Boolean> checkRehashedBucketFn(int newNumBuckets, int currentBucket) {
-    return (keyBytes) ->
-        Math.abs(hashFunction.hashBytes(keyBytes).asInt()) % newNumBuckets == currentBucket;
+  int rehashBucket(byte[] keyBytes, int newNumBuckets) {
+    return Math.abs(hashFunction.hashBytes(keyBytes).asInt()) % newNumBuckets;
   }
 
   ////////////////////////////////////////

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -27,9 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import org.apache.beam.sdk.coders.AtomicCoder;
@@ -175,16 +173,6 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
 
   public HashType getHashType() {
     return hashType;
-  }
-
-  public List<BucketShardId> allBucketShardIds() {
-    List<BucketShardId> allBucketShardIds = new ArrayList<>();
-    for (int i = 0; i < getNumBuckets(); i++) {
-      for (int j = 0; j < getNumShards(); j++) {
-        allBucketShardIds.add(BucketShardId.of(i, j));
-      }
-    }
-    return allBucketShardIds;
   }
 
   /* Business logic */

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -27,7 +27,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import org.apache.beam.sdk.coders.AtomicCoder;
@@ -173,6 +175,16 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
 
   public HashType getHashType() {
     return hashType;
+  }
+
+  public List<BucketShardId> allBucketShardIds() {
+    List<BucketShardId> allBucketShardIds = new ArrayList<>();
+    for (int i = 0; i < getNumBuckets(); i++) {
+      for (int j = 0; j < getNumShards(); j++) {
+        allBucketShardIds.add(BucketShardId.of(i, j));
+      }
+    }
+    return allBucketShardIds;
   }
 
   /* Business logic */

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketShardId.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketShardId.java
@@ -21,6 +21,7 @@ import com.google.auto.value.AutoValue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Serializable;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.VarIntCoder;
@@ -35,7 +36,7 @@ import org.apache.beam.sdk.coders.VarIntCoder;
  * special-case this bucket ID.
  */
 @AutoValue
-public abstract class BucketShardId {
+public abstract class BucketShardId implements Serializable {
 
   private static final int NULL_KEYS_BUCKET_ID = -1;
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketShardId.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketShardId.java
@@ -21,7 +21,6 @@ import com.google.auto.value.AutoValue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.Serializable;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.VarIntCoder;
@@ -36,7 +35,7 @@ import org.apache.beam.sdk.coders.VarIntCoder;
  * special-case this bucket ID.
  */
 @AutoValue
-public abstract class BucketShardId implements Serializable {
+public abstract class BucketShardId {
 
   private static final int NULL_KEYS_BUCKET_ID = -1;
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
+import org.apache.beam.sdk.extensions.smb.SortedBucketTransform.NewBucketMetadataFn;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
@@ -52,6 +53,17 @@ public class JsonSortedBucketIO {
         .setNumShards(SortedBucketIO.DEFAULT_NUM_SHARDS)
         .setHashType(SortedBucketIO.DEFAULT_HASH_TYPE)
         .setSorterMemoryMb(SortedBucketIO.DEFAULT_SORTER_MEMORY_MB)
+        .setKeyClass(keyClass)
+        .setKeyField(keyField)
+        .setFilenameSuffix(DEFAULT_SUFFIX)
+        .setCompression(Compression.UNCOMPRESSED)
+        .build();
+  }
+
+  /** Returns a new {@link TransformOutput} for Avro generic records. */
+  public static <K> TransformOutput<K> transformOutput(Class<K> keyClass, String keyField) {
+    return new AutoValue_JsonSortedBucketIO_TransformOutput.Builder<K>()
+        .setFilenameSuffix(DEFAULT_SUFFIX)
         .setKeyClass(keyClass)
         .setKeyField(keyField)
         .setFilenameSuffix(DEFAULT_SUFFIX)
@@ -216,6 +228,86 @@ public class JsonSortedBucketIO {
       } catch (CannotProvideCoderException | Coder.NonDeterministicException e) {
         throw new IllegalStateException(e);
       }
+    }
+  }
+
+  /**
+   * Writes to BigQuery {@link TableRow} JSON sorted-bucket files using {@link
+   * SortedBucketTransform}.
+   */
+  @AutoValue
+  public abstract static class TransformOutput<K>
+      extends SortedBucketIO.TransformOutput<K, TableRow> {
+
+    // JSON specific
+    @Nullable
+    abstract String getKeyField();
+
+    abstract Compression getCompression();
+
+    abstract Builder<K> toBuilder();
+
+    @AutoValue.Builder
+    abstract static class Builder<K> {
+
+      // Common
+      abstract Builder<K> setKeyClass(Class<K> keyClass);
+
+      abstract Builder<K> setOutputDirectory(ResourceId outputDirectory);
+
+      abstract Builder<K> setTempDirectory(ResourceId tempDirectory);
+
+      abstract Builder<K> setFilenameSuffix(String filenameSuffix);
+
+      // JSON specific
+      abstract Builder<K> setKeyField(String keyField);
+
+      abstract Builder<K> setCompression(Compression compression);
+
+      abstract TransformOutput<K> build();
+    }
+
+    /** Writes to the given output directory. */
+    public TransformOutput<K> to(String outputDirectory) {
+      return toBuilder()
+          .setOutputDirectory(FileSystems.matchNewResource(outputDirectory, true))
+          .build();
+    }
+
+    /** Specifies the temporary directory for writing. */
+    public TransformOutput<K> withTempDirectory(String tempDirectory) {
+      return toBuilder()
+          .setTempDirectory(FileSystems.matchNewResource(tempDirectory, true))
+          .build();
+    }
+
+    /** Specifies the output filename suffix. */
+    public TransformOutput<K> withSuffix(String filenameSuffix) {
+      return toBuilder().setFilenameSuffix(filenameSuffix).build();
+    }
+
+    /** Specifies the output file {@link Compression}. */
+    public TransformOutput<K> withCompression(Compression compression) {
+      return toBuilder().setCompression(compression).build();
+    }
+
+    @Override
+    FileOperations<TableRow> getFileOperations() {
+      return JsonFileOperations.of(getCompression());
+    }
+
+    @Override
+    NewBucketMetadataFn<K, TableRow> getNewBucketMetadataFn() {
+      final String keyField = getKeyField();
+      final Class<K> keyClass = getKeyClass();
+
+      return (numBuckets, numShards, hashType) -> {
+        try {
+          return new JsonBucketMetadata<>(numBuckets, numShards, keyClass, hashType, keyField);
+        } catch (CannotProvideCoderException | Coder.NonDeterministicException e) {
+          throw new IllegalStateException(e);
+        }
+      };
     }
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -159,13 +159,14 @@ public class SortedBucketIO {
       return input.apply(
           new SortedBucketTransform<>(
               keyClass,
-              write.getBucketMetadata(),
+              TargetParallelism.auto(),
               outputDirectory,
               tempDirectory,
               write.getFilenameSuffix(),
               write.getFileOperations(),
               bucketedInputs,
-              toFinalResultT));
+              toFinalResultT,
+              ((numBuckets, numShards) -> write.getBucketMetadata())));
     }
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -17,47 +17,45 @@
 
 package org.apache.beam.sdk.extensions.smb;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.coders.VarIntCoder;
-import org.apache.beam.sdk.extensions.smb.BucketShardId.BucketShardIdCoder;
+import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
+import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.extensions.smb.FileOperations.Writer;
 import org.apache.beam.sdk.extensions.smb.SMBFilenamePolicy.FileAssignment;
+import org.apache.beam.sdk.extensions.smb.SortedBucketSink.RenameBuckets;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSink.WriteResult;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
+import org.apache.beam.sdk.extensions.smb.SortedBucketSource.MergeBucketsReader;
+import org.apache.beam.sdk.io.BoundedSource;
+import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.io.fs.ResourceId;
-import org.apache.beam.sdk.io.fs.ResourceIdCoder;
-import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Metrics;
-import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.schemas.transforms.Group;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.Reshuffle;
-import org.apache.beam.sdk.transforms.display.DisplayData;
-import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
-import org.apache.beam.sdk.transforms.join.CoGbkResultSchema;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.UnsignedBytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link PTransform} that encapsulates both a {@link SortedBucketSource} and {@link
@@ -69,76 +67,52 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Unsig
  * @param <FinalValueT>
  */
 public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PBegin, WriteResult> {
-  private final SMBFilenamePolicy filenamePolicy;
-  private final ResourceId tempDirectory;
-  private final FileOperations<FinalValueT> fileOperations;
-  private final Class<FinalKeyT> finalKeyClass;
-  private final List<BucketedInput<?, ?>> sources;
-  private final BucketMetadata<FinalKeyT, FinalValueT> bucketMetadata;
-  private final TransformFn<FinalKeyT, FinalValueT> transformFn;
+  private final MergeAndWriteBucketsSource<FinalKeyT, FinalValueT> boundedSource;
+  private final FinalizeTransformedBuckets<FinalValueT> finalizeBuckets;
 
   public SortedBucketTransform(
       Class<FinalKeyT> finalKeyClass,
-      BucketMetadata<FinalKeyT, FinalValueT> bucketMetadata,
+      TargetParallelism targetParallelism,
       ResourceId outputDirectory,
       ResourceId tempDirectory,
       String filenameSuffix,
       FileOperations<FinalValueT> fileOperations,
       List<BucketedInput<?, ?>> sources,
-      TransformFn<FinalKeyT, FinalValueT> transformFn) {
-    this.filenamePolicy = new SMBFilenamePolicy(outputDirectory, filenameSuffix);
-    this.tempDirectory = tempDirectory;
-    this.fileOperations = fileOperations;
-    this.finalKeyClass = finalKeyClass;
-    this.sources = sources;
-    this.transformFn = transformFn;
-    this.bucketMetadata = bucketMetadata;
+      TransformFn<FinalKeyT, FinalValueT> transformFn,
+      NewBucketMetadataFn<FinalKeyT, FinalValueT> newBucketMetadataFn) {
+    final SMBFilenamePolicy filenamePolicy = new SMBFilenamePolicy(outputDirectory, filenameSuffix);
+    this.boundedSource =
+        new MergeAndWriteBucketsSource<>(
+            finalKeyClass,
+            sources,
+            targetParallelism,
+            1,
+            0,
+            SourceSpec.from(finalKeyClass, sources),
+            Metrics.distribution(getName(), getName() + "-KeyGroupSize"),
+            -1,
+            filenamePolicy.forTempFiles(tempDirectory),
+            fileOperations,
+            transformFn);
+
+    this.finalizeBuckets =
+        new FinalizeTransformedBuckets<>(
+            fileOperations, newBucketMetadataFn, filenamePolicy.forDestination());
   }
 
   @Override
   public final WriteResult expand(PBegin begin) {
-    Preconditions.checkArgument(
-        bucketMetadata.getNumShards() == 1,
-        "Sharding is not supported in SortedBucketTransform. numShards must == 1.");
-
-    final SourceSpec<FinalKeyT> sourceSpec = SourceSpec.from(finalKeyClass, sources);
-
-    Preconditions.checkArgument(
-        bucketMetadata.getNumBuckets() >= sourceSpec.leastNumBuckets,
-        "numBuckets in BucketMetadata must be >= leastNumBuckets among sources: "
-            + sourceSpec.leastNumBuckets);
-
-    final FileAssignment tempFileAssignment = filenamePolicy.forTempFiles(tempDirectory);
-
-    final Create.Values<Integer> createBuckets =
-        Create.of(
-                IntStream.range(0, sourceSpec.leastNumBuckets).boxed().collect(Collectors.toList()))
-            .withCoder(VarIntCoder.of());
-
-    @SuppressWarnings("deprecation")
-    final Reshuffle.ViaRandomKey<Integer> reshuffle = Reshuffle.viaRandomKey();
-
     return WriteResult.fromTuple(
         begin
             .getPipeline()
-            .apply("CreateBuckets", createBuckets)
-            .apply("ReshuffleKeys", reshuffle)
-            .apply(
-                "MergeTransformWrite",
-                ParDo.of(
-                    new MergeAndWriteBuckets<>(
-                        this.getName(),
-                        sources,
-                        sourceSpec,
-                        tempFileAssignment,
-                        fileOperations,
-                        bucketMetadata,
-                        transformFn)))
-            .setCoder(KvCoder.of(BucketShardIdCoder.of(), ResourceIdCoder.of()))
+            .apply("MergeAndWriteTempBuckets", Read.from(boundedSource))
+            .apply(Group.globally())
             .apply(
                 "FinalizeTempFiles",
-                new SortedBucketSink.RenameBuckets<>(
-                    filenamePolicy.forDestination(), bucketMetadata, fileOperations)));
+                ParDo.of(finalizeBuckets)
+                    .withOutputTags(
+                        FinalizeTransformedBuckets.BUCKETS_TAG,
+                        TupleTagList.of(FinalizeTransformedBuckets.METADATA_TAG))));
   }
 
   @FunctionalInterface
@@ -149,13 +123,62 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
 
   public interface SerializableConsumer<ValueT> extends Consumer<ValueT>, Serializable {}
 
+  public interface NewBucketMetadataFn<K, V> extends Serializable {
+    public BucketMetadata<K, V> createMetadata(int numBuckets, int numShards)
+        throws CannotProvideCoderException, NonDeterministicException;
+  }
+
+  private static class FinalizeTransformedBuckets<FinalValueT>
+      extends DoFn<Iterable<MergedBucket>, KV<BucketShardId, ResourceId>> {
+    private final FileOperations<FinalValueT> fileOperations;
+    private final NewBucketMetadataFn<?, ?> newBucketMetadataFn;
+    private final FileAssignment dstFileAssignment;
+
+    static final TupleTag<KV<BucketShardId, ResourceId>> BUCKETS_TAG =
+        new TupleTag<>("writtenBuckets");
+    static final TupleTag<ResourceId> METADATA_TAG = new TupleTag<>("writtenMetadata");
+
+    public FinalizeTransformedBuckets(
+        FileOperations<FinalValueT> fileOperations,
+        NewBucketMetadataFn<?, ?> newBucketMetadataFn,
+        FileAssignment dstFileAssignment) {
+      this.fileOperations = fileOperations;
+      this.newBucketMetadataFn = newBucketMetadataFn;
+      this.dstFileAssignment = dstFileAssignment;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      final Iterator<MergedBucket> mergedBuckets = c.element().iterator();
+      final Map<BucketShardId, ResourceId> writtenBuckets = new HashMap<>();
+
+      BucketMetadata<?, ?> bucketMetadata = null;
+      while (mergedBuckets.hasNext()) {
+        final MergedBucket bucket = mergedBuckets.next();
+        if (bucketMetadata == null) {
+          try {
+            bucketMetadata = newBucketMetadataFn.createMetadata(bucket.totalNumBuckets, 1);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        }
+        writtenBuckets.put(bucket.bucketShardId, bucket.destination);
+      }
+      RenameBuckets.moveFiles(
+          bucketMetadata,
+          writtenBuckets,
+          dstFileAssignment,
+          fileOperations,
+          bucketDst -> c.output(BUCKETS_TAG, bucketDst),
+          metadataDst -> c.output(METADATA_TAG, metadataDst));
+    }
+  }
+
   private static class OutputCollector<ValueT> implements SerializableConsumer<ValueT> {
     private final Writer<ValueT> writer;
-    private final Counter elementsWritten;
 
-    OutputCollector(Writer<ValueT> writer, Counter elementsWritten) {
+    OutputCollector(Writer<ValueT> writer) {
       this.writer = writer;
-      this.elementsWritten = elementsWritten;
     }
 
     void onComplete() {
@@ -170,192 +193,195 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
     public void accept(ValueT t) {
       try {
         writer.write(t);
-        elementsWritten.inc();
       } catch (IOException e) {
         throw new RuntimeException("Write of element " + t + " failed: ", e);
       }
     }
   }
 
-  private static class MergeAndWriteBuckets<FinalKeyT, FinalValueT>
-      extends DoFn<Integer, KV<BucketShardId, ResourceId>> {
-    private static final Comparator<byte[]> bytesComparator =
-        UnsignedBytes.lexicographicalComparator();
+  private static class MergedBucket implements Serializable {
+    final ResourceId destination;
+    final BucketShardId bucketShardId;
+    final Integer totalNumBuckets;
 
-    private static final Comparator<Entry<TupleTag, KV<byte[], Iterator<?>>>> keyComparator =
-        (o1, o2) -> bytesComparator.compare(o1.getValue().getKey(), o2.getValue().getKey());
-
-    private final List<BucketedInput<?, ?>> sources;
-    private final FileAssignment fileAssignment;
-    private final FileOperations<FinalValueT> fileOperations;
-    private final TransformFn<FinalKeyT, FinalValueT> transformFn;
-    private final BucketMetadata<FinalKeyT, FinalValueT> bucketMetadata;
-    private final Coder<FinalKeyT> keyCoder;
-    private final int leastNumBuckets;
-
-    private final Counter elementsWritten;
-    private final Counter elementsRead;
-    private final Distribution keyGroupSize;
-
-    MergeAndWriteBuckets(
-        String transformName,
-        List<BucketedInput<?, ?>> sources,
-        SourceSpec<FinalKeyT> sourceSpec,
-        FileAssignment fileAssignment,
-        FileOperations<FinalValueT> fileOperations,
-        BucketMetadata<FinalKeyT, FinalValueT> bucketMetadata,
-        TransformFn<FinalKeyT, FinalValueT> transformFn) {
-      this.sources = sources;
-      this.fileAssignment = fileAssignment;
-      this.fileOperations = fileOperations;
-      this.transformFn = transformFn;
-      this.bucketMetadata = bucketMetadata;
-      this.keyCoder = sourceSpec.keyCoder;
-      this.leastNumBuckets = sourceSpec.leastNumBuckets;
-
-      elementsWritten =
-          Metrics.counter(SortedBucketTransform.class, transformName + "-ElementsWritten");
-      elementsRead = Metrics.counter(SortedBucketTransform.class, transformName + "-ElementsRead");
-      keyGroupSize =
-          Metrics.distribution(SortedBucketTransform.class, transformName + "-KeyGroupSize");
+    MergedBucket(BucketShardId bucketShardId, ResourceId destination, Integer totalNumBuckets) {
+      this.destination = destination;
+      this.bucketShardId = bucketShardId;
+      this.totalNumBuckets = totalNumBuckets;
     }
 
     @Override
-    public void populateDisplayData(Builder builder) {
-      super.populateDisplayData(builder);
-      builder.add(DisplayData.item("keyCoder", keyCoder.getClass()));
-      builder.add(DisplayData.item("numBuckets", bucketMetadata.getNumBuckets()));
-      builder.add(DisplayData.item("numShards", bucketMetadata.getNumShards()));
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      MergedBucket that = (MergedBucket) o;
+      return Objects.equals(destination, that.destination)
+          && Objects.equals(bucketShardId, that.bucketShardId)
+          && Objects.equals(totalNumBuckets, that.totalNumBuckets);
     }
 
-    @ProcessElement
-    public void processElement(ProcessContext c) {
-      final int bucketId = c.element();
-      final boolean reHashBucket = bucketMetadata.getNumBuckets() > leastNumBuckets;
+    @Override
+    public int hashCode() {
+      return Objects.hash(destination, bucketShardId, totalNumBuckets);
+    }
+  }
 
-      final Map<Integer, OutputCollector<FinalValueT>> bucketsToWriters = new HashMap<>();
-      final List<KV<BucketShardId, ResourceId>> bucketsToDsts = new ArrayList<>();
+  static class MergeAndWriteBucketsSource<FinalKeyT, FinalValueT>
+      extends BoundedSource<MergedBucket> {
+    private static final Logger LOG = LoggerFactory.getLogger(MergeAndWriteBucketsSource.class);
 
-      for (int bucketFanout = bucketId;
-          bucketFanout < bucketMetadata.getNumBuckets();
-          bucketFanout += leastNumBuckets) {
-        final BucketShardId bucketShardId = BucketShardId.of(bucketFanout, 0);
-        final ResourceId dst = fileAssignment.forBucket(bucketShardId, bucketMetadata);
+    private final Class<FinalKeyT> finalKeyClass;
+    private final List<BucketedInput<?, ?>> sources;
+    private final TargetParallelism targetParallelism;
+    private final SourceSpec<FinalKeyT> sourceSpec;
+    private final Distribution keyGroupSize;
+    private final FileAssignment fileAssignment;
+    private final FileOperations<FinalValueT> fileOperations;
+    private final TransformFn<FinalKeyT, FinalValueT> transformFn;
 
-        try {
-          bucketsToWriters.put(
-              bucketFanout,
-              new OutputCollector<>(fileOperations.createWriter(dst), elementsWritten));
-          bucketsToDsts.add(KV.of(bucketShardId, dst));
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
+    private final int effectiveParallelism;
+    private final int bucketOffsetId;
+    private long estimatedSizeBytes;
+
+    MergeAndWriteBucketsSource(
+        Class<FinalKeyT> finalKeyClass,
+        List<BucketedInput<?, ?>> sources,
+        TargetParallelism targetParallelism,
+        int effectiveParallelism,
+        int bucketOffsetId,
+        SourceSpec<FinalKeyT> sourceSpec,
+        Distribution keyGroupSize,
+        long estimatedSizeBytes,
+        FileAssignment fileAssignment,
+        FileOperations<FinalValueT> fileOperations,
+        TransformFn<FinalKeyT, FinalValueT> transformFn) {
+      this.finalKeyClass = finalKeyClass;
+      this.sources = sources;
+      this.targetParallelism = targetParallelism;
+      this.effectiveParallelism = effectiveParallelism;
+      this.bucketOffsetId = bucketOffsetId;
+      this.sourceSpec = sourceSpec;
+      this.estimatedSizeBytes = estimatedSizeBytes;
+      this.keyGroupSize = keyGroupSize;
+      this.fileAssignment = fileAssignment;
+      this.fileOperations = fileOperations;
+      this.transformFn = transformFn;
+    }
+
+    public MergeAndWriteBucketsSource<FinalKeyT, FinalValueT> split(
+        int bucketOffsetId, int adjustedParallelism, long estimatedSizeBytes) {
+      return new MergeAndWriteBucketsSource<>(
+          finalKeyClass,
+          sources,
+          targetParallelism,
+          adjustedParallelism,
+          bucketOffsetId,
+          sourceSpec,
+          keyGroupSize,
+          estimatedSizeBytes,
+          fileAssignment,
+          fileOperations,
+          transformFn);
+    }
+
+    @Override
+    public List<? extends BoundedSource<MergedBucket>> split(
+        long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
+
+      final int adjustedParallelism =
+          SortedBucketSource.getFanout(
+              sourceSpec,
+              effectiveParallelism,
+              targetParallelism,
+              getEstimatedSizeBytes(options),
+              desiredBundleSizeBytes);
+
+      if (adjustedParallelism == 1) {
+        return Collections.singletonList(this);
       }
-      final KeyGroupIterator[] iterators =
-          sources.stream()
-              .map(i -> i.createIterator(c.element(), leastNumBuckets))
-              .toArray(KeyGroupIterator[]::new);
 
-      merge(
-          iterators,
-          BucketedInput.schemaOf(sources),
-          mergedKeyGroup -> {
-            int assignedBucket =
-                reHashBucket ? bucketMetadata.getBucketId(mergedKeyGroup.getKey()) : bucketId;
+      LOG.error("Parallelism was adjusted to " + adjustedParallelism);
 
-            try {
-              transformFn.writeTransform(
-                  KV.of(
-                      keyCoder.decode(new ByteArrayInputStream(mergedKeyGroup.getKey())),
-                      mergedKeyGroup.getValue()),
-                  bucketsToWriters.get(assignedBucket));
-            } catch (Exception e) {
-              throw new RuntimeException("Failed to decode and merge key group", e);
+      final long estSplitSize = estimatedSizeBytes / adjustedParallelism;
+
+      return IntStream.range(0, adjustedParallelism)
+          .boxed()
+          .map(i -> this.split(i, adjustedParallelism, estSplitSize))
+          .collect(Collectors.toList());
+    }
+
+    @Override
+    public long getEstimatedSizeBytes(PipelineOptions options) throws Exception {
+      if (estimatedSizeBytes == -1) {
+        estimatedSizeBytes =
+            sources.parallelStream().mapToLong(BucketedInput::getOrSampleByteSize).sum();
+
+        LOG.info("Estimated byte size is " + estimatedSizeBytes);
+      }
+
+      return estimatedSizeBytes;
+    }
+
+    @Override
+    public Coder<MergedBucket> getOutputCoder() {
+      return SerializableCoder.of(MergedBucket.class);
+    }
+
+    @Override
+    public BoundedReader<MergedBucket> createReader(PipelineOptions options) throws IOException {
+      final BoundedSource<MergedBucket> currentSource = this;
+
+      return new BoundedReader<MergedBucket>() {
+        private MergeBucketsReader<FinalKeyT> keyGroupReader;
+
+        @Override
+        public boolean start() throws IOException {
+          keyGroupReader =
+              new MergeBucketsReader<>(
+                  sources, bucketOffsetId, effectiveParallelism, sourceSpec, null, keyGroupSize);
+          return keyGroupReader.start();
+        }
+
+        @Override
+        public boolean advance() throws IOException {
+          return keyGroupReader.advance();
+        }
+
+        @Override
+        public MergedBucket getCurrent() throws NoSuchElementException {
+          final BucketShardId bucketShardId = BucketShardId.of(bucketOffsetId, 0);
+          final ResourceId dst = fileAssignment.forBucket(bucketShardId, effectiveParallelism, 1);
+          final OutputCollector<FinalValueT> outputCollector;
+
+          try {
+            outputCollector = new OutputCollector<>(fileOperations.createWriter(dst));
+            KV<FinalKeyT, CoGbkResult> mergedKeyGroup = keyGroupReader.getCurrent();
+            while (true) {
+              transformFn.writeTransform(mergedKeyGroup, outputCollector);
+
+              if (!keyGroupReader.advance()) {
+                break;
+              }
+              mergedKeyGroup = keyGroupReader.getCurrent();
             }
-          },
-          elementsRead,
-          keyGroupSize);
 
-      bucketsToDsts.forEach(
-          bucketShardAndDst -> {
-            bucketsToWriters.get(bucketShardAndDst.getKey().getBucketId()).onComplete();
-            c.output(bucketShardAndDst);
-          });
-    }
-
-    static void merge(
-        KeyGroupIterator[] iterators,
-        CoGbkResultSchema resultSchema,
-        Consumer<KV<byte[], CoGbkResult>> consumer,
-        Counter elementsRead,
-        Distribution keyGroupSize) {
-      final int numSources = iterators.length;
-
-      final TupleTagList tupleTags = resultSchema.getTupleTagList();
-      final Map<TupleTag, KV<byte[], Iterator<?>>> nextKeyGroups = new HashMap<>();
-
-      while (true) {
-        int completedSources = 0;
-        // Advance key-value groups from each source
-        for (int i = 0; i < numSources; i++) {
-          final KeyGroupIterator it = iterators[i];
-          if (nextKeyGroups.containsKey(tupleTags.get(i))) {
-            continue;
+            outputCollector.onComplete();
+          } catch (Exception e) {
+            throw new RuntimeException("Failed to write merged key group", e);
           }
-          if (it.hasNext()) {
-            @SuppressWarnings("unchecked")
-            final KV<byte[], Iterator<?>> next = it.next();
-            nextKeyGroups.put(tupleTags.get(i), next);
-          } else {
-            completedSources++;
-          }
+
+          return new MergedBucket(bucketShardId, dst, effectiveParallelism);
         }
 
-        if (nextKeyGroups.isEmpty()) {
-          break;
+        @Override
+        public void close() throws IOException {}
+
+        @Override
+        public BoundedSource<MergedBucket> getCurrentSource() {
+          return currentSource;
         }
-
-        // Find next key-value groups
-        final Map.Entry<TupleTag, KV<byte[], Iterator<?>>> minKeyEntry =
-            nextKeyGroups.entrySet().stream().min(keyComparator).orElse(null);
-
-        final Iterator<Map.Entry<TupleTag, KV<byte[], Iterator<?>>>> nextKeyGroupsIt =
-            nextKeyGroups.entrySet().iterator();
-        final List<Iterable<?>> valueMap = new ArrayList<>();
-        for (int i = 0; i < resultSchema.size(); i++) {
-          valueMap.add(new ArrayList<>());
-        }
-
-        int keyGroupCount = 0;
-        while (nextKeyGroupsIt.hasNext()) {
-          final Map.Entry<TupleTag, KV<byte[], Iterator<?>>> entry = nextKeyGroupsIt.next();
-          if (keyComparator.compare(entry, minKeyEntry) == 0) {
-            int index = resultSchema.getIndex(entry.getKey());
-            @SuppressWarnings("unchecked")
-            final List<Object> values = (List<Object>) valueMap.get(index);
-            // TODO: this exhausts everything from the "lazy" iterator and can be expensive.
-            // To fix we have to make the underlying Reader range aware so that it's safe to
-            // re-iterate or stop without exhausting remaining elements in the value group.
-            entry.getValue().getValue().forEachRemaining(values::add);
-
-            nextKeyGroupsIt.remove();
-            keyGroupCount += values.size();
-          }
-        }
-
-        keyGroupSize.update(keyGroupCount);
-        elementsRead.inc(keyGroupCount);
-
-        final KV<byte[], CoGbkResult> mergedKeyGroup =
-            KV.of(
-                minKeyEntry.getValue().getKey(),
-                CoGbkResultUtil.newCoGbkResult(resultSchema, valueMap));
-        consumer.accept(mergedKeyGroup);
-
-        if (completedSources == numSources) {
-          break;
-        }
-      }
+      };
     }
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SourceSpec.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SourceSpec.java
@@ -22,31 +22,41 @@ import java.util.List;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
+import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 import org.apache.beam.sdk.extensions.smb.BucketMetadataUtil.PartitionMetadata;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class SourceSpec<K> implements Serializable {
+  private static Logger LOG = LoggerFactory.getLogger(SourceSpec.class);
+
   int leastNumBuckets;
   int greatestNumBuckets;
   Coder<K> keyCoder;
+  HashType hashType;
 
-  private SourceSpec(int leastNumBuckets, int greatestNumBuckets, Coder<K> keyCoder) {
+  private SourceSpec(
+      int leastNumBuckets, int greatestNumBuckets, Coder<K> keyCoder, HashType hashType) {
     this.leastNumBuckets = leastNumBuckets;
     this.greatestNumBuckets = greatestNumBuckets;
     this.keyCoder = keyCoder;
+    this.hashType = hashType;
   }
 
   static <KeyT> SourceSpec<KeyT> from(
       Class<KeyT> finalKeyClass, List<BucketedInput<?, ?>> sources) {
     BucketMetadata<?, ?> first = null;
     Coder<KeyT> finalKeyCoder = null;
+    HashType hashType = null;
 
     // Check metadata of each source
     for (BucketedInput<?, ?> source : sources) {
       final BucketMetadata<?, ?> current = source.getMetadata();
       if (first == null) {
         first = current;
+        hashType = current.getHashType();
       } else {
         Preconditions.checkState(
             first.isCompatibleWith(current),
@@ -85,7 +95,9 @@ class SourceSpec<K> implements Serializable {
     Preconditions.checkNotNull(
         finalKeyCoder, "Could not infer coder for key class %s", finalKeyClass);
 
-    return new SourceSpec<>(leastNumBuckets, greatestNumBuckets, finalKeyCoder);
+    Preconditions.checkNotNull(hashType, "Could not infer hash type for sources");
+
+    return new SourceSpec<>(leastNumBuckets, greatestNumBuckets, finalKeyCoder, hashType);
   }
 
   int getParallelism(TargetParallelism targetParallelism) {
@@ -96,6 +108,18 @@ class SourceSpec<K> implements Serializable {
     } else if (targetParallelism.isAuto()) {
       throw new UnsupportedOperationException("Can't derive a static value for AutoParallelism");
     } else {
+      Preconditions.checkArgument(
+          (targetParallelism.getValue() & targetParallelism.getValue() - 1) == 0,
+          String.format(
+              "Target parallelism must be a power of 2. Was: %d", targetParallelism.getValue()));
+
+      if (targetParallelism.getValue() > greatestNumBuckets) {
+        LOG.warn(
+            String.format(
+                "You have selected a parallelism > the greatest number of buckets (%d). "
+                    + "Unless you are applying a SortedBucketTransform, consider a lower number.",
+                greatestNumBuckets));
+      }
       return targetParallelism.getValue();
     }
   }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SourceSpec.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SourceSpec.java
@@ -89,8 +89,6 @@ class SourceSpec<K> implements Serializable {
   }
 
   int getParallelism(TargetParallelism targetParallelism) {
-    int parallelism;
-
     if (targetParallelism.isMin()) {
       return leastNumBuckets;
     } else if (targetParallelism.isMax()) {
@@ -98,18 +96,7 @@ class SourceSpec<K> implements Serializable {
     } else if (targetParallelism.isAuto()) {
       throw new UnsupportedOperationException("Can't derive a static value for AutoParallelism");
     } else {
-      parallelism = targetParallelism.getValue();
-
-      Preconditions.checkArgument(
-          ((parallelism & parallelism - 1) == 0)
-              && parallelism >= leastNumBuckets
-              && parallelism <= greatestNumBuckets,
-          String.format(
-              "Target parallelism must be a power of 2 between the least (%d) and "
-                  + "greatest (%d) number of buckets in sources. Was: %d",
-              leastNumBuckets, greatestNumBuckets, parallelism));
-
-      return parallelism;
+      return targetParallelism.getValue();
     }
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
@@ -24,6 +24,7 @@ import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
+import org.apache.beam.sdk.extensions.smb.SortedBucketTransform.NewBucketMetadataFn;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
@@ -60,6 +61,17 @@ public class TensorFlowBucketIO {
         .setNumShards(SortedBucketIO.DEFAULT_NUM_SHARDS)
         .setHashType(SortedBucketIO.DEFAULT_HASH_TYPE)
         .setSorterMemoryMb(SortedBucketIO.DEFAULT_SORTER_MEMORY_MB)
+        .setKeyClass(keyClass)
+        .setKeyField(keyField)
+        .setFilenameSuffix(DEFAULT_SUFFIX)
+        .setCompression(Compression.UNCOMPRESSED)
+        .build();
+  }
+
+  /** Returns a new {@link TransformOutput} for Avro generic records. */
+  public static <K> TransformOutput<K> transformOutput(Class<K> keyClass, String keyField) {
+    return new AutoValue_TensorFlowBucketIO_TransformOutput.Builder<K>()
+        .setFilenameSuffix(DEFAULT_SUFFIX)
         .setKeyClass(keyClass)
         .setKeyField(keyField)
         .setFilenameSuffix(DEFAULT_SUFFIX)
@@ -228,6 +240,87 @@ public class TensorFlowBucketIO {
       } catch (CannotProvideCoderException | Coder.NonDeterministicException e) {
         throw new IllegalStateException(e);
       }
+    }
+  }
+
+  /**
+   * Writes to sorted-bucket TensorFlow TFRecord files with TensorFlow {@link Example} records with
+   * {@link SortedBucketTransform}.
+   */
+  @AutoValue
+  public abstract static class TransformOutput<K>
+      extends SortedBucketIO.TransformOutput<K, Example> {
+
+    // JSON specific
+    @Nullable
+    abstract String getKeyField();
+
+    abstract Compression getCompression();
+
+    abstract Builder<K> toBuilder();
+
+    @AutoValue.Builder
+    abstract static class Builder<K> {
+
+      // Common
+      abstract Builder<K> setKeyClass(Class<K> keyClass);
+
+      abstract Builder<K> setOutputDirectory(ResourceId outputDirectory);
+
+      abstract Builder<K> setTempDirectory(ResourceId tempDirectory);
+
+      abstract Builder<K> setFilenameSuffix(String filenameSuffix);
+
+      // JSON specific
+      abstract Builder<K> setKeyField(String keyField);
+
+      abstract Builder<K> setCompression(Compression compression);
+
+      abstract TransformOutput<K> build();
+    }
+
+    /** Writes to the given output directory. */
+    public TransformOutput<K> to(String outputDirectory) {
+      return toBuilder()
+          .setOutputDirectory(FileSystems.matchNewResource(outputDirectory, true))
+          .build();
+    }
+
+    /** Specifies the temporary directory for writing. */
+    public TransformOutput<K> withTempDirectory(String tempDirectory) {
+      return toBuilder()
+          .setTempDirectory(FileSystems.matchNewResource(tempDirectory, true))
+          .build();
+    }
+
+    /** Specifies the output filename suffix. */
+    public TransformOutput<K> withSuffix(String filenameSuffix) {
+      return toBuilder().setFilenameSuffix(filenameSuffix).build();
+    }
+
+    /** Specifies the output file {@link Compression}. */
+    public TransformOutput<K> withCompression(Compression compression) {
+      return toBuilder().setCompression(compression).build();
+    }
+
+    @Override
+    FileOperations<Example> getFileOperations() {
+      return TensorFlowFileOperations.of(getCompression());
+    }
+
+    @Override
+    NewBucketMetadataFn<K, Example> getNewBucketMetadataFn() {
+      final String keyField = getKeyField();
+      final Class<K> keyClass = getKeyClass();
+
+      return (numBuckets, numShards, hashType) -> {
+        try {
+          return new TensorFlowBucketMetadata<>(
+              numBuckets, numShards, keyClass, hashType, keyField);
+        } catch (CannotProvideCoderException | Coder.NonDeterministicException e) {
+          throw new IllegalStateException(e);
+        }
+      };
     }
   }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -671,7 +671,7 @@ public class SortedBucketSourceTest {
                     Stream.concat(l.stream(), r.stream()).sorted().collect(Collectors.toList())));
   }
 
-  private static void verifyMetrics(
+  static void verifyMetrics(
       PipelineResult result, Map<String, DistributionResult> expectedDistributions) {
     final Map<String, DistributionResult> actualDistributions =
         ImmutableList.copyOf(result.metrics().allMetrics().getDistributions().iterator()).stream()

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -61,6 +61,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -310,25 +311,6 @@ public class SortedBucketSourceTest {
                 BucketShardId.of(1, 0), Lists.newArrayList("c7", "c8"))));
   }
 
-  // For non-minimal parallelism, test input keys *must* hash to their corresponding bucket IDs,
-  // since a rehash is required in the merge step
-  @Test
-  @Category(NeedsRunner.class)
-  public void testPartitionedInputsMixedBucketsMaxParallelism() throws Exception {
-    testPartitioned(
-        ImmutableList.of(
-            ImmutableMap.of(
-                BucketShardId.of(0, 0), Lists.newArrayList("w1", "w2"),
-                BucketShardId.of(1, 0), Lists.newArrayList("c1", "c2")),
-            ImmutableMap.of(BucketShardId.of(0, 0), Lists.newArrayList("w3", "w4"))),
-        ImmutableList.of(
-            ImmutableMap.of(BucketShardId.of(0, 0), Lists.newArrayList("w5", "w6")),
-            ImmutableMap.of(
-                BucketShardId.of(0, 0), Lists.newArrayList("w7", "w8"),
-                BucketShardId.of(1, 0), Lists.newArrayList("c7", "c8"))),
-        TargetParallelism.max());
-  }
-
   @Test
   @Category(NeedsRunner.class)
   public void testMixedBucketsMixedShardMaxParallelism() throws Exception {
@@ -376,6 +358,8 @@ public class SortedBucketSourceTest {
         TargetParallelism.auto());
   }
 
+  // For non-minimal parallelism, test input keys *must* hash to their corresponding bucket IDs,
+  // since a rehash is required in the merge step
   @Test
   @Category(NeedsRunner.class)
   public void testPartitionedInputsMixedBucketsAutoParallelism() throws Exception {
@@ -398,6 +382,44 @@ public class SortedBucketSourceTest {
                 BucketShardId.of(0, 0), Lists.newArrayList(),
                 BucketShardId.of(1, 0), Lists.newArrayList("c7", "c8"))),
         TargetParallelism.auto());
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testPartitionedInputsMixedBucketsMaxParallelism() throws Exception {
+    testPartitioned(
+        ImmutableList.of(
+            ImmutableMap.of(BucketShardId.of(0, 0), Lists.newArrayList("c1", "w1", "x1", "z1")),
+            ImmutableMap.of(BucketShardId.of(0, 0), Lists.newArrayList("w1", "w2"))),
+        ImmutableList.of(
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("w5", "w6"),
+                BucketShardId.of(1, 0), Lists.newArrayList("t1", "t2", "x1")),
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("w3", "w4"),
+                BucketShardId.of(1, 0), Lists.newArrayList("c1", "c2"),
+                BucketShardId.of(2, 0), Lists.newArrayList("u1", "u2"),
+                BucketShardId.of(3, 0), Lists.newArrayList("r1", "r2"))),
+        TargetParallelism.max());
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testPartitionedInputsMixedBucketsCustomParallelism() throws Exception {
+    testPartitioned(
+        ImmutableList.of(
+            ImmutableMap.of(BucketShardId.of(0, 0), Lists.newArrayList("c1", "w1", "x1", "z1")),
+            ImmutableMap.of(BucketShardId.of(0, 0), Lists.newArrayList("w1", "w2"))),
+        ImmutableList.of(
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("w5", "w6"),
+                BucketShardId.of(1, 0), Lists.newArrayList("t1", "t2", "x1")),
+            ImmutableMap.of(
+                BucketShardId.of(0, 0), Lists.newArrayList("w3", "w4"),
+                BucketShardId.of(1, 0), Lists.newArrayList("c1", "c2"),
+                BucketShardId.of(2, 0), Lists.newArrayList("u1", "u2"),
+                BucketShardId.of(3, 0), Lists.newArrayList("r1", "r2"))),
+        TargetParallelism.of(2));
   }
 
   @SuppressWarnings("unchecked")

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
@@ -162,7 +162,7 @@ public class SortedBucketTransformTest {
       Assert.assertEquals(expectedNumBuckets, numBucketsInMetadata);
     } else {
       Assert.assertTrue(numBucketsInMetadata <= 4);
-      Assert.assertTrue(numBucketsInMetadata >= 2);
+      Assert.assertTrue(numBucketsInMetadata >= 1);
     }
 
     Assert.assertEquals(1, outputs.getKey().getNumShards());

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
@@ -23,16 +23,12 @@ import static org.apache.beam.sdk.extensions.smb.TestUtils.fromFolder;
 import java.nio.channels.Channels;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.extensions.smb.SMBFilenamePolicy.FileAssignment;
 import org.apache.beam.sdk.extensions.smb.SortedBucketTransform.TransformFn;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.metrics.DistributionResult;
-import org.apache.beam.sdk.metrics.MetricResult;
-import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.KV;
@@ -122,56 +118,54 @@ public class SortedBucketTransformTest {
   }
 
   @Test
-  public void testSortedBucketTransformNoFanout() throws Exception {
-    final TestBucketMetadata outputMetadata = TestBucketMetadata.of(2, 1);
-
-    transformPipeline.apply(
-        new SortedBucketTransform<>(
-            String.class,
-            TargetParallelism.min(),
-            fromFolder(outputFolder),
-            fromFolder(tempFolder),
-            ".txt",
-            new TestFileOperations(),
-            sources,
-            mergeFunction,
-            TestBucketMetadata::of));
-
-    final PipelineResult result = transformPipeline.run();
-    result.waitUntilFinish();
-
-    final KV<BucketMetadata, Set<String>> outputs = readAllFrom(outputFolder, outputMetadata);
-    Assert.assertEquals(expected, outputs.getValue());
-    Assert.assertEquals(outputMetadata, outputs.getKey());
-
-    SortedBucketSourceTest.verifyMetrics(
-        result,
-        ImmutableMap.of(
-            "SortedBucketTransform-KeyGroupSize", DistributionResult.create(10, 7, 1, 2)));
+  public void testSortedBucketTransformMinParallelism() throws Exception {
+    test(TargetParallelism.min(), 2);
   }
 
   @Test
-  public void testWorksWithBucketFanout() throws Exception {
-    final TestBucketMetadata outputMetadata = TestBucketMetadata.of(8, 1);
+  public void testSortedBucketTransformMaxParallelism() throws Exception {
+    test(TargetParallelism.max(), 4);
+  }
 
+  @Test
+  public void testSortedBucketTransformAutoParallelism() throws Exception {
+    test(TargetParallelism.auto(), -1);
+  }
+
+  @Test
+  public void testSortedBucketTransformCustomParallelism() throws Exception {
+    test(TargetParallelism.of(8), 8);
+  }
+
+  private void test(TargetParallelism targetParallelism, int expectedNumBuckets) throws Exception {
     transformPipeline.apply(
         new SortedBucketTransform<>(
             String.class,
-            TargetParallelism.of(8),
+            sources,
+            targetParallelism,
+            mergeFunction,
             fromFolder(outputFolder),
             fromFolder(tempFolder),
-            ".txt",
+            (numBuckets, numShards, hashType) -> TestBucketMetadata.of(numBuckets, numShards),
             new TestFileOperations(),
-            sources,
-            mergeFunction,
-            TestBucketMetadata::of));
+            ".txt"));
 
     final PipelineResult result = transformPipeline.run();
     result.waitUntilFinish();
 
-    final KV<BucketMetadata, Set<String>> outputs = readAllFrom(outputFolder, outputMetadata);
+    final KV<BucketMetadata, Set<String>> outputs = readAllFrom(outputFolder);
     Assert.assertEquals(expected, outputs.getValue());
-    Assert.assertEquals(outputMetadata, outputs.getKey());
+
+    int numBucketsInMetadata = outputs.getKey().getNumBuckets();
+
+    if (!targetParallelism.isAuto()) {
+      Assert.assertEquals(expectedNumBuckets, numBucketsInMetadata);
+    } else {
+      Assert.assertTrue(numBucketsInMetadata <= 4);
+      Assert.assertTrue(numBucketsInMetadata >= 2);
+    }
+
+    Assert.assertEquals(1, outputs.getKey().getNumShards());
 
     SortedBucketSourceTest.verifyMetrics(
         result,
@@ -179,10 +173,14 @@ public class SortedBucketTransformTest {
             "SortedBucketTransform-KeyGroupSize", DistributionResult.create(10, 7, 1, 2)));
   }
 
-  private static KV<BucketMetadata, Set<String>> readAllFrom(
-      TemporaryFolder folder, TestBucketMetadata metadata) throws Exception {
+  private static KV<BucketMetadata, Set<String>> readAllFrom(TemporaryFolder folder)
+      throws Exception {
     final FileAssignment fileAssignment =
         new SMBFilenamePolicy(fromFolder(folder), ".txt").forDestination();
+
+    BucketMetadata metadata =
+        BucketMetadata.from(
+            Channels.newInputStream(FileSystems.open(fileAssignment.forMetadata())));
 
     final Set<String> outputElements = new HashSet<>();
 
@@ -194,9 +192,6 @@ public class SortedBucketTransformTest {
       outputReader.iterator().forEachRemaining(outputElements::add);
     }
 
-    return KV.of(
-        BucketMetadata.from(
-            Channels.newInputStream(FileSystems.open(fileAssignment.forMetadata()))),
-        outputElements);
+    return KV.of(metadata, outputElements);
   }
 }


### PR DESCRIPTION
Refactored `SortedBucketTransform` to use a `BoundedSource` transform that shares its merging logic with `SortedBucketSource` and allows users to specify a `TargetParallelism`. Additionally I cleaned up the API a bit so it's not just partially fusing aspects of a `SortedBucketIO.Read` and `SortedBucketIO.Write`. The API now looks like:

```scala
sc.sortMergeTransform(
  classOf[KeyClass],
  AvroSortedBucketIO.read(...).from(...),
  AvroSortedBucketIO.read(...).from(...),
  TargetParallelism.auto()
).to(
  AvroSortedBucketIO
     .transformOutput(classOf[KeyClass], "key_field", classOf[ValueClass])
     .to("gs://my_output")
).via {
  case (key, (lhs, rhs), outputCollector) =>
     val v: ValueClass = ...
     outputCollector.accept(v)
}
```

The number of buckets in the output is now determined by the parallelism. I.e. if they use `TargetParallelism.auto()`, then the Dataflow runner heuristic will decide, or they can use `TargetParallelism.of(2)` to end up with 2 buckets in the output. numShards will always be 1 and the HashType will always match the source. The only aspects of the output metadata the user needs to explicitly specify is key field/key class.

I know the diff on this PR is really awful -- a lot of it is boilerplate AutoValue/Builder stuff to accommodate the API changes :/ Overall there is less duplicated logic between SMB Transform and SMB source/sink now and I think a less confusing API.

benchmarks:
not that surprisingly, there's not a huge change because the bulk of the job is not super parallelizable (writing to a single file per worker), but BoundedSource impl looks a bit better.

Existing, non-BoundedSource impl:
![Screen Shot 2020-06-24 at 5 12 05 PM](https://user-images.githubusercontent.com/1360529/85781376-9d43dd00-b6f3-11ea-9736-184cbd7d1b71.png)

New boundedSource impl:
![Screen Shot 2020-06-25 at 2 42 34 PM](https://user-images.githubusercontent.com/1360529/85781455-b2b90700-b6f3-11ea-9fae-87eb7621ef25.png)

