### PR TITLE
Ensures the future returned by addCallback will complete

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
@@ -61,14 +61,22 @@ public class FutureHandlers {
           new FutureCallback<V>() {
             @Override
             public void onSuccess(@Nullable V result) {
-              onSuccess.apply(result);
+              try {
+                onSuccess.apply(result);
+              } catch (RuntimeException | Error e) {
+                f.setException(e);
+                return;
+              }
               f.set(result);
             }
 
             @Override
             public void onFailure(Throwable t) {
-              onFailure.apply(t);
-              f.setException(t);
+              try {
+                onFailure.apply(t);
+              } finally {
+                f.setException(t);
+              }
             }
           },
           MoreExecutors.directExecutor());


### PR DESCRIPTION
I also faced https://github.com/spotify/scio/issues/1191.
The stack trace is almost same. BigtableDoFn waits forever at waitForFutures in finishBundle.

I don't have a confidence that this fix will solve it completely, but I think it is worth to fix.