### PR TITLE
allow user-supplied filename prefix for smb writes/reads

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
@@ -76,10 +76,11 @@ object SortMergeBucketWriteExample {
       .saveAsSortedBucket(
         AvroSortedBucketIO
           .write(classOf[Integer], "userId", SortMergeBucketExample.UserDataSchema)
-          .to(args("userOutput"))
+          .to(args("users"))
           .withTempDirectory(sc.options.getTempLocation)
           .withCodec(CodecFactory.snappyCodec())
           .withHashType(HashType.MURMUR3_32)
+          .withFilenamePrefix("example-prefix")
           .withNumBuckets(2)
           .withNumShards(1)
       )
@@ -98,11 +99,12 @@ object SortMergeBucketWriteExample {
       .saveAsSortedBucket(
         AvroSortedBucketIO
           .write[Integer, Account](classOf[Integer], "id", classOf[Account])
-          .to(args("accountOutput"))
+          .to(args("accounts"))
           .withSorterMemoryMb(128)
           .withTempDirectory(sc.options.getTempLocation)
           .withCodec(CodecFactory.snappyCodec())
           .withHashType(HashType.MURMUR3_32)
+          .withFilenamePrefix("part") // Default is "bucket"
           .withNumBuckets(1)
           .withNumShards(1)
       )
@@ -135,10 +137,10 @@ object SortMergeBucketJoinExample {
       classOf[Integer],
       AvroSortedBucketIO
         .read(new TupleTag[GenericRecord]("lhs"), SortMergeBucketExample.UserDataSchema)
-        .from(args("lhsInput")),
+        .from(args("users")),
       AvroSortedBucketIO
         .read(new TupleTag[Account]("rhs"), classOf[Account])
-        .from(args("rhsInput")),
+        .from(args("accounts")),
       TargetParallelism.max()
     ).map(mapFn) // Apply mapping function
       .saveAsTextFile(args("output"))
@@ -160,10 +162,10 @@ object SortMergeBucketTransformExample {
       classOf[Integer],
       AvroSortedBucketIO
         .read(new TupleTag[GenericRecord]("lhs"), SortMergeBucketExample.UserDataSchema)
-        .from(args("lhsInput")),
+        .from(args("users")),
       AvroSortedBucketIO
         .read(new TupleTag[Account]("rhs"), classOf[Account])
-        .from(args("rhsInput")),
+        .from(args("accounts")),
       TargetParallelism.auto()
     ).to(
       AvroSortedBucketIO

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/SortMergeBucketExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/SortMergeBucketExampleTest.scala
@@ -41,8 +41,8 @@ class SortMergeBucketExampleTest extends AnyFlatSpec with Matchers {
     (userDir, accountDir, joinOutputDir) =>
       SortMergeBucketWriteExample.main(
         Array(
-          s"--userOutput=$userDir",
-          s"--accountOutput=$accountDir"
+          s"--users=$userDir",
+          s"--accounts=$accountDir"
         )
       )
 
@@ -55,8 +55,8 @@ class SortMergeBucketExampleTest extends AnyFlatSpec with Matchers {
 
       SortMergeBucketJoinExample.main(
         Array(
-          s"--lhsInput=$userDir",
-          s"--rhsInput=$accountDir",
+          s"--users=$userDir",
+          s"--accounts=$accountDir",
           s"--output=$joinOutputDir"
         )
       )
@@ -69,15 +69,15 @@ class SortMergeBucketExampleTest extends AnyFlatSpec with Matchers {
     (userDir, accountDir, joinOutputDir) =>
       SortMergeBucketWriteExample.main(
         Array(
-          s"--userOutput=$userDir",
-          s"--accountOutput=$accountDir"
+          s"--users=$userDir",
+          s"--accounts=$accountDir"
         )
       )
 
       SortMergeBucketTransformExample.main(
         Array(
-          s"--lhsInput=$userDir",
-          s"--rhsInput=$accountDir",
+          s"--users=$userDir",
+          s"--accounts=$accountDir",
           s"--output=$joinOutputDir"
         )
       )

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -72,7 +72,7 @@ public class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetada
             keyField,
             keyClass,
             new ReflectData(recordClass.getClassLoader()).getSchema(recordClass)),
-        filenamePrefix);
+            filenamePrefix);
   }
 
   public AvroBucketMetadata(

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -59,6 +59,7 @@ public class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetada
       Class<K> keyClass,
       BucketMetadata.HashType hashType,
       String keyField,
+      String filenamePrefix,
       Class<V> recordClass)
       throws CannotProvideCoderException, NonDeterministicException {
     this(
@@ -70,7 +71,8 @@ public class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetada
         validateKeyField(
             keyField,
             keyClass,
-            new ReflectData(recordClass.getClassLoader()).getSchema(recordClass)));
+            new ReflectData(recordClass.getClassLoader()).getSchema(recordClass)),
+        filenamePrefix);
   }
 
   public AvroBucketMetadata(
@@ -79,6 +81,7 @@ public class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetada
       Class<K> keyClass,
       BucketMetadata.HashType hashType,
       String keyField,
+      String filenamePrefix,
       Schema schema)
       throws CannotProvideCoderException, NonDeterministicException {
     this(
@@ -87,7 +90,8 @@ public class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetada
         numShards,
         keyClass,
         hashType,
-        validateKeyField(keyField, keyClass, schema));
+        validateKeyField(keyField, keyClass, schema),
+        filenamePrefix);
   }
 
   @JsonCreator
