### PR TITLE
Add support for String/ByteString TF Bucket key types

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
@@ -70,7 +70,7 @@ public class TensorFlowBucketMetadata<K> extends BucketMetadata<K, Example> {
     } else if (getKeyClass() == ByteString.class) {
       BytesList values = feature.getBytesList();
       Preconditions.checkState(values.getValueCount() == 1, "Number of feature in keyField != 1");
-      return (K) ByteString.copyFrom(values.getValue(0).toByteArray());
+      return (K) values.getValue(0);
     } else if (getKeyClass() == String.class) {
       BytesList values = feature.getBytesList();
       Preconditions.checkState(values.getValueCount() == 1, "Number of feature in keyField != 1");

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
@@ -19,7 +19,7 @@ package org.apache.beam.sdk.extensions.smb;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Objects;
+import com.google.protobuf.ByteString;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -67,6 +67,14 @@ public class TensorFlowBucketMetadata<K> extends BucketMetadata<K, Example> {
       BytesList values = feature.getBytesList();
       Preconditions.checkState(values.getValueCount() == 1, "Number of feature in keyField != 1");
       return (K) values.getValue(0).toByteArray();
+    } else if (getKeyClass() == ByteString.class) {
+      BytesList values = feature.getBytesList();
+      Preconditions.checkState(values.getValueCount() == 1, "Number of feature in keyField != 1");
+      return (K) ByteString.copyFrom(values.getValue(0).toByteArray());
+    } else if (getKeyClass() == String.class) {
+      BytesList values = feature.getBytesList();
+      Preconditions.checkState(values.getValueCount() == 1, "Number of feature in keyField != 1");
+      return (K) values.getValue(0).toStringUtf8();
     } else if (getKeyClass() == Long.class) {
       Int64List values = feature.getInt64List();
       Preconditions.checkState(values.getValueCount() == 1, "Number of feature in keyField != 1");

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
@@ -71,6 +71,16 @@ public class TensorFlowBucketMetadataTest {
             .extractKey(example));
 
     Assert.assertEquals(
+        ByteString.copyFrom("data".getBytes()),
+        new TensorFlowBucketMetadata<>(1, 1, ByteString.class, HashType.MURMUR3_32, "bytes")
+            .extractKey(example));
+
+    Assert.assertEquals(
+        "data",
+        new TensorFlowBucketMetadata<>(1, 1, String.class, HashType.MURMUR3_32, "bytes")
+            .extractKey(example));
+
+    Assert.assertEquals(
         (Long) 12345L,
         new TensorFlowBucketMetadata<>(1, 1, Long.class, HashType.MURMUR3_32, "int")
             .extractKey(example));
@@ -79,12 +89,6 @@ public class TensorFlowBucketMetadataTest {
         NonDeterministicException.class,
         () ->
             new TensorFlowBucketMetadata<>(1, 1, Float.class, HashType.MURMUR3_32, "float")
-                .extractKey(example));
-
-    Assert.assertThrows(
-        IllegalStateException.class,
-        () ->
-            new TensorFlowBucketMetadata<>(1, 1, String.class, HashType.MURMUR3_32, "bytes")
                 .extractKey(example));
   }
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
@@ -90,6 +90,12 @@ public class TensorFlowBucketMetadataTest {
         () ->
             new TensorFlowBucketMetadata<>(1, 1, Float.class, HashType.MURMUR3_32, "float")
                 .extractKey(example));
+
+    Assert.assertThrows(
+        IllegalStateException.class,
+        () ->
+            new TensorFlowBucketMetadata<>(1, 1, Integer.class, HashType.MURMUR3_32, "bytes")
+                .extractKey(example));
   }
 
   @Test


### PR DESCRIPTION
`String`/`ByteString` key types are supported when writing TF `Example`s to SMB buckets (since the type need only be encodeable). These types are however not supported when reading TF `Example`s from said buckets. 

This PR adds support for `String`/`ByteString` key types when extracting SMB bucket keys.

