### PR TITLE
Idiomatic APIs to support beam readFiles APIs

### DIFF
--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
@@ -86,6 +86,7 @@ object ObjectFileIO {
   val WriteParam = AvroIO.WriteParam
 }
 
+/** Read multiple files/file-patterns with beam AvroIO readFiles API */
 final case class ObjectReadFilesIO[T: Coder](paths: Iterable[String]) extends AvroIO[T] {
   override type ReadP = Unit
   override type WriteP = Nothing
@@ -143,6 +144,7 @@ object ProtobufIO {
   val WriteParam = AvroIO.WriteParam
 }
 
+/** Read multiple files/file-patterns with beam AvroIO readFiles API */
 final case class ProtobufReadFilesIO[T <: Message: ClassTag](paths: Iterable[String])
     extends AvroIO[T] {
   override type ReadP = Unit
@@ -213,6 +215,7 @@ final case class SpecificRecordIO[T <: SpecificRecord: ClassTag: Coder](path: St
     SpecificRecordTap[T](ScioUtil.addPartSuffix(path))
 }
 
+/** Read multiple files/file-patterns with beam AvroIO readFiles API */
 final case class SpecificRecordReadFilesIO[T <: SpecificRecord: ClassTag: Coder](
   paths: Iterable[String]
 ) extends AvroIO[T] {
@@ -339,6 +342,15 @@ final case class GenericRecordParseIO[T](path: String, parseFn: GenericRecord =>
     GenericRecordParseTap[T](ScioUtil.addPartSuffix(path), parseFn)
 }
 
+/**
+ * Given a parseFn, read [[org.apache.avro.generic.GenericRecord GenericRecord]]
+ * and apply a function mapping [[GenericRecord => T]] before producing output.
+ * This IO applies the function at the time of de-serializing Avro GenericRecords.
+ *
+ * This IO doesn't define write, and should not be used to write Avro GenericRecords.
+ *
+ * This IO read multiple files/file-patterns with beam AvroIO readFiles API
+ */
 final case class GenericRecordParseFilesIO[T](paths: Iterable[String], parseFn: GenericRecord => T)(
   implicit coder: Coder[T]
 ) extends AvroIO[T] {
@@ -447,6 +459,7 @@ object AvroTyped {
     }
   }
 
+  /** Read multiple files/file-patterns with beam AvroIO readFiles API */
   final case class AvroReadFilesIO[T <: HasAvroAnnotation: ClassTag: TypeTag: Coder](
     paths: Iterable[String]
   ) extends ScioIO[T] {
@@ -488,8 +501,10 @@ trait AvroReadFilesIO[T] extends ScioIO[T] {
   final override val tapT = TapOf[T]
 }
 
+
 object AvroReadFilesIO {
 
+  /** TestIO implementation to use with JobTests. */
   @inline final def apply[T](paths: Iterable[String]): AvroReadFilesIO[T] =
     new AvroReadFilesIO[T] with TestIO[T] {
       override def testId: String = s"AvroReadFilesIO($paths)"

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
@@ -447,3 +447,15 @@ object AvroTyped {
     }
   }
 }
+
+trait AvroReadFilesIO[T] extends ScioIO[T] {
+  final override val tapT = TapOf[T]
+}
+
+object AvroReadFilesIO {
+
+  @inline final def apply[T](paths: Iterable[String]): AvroReadFilesIO[T] =
+    new AvroReadFilesIO[T] with TestIO[T] {
+      override def testId: String = s"AvroReadFilesIO($paths)"
+    }
+}

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
@@ -501,7 +501,6 @@ trait AvroReadFilesIO[T] extends ScioIO[T] {
   final override val tapT = TapOf[T]
 }
 
-
 object AvroReadFilesIO {
 
   /** TestIO implementation to use with JobTests. */

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
@@ -46,6 +46,9 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   def avroFile(path: String, schema: Schema): SCollection[GenericRecord] =
     self.read(GenericRecordIO(path, schema))(Coder.avroGenericRecordCoder(schema))
 
+  def avroFiles(paths: Iterable[String], schema: Schema): SCollection[GenericRecord] =
+    self.read(GenericRecordReadFilesIO(paths, schema))(Coder.avroGenericRecordCoder(schema))
+
   /**
    * Get an SCollection of type [[T]] for data stored in Avro format after applying
    * parseFn to map a serialized [[org.apache.avro.generic.GenericRecord GenericRecord]]
@@ -80,6 +83,13 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
    */
   def avroFile[T <: SpecificRecord: ClassTag: Coder](path: String): SCollection[T] =
     self.read(SpecificRecordIO[T](path))
+
+  /**
+   * Get an SCollection of type [[org.apache.avro.specific.SpecificRecord SpecificRecord]]
+   * for all Avro files/file-patterns.
+   */
+  def avroFiles[T <: SpecificRecord: ClassTag: Coder](paths: Iterable[String]): SCollection[T] =
+    self.read(SpecificRecordReadFilesIO[T](paths))
 
   /**
    * Get a typed SCollection from an Avro schema.

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
@@ -43,6 +43,9 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   def objectFile[T: Coder](path: String): SCollection[T] =
     self.read(ObjectFileIO[T](path))
 
+  def objectFiles[T: Coder](paths: Iterable[String]): SCollection[T] =
+    self.read(ObjectReadFilesIO[T](paths))
+
   def avroFile(path: String, schema: Schema): SCollection[GenericRecord] =
     self.read(GenericRecordIO(path, schema))(Coder.avroGenericRecordCoder(schema))
 
@@ -112,6 +115,9 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
    */
   def protobufFile[T <: Message: ClassTag: Coder](path: String): SCollection[T] =
     self.read(ProtobufIO[T](path))
+
+  def protobufFiles[T <: Message: ClassTag: Coder](paths: Iterable[String]): SCollection[T] =
+    self.read(ProtobufReadFilesIO[T](paths))
 }
 
 /** Enhanced with Avro methods. */

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
@@ -108,6 +108,19 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
     self.read(AvroTyped.AvroIO[T](path))
 
   /**
+   * Get a typed SCollection from an Avro schema.
+   *
+   * Note that `T` must be annotated with
+   * [[com.spotify.scio.avro.types.AvroType AvroType.fromSchema]],
+   * [[com.spotify.scio.avro.types.AvroType AvroType.fromPath]], or
+   * [[com.spotify.scio.avro.types.AvroType AvroType.toSchema]].
+   */
+  def typedAvroFiles[T <: HasAvroAnnotation: ClassTag: TypeTag: Coder](
+    paths: Iterable[String]
+  ): SCollection[T] =
+    self.read(AvroTyped.AvroReadFilesIO[T](paths))
+
+  /**
    * Get an SCollection for a Protobuf file.
    *
    * Protobuf messages are serialized into `Array[Byte]` and stored in Avro files to leverage

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
@@ -43,12 +43,27 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   def objectFile[T: Coder](path: String): SCollection[T] =
     self.read(ObjectFileIO[T](path))
 
+  /**
+   * Get an SCollection for an object file using default serialization.
+   *
+   * Serialized objects are stored in Avro files to leverage Avro's block file format. Note that
+   * serialization is not guaranteed to be compatible across Scio releases.
+   *
+   * Note: For better performance and scalability, input paths should match large number of files
+   * (i.e tens of thousands or more). If not use `SCollection.union(paths.map(sc.objectFile(_)))` instead.
+   * Calling this with a small number of matching files may decreased the performance.
+   */
   def objectFiles[T: Coder](paths: Iterable[String]): SCollection[T] =
     self.read(ObjectReadFilesIO[T](paths))
 
   def avroFile(path: String, schema: Schema): SCollection[GenericRecord] =
     self.read(GenericRecordIO(path, schema))(Coder.avroGenericRecordCoder(schema))
 
+  /**
+   * Note: For better performance and scalability, input paths should match large number of files
+   * (i.e tens of thousands or more). If not use `SCollection.union(paths.map(sc.avroFile(_)))` instead.
+   * Calling this with a small number of matching files may decreased the performance.
+   */
   def avroFiles(paths: Iterable[String], schema: Schema): SCollection[GenericRecord] =
     self.read(GenericRecordReadFilesIO(paths, schema))(Coder.avroGenericRecordCoder(schema))
 
@@ -90,6 +105,10 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   /**
    * Get an SCollection of type [[org.apache.avro.specific.SpecificRecord SpecificRecord]]
    * for all Avro files/file-patterns.
+   *
+   * Note: For better performance and scalability, input paths should match large number of files
+   * (i.e tens of thousands or more). If not use `SCollection.union(paths.map(sc.avroFile(_)))` instead.
+   * Calling this with a small number of matching files may decreased the performance.
    */
   def avroFiles[T <: SpecificRecord: ClassTag: Coder](paths: Iterable[String]): SCollection[T] =
     self.read(SpecificRecordReadFilesIO[T](paths))
@@ -110,6 +129,10 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   /**
    * Get a typed SCollection from an Avro schema.
    *
+   * Note: For better performance and scalability, input paths should match large number of files
+   * (i.e tens of thousands or more). If not use `SCollection.union(paths.map(sc.typedAvroFile(_)))` instead.
+   * Calling this with a small number of matching files may decreased the performance.
+   *
    * Note that `T` must be annotated with
    * [[com.spotify.scio.avro.types.AvroType AvroType.fromSchema]],
    * [[com.spotify.scio.avro.types.AvroType AvroType.fromPath]], or
@@ -129,6 +152,16 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   def protobufFile[T <: Message: ClassTag: Coder](path: String): SCollection[T] =
     self.read(ProtobufIO[T](path))
 
+  /**
+   * Get an SCollection for all matching Protobuf files.
+   *
+   * Protobuf messages are serialized into `Array[Byte]` and stored in Avro files to leverage
+   * Avro's block file format.
+   *
+   * Note: For better performance and scalability, input paths should match large number of files
+   * (i.e tens of thousands or more). If not use `SCollection.union(paths.map(sc.protobufFile(_)))` instead.
+   * Calling this with a small number of matching files may decreased the performance.
+   */
   def protobufFiles[T <: Message: ClassTag: Coder](paths: Iterable[String]): SCollection[T] =
     self.read(ProtobufReadFilesIO[T](paths))
 }

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/taps.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/taps.scala
@@ -99,6 +99,7 @@ final case class GenericRecordParseFilesTap[T: Coder](
   paths: Iterable[String],
   parseFn: GenericRecord => T
 ) extends Tap[T] {
+
   /** Read data set into memory. */
   override def value: Iterator[T] =
     paths.iterator.flatMap(p =>

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/taps.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/taps.scala
@@ -70,8 +70,9 @@ final case class SpecificRecordTap[T <: SpecificRecord: ClassTag: Coder](path: S
 }
 
 /** Tap for reading multiple Avro files/file-patterns as SpecificRecords. */
-final case class SpecificRecordReadFilesTap[T <: SpecificRecord: ClassTag: Coder](paths: Iterable[String])
-  extends Tap[T] {
+final case class SpecificRecordReadFilesTap[T <: SpecificRecord: ClassTag: Coder](
+  paths: Iterable[String]
+) extends Tap[T] {
   override def value: Iterator[T] = paths.iterator.flatMap(p => FileStorage(p).avroFile[T])
 
   override def open(sc: ScioContext): SCollection[T] = sc.avroFiles[T](paths)

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -782,6 +782,13 @@ class ScioContext private[scio] (
   ): SCollection[String] =
     this.read(TextIO(path))(TextIO.ReadParam(compression))
 
+  /**
+   * Get an SCollection for a list of text files.
+   *
+   * Note: For better performance and scalability, input paths should match large number of files
+   * (i.e tens of thousands or more). If not use `SCollection.union(paths.map(sc.textFile(_)))` instead.
+   * Calling this with a small number of matching files may decreased the performance.
+   */
   def textFiles(
     paths: Iterable[String],
     compression: beam.Compression = beam.Compression.AUTO

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -782,6 +782,12 @@ class ScioContext private[scio] (
   ): SCollection[String] =
     this.read(TextIO(path))(TextIO.ReadParam(compression))
 
+  def textFiles(
+    paths: Iterable[String],
+    compression: beam.Compression = beam.Compression.AUTO
+  ): SCollection[String] =
+    this.read(TextReadFilesIO(paths))(TextIO.ReadParam(compression))
+
   /**
    * Get an SCollection with a custom input transform. The transform should have a unique name.
    * @group input

--- a/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
@@ -75,6 +75,12 @@ final case class TextTap(path: String) extends Tap[String] {
   override def open(sc: ScioContext): SCollection[String] = sc.textFile(path)
 }
 
+final case class TextReadFilesTap(paths: Iterable[String]) extends Tap[String] {
+  override def value: Iterator[String] = paths.iterator.flatMap(p => FileStorage(p).textFile)
+
+  override def open(sc: ScioContext): SCollection[String] = sc.textFiles(paths)
+}
+
 final private[scio] class InMemoryTap[T: Coder] extends Tap[T] {
   private[scio] val id: String = UUID.randomUUID().toString
   override def value: Iterator[T] = InMemorySink.get(id).iterator

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroReadFilesExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroReadFilesExample.scala
@@ -1,0 +1,38 @@
+package com.spotify.scio.examples.extra
+import com.spotify.scio.ContextAndArgs
+import com.spotify.scio.avro._
+import com.spotify.scio.avro.types.AvroType
+// Example: Read multiple files/file-patterns
+// Usage:
+
+// `sbt "runMain com.spotify.scio.examples.extra.AvroReadFilesExample
+// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --inputs=[INPUT_1].avro,[INPUT_2].avro --output=[OUTPUT].avro"`
+object AvroReadFilesExample {
+
+  @AvroType.toSchema
+  case class Raw(text: String)
+  final case class WordCount(word: String, count: Int)
+
+  def main(cmdlineArgs: Array[String]): Unit = {
+//  Create `ScioContext` and `Args`
+    val (sc, args) = ContextAndArgs(cmdlineArgs)
+
+//  pass `--inputs=<file_1>,<file_2>,....` or `--inputs=<file_pattern_1>,<file_pattern_2>`
+//  i.e  `--inputs=first.avro,second.avro`
+//  Also support any combination of files and patterns
+    val inputs = args.list("inputs")
+
+//  Read avro data from multiple files or file-patterns
+    sc.typedAvroFiles[Raw](inputs)
+      .flatMap(r => r.text.split("\\s"))
+      .map(w => (w, 1))
+      .sumByKey
+      .map(WordCount.tupled)
+      .saveAsTextFile(args("output"))
+
+    sc.run()
+    ()
+  }
+
+}


### PR DESCRIPTION
Fixes: https://github.com/spotify/scio/issues/2776

Scio doesn't have a nice way to deal with beam `readFiles` (read multiple files) APIs. Scio users either have to use beam transform `PTransform[PCollection[beam.FileIO.ReadableFile], PCollection[A]]` or  use single file/file-pattern read API with  `SCollection.unionAll(..)` to read multiple filepatterns/files. Here I have extended `TextIO`, `GenericRecordIO` and `SpecificRecordIO` to support both single file/filepattern and multiple files/filepatterns. 

User have to use slightly different APIs available in ScioContext e.g `sc.textFile(path)` ,  `sc.textFiles(paths)` to read single or multiple files respectively. 

The PR introduces the following new APIs to users along with existing single file/filepattern read APIs
- `sc.textFiles(paths)`
with `import com.spotify.scio.avro._` 
- `sc.avroFiles(paths, schema)`
- `sc.avroFiles[T <: SpecificRecord: ClassTag: Coder](paths)`
- `sc.objectFiles(paths)`
- `sc.protobufFiles(paths)`
- `sc.typedAvroFiles(paths)`


Added `AvroReadFilesExample`