@@ -97,9 +101,10 @@ public class AvroBucketMetadata<K, V extends GenericRecord> extends BucketMetada
       @JsonProperty("numShards") int numShards,
       @JsonProperty("keyClass") Class<K> keyClass,
       @JsonProperty("hashType") BucketMetadata.HashType hashType,
-      @JsonProperty("keyField") String keyField)
+      @JsonProperty("keyField") String keyField,
+      @JsonProperty(value = "filenamePrefix", required = false) String filenamePrefix)
       throws CannotProvideCoderException, NonDeterministicException {
-    super(version, numBuckets, numShards, keyClass, hashType);
+    super(version, numBuckets, numShards, keyClass, hashType, filenamePrefix);
     this.keyField = keyField;
     this.keyPath = toKeyPath(keyField);
   }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -110,7 +110,8 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
     this.hashFunction = hashType.create();
     this.keyCoder = getKeyCoder();
     this.version = version;
-    this.filenamePrefix = filenamePrefix != null ? filenamePrefix : SortedBucketIO.DEFAULT_FILENAME_PREFIX;
+    this.filenamePrefix =
+        filenamePrefix != null ? filenamePrefix : SortedBucketIO.DEFAULT_FILENAME_PREFIX;
   }
 
   @JsonIgnore

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -78,12 +78,25 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
 
   @JsonProperty private final HashType hashType;
 
+  @JsonProperty private final String filenamePrefix;
+
   @JsonIgnore private final HashFunction hashFunction;
 
   @JsonIgnore private final Coder<K> keyCoder;
 
   public BucketMetadata(
       int version, int numBuckets, int numShards, Class<K> keyClass, HashType hashType)
+      throws CannotProvideCoderException, NonDeterministicException {
+    this(version, numBuckets, numShards, keyClass, hashType, null);
+  }
+
+  public BucketMetadata(
+      int version,
+      int numBuckets,
+      int numShards,
+      Class<K> keyClass,
+      HashType hashType,
+      String filenamePrefix)
       throws CannotProvideCoderException, NonDeterministicException {
     Preconditions.checkArgument(
         numBuckets > 0 && ((numBuckets & (numBuckets - 1)) == 0),
@@ -97,6 +110,7 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
     this.hashFunction = hashType.create();
     this.keyCoder = getKeyCoder();
     this.version = version;
+    this.filenamePrefix = filenamePrefix != null ? filenamePrefix : SortedBucketIO.DEFAULT_FILENAME_PREFIX;
   }
 
   @JsonIgnore
@@ -123,6 +137,7 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
     builder.add(DisplayData.item("hashType", hashType.toString()));
     builder.add(DisplayData.item("keyClass", keyClass));
     builder.add(DisplayData.item("keyCoder", keyCoder.getClass()));
+    builder.add(DisplayData.item("filenamePrefix", filenamePrefix));
   }
 
   /** Enumerated hashing schemes available for an SMB write. */
@@ -172,6 +187,10 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
 
   public HashType getHashType() {
     return hashType;
+  }
+
+  public String getFilenamePrefix() {
+    return filenamePrefix;
   }
 
   /* Business logic */

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
@@ -44,9 +44,17 @@ public class JsonBucketMetadata<K> extends BucketMetadata<K, TableRow> {
       int numShards,
       Class<K> keyClass,
       BucketMetadata.HashType hashType,
-      String keyField)
+      String keyField,
+      String filenamePrefix)
       throws CannotProvideCoderException, NonDeterministicException {
-    this(BucketMetadata.CURRENT_VERSION, numBuckets, numShards, keyClass, hashType, keyField);
+    this(
+        BucketMetadata.CURRENT_VERSION,
+        numBuckets,
+        numShards,
+        keyClass,
+        hashType,
+        keyField,
+        filenamePrefix);
   }
 
   @JsonCreator
