### PR TITLE
(fix #3278) Warn on chained .groupByKey.join

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -795,7 +795,9 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * @group per_key
    */
   def groupByKey(implicit koder: Coder[K], voder: Coder[V]): SCollection[(K, Iterable[V])] =
-    this.applyPerKey(GroupByKey.create[K, V]())(kvIterableToTuple)
+    this
+      .applyPerKey(GroupByKey.create[K, V]())(kvIterableToTuple)
+      .withState(_.copy(postGbkOp = true))
 
   /**
    * Batches inputs to a desired batch size. Batches will contain only elements of a single key.

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -90,7 +90,7 @@ object SCollection {
   ): PairSkewedSCollectionFunctions[K, V] =
     new PairSkewedSCollectionFunctions(s)
 
-  final private[scio] case class State(postCoGroup: Boolean = false)
+  final private[scio] case class State(postGbkOp: Boolean = false)
 }
 
 /**

--- a/scio-test/src/test/scala/com/spotify/scio/values/StateTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/StateTest.scala
@@ -87,4 +87,13 @@ class StateTest extends AnyFlatSpec with Matchers {
         }
     }
   }
+
+  it should "fail chained groupBys with joins" in {
+    testCogroup {
+      case (a, b, _) =>
+        an[RuntimeException] shouldBe thrownBy {
+          a.groupByKey.join(b)
+        }
+    }
+  }
 }


### PR DESCRIPTION
looks like some of the circleCI tests are failing bc of a BigQuery timeout -- tests pass otherwise