### PR TITLE
Clarify T <: HasAnnotation vs T: Schema methods in 0.9 migration doc

### DIFF
--- a/site/src/paradox/io/Type-Safe-BigQuery.md
+++ b/site/src/paradox/io/Type-Safe-BigQuery.md
@@ -199,6 +199,32 @@ In addition, `BigQueryType.fromTable` and `BigQueryTable.fromQuery` generate `ta
 
 import com.spotify.scio.bigquery.types.BigQueryTypeUser defined companion objects may interfere with macro code generation so for now do not provide one to a case class annotated with `@BigQueryType.toTable`, i.e. `object Row`.
 
+## BigQuery reads using `Schema`
+Classes generated from `@BigQueryType` annotations extend the @scaladoc[HasAnnotation](com.spotify.scio.bigquery.types.BigQueryType$$HasAnnotation) trait, and most of Scio's @scaladoc[user-facing BigQuery APIs](com.spotify.scio.bigquery.syntax.ScioContextOps) expect a
+parameterized type `T <: HasAnnotation`. However, Scio also offers a typed BigQuery read API that accepts any type `T` with an explicit @github[Schema](/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala) instance in scope:
+
+```scala
+def typedBigQueryTable[T: Schema: Coder: ClassTag](table: Table): SCollection[T]
+```
+
+A `Schema` will be implicitly derived at compile time (similar to @ref[Coder](../internals/Coders.md)s) for case classes and certain traits like Lists, Maps, and Options.
+
+
+```scala mdoc:reset
+import com.spotify.scio.bigquery._
+import com.spotify.scio.ContextAndArgs
+
+case class Shakespeare(word: String, word_count: Long, corpus: String, corpus_date: Long)
+
+def main(cmdlineArgs: Array[String]): Unit = {
+  val (sc, args) = ContextAndArgs(cmdlineArgs)
+  sc
+    .typedBigQueryTable[Shakespeare](Table.Spec("bigquery-public-data:samples.shakespeare"))
+}
+```
+
+For more information on Schema materialization, see the @ref:[V0.8.0 Migration Guide](../migrations/v0.8.0-Migration-Guide.md).
+
 ## Using type safe BigQuery
 
 ### Type safe BigQuery with Scio

--- a/site/src/paradox/io/Type-Safe-BigQuery.md
+++ b/site/src/paradox/io/Type-Safe-BigQuery.md
@@ -201,7 +201,7 @@ import com.spotify.scio.bigquery.types.BigQueryTypeUser defined companion object
 
 ## BigQuery reads using `Schema`
 Classes generated from `@BigQueryType` annotations extend the @scaladoc[HasAnnotation](com.spotify.scio.bigquery.types.BigQueryType$$HasAnnotation) trait, and most of Scio's @scaladoc[user-facing BigQuery APIs](com.spotify.scio.bigquery.syntax.ScioContextOps) expect a
-parameterized type `T <: HasAnnotation`. However, Scio also offers a typed BigQuery read API that accepts any type `T` with an explicit @github[Schema](/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala) instance in scope:
+parameterized type `T <: HasAnnotation`. However, Scio also offers a typed BigQuery read API that accepts any type `T` with an implicit @github[Schema](/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala) instance in scope:
 
 ```scala
 def typedBigQueryTable[T: Schema: Coder: ClassTag](table: Table): SCollection[T]

--- a/site/src/paradox/migrations/v0.9.0-Migration-Guide.md
+++ b/site/src/paradox/migrations/v0.9.0-Migration-Guide.md
@@ -68,16 +68,14 @@ def tableReference: TableReference = ???
 def table: Table = Table.Ref(tableReference)
 ```
 
-Below are some of the affected methods and suggestions on how you can migrate:
+Bellow are some of the affected methods and suggestion on how you can migrate:
 
 ```diff
 - typedBigQuery(table: TableReference, ...)
-+ typedBigQuery[T <: HasAnnotation](source: Table.Spec(tableSpec))
-+ typedBigQueryTable[T: Schema](table: Table.Ref(tableReference), ...)
++ typedBigQuery(table: Table.Ref(tableReference), ...)
 
 - typedBigQuery(tableSpec: String, ...)
