### PR TITLE
[SMB] delete file early in NativeFileSorter

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/NativeFileSorter.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/NativeFileSorter.java
@@ -138,6 +138,7 @@ class NativeFileSorter {
       }
     } finally {
       inputStream.close();
+      dataFile.delete();
     }
     return files;
   }


### PR DESCRIPTION
Upstream: https://github.com/apache/beam/pull/12681
Delete `dataFile` as soon as we're done sort in batch from it.