### PR TITLE
fix JDBC syntax & remove redundant coder

### DIFF
--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/syntax/AllSyntax.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/syntax/AllSyntax.scala
@@ -17,4 +17,4 @@
 
 package com.spotify.scio.jdbc.syntax
 
-trait AllSyntax extends SCollectionSyntax with ScioContextSyntax
+trait AllSyntax extends ScioContextSyntax with SCollectionSyntax

--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/syntax/SCollectionSyntax.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/syntax/SCollectionSyntax.scala
@@ -18,52 +18,19 @@
 package com.spotify.scio.jdbc.syntax
 
 import com.spotify.scio.values.SCollection
-import com.spotify.scio.coders.Coder
+import com.spotify.scio.jdbc.JdbcWriteOptions
+import com.spotify.scio.io.ClosedTap
+import com.spotify.scio.jdbc.JdbcWrite
 
-import scala.reflect.ClassTag
-import com.spotify.scio.ScioContext
-import com.spotify.scio.jdbc.sharded.{JdbcShardedReadOptions, JdbcShardedSelect}
-import com.spotify.scio.jdbc.{JdbcReadOptions, JdbcSelect}
+/** Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with JDBC methods. */
+final class JdbcSCollectionOps[T](private val self: SCollection[T]) extends AnyVal {
 
-/** Enhanced version of [[ScioContext]] with JDBC methods. */
-final class JdbcScioContextOps(private val self: ScioContext) extends AnyVal {
-
-  /** Get an SCollection for a JDBC query. */
-  def jdbcSelect[T: ClassTag: Coder](readOptions: JdbcReadOptions[T]): SCollection[T] =
-    self.read(JdbcSelect(readOptions))
-
-  /**
-   * Sharded JDBC read from a table or materialized view.
-   * @param readOptions The following paramters in the options class could be specified:
-   *
-   *                    shardColumn: the column to shard by. Must be
-   *                    of integer/long type ideally with evenly distributed values.
-   *
-   *                    numShards: number of shards to split the table into for reading.
-   *                    There is no guarantee that Beam will actually execute reads in parallel.
-   *                    It is up to Beam auto scaler to decide the level of parallelism to use
-   *                    (number of workers and threads per worker). But the behavior could be
-   *                    controlled with maxNumWorkers and numberOfWorkerHarnessThreads parameters
-   *                    (see more details about these parameters here). Defaults to 4.
-   *
-   *                    tableName: name of a table or materialized view to read from
-   *
-   *                    fetchSize: number of records to read from the
-   *                    JDBC source per one call to a database. Default value is 100,000. Set to
-   *                    -1 to make it unbounded.
-   *                    shard: An implementation of the [[com.spotify.scio.jdbc.sharded.Shard]]
-   *                    trait which knows how to shard a column of a type S. Example of sharding
-   *                    by a column of type Long:
-   *                    {{{
-   *                      sc.jdbcShardedSelect(getShardedReadOptions(opts), Shard.range[Long])
-   *                    }}}
-   */
-  def jdbcShardedSelect[T: Coder, S](
-    readOptions: JdbcShardedReadOptions[T, S]
-  ): SCollection[T] = self.read(JdbcShardedSelect(readOptions))
-
+  /** Save this SCollection as a JDBC database. */
+  def saveAsJdbc(writeOptions: JdbcWriteOptions[T]): ClosedTap[Nothing] =
+    self.write(JdbcWrite(writeOptions))
 }
 
 trait SCollectionSyntax {
-  implicit def jdbcScioContextOps(sc: ScioContext): JdbcScioContextOps = new JdbcScioContextOps(sc)
+  implicit def jdbcSCollectionOps[T](sc: SCollection[T]): JdbcSCollectionOps[T] =
+    new JdbcSCollectionOps(sc)
 }

--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/syntax/ScioContextSyntax.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/syntax/ScioContextSyntax.scala
@@ -16,23 +16,53 @@
  */
 
 package com.spotify.scio.jdbc.syntax
+
 import com.spotify.scio.values.SCollection
-import com.spotify.scio.jdbc.JdbcWriteOptions
 import com.spotify.scio.coders.Coder
-import com.spotify.scio.io.ClosedTap
-import com.spotify.scio.jdbc.JdbcWrite
 
-/** Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with JDBC methods. */
-final class JdbcSCollectionOps[T](private val self: SCollection[T]) extends AnyVal {
+import scala.reflect.ClassTag
+import com.spotify.scio.ScioContext
+import com.spotify.scio.jdbc.sharded.{JdbcShardedReadOptions, JdbcShardedSelect}
+import com.spotify.scio.jdbc.{JdbcReadOptions, JdbcSelect}
 
-  /** Save this SCollection as a JDBC database. */
-  def saveAsJdbc(
-    writeOptions: JdbcWriteOptions[T]
-  )(implicit coder: Coder[T]): ClosedTap[Nothing] =
-    self.write(JdbcWrite(writeOptions))
+/** Enhanced version of [[ScioContext]] with JDBC methods. */
+final class JdbcScioContextOps(private val self: ScioContext) extends AnyVal {
+
+  /** Get an SCollection for a JDBC query. */
+  def jdbcSelect[T: ClassTag: Coder](readOptions: JdbcReadOptions[T]): SCollection[T] =
+    self.read(JdbcSelect(readOptions))
+
+  /**
+   * Sharded JDBC read from a table or materialized view.
+   * @param readOptions The following paramters in the options class could be specified:
+   *
+   *                    shardColumn: the column to shard by. Must be
+   *                    of integer/long type ideally with evenly distributed values.
+   *
+   *                    numShards: number of shards to split the table into for reading.
+   *                    There is no guarantee that Beam will actually execute reads in parallel.
+   *                    It is up to Beam auto scaler to decide the level of parallelism to use
+   *                    (number of workers and threads per worker). But the behavior could be
+   *                    controlled with maxNumWorkers and numberOfWorkerHarnessThreads parameters
+   *                    (see more details about these parameters here). Defaults to 4.
+   *
+   *                    tableName: name of a table or materialized view to read from
+   *
+   *                    fetchSize: number of records to read from the
+   *                    JDBC source per one call to a database. Default value is 100,000. Set to
+   *                    -1 to make it unbounded.
+   *                    shard: An implementation of the [[com.spotify.scio.jdbc.sharded.Shard]]
+   *                    trait which knows how to shard a column of a type S. Example of sharding
+   *                    by a column of type Long:
+   *                    {{{
+   *                      sc.jdbcShardedSelect(getShardedReadOptions(opts), Shard.range[Long])
+   *                    }}}
+   */
+  def jdbcShardedSelect[T: Coder, S](
+    readOptions: JdbcShardedReadOptions[T, S]
+  ): SCollection[T] = self.read(JdbcShardedSelect(readOptions))
+
 }
-
 trait ScioContextSyntax {
-  implicit def jdbcSCollectionOps[T](sc: SCollection[T]): JdbcSCollectionOps[T] =
-    new JdbcSCollectionOps(sc)
+  implicit def jdbcScioContextOps(sc: ScioContext): JdbcScioContextOps = new JdbcScioContextOps(sc)
 }


### PR DESCRIPTION
@stormy-ua FYI, the `{ScioContext,SCollection}Syntax` content are flipped.