@@ -56,9 +64,10 @@ public class JsonBucketMetadata<K> extends BucketMetadata<K, TableRow> {
       @JsonProperty("numShards") int numShards,
       @JsonProperty("keyClass") Class<K> keyClass,
       @JsonProperty("hashType") BucketMetadata.HashType hashType,
-      @JsonProperty("keyField") String keyField)
+      @JsonProperty("keyField") String keyField,
+      @JsonProperty(value = "filenamePrefix", required = false) String filenamePrefix)
       throws CannotProvideCoderException, NonDeterministicException {
-    super(version, numBuckets, numShards, keyClass, hashType);
+    super(version, numBuckets, numShards, keyClass, hashType, filenamePrefix);
     this.keyField = keyField;
     this.keyPath = keyField.split("\\.");
   }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -51,6 +51,7 @@ public class SortedBucketIO {
   static final int DEFAULT_NUM_SHARDS = 1;
   static final HashType DEFAULT_HASH_TYPE = HashType.MURMUR3_128;
   static final int DEFAULT_SORTER_MEMORY_MB = 1024;
+  static final String DEFAULT_FILENAME_PREFIX = "bucket";
   static final TargetParallelism DEFAULT_PARALLELISM = TargetParallelism.auto();
 
   /** Co-groups sorted-bucket sources with the same sort key. */
@@ -139,6 +140,7 @@ public class SortedBucketIO {
     private final NewBucketMetadataFn<K, V> newBucketMetadataFn;
     private final FileOperations<V> fileOperations;
     private final String filenameSuffix;
+    private final String filenamePrefix;
 
     private CoGbkTransform(
         Class<K> keyClass,
@@ -153,6 +155,7 @@ public class SortedBucketIO {
       this.newBucketMetadataFn = transform.getNewBucketMetadataFn();
       this.fileOperations = transform.getFileOperations();
       this.filenameSuffix = transform.getFilenameSuffix();
+      this.filenamePrefix = transform.getFilenamePrefix();
     }
 
     public CoGbkTransform<K, V> via(TransformFn<K, V> toFinalResultT) {
@@ -183,7 +186,8 @@ public class SortedBucketIO {
               tmpDir,
               newBucketMetadataFn,
               fileOperations,
-              filenameSuffix));
+              filenameSuffix,
+              filenamePrefix));
     }
   }
 
@@ -197,6 +201,8 @@ public class SortedBucketIO {
     abstract ResourceId getTempDirectory();
 
     abstract String getFilenameSuffix();
+
+    abstract String getFilenamePrefix();
 
     abstract FileOperations<V> getFileOperations();
 
@@ -214,6 +220,8 @@ public class SortedBucketIO {
     abstract int getNumBuckets();
 
     abstract int getNumShards();
+
+    abstract String getFilenamePrefix();
 
     abstract Class<K> getKeyClass();
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSink.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSink.java
@@ -157,7 +157,8 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
       int sorterMemoryMb,
       int keyCacheSize) {
     this.bucketMetadata = bucketMetadata;
-    this.filenamePolicy = new SMBFilenamePolicy(outputDirectory, filenameSuffix);
+    this.filenamePolicy =
+        new SMBFilenamePolicy(outputDirectory, bucketMetadata.getFilenamePrefix(), filenameSuffix);
     this.tempDirectory = tempDirectory;
     this.fileOperations = fileOperations;
     this.sorterMemoryMb = sorterMemoryMb;
@@ -753,7 +754,9 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
         boolean verifyKeyExtraction,
         int keyCacheSize) {
       this.bucketMetadata = bucketMetadata;
-      this.filenamePolicy = new SMBFilenamePolicy(outputDirectory, filenameSuffix);
+      this.filenamePolicy =
+          new SMBFilenamePolicy(
+              outputDirectory, bucketMetadata.getFilenamePrefix(), filenameSuffix);
       this.tempDirectory = tempDirectory;
       this.fileOperations = fileOperations;
       this.sorterMemoryMb = sorterMemoryMb;

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -85,8 +85,10 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
       ResourceId tempDirectory,
       NewBucketMetadataFn<FinalKeyT, FinalValueT> newBucketMetadataFn,
       FileOperations<FinalValueT> fileOperations,
-      String filenameSuffix) {
-    final SMBFilenamePolicy filenamePolicy = new SMBFilenamePolicy(outputDirectory, filenameSuffix);
+      String filenameSuffix,
+      String filenamePrefix) {
+    final SMBFilenamePolicy filenamePolicy =
+        new SMBFilenamePolicy(outputDirectory, filenamePrefix, filenameSuffix);
     final SourceSpec<FinalKeyT> sourceSpec = SourceSpec.from(finalKeyClass, sources);
 
     boundedSource =

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
@@ -41,9 +41,17 @@ public class TensorFlowBucketMetadata<K> extends BucketMetadata<K, Example> {
       int numShards,
       Class<K> keyClass,
       BucketMetadata.HashType hashType,
-      String keyField)
+      String keyField,
+      String filenamePrefix)
       throws CannotProvideCoderException, NonDeterministicException {
-    this(BucketMetadata.CURRENT_VERSION, numBuckets, numShards, keyClass, hashType, keyField);
+    this(
+        BucketMetadata.CURRENT_VERSION,
+        numBuckets,
+        numShards,
+        keyClass,
+        hashType,
+        keyField,
+        filenamePrefix);
   }
 
   @JsonCreator
@@ -53,9 +61,10 @@ public class TensorFlowBucketMetadata<K> extends BucketMetadata<K, Example> {
       @JsonProperty("numShards") int numShards,
       @JsonProperty("keyClass") Class<K> keyClass,
       @JsonProperty("hashType") BucketMetadata.HashType hashType,
-      @JsonProperty("keyField") String keyField)
+      @JsonProperty("keyField") String keyField,
+      @JsonProperty(value = "filenamePrefix", required = false) String filenamePrefix)
       throws CannotProvideCoderException, NonDeterministicException {
-    super(version, numBuckets, numShards, keyClass, hashType);
+    super(version, numBuckets, numShards, keyClass, hashType, filenamePrefix);
     this.keyField = keyField;
   }
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
@@ -132,6 +132,7 @@ public class AvroBucketMetadataTest {
                 ByteBuffer.class,
                 HashType.MURMUR3_32,
                 "locationUnion.countryId",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX,
                 RECORD_SCHEMA)
             .extractKey(user));
 