-+ typedBigQuery[T <: HasAnnotation](source: Table.Spec(tableSpec))
-+ typedBigQueryTable[T: Schema](tableSpec: Table.Spec(tableSpec), ...)
++ typedBigQuery(tableSpec: Table.Spec(tableSpec), ...)
 
 - saveAsBigQuery(table: TableReference, ...)
 + saveAsBigQueryTable(table: Table.Ref(tableReference), ...)
@@ -104,11 +102,6 @@ Methods with only argument type change:
 - saveAsTypedBigQuery(tableSpec: String, ...)
 + saveAsTypedBigQuery(tableSpec: Table.Spec(tableSpec), ...)
 ```
-
-#### `T <: HasAnnotation` vs. `T: Schema`
-As shown above, typed BigQuery reads can accept a parameterized type `T` that either extends `HasAnnotation` or has an implicit @github[Schema](/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala) instance.
-Any class with a `@BigQueryType` annotation will be expanded to extend `HasAnnotation`. (These methods actually accept an `Option` of a Table, because some `@BigQueryType` annotations, such as `fromTable`, already encode sufficient information about the BQ source.)
-On the other hand, a `Schema` will be implicitly derived for case classes and certain traits like Lists, Maps, and Options, similarly to how @ref[Coders](../internals/Coders.md) work. For more information on Schema materialization, see the @ref:[V0.8.0 Migration Guide](v0.8.0-Migration-Guide.md).
 
 #### BigQuery deprecations
 

--- a/site/src/paradox/migrations/v0.9.0-Migration-Guide.md
+++ b/site/src/paradox/migrations/v0.9.0-Migration-Guide.md
@@ -68,14 +68,16 @@ def tableReference: TableReference = ???
 def table: Table = Table.Ref(tableReference)
 ```
 
-Bellow are some of the affected methods and suggestion on how you can migrate:
+Below are some of the affected methods and suggestions on how you can migrate:
 
 ```diff
 - typedBigQuery(table: TableReference, ...)
-+ typedBigQueryTable(table: Table.Ref(tableReference), ...)
++ typedBigQuery[T <: HasAnnotation](source: Table.Spec(tableSpec))
++ typedBigQueryTable[T: Schema](table: Table.Ref(tableReference), ...)
 
 - typedBigQuery(tableSpec: String, ...)
-+ typedBigQueryTable(tableSpec: Table.Spec(tableSpec), ...)
++ typedBigQuery[T <: HasAnnotation](source: Table.Spec(tableSpec))
++ typedBigQueryTable[T: Schema](tableSpec: Table.Spec(tableSpec), ...)
 
 - saveAsBigQuery(table: TableReference, ...)
 + saveAsBigQueryTable(table: Table.Ref(tableReference), ...)
@@ -102,6 +104,11 @@ Methods with only argument type change:
 - saveAsTypedBigQuery(tableSpec: String, ...)
 + saveAsTypedBigQuery(tableSpec: Table.Spec(tableSpec), ...)
 ```
+
+#### `T <: HasAnnotation` vs. `T: Schema`
+As shown above, typed BigQuery reads can accept a parameterized type `T` that either extends `HasAnnotation` or has an implicit @github[Schema](/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala) instance.
+Any class with a `@BigQueryType` annotation will be expanded to extend `HasAnnotation`. (These methods actually accept an `Option` of a Table, because some `@BigQueryType` annotations, such as `fromTable`, already encode sufficient information about the BQ source.)
+On the other hand, a `Schema` will be implicitly derived for case classes and certain traits like Lists, Maps, and Options, similarly to how @ref[Coders](../internals/Coders.md) work. For more information on Schema materialization, see the @ref:[V0.8.0 Migration Guide](v0.8.0-Migration-Guide.md).
 
 #### BigQuery deprecations
 


### PR DESCRIPTION
related to a support question yesterday about the migration path not working for a `@BigQueryType.fromTable` read when the user switched to the `typedBigQueryTable` -- a Schema could not be inferred for the non-case-class. I wanted to add some clarification on the new BQ Read APIs since the `typedBigQueryTable[T: Schema]` may not work for every use case. 

also, Git is displaying the diff terribly! I just added alternate methods for the first two API examples, as well as a clarifying paragraph.