### PR TITLE
Add raw beam coder materializer

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -77,6 +77,9 @@ private[scio] object Ref {
   def unapply[T](c: Ref[T]): Option[(String, Coder[T])] = Option((c.typeName, c.value))
 }
 
+final case class RawBeam[T] private (beam: BCoder[T]) extends Coder[T] {
+  override def toString: String = s"RawBeam($beam)"
+}
 final case class Beam[T] private (beam: BCoder[T]) extends Coder[T] {
   override def toString: String = s"Beam($beam)"
 }
@@ -395,6 +398,8 @@ final private[scio] case class RecordCoder[T](
 sealed trait CoderGrammar {
 
   /** Create a ScioCoder from a Beam Coder */
+  def raw[T](beam: BCoder[T]): Coder[T] =
+    RawBeam(beam)
   def beam[T](beam: BCoder[T]): Coder[T] =
     Beam(beam)
   def kv[K, V](koder: Coder[K], voder: Coder[V]): Coder[KV[K, V]] =

--- a/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
@@ -55,6 +55,7 @@ object CoderMaterializer {
     coder: Coder[T]
   ): BCoder[T] =
     coder match {
+      case RawBeam(c) => c
       // #1734: do not wrap native beam coders
       case Beam(c) if c.getClass.getPackage.getName.startsWith("org.apache.beam") =>
         nullCoder(o, c)

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -52,7 +52,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     ParDo.of(Functions.mapFn((kv: (K, V)) => KV.of(kv._1, kv._2)))
 
   private[scio] def toKV(implicit koder: Coder[K], voder: Coder[V]): SCollection[KV[K, V]] =
-    self.applyTransform(toKvTransform).setCoder(CoderMaterializer.kvCoder[K, V](context))
+    self.applyTransform(toKvTransform)(Coder.raw(CoderMaterializer.kvCoder[K, V](context)))
 
   private[values] def applyPerKey[UI: Coder, UO: Coder](
     t: PTransform[_ >: PCollection[KV[K, V]], PCollection[KV[K, UI]]]
@@ -61,8 +61,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   )(implicit koder: Coder[K], voder: Coder[V]): SCollection[(K, UO)] =
     self.transform(
       _.withName("TupleToKv").toKV
-        .applyTransform(t)
-        .setCoder(CoderMaterializer.kvCoder[K, UI](context))
+        .applyTransform(t)(Coder.raw(CoderMaterializer.kvCoder[K, UI](context)))
         .withName("KvToTuple")
         .map(f)
     )

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -577,8 +577,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
       val cf = ClosureCleaner.clean(f)
       val cg = ClosureCleaner.clean(g)
 
-      _.map(t => KV.of(cf(t), cg(t)))
-        .setCoder(CoderMaterializer.kvCoder[K, U](context))
+      _.map(t => KV.of(cf(t), cg(t)))(Coder.raw(CoderMaterializer.kvCoder[K, U](context)))
         .pApply(GroupByKey.create[K, U]())
         .map(kvIterableToTuple)
     }
@@ -599,8 +598,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     this.transform {
       val cf = ClosureCleaner.clean(f)
 
-      _.map(t => KV.of(cf(t), t))
-        .setCoder(CoderMaterializer.kvCoder[K, T](context))
+      _.map(t => KV.of(cf(t), t))(Coder.raw(CoderMaterializer.kvCoder[K, T](context)))
         .pApply(Combine.perKey(Functions.reduceFn(context, g)))
         .map(kvToTuple)
     }


### PR DESCRIPTION
The idea here is to allow us to set the raw beam coder (native or not) without being wrapped in  `NullableCoder` and `WrappedBCoder`. This is useful in situations where 1) the underlying transform checks for a given coder instance and 2) where wrapping it in a `NullableCoder` does not make sense.