### PR TITLE
Add support for JDBC sharding by UUID encoded as string

### DIFF
--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/sharded/Shard.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/sharded/Shard.scala
@@ -71,6 +71,12 @@ object Shard {
   implicit val hexLowerStringJdbcShardable: RangeShard[ShardString.HexLowerString] =
     new RangeStringShard[ShardString.HexLowerString]
 
+  implicit val uuidLowerStringJdbcShardable: RangeShard[ShardString.UuidLowerString] =
+    new RangeStringShard[ShardString.UuidLowerString]
+
+  implicit val uuidUpperStringJdbcShardable: RangeShard[ShardString.UuidUpperString] =
+    new RangeStringShard[ShardString.UuidUpperString]
+
   implicit val base64StringJdbcShardable: RangeShard[ShardString.Base64String] =
     new RangeStringShard[ShardString.Base64String]
 

--- a/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/sharded/JdbcRangeStringShardTests.scala
+++ b/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/sharded/JdbcRangeStringShardTests.scala
@@ -74,4 +74,64 @@ class JdbcRangeStringShardTests extends AnyFlatSpec {
       )
     )
   }
+
+  "hex uuid lower shardable" must "partition a range of uuid strings in the lower case" in {
+    val shard = Shard.range[UuidLowerString]
+    val queries = shard.partition(
+      Range(UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6310"),
+        UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6337")), 3)
+
+    queries must contain theSameElementsAs (
+      Seq(
+        RangeShardQuery(
+          Range(UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6310"),
+            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb631d")),
+          upperBoundInclusive = false,
+          quoteValues = true
+        ),
+        RangeShardQuery(
+          Range(UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb631d"),
+            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb632a")),
+          upperBoundInclusive = false,
+          quoteValues = true
+        ),
+        RangeShardQuery(
+          Range(UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb632a"),
+            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6337")),
+          upperBoundInclusive = true,
+          quoteValues = true
+        )
+      )
+      )
+  }
+
+  "hex uuid upper shardable" must "partition a range of uuid strings in the upper case" in {
+    val shard = Shard.range[UuidUpperString]
+    val queries = shard.partition(
+      Range(UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6310"),
+        UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6337")), 3)
+
+    queries must contain theSameElementsAs (
+      Seq(
+        RangeShardQuery(
+          Range(UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6310"),
+            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB631D")),
+          upperBoundInclusive = false,
+          quoteValues = true
+        ),
+        RangeShardQuery(
+          Range(UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB631D"),
+            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB632A")),
+          upperBoundInclusive = false,
+          quoteValues = true
+        ),
+        RangeShardQuery(
+          Range(UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB632A"),
+            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6337")),
+          upperBoundInclusive = true,
+          quoteValues = true
+        )
+      )
+      )
+  }
 }

--- a/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/sharded/JdbcRangeStringShardTests.scala
+++ b/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/sharded/JdbcRangeStringShardTests.scala
@@ -78,60 +78,80 @@ class JdbcRangeStringShardTests extends AnyFlatSpec {
   "hex uuid lower shardable" must "partition a range of uuid strings in the lower case" in {
     val shard = Shard.range[UuidLowerString]
     val queries = shard.partition(
-      Range(UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6310"),
-        UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6337")), 3)
+      Range(
+        UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6310"),
+        UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6337")
+      ),
+      3
+    )
 
     queries must contain theSameElementsAs (
       Seq(
         RangeShardQuery(
-          Range(UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6310"),
-            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb631d")),
+          Range(
+            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6310"),
+            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb631d")
+          ),
           upperBoundInclusive = false,
           quoteValues = true
         ),
         RangeShardQuery(
-          Range(UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb631d"),
-            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb632a")),
+          Range(
+            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb631d"),
+            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb632a")
+          ),
           upperBoundInclusive = false,
           quoteValues = true
         ),
         RangeShardQuery(
-          Range(UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb632a"),
-            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6337")),
+          Range(
+            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb632a"),
+            UuidLowerString("a2c9cba1-eaa5-4c3d-b099-896730eb6337")
+          ),
           upperBoundInclusive = true,
           quoteValues = true
         )
       )
-      )
+    )
   }
 
   "hex uuid upper shardable" must "partition a range of uuid strings in the upper case" in {
     val shard = Shard.range[UuidUpperString]
     val queries = shard.partition(
-      Range(UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6310"),
-        UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6337")), 3)
+      Range(
+        UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6310"),
+        UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6337")
+      ),
+      3
+    )
 
     queries must contain theSameElementsAs (
       Seq(
         RangeShardQuery(
-          Range(UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6310"),
-            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB631D")),
+          Range(
+            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6310"),
+            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB631D")
+          ),
           upperBoundInclusive = false,
           quoteValues = true
         ),
         RangeShardQuery(
-          Range(UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB631D"),
-            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB632A")),
+          Range(
+            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB631D"),
+            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB632A")
+          ),
           upperBoundInclusive = false,
           quoteValues = true
         ),
         RangeShardQuery(
-          Range(UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB632A"),
-            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6337")),
+          Range(
+            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB632A"),
+            UuidUpperString("A2C9CBA1-EAA5-4C3D-B099-896730EB6337")
+          ),
           upperBoundInclusive = true,
           quoteValues = true
         )
       )
-      )
+    )
   }
 }

--- a/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/sharded/ShardedQueryTests.scala
+++ b/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/sharded/ShardedQueryTests.scala
@@ -52,7 +52,7 @@ class ShardedQueryTests extends AnyFlatSpec {
   "toSelectStatement" must "produce the correct statement for hex string in upper case" in {
 
     val shardQuery = RangeShardQuery[HexUpperString](
-      Range(HexUpperString("a"), HexUpperString("f")),
+      Range(HexUpperString("A"), HexUpperString("F")),
       upperBoundInclusive = true,
       quoteValues = true
     )


### PR DESCRIPTION
There was a request from a team for JDBC sharding by a column with UUIDs encoded as strings e.g. "a2c9cba1-eaa5-4c3d-b099-896730eb6302". In their case the column is the primary key and sharding gives a significant improvement in the performance. The job running time decreased from 1 hr down to 20 mins with fewer workers. 

Even though we were able to produce a temporary solution w/o changing `scio-jdbc` it would be great to add a cleaner solution to scio directly so that it could be used by others for similar use cases.

The change adds two new `ShardString` subclasses, namely `UuidLowerString` and `UuidUpperString`. The former represents a UUID encoded as a string in the lower case e.g. "a2c9cba1-eaa5-4c3d-b099-896730eb6310" and the latter a UUID encoded as a string in the upper case "A2C9CBA1-EAA5-4C3D-B099-896730EB6310". The implementation projects UUIDs onto a space of `BigInt`s by removing dashes `-` first and then converting from the hex representation to `BigInt` exactly the same were it is done for `HexUpperString` and `HexLowerString`.

 If UUIDs have more or less uniform distribution the sharding approach might produce relatively even shards by using the approach described above. 