### PR TITLE
Add state to exception message when pipeline is cancelled

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -659,8 +659,9 @@ class ScioContext private[scio] (
         val state = pipelineResult.waitUntilFinish(time.Duration.millis(wait))
         if (state == null && cancelJob) {
           pipelineResult.cancel()
+          val finalState = pipelineResult.getState()
           val cause = new InterruptedException(
-            s"Job cancelled after exceeding timeout value $duration"
+            s"Job cancelled after exceeding timeout value $duration with final state $finalState"
           )
           throw new PipelineExecutionException(cause)
         }

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -661,7 +661,7 @@ class ScioContext private[scio] (
           pipelineResult.cancel()
           val finalState = pipelineResult.getState()
           val cause = new InterruptedException(
-            s"Job cancelled after exceeding timeout value $duration with final state $finalState"
+            s"Job cancelled after exceeding timeout value $duration with state $finalState"
           )
           throw new PipelineExecutionException(cause)
         }


### PR DESCRIPTION

I've noticed that some stuck Dataflow jobs that did not got cancelled.

We do have:

> val scioResult = scioExecutionContext.waitUntilDone(Duration.create(4, TimeUnit.HOURS))

And logs show:

> Caused by: java.lang.InterruptedException: Job cancelled after exceeding timeout value 4 hours
> INFO: 	at com.spotify.scio.ScioContext$$anon$2.waitUntilFinish(ScioContext.scala:649)

Still, it seems the jobs are not always cancelled. I had a look on [`DataflowJob.cancel()`] (https://github.com/apache/beam/blob/6fdde4f4eab72b49b10a8bb1cb3be263c5c416b5/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineJob.java#L405) and it should throw some exceptions in case of issues cancelling. Although I am not sure what could be happening here, it would be nice to surface the job state after issuing the cancel operation.