@@ -143,6 +144,7 @@ public class AvroBucketMetadataTest {
                 ByteBuffer.class,
                 HashType.MURMUR3_32,
                 "locationUnion.postalCode",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX,
                 RECORD_SCHEMA)
             .extractKey(user));
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
@@ -102,13 +102,26 @@ public class AvroBucketMetadataTest {
 
     Assert.assertEquals(
         (Long) 10L,
-        new AvroBucketMetadata<>(1, 1, Long.class, HashType.MURMUR3_32, "id", RECORD_SCHEMA)
+        new AvroBucketMetadata<>(
+                1,
+                1,
+                Long.class,
+                HashType.MURMUR3_32,
+                "id",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+                RECORD_SCHEMA)
             .extractKey(user));
 
     Assert.assertEquals(
         countryIdAsBytes,
         new AvroBucketMetadata<>(
-                1, 1, ByteBuffer.class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA)
+                1,
+                1,
+                ByteBuffer.class,
+                HashType.MURMUR3_32,
+                "location.countryId",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+                RECORD_SCHEMA)
             .extractKey(user));
 
     Assert.assertEquals(
@@ -135,7 +148,14 @@ public class AvroBucketMetadataTest {
 
     Assert.assertEquals(
         "Jr",
-        new AvroBucketMetadata<>(1, 1, String.class, HashType.MURMUR3_32, "suffix", RECORD_SCHEMA)
+        new AvroBucketMetadata<>(
+                1,
+                1,
+                String.class,
+                HashType.MURMUR3_32,
+                "suffix",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+                RECORD_SCHEMA)
             .extractKey(user));
 
     /*
@@ -155,7 +175,13 @@ public class AvroBucketMetadataTest {
     Assert.assertEquals(
         "green",
         new AvroBucketMetadata<>(
-                1, 1, String.class, HashType.MURMUR3_32, "favorite_color", AvroGeneratedUser.class)
+                1,
+                1,
+                String.class,
+                HashType.MURMUR3_32,
+                "favorite_color",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+                AvroGeneratedUser.class)
             .extractKey(user));
 
     Assert.assertEquals(
@@ -166,6 +192,7 @@ public class AvroBucketMetadataTest {
                 Integer.class,
                 HashType.MURMUR3_32,
                 "favorite_number",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX,
                 AvroGeneratedUser.class)
             .extractKey(user));
   }
@@ -173,7 +200,14 @@ public class AvroBucketMetadataTest {
   @Test
   public void testCoding() throws Exception {
     final AvroBucketMetadata<String, GenericRecord> metadata =
-        new AvroBucketMetadata<>(1, 1, 1, String.class, HashType.MURMUR3_32, "favorite_color");
+        new AvroBucketMetadata<>(
+            1,
+            1,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "favorite_color",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     final BucketMetadata<String, GenericRecord> copy = BucketMetadata.from(metadata.toString());
     Assert.assertEquals(metadata.getVersion(), copy.getVersion());
@@ -187,7 +221,13 @@ public class AvroBucketMetadataTest {
   public void testVersionDefault() throws Exception {
     final AvroBucketMetadata<String, GenericRecord> metadata =
         new AvroBucketMetadata<>(
-            1, 1, String.class, HashType.MURMUR3_32, "favorite_color", AvroGeneratedUser.SCHEMA$);
+            1,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "favorite_color",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+            AvroGeneratedUser.SCHEMA$);
 
     Assert.assertEquals(BucketMetadata.CURRENT_VERSION, metadata.getVersion());
   }
@@ -196,7 +236,13 @@ public class AvroBucketMetadataTest {
   public void testDisplayData() throws Exception {
     final AvroBucketMetadata<String, GenericRecord> metadata =
         new AvroBucketMetadata<>(
-            2, 1, String.class, HashType.MURMUR3_32, "favorite_color", AvroGeneratedUser.SCHEMA$);
+            2,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "favorite_color",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+            AvroGeneratedUser.SCHEMA$);
 
     final DisplayData displayData = DisplayData.from(metadata);
     MatcherAssert.assertThat(displayData, hasDisplayItem("numBuckets", 2));
@@ -214,19 +260,43 @@ public class AvroBucketMetadataTest {
   public void testSameSourceCompatibility() throws Exception {
     final AvroBucketMetadata<String, GenericRecord> metadata1 =
         new AvroBucketMetadata<>(
-            2, 1, String.class, HashType.MURMUR3_32, "name", AvroGeneratedUser.SCHEMA$);
+            2,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "name",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+            AvroGeneratedUser.SCHEMA$);
 
     final AvroBucketMetadata<String, GenericRecord> metadata2 =
         new AvroBucketMetadata<>(
-            2, 1, String.class, HashType.MURMUR3_32, "favorite_color", AvroGeneratedUser.SCHEMA$);
+            2,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "favorite_color",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+            AvroGeneratedUser.SCHEMA$);
 
     final AvroBucketMetadata<String, GenericRecord> metadata3 =
         new AvroBucketMetadata<>(
-            4, 1, String.class, HashType.MURMUR3_32, "favorite_color", AvroGeneratedUser.SCHEMA$);
+            4,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "favorite_color",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+            AvroGeneratedUser.SCHEMA$);
 
     final AvroBucketMetadata<Integer, GenericRecord> metadata4 =
         new AvroBucketMetadata<>(
-            4, 1, Integer.class, HashType.MURMUR3_32, "favorite_number", AvroGeneratedUser.SCHEMA$);
+            4,
+            1,
+            Integer.class,
+            HashType.MURMUR3_32,
+            "favorite_number",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+            AvroGeneratedUser.SCHEMA$);
 
     Assert.assertFalse(metadata1.isPartitionCompatible(metadata2));
     Assert.assertTrue(metadata2.isPartitionCompatible(metadata3));
@@ -237,13 +307,25 @@ public class AvroBucketMetadataTest {
   public void testKeyTypeCheckingBytes()
       throws CannotProvideCoderException, NonDeterministicException {
     new AvroBucketMetadata<>(
-        1, 1, ByteBuffer.class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA);
+        1,
+        1,
+        ByteBuffer.class,
+        HashType.MURMUR3_32,
+        "location.countryId",
+        SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+        RECORD_SCHEMA);
 
     Assert.assertThrows(
         IllegalArgumentException.class,
         () ->
             new AvroBucketMetadata<>(
-                1, 1, String.class, HashType.MURMUR3_32, "location.countryId", RECORD_SCHEMA));
+                1,
+                1,
+                String.class,
+                HashType.MURMUR3_32,
+                "location.countryId",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+                RECORD_SCHEMA));
   }
 
   @Test
@@ -256,19 +338,37 @@ public class AvroBucketMetadataTest {
     final Schema illegalUnionSchema2 = createUnionRecordOfTypes(Type.STRING, Type.BYTES, Type.NULL);
 
     new AvroBucketMetadata<>(
-        1, 1, String.class, HashType.MURMUR3_32, "unionField", legalUnionSchema);
+        1,
+        1,
+        String.class,
+        HashType.MURMUR3_32,
+        "unionField",
+        SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+        legalUnionSchema);
 
     Assert.assertThrows(
         IllegalArgumentException.class,
         () ->
             new AvroBucketMetadata<>(
-                1, 1, String.class, HashType.MURMUR3_32, "unionField", illegalUnionSchema1));
+                1,
+                1,
+                String.class,
+                HashType.MURMUR3_32,
+                "unionField",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+                illegalUnionSchema1));
 
     Assert.assertThrows(
         IllegalArgumentException.class,
         () ->
             new AvroBucketMetadata<>(
-                1, 1, String.class, HashType.MURMUR3_32, "unionField", illegalUnionSchema2));
+                1,
+                1,
+                String.class,
+                HashType.MURMUR3_32,
+                "unionField",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+                illegalUnionSchema2));
   }
 
   private static Schema createUnionRecordOfTypes(Schema.Type... types) {

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
@@ -45,11 +45,24 @@ public class JsonBucketMetadataTest {
 
     Assert.assertEquals(
         (Integer) 10,
-        new JsonBucketMetadata<>(1, 1, Integer.class, HashType.MURMUR3_32, "age").extractKey(user));
+        new JsonBucketMetadata<>(
+                1,
+                1,
+                Integer.class,
+                HashType.MURMUR3_32,
+                "age",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX)
+            .extractKey(user));
 
     Assert.assertEquals(
         "US",
-        new JsonBucketMetadata<>(1, 1, String.class, HashType.MURMUR3_32, "location.currentCountry")
+        new JsonBucketMetadata<>(
+                1,
+                1,
+                String.class,
+                HashType.MURMUR3_32,
+                "location.currentCountry",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX)
             .extractKey(user));
 
     /*
@@ -65,7 +78,14 @@ public class JsonBucketMetadataTest {
   @Test
   public void testCoding() throws Exception {
     final JsonBucketMetadata<String> metadata =
-        new JsonBucketMetadata<>(1, 1, 1, String.class, HashType.MURMUR3_32, "favorite_color");
+        new JsonBucketMetadata<>(
+            1,
+            1,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "favorite_color",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     final BucketMetadata<String, TableRow> copy = BucketMetadata.from(metadata.toString());
     Assert.assertEquals(metadata.getVersion(), copy.getVersion());
@@ -78,7 +98,13 @@ public class JsonBucketMetadataTest {
   @Test
   public void testVersionDefault() throws Exception {
     final JsonBucketMetadata<String> metadata =
-        new JsonBucketMetadata<>(1, 1, String.class, HashType.MURMUR3_32, "favorite_color");
+        new JsonBucketMetadata<>(
+            1,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "favorite_color",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     Assert.assertEquals(BucketMetadata.CURRENT_VERSION, metadata.getVersion());
   }
@@ -86,7 +112,13 @@ public class JsonBucketMetadataTest {
   @Test
   public void testDisplayData() throws Exception {
     final JsonBucketMetadata<String> metadata =
-        new JsonBucketMetadata<>(2, 1, String.class, HashType.MURMUR3_32, "favorite_color");
+        new JsonBucketMetadata<>(
+            2,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "favorite_color",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     final DisplayData displayData = DisplayData.from(metadata);
     MatcherAssert.assertThat(displayData, hasDisplayItem("numBuckets", 2));
@@ -103,16 +135,40 @@ public class JsonBucketMetadataTest {
   @Test
   public void testSameSourceCompatibility() throws Exception {
     final JsonBucketMetadata<String> metadata1 =
-        new JsonBucketMetadata<>(2, 1, String.class, HashType.MURMUR3_32, "favorite_country");
+        new JsonBucketMetadata<>(
+            2,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "favorite_country",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     final JsonBucketMetadata<String> metadata2 =
-        new JsonBucketMetadata<>(2, 1, String.class, HashType.MURMUR3_32, "favorite_color");
+        new JsonBucketMetadata<>(
+            2,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "favorite_color",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     final JsonBucketMetadata<String> metadata3 =
-        new JsonBucketMetadata<>(4, 1, String.class, HashType.MURMUR3_32, "favorite_color");
+        new JsonBucketMetadata<>(
+            4,
+            1,
+            String.class,
+            HashType.MURMUR3_32,
+            "favorite_color",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     final JsonBucketMetadata<Long> metadata4 =
-        new JsonBucketMetadata<>(4, 1, Long.class, HashType.MURMUR3_32, "favorite_color");
+        new JsonBucketMetadata<>(
+            4,
+            1,
+            Long.class,
+            HashType.MURMUR3_32,
+            "favorite_color",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     Assert.assertFalse(metadata1.isPartitionCompatible(metadata2));
     Assert.assertTrue(metadata2.isPartitionCompatible(metadata3));

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSinkTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSinkTest.java
@@ -206,8 +206,7 @@ public class SortedBucketSinkTest {
     Assert.assertEquals(0, output.getRoot().listFiles().length);
   }
 
-  private void test(int numBuckets, int numShards, boolean useKeyCache)
-      throws Exception {
+  private void test(int numBuckets, int numShards, boolean useKeyCache) throws Exception {
     final TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
 
     final int keyCacheSize = useKeyCache ? 100 : 0;

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -76,10 +76,13 @@ public class SortedBucketSourceTest {
   private SMBFilenamePolicy lhsPolicy;
   private SMBFilenamePolicy rhsPolicy;
 
+  private static final String LHS_FILENAME_PREFIX = "lhs-filename-prefix"; // Custom prefix
+  private static final String RHS_FILENAME_PREFIX = "bucket"; // Default prefix
+
   @Before
   public void setup() {
-    lhsPolicy = new SMBFilenamePolicy(fromFolder(lhsFolder), ".txt");
-    rhsPolicy = new SMBFilenamePolicy(fromFolder(rhsFolder), ".txt");
+    lhsPolicy = new SMBFilenamePolicy(fromFolder(lhsFolder), LHS_FILENAME_PREFIX, ".txt");
+    rhsPolicy = new SMBFilenamePolicy(fromFolder(rhsFolder), RHS_FILENAME_PREFIX, ".txt");
   }
 
   @Test
@@ -240,7 +243,7 @@ public class SortedBucketSourceTest {
     int numBuckets = maxId(input.keySet(), BucketShardId::getBucketId) + 1;
     int numShards = maxId(input.keySet(), BucketShardId::getShardId) + 1;
 
-    TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
+    TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards, LHS_FILENAME_PREFIX);
 
     write(lhsPolicy.forDestination(), metadata, input);
 
@@ -496,8 +499,10 @@ public class SortedBucketSourceTest {
     int rhsNumBuckets = maxId(rhsInput.keySet(), BucketShardId::getBucketId) + 1;
     int rhsNumShards = maxId(rhsInput.keySet(), BucketShardId::getShardId) + 1;
 
-    TestBucketMetadata lhsMetadata = TestBucketMetadata.of(lhsNumBuckets, lhsNumShards);
-    TestBucketMetadata rhsMetadata = TestBucketMetadata.of(rhsNumBuckets, rhsNumShards);
+    TestBucketMetadata lhsMetadata =
+        TestBucketMetadata.of(lhsNumBuckets, lhsNumShards, LHS_FILENAME_PREFIX);
+    TestBucketMetadata rhsMetadata =
+        TestBucketMetadata.of(rhsNumBuckets, rhsNumShards, RHS_FILENAME_PREFIX);
 
     write(lhsPolicy.forDestination(), lhsMetadata, lhsInput);
     write(rhsPolicy.forDestination(), rhsMetadata, rhsInput);
@@ -551,11 +556,13 @@ public class SortedBucketSourceTest {
     for (Map<BucketShardId, List<String>> input : lhsInputs) {
       int numBuckets = maxId(input.keySet(), BucketShardId::getBucketId) + 1;
       int numShards = maxId(input.keySet(), BucketShardId::getShardId) + 1;
-      TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
+      TestBucketMetadata metadata =
+          TestBucketMetadata.of(numBuckets, numShards, LHS_FILENAME_PREFIX);
       ResourceId destination =
           LocalResources.fromFile(
               partitionedInputFolder.newFolder("lhs" + lhsInputs.indexOf(input)), true);
-      FileAssignment fileAssignment = new SMBFilenamePolicy(destination, ".txt").forDestination();
+      FileAssignment fileAssignment =
+          new SMBFilenamePolicy(destination, metadata.getFilenamePrefix(), ".txt").forDestination();
       write(fileAssignment, metadata, input);
       lhsPaths.add(destination);
       input.forEach(
@@ -575,11 +582,13 @@ public class SortedBucketSourceTest {
     for (Map<BucketShardId, List<String>> input : rhsInputs) {
       int numBuckets = maxId(input.keySet(), BucketShardId::getBucketId) + 1;
       int numShards = maxId(input.keySet(), BucketShardId::getShardId) + 1;
-      TestBucketMetadata metadata = TestBucketMetadata.of(numBuckets, numShards);
+      TestBucketMetadata metadata =
+          TestBucketMetadata.of(numBuckets, numShards, RHS_FILENAME_PREFIX);
       ResourceId destination =
           LocalResources.fromFile(
               partitionedInputFolder.newFolder("rhs" + rhsInputs.indexOf(input)), true);
-      FileAssignment fileAssignment = new SMBFilenamePolicy(destination, ".txt").forDestination();
+      FileAssignment fileAssignment =
+          new SMBFilenamePolicy(destination, metadata.getFilenamePrefix(), ".txt").forDestination();
       write(fileAssignment, metadata, input);
       rhsPaths.add(destination);
       input.forEach(

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
@@ -148,7 +148,8 @@ public class SortedBucketTransformTest {
             fromFolder(tempFolder),
             (numBuckets, numShards, hashType) -> TestBucketMetadata.of(numBuckets, numShards),
             new TestFileOperations(),
-            ".txt"));
+            ".txt",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX));
 
     final PipelineResult result = transformPipeline.run();
     result.waitUntilFinish();
@@ -176,7 +177,8 @@ public class SortedBucketTransformTest {
   private static KV<BucketMetadata, Set<String>> readAllFrom(TemporaryFolder folder)
       throws Exception {
     final FileAssignment fileAssignment =
-        new SMBFilenamePolicy(fromFolder(folder), ".txt").forDestination();
+        new SMBFilenamePolicy(fromFolder(folder), SortedBucketIO.DEFAULT_FILENAME_PREFIX, ".txt")
+            .forDestination();
 
     BucketMetadata metadata =
         BucketMetadata.from(

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
@@ -67,41 +67,83 @@ public class TensorFlowBucketMetadataTest {
 
     Assert.assertArrayEquals(
         "data".getBytes(Charset.defaultCharset()),
-        new TensorFlowBucketMetadata<>(1, 1, byte[].class, HashType.MURMUR3_32, "bytes")
+        new TensorFlowBucketMetadata<>(
+                1,
+                1,
+                byte[].class,
+                HashType.MURMUR3_32,
+                "bytes",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX)
             .extractKey(example));
 
     Assert.assertEquals(
         ByteString.copyFrom("data".getBytes()),
-        new TensorFlowBucketMetadata<>(1, 1, ByteString.class, HashType.MURMUR3_32, "bytes")
+        new TensorFlowBucketMetadata<>(
+                1,
+                1,
+                ByteString.class,
+                HashType.MURMUR3_32,
+                "bytes",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX)
             .extractKey(example));
 
     Assert.assertEquals(
         "data",
-        new TensorFlowBucketMetadata<>(1, 1, String.class, HashType.MURMUR3_32, "bytes")
+        new TensorFlowBucketMetadata<>(
+                1,
+                1,
+                String.class,
+                HashType.MURMUR3_32,
+                "bytes",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX)
             .extractKey(example));
 
     Assert.assertEquals(
         (Long) 12345L,
-        new TensorFlowBucketMetadata<>(1, 1, Long.class, HashType.MURMUR3_32, "int")
+        new TensorFlowBucketMetadata<>(
+                1,
+                1,
+                Long.class,
+                HashType.MURMUR3_32,
+                "int",
+                SortedBucketIO.DEFAULT_FILENAME_PREFIX)
             .extractKey(example));
 
     Assert.assertThrows(
         NonDeterministicException.class,
         () ->
-            new TensorFlowBucketMetadata<>(1, 1, Float.class, HashType.MURMUR3_32, "float")
+            new TensorFlowBucketMetadata<>(
+                    1,
+                    1,
+                    Float.class,
+                    HashType.MURMUR3_32,
+                    "float",
+                    SortedBucketIO.DEFAULT_FILENAME_PREFIX)
                 .extractKey(example));
 
     Assert.assertThrows(
         IllegalStateException.class,
         () ->
-            new TensorFlowBucketMetadata<>(1, 1, Integer.class, HashType.MURMUR3_32, "bytes")
+            new TensorFlowBucketMetadata<>(
+                    1,
+                    1,
+                    Integer.class,
+                    HashType.MURMUR3_32,
+                    "bytes",
+                    SortedBucketIO.DEFAULT_FILENAME_PREFIX)
                 .extractKey(example));
   }
 
   @Test
   public void testDisplayData() throws Exception {
     final TensorFlowBucketMetadata<byte[]> metadata =
-        new TensorFlowBucketMetadata<>(2, 1, byte[].class, HashType.MURMUR3_32, "bytes");
+        new TensorFlowBucketMetadata<>(
+            2,
+            1,
+            byte[].class,
+            HashType.MURMUR3_32,
+            "bytes",
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     final DisplayData displayData = DisplayData.from(metadata);
     MatcherAssert.assertThat(displayData, hasDisplayItem("numBuckets", 2));
@@ -118,17 +160,21 @@ public class TensorFlowBucketMetadataTest {
   @Test
   public void testSameSourceCompatibility() throws Exception {
     final TensorFlowBucketMetadata<byte[]> metadata1 =
-        new TensorFlowBucketMetadata<>(2, 1, byte[].class, HashType.MURMUR3_32, "foo");
+        new TensorFlowBucketMetadata<>(
+            2, 1, byte[].class, HashType.MURMUR3_32, "foo", SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     final TensorFlowBucketMetadata<byte[]> metadata2 =
-        new TensorFlowBucketMetadata<>(2, 1, byte[].class, HashType.MURMUR3_32, "bar");
+        new TensorFlowBucketMetadata<>(
+            2, 1, byte[].class, HashType.MURMUR3_32, "bar", SortedBucketIO.DEFAULT_FILENAME_PREFIX);
     ;
 
     final TensorFlowBucketMetadata<byte[]> metadata3 =
-        new TensorFlowBucketMetadata<>(4, 1, byte[].class, HashType.MURMUR3_32, "bar");
+        new TensorFlowBucketMetadata<>(
+            4, 1, byte[].class, HashType.MURMUR3_32, "bar", SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     final TensorFlowBucketMetadata<String> metadata4 =
-        new TensorFlowBucketMetadata<>(4, 1, String.class, HashType.MURMUR3_32, "bar");
+        new TensorFlowBucketMetadata<>(
+            4, 1, String.class, HashType.MURMUR3_32, "bar", SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     Assert.assertFalse(metadata1.isPartitionCompatible(metadata2));
     Assert.assertTrue(metadata2.isPartitionCompatible(metadata3));

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TestBucketMetadata.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TestBucketMetadata.java
@@ -29,7 +29,12 @@ class TestBucketMetadata extends BucketMetadata<String, String> {
 
   static TestBucketMetadata of(int numBuckets, int numShards)
       throws CannotProvideCoderException, NonDeterministicException {
-    return new TestBucketMetadata(numBuckets, numShards, HashType.MURMUR3_32);
+    return of(numBuckets, numShards, SortedBucketIO.DEFAULT_FILENAME_PREFIX);
+  }
+
+  static TestBucketMetadata of(int numBuckets, int numShards, String filenamePrefix)
+      throws CannotProvideCoderException, NonDeterministicException {
+    return new TestBucketMetadata(numBuckets, numShards, HashType.MURMUR3_32, filenamePrefix);
   }
 
   TestBucketMetadata withKeyIndex(int keyIndex) {
@@ -40,9 +45,10 @@ class TestBucketMetadata extends BucketMetadata<String, String> {
   TestBucketMetadata(
       @JsonProperty("numBuckets") int numBuckets,
       @JsonProperty("numShards") int numShards,
-      @JsonProperty("hashType") HashType hashType)
+      @JsonProperty("hashType") HashType hashType,
+      @JsonProperty("filenamePrefix") String filenamePrefix)
       throws CannotProvideCoderException, NonDeterministicException {
-    this(BucketMetadata.CURRENT_VERSION, numBuckets, numShards, hashType);
+    this(BucketMetadata.CURRENT_VERSION, numBuckets, numShards, hashType, filenamePrefix);
   }
 
   @JsonCreator
@@ -50,9 +56,10 @@ class TestBucketMetadata extends BucketMetadata<String, String> {
       @JsonProperty("version") int version,
       @JsonProperty("numBuckets") int numBuckets,
       @JsonProperty("numShards") int numShards,
-      @JsonProperty("hashType") HashType hashType)
+      @JsonProperty("hashType") HashType hashType,
+      @JsonProperty("filenamePrefix") String filenamePrefix)
       throws CannotProvideCoderException, NonDeterministicException {
-    super(version, numBuckets, numShards, String.class, hashType);
+    super(version, numBuckets, numShards, String.class, hashType, filenamePrefix);
   }
 
   @Override


### PR DESCRIPTION
I.e. `"part"` instead of `"bucket"` so that the output file naming is in parity with non-smb writes.

This is a relatively small change (it's just an optional field added to `BucketMetadata`) but unfortunately requires a **ton** of small code changes to Java boilerplate 😭 

I tested that it's backwards compat--if the `metadata.json` file lacks a `filenamePrefix` field, it will default to `"bucket"`.