### PR TITLE
Filter out potentially included env directories

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -136,14 +136,11 @@ private object RunnerContext {
     pipelineOptions: PipelineOptions,
     classLoader: ClassLoader
   ): Iterable[String] = {
-    // exclude jars from JAVA_HOME and files from current directory
-    val javaHome = new File(CoreSysProps.Home.value).getCanonicalPath
-    val userDir = new File(CoreSysProps.UserDir.value).getCanonicalPath
-
+    val matchesEnvDir: String => Boolean = _.matches(s"${sys.props("user.home")}/\\..+/.+")
     val classPathJars = PipelineResources
       .detectClassPathResourcesToStage(classLoader, pipelineOptions)
       .asScala
-      .filter(path => !path.startsWith(javaHome) && path != userDir)
+      .filterNot(matchesEnvDir)
 
     logger.debug(s"Classpath jars: ${classPathJars.mkString(":")}")
 


### PR DESCRIPTION
* Less jars being staged
* example of excluded directories: .sbt / .sdkman
* When using SBT to launch jobs SBT jars are included in the staged files. This will avoid their inclusion and aliviate the need to use `run / fork := true`. Staged files will be the same with or without this SBT setting.

