### PR TITLE
AvroBucketMetadata should validate keyPath (fix #3038)

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
@@ -167,7 +167,8 @@ object SortMergeBucketTransformExample {
       TargetParallelism.auto()
     ).to(
       AvroSortedBucketIO
-        .transformOutput(classOf[Integer], "userId", classOf[Account])
+        .transformOutput(classOf[Integer], "id", classOf[Account])
+        .write(classOf[Integer], "id", classOf[Account])
         .to(args("output"))
     ).via {
       case (key, (users, accounts), outputCollector) =>

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
@@ -168,7 +168,6 @@ object SortMergeBucketTransformExample {
     ).to(
       AvroSortedBucketIO
         .transformOutput(classOf[Integer], "id", classOf[Account])
-        .write(classOf[Integer], "id", classOf[Account])
         .to(args("output"))
     ).via {
       case (key, (users, accounts), outputCollector) =>

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -31,7 +30,6 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -45,7 +43,6 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 
 /**
  * {@link org.apache.beam.sdk.extensions.smb.BucketMetadata} for Avro {@link GenericRecord} records.
@@ -164,18 +161,18 @@ public class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetada
             "Leaf key field %s does not exist in schema %s",
             keyPath[keyPath.length - 1], currSchema));
 
-    final Set<Class<?>> finalKeyFieldClasses = getKeyClassFromSchema(finalKeyField.schema());
+    final Class<?> finalKeyFieldClass = getKeyClassFromSchema(finalKeyField.schema());
 
     Preconditions.checkArgument(
-        finalKeyFieldClasses.stream().anyMatch(c -> c.isAssignableFrom(keyClass)),
+        finalKeyFieldClass.isAssignableFrom(keyClass),
         String.format(
-            "Key class %s did not conform to its Avro schema. Must be one of: %s",
-            keyClass, finalKeyFieldClasses));
+            "Key class %s did not conform to its Avro schema. Must be of class: %s",
+            keyClass, finalKeyFieldClass));
 
     return keyField;
   }
 
-  private static Set<Class<?>> getKeyClassFromSchema(Schema schema) {
+  private static Class<?> getKeyClassFromSchema(Schema schema) {
     Schema.Type schemaType = schema.getType();
 
     if (schemaType == Schema.Type.UNION) {
@@ -196,37 +193,37 @@ public class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetada
               + schema);
     }
 
-    return getClassesForType(schemaType);
+    return getClassForType(schemaType);
   }
 
-  private static Set<Class<?>> getClassesForType(Schema.Type schemaType) {
+  private static Class<?> getClassForType(Schema.Type schemaType) {
     switch (schemaType) {
       case RECORD:
-        return ImmutableSet.of(GenericRecord.class);
+        return GenericRecord.class;
       case NULL:
         throw new IllegalArgumentException("Key field cannot be of type Null");
       case ARRAY:
-        return ImmutableSet.of(Collection.class);
+        return Collection.class;
       case BOOLEAN:
-        return ImmutableSet.of(Boolean.class);
+        return Boolean.class;
       case MAP:
-        return ImmutableSet.of(Map.class);
+        return Map.class;
       case ENUM:
-        return ImmutableSet.of(String.class);
+        return String.class;
       case INT:
-        return ImmutableSet.of(Integer.class);
+        return Integer.class;
       case DOUBLE:
-        return ImmutableSet.of(Double.class);
+        return Double.class;
       case LONG:
-        return ImmutableSet.of(Long.class);
+        return Long.class;
       case STRING:
-        return ImmutableSet.of(CharSequence.class);
+        return CharSequence.class;
       case FIXED:
-        return ImmutableSet.of(GenericData.Fixed.class);
+        return GenericData.Fixed.class;
       case FLOAT:
-        return ImmutableSet.of(Float.class);
+        return Float.class;
       case BYTES:
-        return ImmutableSet.of(byte[].class, ByteString.class, ByteBuffer.class);
+        return ByteBuffer.class;
       default:
         throw new IllegalStateException("Can't match key field schema type " + schemaType);
     }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -36,7 +36,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.reflect.ReflectData;
-import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
@@ -57,32 +56,15 @@ public class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetada
 
   @JsonIgnore private final String[] keyPath;
 
-  public static <KeyT, ValueT extends GenericRecord> AvroBucketMetadata<KeyT, ValueT> of(
+  public AvroBucketMetadata(
       int numBuckets,
       int numShards,
-      Class<KeyT> keyClass,
+      Class<K> keyClass,
       BucketMetadata.HashType hashType,
       String keyField,
-      Schema schema)
+      Class<V> recordClass)
       throws CannotProvideCoderException, NonDeterministicException {
-    return new AvroBucketMetadata<>(
-        BucketMetadata.CURRENT_VERSION,
-        numBuckets,
-        numShards,
-        keyClass,
-        hashType,
-        validateKeyField(keyField, keyClass, schema));
-  }
-
-  public static <KeyT, ValueT extends SpecificRecordBase> AvroBucketMetadata<KeyT, ValueT> of(
-      int numBuckets,
-      int numShards,
-      Class<KeyT> keyClass,
-      BucketMetadata.HashType hashType,
-      String keyField,
-      Class<ValueT> recordClass)
-      throws CannotProvideCoderException, NonDeterministicException {
-    return new AvroBucketMetadata<>(
+    this(
         BucketMetadata.CURRENT_VERSION,
         numBuckets,
         numShards,
@@ -92,6 +74,23 @@ public class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetada
             keyField,
             keyClass,
             new ReflectData(recordClass.getClassLoader()).getSchema(recordClass)));
+  }
+
+  public AvroBucketMetadata(
+      int numBuckets,
+      int numShards,
+      Class<K> keyClass,
+      BucketMetadata.HashType hashType,
+      String keyField,
+      Schema schema)
+      throws CannotProvideCoderException, NonDeterministicException {
+    this(
+        BucketMetadata.CURRENT_VERSION,
+        numBuckets,
+        numShards,
+        keyClass,
+        hashType,
+        validateKeyField(keyField, keyClass, schema));
   }
 
   @JsonCreator

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
@@ -412,7 +412,13 @@ public class AvroSortedBucketIO {
 
       return (numBuckets, numShards, hashType) -> {
         try {
-          return new AvroBucketMetadata<>(numBuckets, numShards, keyClass, hashType, keyField);
+          if (getSchema() != null) {
+            return new AvroBucketMetadata<>(
+                numBuckets, numShards, keyClass, hashType, keyField, getSchema());
+          } else {
+            return new AvroBucketMetadata<>(
+                numBuckets, numShards, keyClass, hashType, keyField, getRecordClass());
+          }
         } catch (CannotProvideCoderException | Coder.NonDeterministicException e) {
           throw new IllegalStateException(e);
         }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
@@ -409,15 +409,17 @@ public class AvroSortedBucketIO {
     NewBucketMetadataFn<K, T> getNewBucketMetadataFn() {
       final String keyField = getKeyField();
       final Class<K> keyClass = getKeyClass();
+      final Schema schema = getSchema();
+      final Class<T> recordClass = getRecordClass();
 
       return (numBuckets, numShards, hashType) -> {
         try {
-          if (getSchema() != null) {
+          if (schema != null) {
             return new AvroBucketMetadata<>(
-                numBuckets, numShards, keyClass, hashType, keyField, getSchema());
+                numBuckets, numShards, keyClass, hashType, keyField, schema);
           } else {
             return new AvroBucketMetadata<>(
-                numBuckets, numShards, keyClass, hashType, keyField, getRecordClass());
+                numBuckets, numShards, keyClass, hashType, keyField, recordClass);
           }
         } catch (CannotProvideCoderException | Coder.NonDeterministicException e) {
           throw new IllegalStateException(e);

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
@@ -287,11 +287,26 @@ public class AvroSortedBucketIO {
               AvroFileOperations.of((Class<SpecificRecordBase>) getRecordClass(), getCodec());
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     BucketMetadata<K, T> getBucketMetadata() {
       try {
-        return new AvroBucketMetadata<>(
-            getNumBuckets(), getNumShards(), getKeyClass(), getHashType(), getKeyField());
+        return getRecordClass() == null
+            ? AvroBucketMetadata.of(
+                getNumBuckets(),
+                getNumShards(),
+                getKeyClass(),
+                getHashType(),
+                getKeyField(),
+                getSchema())
+            : (AvroBucketMetadata<K, T>)
+                AvroBucketMetadata.of(
+                    getNumBuckets(),
+                    getNumShards(),
+                    getKeyClass(),
+                    getHashType(),
+                    getKeyField(),
+                    (Class<SpecificRecordBase>) getRecordClass());
       } catch (CannotProvideCoderException | Coder.NonDeterministicException e) {
         throw new IllegalStateException(e);
       }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
@@ -292,7 +292,7 @@ public class AvroSortedBucketIO {
     BucketMetadata<K, T> getBucketMetadata() {
       try {
         return getRecordClass() == null
-            ? AvroBucketMetadata.of(
+            ? new AvroBucketMetadata<>(
                 getNumBuckets(),
                 getNumShards(),
                 getKeyClass(),
@@ -300,7 +300,7 @@ public class AvroSortedBucketIO {
                 getKeyField(),
                 getSchema())
             : (AvroBucketMetadata<K, T>)
-                AvroBucketMetadata.of(
+                new AvroBucketMetadata<>(
                     getNumBuckets(),
                     getNumShards(),
                     getKeyClass(),

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.extensions.smb;
 
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 
-import com.google.protobuf.ByteString;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -189,12 +188,6 @@ public class AvroBucketMetadataTest {
   @Test
   public void testKeyTypeCheckingBytes()
       throws CannotProvideCoderException, NonDeterministicException {
-    new AvroBucketMetadata<>(
-        1, 1, byte[].class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA);
-
-    new AvroBucketMetadata<>(
-        1, 1, ByteString.class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA);
-
     new AvroBucketMetadata<>(
         1, 1, ByteBuffer.class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA);
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
@@ -82,12 +82,12 @@ public class AvroBucketMetadataTest {
 
     Assert.assertEquals(
         (Long) 10L,
-        AvroBucketMetadata.of(1, 1, Long.class, HashType.MURMUR3_32, "id", RECORD_SCHEMA)
+        new AvroBucketMetadata<>(1, 1, Long.class, HashType.MURMUR3_32, "id", RECORD_SCHEMA)
             .extractKey(user));
 
     Assert.assertEquals(
         countryIdAsBytes,
-        AvroBucketMetadata.of(
+        new AvroBucketMetadata<>(
                 1, 1, ByteBuffer.class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA)
             .extractKey(user));
 
@@ -95,7 +95,7 @@ public class AvroBucketMetadataTest {
     FIXME: BucketMetadata should allow custom coder?
     Assert.assertEquals(
         Arrays.asList("CN", "MX"),
-        AvroBucketMetadata.of(
+        new AvroBucketMetadata<>(
                 1, 1, ArrayList.class, HashType.MURMUR3_32, "location.prevCountries")
             .extractKey(user));
      */
@@ -107,13 +107,13 @@ public class AvroBucketMetadataTest {
 
     Assert.assertEquals(
         "green",
-        AvroBucketMetadata.of(
+        new AvroBucketMetadata<>(
                 1, 1, String.class, HashType.MURMUR3_32, "favorite_color", AvroGeneratedUser.class)
             .extractKey(user));
 
     Assert.assertEquals(
         (Integer) 50,
-        AvroBucketMetadata.of(
+        new AvroBucketMetadata<>(
                 1,
                 1,
                 Integer.class,
@@ -139,7 +139,7 @@ public class AvroBucketMetadataTest {
   @Test
   public void testVersionDefault() throws Exception {
     final AvroBucketMetadata<String, GenericRecord> metadata =
-        AvroBucketMetadata.of(
+        new AvroBucketMetadata<>(
             1, 1, String.class, HashType.MURMUR3_32, "favorite_color", AvroGeneratedUser.SCHEMA$);
 
     Assert.assertEquals(BucketMetadata.CURRENT_VERSION, metadata.getVersion());
@@ -148,7 +148,7 @@ public class AvroBucketMetadataTest {
   @Test
   public void testDisplayData() throws Exception {
     final AvroBucketMetadata<String, GenericRecord> metadata =
-        AvroBucketMetadata.of(
+        new AvroBucketMetadata<>(
             2, 1, String.class, HashType.MURMUR3_32, "favorite_color", AvroGeneratedUser.SCHEMA$);
 
     final DisplayData displayData = DisplayData.from(metadata);
@@ -166,19 +166,19 @@ public class AvroBucketMetadataTest {
   @Test
   public void testSameSourceCompatibility() throws Exception {
     final AvroBucketMetadata<String, GenericRecord> metadata1 =
-        AvroBucketMetadata.of(
+        new AvroBucketMetadata<>(
             2, 1, String.class, HashType.MURMUR3_32, "name", AvroGeneratedUser.SCHEMA$);
 
     final AvroBucketMetadata<String, GenericRecord> metadata2 =
-        AvroBucketMetadata.of(
+        new AvroBucketMetadata<>(
             2, 1, String.class, HashType.MURMUR3_32, "favorite_color", AvroGeneratedUser.SCHEMA$);
 
     final AvroBucketMetadata<String, GenericRecord> metadata3 =
-        AvroBucketMetadata.of(
+        new AvroBucketMetadata<>(
             4, 1, String.class, HashType.MURMUR3_32, "favorite_color", AvroGeneratedUser.SCHEMA$);
 
     final AvroBucketMetadata<Integer, GenericRecord> metadata4 =
-        AvroBucketMetadata.of(
+        new AvroBucketMetadata<>(
             4, 1, Integer.class, HashType.MURMUR3_32, "favorite_number", AvroGeneratedUser.SCHEMA$);
 
     Assert.assertFalse(metadata1.isPartitionCompatible(metadata2));
@@ -189,19 +189,19 @@ public class AvroBucketMetadataTest {
   @Test
   public void testKeyTypeCheckingBytes()
       throws CannotProvideCoderException, NonDeterministicException {
-    AvroBucketMetadata.of(
+    new AvroBucketMetadata<>(
         1, 1, byte[].class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA);
 
-    AvroBucketMetadata.of(
+    new AvroBucketMetadata<>(
         1, 1, ByteString.class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA);
 
-    AvroBucketMetadata.of(
+    new AvroBucketMetadata<>(
         1, 1, ByteBuffer.class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA);
 
     Assert.assertThrows(
         IllegalArgumentException.class,
         () ->
-            AvroBucketMetadata.of(
+            new AvroBucketMetadata<>(
                 1, 1, String.class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA));
   }
 
@@ -221,7 +221,7 @@ public class AvroBucketMetadataTest {
                     "",
                     "a")));
 
-    AvroBucketMetadata.of(1, 1, String.class, HashType.MURMUR3_32, "enumField", enumSchema);
+    new AvroBucketMetadata<>(1, 1, String.class, HashType.MURMUR3_32, "enumField", enumSchema);
   }
 
   @Test
@@ -233,18 +233,19 @@ public class AvroBucketMetadataTest {
     // Three types
     final Schema illegalUnionSchema2 = createUnionRecordOfTypes(Type.STRING, Type.BYTES, Type.NULL);
 
-    AvroBucketMetadata.of(1, 1, String.class, HashType.MURMUR3_32, "unionField", legalUnionSchema);
+    new AvroBucketMetadata<>(
+        1, 1, String.class, HashType.MURMUR3_32, "unionField", legalUnionSchema);
 
     Assert.assertThrows(
         IllegalArgumentException.class,
         () ->
-            AvroBucketMetadata.of(
+            new AvroBucketMetadata<>(
                 1, 1, String.class, HashType.MURMUR3_32, "unionField", illegalUnionSchema1));
 
     Assert.assertThrows(
         IllegalArgumentException.class,
         () ->
-            AvroBucketMetadata.of(
+            new AvroBucketMetadata<>(
                 1, 1, String.class, HashType.MURMUR3_32, "unionField", illegalUnionSchema2));
   }
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
@@ -65,7 +65,12 @@ public class AvroBucketMetadataTest {
           false,
           Lists.newArrayList(
               new Schema.Field("id", Schema.create(Schema.Type.LONG), "", 0L),
-              new Schema.Field("location", LOCATION_SCHEMA, "", Collections.emptyList())));
+              new Schema.Field("location", LOCATION_SCHEMA, "", Collections.emptyList()),
+              new Schema.Field(
+                  "suffix",
+                  Schema.createEnum("Suffix", "", "", Lists.newArrayList("Jr", "Sr", "None")),
+                  "",
+                  "None")));
 
   @Test
   public void testGenericRecord() throws Exception {
@@ -77,7 +82,11 @@ public class AvroBucketMetadataTest {
             .build();
 
     final GenericRecord user =
-        new GenericRecordBuilder(RECORD_SCHEMA).set("id", 10L).set("location", location).build();
+        new GenericRecordBuilder(RECORD_SCHEMA)
+            .set("id", 10L)
+            .set("location", location)
+            .set("suffix", "Jr")
+            .build();
 
     Assert.assertEquals(
         (Long) 10L,
@@ -88,6 +97,11 @@ public class AvroBucketMetadataTest {
         countryIdAsBytes,
         new AvroBucketMetadata<>(
                 1, 1, ByteBuffer.class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA)
+            .extractKey(user));
+
+    Assert.assertEquals(
+        "Jr",
+        new AvroBucketMetadata<>(1, 1, String.class, HashType.MURMUR3_32, "suffix", RECORD_SCHEMA)
             .extractKey(user));
 
     /*
@@ -196,25 +210,6 @@ public class AvroBucketMetadataTest {
         () ->
             new AvroBucketMetadata<>(
                 1, 1, String.class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA));
-  }
-
-  @Test
-  public void testKeyTypeCheckingEnum()
-      throws CannotProvideCoderException, NonDeterministicException {
-    final Schema enumSchema =
-        Schema.createRecord(
-            "enumSchema",
-            "",
-            "",
-            false,
-            Lists.newArrayList(
-                new Schema.Field(
-                    "enumField",
-                    Schema.createEnum("enumType", "", "", Lists.newArrayList("a", "b", "c")),
-                    "",
-                    "a")));
-
-    new AvroBucketMetadata<>(1, 1, String.class, HashType.MURMUR3_32, "enumField", enumSchema);
   }
 
   @Test

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
@@ -20,6 +20,10 @@ package org.apache.beam.sdk.extensions.smb;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 
 import com.google.api.services.bigquery.model.TableRow;
+import java.util.Collections;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -69,7 +73,15 @@ public class BucketMetadataTest {
   public void testSubTyping() throws Exception {
     final BucketMetadata<String, String> test = new TestBucketMetadata(16, 4, HashType.MURMUR3_32);
     final BucketMetadata<String, GenericRecord> avro =
-        new AvroBucketMetadata<>(16, 4, String.class, HashType.MURMUR3_32, "keyField");
+        AvroBucketMetadata.of(
+            16,
+            4,
+            String.class,
+            HashType.MURMUR3_32,
+            "keyField",
+            Schema.createRecord(
+                Collections.singletonList(
+                    new Field("keyField", Schema.create(Type.STRING), "", ""))));
     final BucketMetadata<String, TableRow> json =
         new JsonBucketMetadata<>(16, 4, String.class, HashType.MURMUR3_32, "keyField");
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
@@ -20,14 +20,11 @@ package org.apache.beam.sdk.extensions.smb;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 
 import com.google.api.services.bigquery.model.TableRow;
-import java.util.Collections;
-import org.apache.avro.Schema;
-import org.apache.avro.Schema.Field;
-import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
+import org.apache.beam.sdk.io.AvroGeneratedUser;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -73,15 +70,8 @@ public class BucketMetadataTest {
   public void testSubTyping() throws Exception {
     final BucketMetadata<String, String> test = new TestBucketMetadata(16, 4, HashType.MURMUR3_32);
     final BucketMetadata<String, GenericRecord> avro =
-        AvroBucketMetadata.of(
-            16,
-            4,
-            String.class,
-            HashType.MURMUR3_32,
-            "keyField",
-            Schema.createRecord(
-                Collections.singletonList(
-                    new Field("keyField", Schema.create(Type.STRING), "", ""))));
+        new AvroBucketMetadata<>(
+            16, 4, String.class, HashType.MURMUR3_32, "favorite_color", AvroGeneratedUser.SCHEMA$);
     final BucketMetadata<String, TableRow> json =
         new JsonBucketMetadata<>(16, 4, String.class, HashType.MURMUR3_32, "keyField");
 


### PR DESCRIPTION
validates `keyPath` against the Avro schema as well as type-checking `keyClass` to the type Avro returns when calling #get on a `GenericRecord`.