### PR TITLE
Add specialized TupleCoders

### DIFF
--- a/scio-core/src/main/scala-2.13/com/spotify/scio/coders/instances/TupleCoders.scala
+++ b/scio-core/src/main/scala-2.13/com/spotify/scio/coders/instances/TupleCoders.scala
@@ -1,0 +1,4711 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !! generated with tuplecoders.py
+// !! DO NOT EDIT MANUALLY
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+package com.spotify.scio.coders.instances
+
+import java.io.{InputStream, OutputStream}
+
+import com.spotify.scio.coders.{Coder, CoderStackTrace}
+import org.apache.beam.sdk.coders.Coder.NonDeterministicException
+import org.apache.beam.sdk.coders.{Coder => BCoder, _}
+import org.apache.beam.sdk.util.common.ElementByteSizeObserver
+
+import scala.jdk.CollectionConverters._
+
+trait TupleCoders {
+
+  final private class Tuple2Coder[A, B](ac: BCoder[A], bc: BCoder[B]) extends AtomicCoder[(A, B)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TB](msg: => (String, String))(f: => TB): TB =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple2: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+    }
+    override def decode(is: InputStream): (A, B) =
+      (onErrorMsg("decode" -> "_1")(ac.decode(is)), onErrorMsg("decode" -> "_2")(bc.decode(is)))
+
+    override def toString: String =
+      s"Tuple2Coder(_1 -> $ac, _2 -> $bc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List("_1" -> ac, "_2" -> bc)
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (ac.structuralValue(value._1), bc.structuralValue(value._2))
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(value._2)
+
+    override def registerByteSizeObserver(
+      value: (A, B),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+    }
+  }
+
+  implicit def tuple2Coder[A, B](implicit CA: Coder[A], CB: Coder[B]): Coder[(A, B)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB)(bc => Coder.beam(new Tuple2Coder[A, B](ac, bc)))
+    }
+
+  final private class Tuple3Coder[A, B, C](ac: BCoder[A], bc: BCoder[B], cc: BCoder[C])
+      extends AtomicCoder[(A, B, C)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TC](msg: => (String, String))(f: => TC): TC =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple3: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+    }
+    override def decode(is: InputStream): (A, B, C) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple3Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List("_1" -> ac, "_2" -> bc, "_3" -> cc)
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (ac.structuralValue(value._1), bc.structuralValue(value._2), cc.structuralValue(value._3))
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+    }
+  }
+
+  implicit def tuple3Coder[A, B, C](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C]
+  ): Coder[(A, B, C)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC)(cc => Coder.beam(new Tuple3Coder[A, B, C](ac, bc, cc)))
+      }
+    }
+
+  final private class Tuple4Coder[A, B, C, D](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D]
+  ) extends AtomicCoder[(A, B, C, D)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TD](msg: => (String, String))(f: => TD): TD =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple4: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple4Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List("_1" -> ac, "_2" -> bc, "_3" -> cc, "_4" -> dc)
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+    }
+  }
+
+  implicit def tuple4Coder[A, B, C, D](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D]
+  ): Coder[(A, B, C, D)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD)(dc => Coder.beam(new Tuple4Coder[A, B, C, D](ac, bc, cc, dc)))
+        }
+      }
+    }
+
+  final private class Tuple5Coder[A, B, C, D, E](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E]
+  ) extends AtomicCoder[(A, B, C, D, E)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TE](msg: => (String, String))(f: => TE): TE =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple5: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple5Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List("_1" -> ac, "_2" -> bc, "_3" -> cc, "_4" -> dc, "_5" -> ec)
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+    }
+  }
+
+  implicit def tuple5Coder[A, B, C, D, E](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E]
+  ): Coder[(A, B, C, D, E)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE)(ec =>
+              Coder.beam(new Tuple5Coder[A, B, C, D, E](ac, bc, cc, dc, ec))
+            )
+          }
+        }
+      }
+    }
+
+  final private class Tuple6Coder[A, B, C, D, E, G](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G]
+  ) extends AtomicCoder[(A, B, C, D, E, G)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TF](msg: => (String, String))(f: => TF): TF =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple6: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple6Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List("_1" -> ac, "_2" -> bc, "_3" -> cc, "_4" -> dc, "_5" -> ec, "_6" -> gc)
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E, G)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+    }
+  }
+
+  implicit def tuple6Coder[A, B, C, D, E, G](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G]
+  ): Coder[(A, B, C, D, E, G)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG)(gc =>
+                Coder.beam(new Tuple6Coder[A, B, C, D, E, G](ac, bc, cc, dc, ec, gc))
+              )
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple7Coder[A, B, C, D, E, G, H](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TG](msg: => (String, String))(f: => TG): TG =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple7: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple7Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs =
+        List("_1" -> ac, "_2" -> bc, "_3" -> cc, "_4" -> dc, "_5" -> ec, "_6" -> gc, "_7" -> hc)
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E, G, H)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+    }
+  }
+
+  implicit def tuple7Coder[A, B, C, D, E, G, H](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H]
+  ): Coder[(A, B, C, D, E, G, H)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH)(hc =>
+                  Coder.beam(new Tuple7Coder[A, B, C, D, E, G, H](ac, bc, cc, dc, ec, gc, hc))
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple8Coder[A, B, C, D, E, G, H, I](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TH](msg: => (String, String))(f: => TH): TH =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple8: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple8Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E, G, H, I)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+    }
+  }
+
+  implicit def tuple8Coder[A, B, C, D, E, G, H, I](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I]
+  ): Coder[(A, B, C, D, E, G, H, I)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI)(ic =>
+                    Coder.beam(
+                      new Tuple8Coder[A, B, C, D, E, G, H, I](ac, bc, cc, dc, ec, gc, hc, ic)
+                    )
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple9Coder[A, B, C, D, E, G, H, I, J](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TI](msg: => (String, String))(f: => TI): TI =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple9: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I, J), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple9Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E, G, H, I, J)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+    }
+  }
+
+  implicit def tuple9Coder[A, B, C, D, E, G, H, I, J](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J]
+  ): Coder[(A, B, C, D, E, G, H, I, J)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ)(jc =>
+                      Coder.beam(
+                        new Tuple9Coder[A, B, C, D, E, G, H, I, J](
+                          ac,
+                          bc,
+                          cc,
+                          dc,
+                          ec,
+                          gc,
+                          hc,
+                          ic,
+                          jc
+                        )
+                      )
+                    )
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple10Coder[A, B, C, D, E, G, H, I, J, K](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TJ](msg: => (String, String))(f: => TJ): TJ =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple10: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I, J, K), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple10Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E, G, H, I, J, K)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+    }
+  }
+
+  implicit def tuple10Coder[A, B, C, D, E, G, H, I, J, K](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK)(kc =>
+                        Coder.beam(
+                          new Tuple10Coder[A, B, C, D, E, G, H, I, J, K](
+                            ac,
+                            bc,
+                            cc,
+                            dc,
+                            ec,
+                            gc,
+                            hc,
+                            ic,
+                            jc,
+                            kc
+                          )
+                        )
+                      )
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple11Coder[A, B, C, D, E, G, H, I, J, K, L](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TK](msg: => (String, String))(f: => TK): TK =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple11: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I, J, K, L), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple11Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+    }
+  }
+
+  implicit def tuple11Coder[A, B, C, D, E, G, H, I, J, K, L](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL)(lc =>
+                          Coder.beam(
+                            new Tuple11Coder[A, B, C, D, E, G, H, I, J, K, L](
+                              ac,
+                              bc,
+                              cc,
+                              dc,
+                              ec,
+                              gc,
+                              hc,
+                              ic,
+                              jc,
+                              kc,
+                              lc
+                            )
+                          )
+                        )
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple12Coder[A, B, C, D, E, G, H, I, J, K, L, M](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TL](msg: => (String, String))(f: => TL): TL =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple12: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I, J, K, L, M), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple12Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L, M)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+    }
+  }
+
+  implicit def tuple12Coder[A, B, C, D, E, G, H, I, J, K, L, M](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM)(mc =>
+                            Coder.beam(
+                              new Tuple12Coder[A, B, C, D, E, G, H, I, J, K, L, M](
+                                ac,
+                                bc,
+                                cc,
+                                dc,
+                                ec,
+                                gc,
+                                hc,
+                                ic,
+                                jc,
+                                kc,
+                                lc,
+                                mc
+                              )
+                            )
+                          )
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple13Coder[A, B, C, D, E, G, H, I, J, K, L, M, N](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TM](msg: => (String, String))(f: => TM): TM =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple13: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I, J, K, L, M, N), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple13Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L, M, N)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+    }
+  }
+
+  implicit def tuple13Coder[A, B, C, D, E, G, H, I, J, K, L, M, N](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN)(nc =>
+                              Coder.beam(
+                                new Tuple13Coder[A, B, C, D, E, G, H, I, J, K, L, M, N](
+                                  ac,
+                                  bc,
+                                  cc,
+                                  dc,
+                                  ec,
+                                  gc,
+                                  hc,
+                                  ic,
+                                  jc,
+                                  kc,
+                                  lc,
+                                  mc,
+                                  nc
+                                )
+                              )
+                            )
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple14Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TN](msg: => (String, String))(f: => TN): TN =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple14: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N, O) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple14Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+    }
+  }
+
+  implicit def tuple14Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO)(oc =>
+                                Coder.beam(
+                                  new Tuple14Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O](
+                                    ac,
+                                    bc,
+                                    cc,
+                                    dc,
+                                    ec,
+                                    gc,
+                                    hc,
+                                    ic,
+                                    jc,
+                                    kc,
+                                    lc,
+                                    mc,
+                                    nc,
+                                    oc
+                                  )
+                                )
+                              )
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple15Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TO](msg: => (String, String))(f: => TO): TO =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple15: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple15Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+    }
+  }
+
+  implicit def tuple15Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP)(pc =>
+                                  Coder.beam(
+                                    new Tuple15Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P](
+                                      ac,
+                                      bc,
+                                      cc,
+                                      dc,
+                                      ec,
+                                      gc,
+                                      hc,
+                                      ic,
+                                      jc,
+                                      kc,
+                                      lc,
+                                      mc,
+                                      nc,
+                                      oc,
+                                      pc
+                                    )
+                                  )
+                                )
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple16Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TP](msg: => (String, String))(f: => TP): TP =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple16: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple16Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+    }
+  }
+
+  implicit def tuple16Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ)(qc =>
+                                    Coder.beam(
+                                      new Tuple16Coder[
+                                        A,
+                                        B,
+                                        C,
+                                        D,
+                                        E,
+                                        G,
+                                        H,
+                                        I,
+                                        J,
+                                        K,
+                                        L,
+                                        M,
+                                        N,
+                                        O,
+                                        P,
+                                        Q
+                                      ](
+                                        ac,
+                                        bc,
+                                        cc,
+                                        dc,
+                                        ec,
+                                        gc,
+                                        hc,
+                                        ic,
+                                        jc,
+                                        kc,
+                                        lc,
+                                        mc,
+                                        nc,
+                                        oc,
+                                        pc,
+                                        qc
+                                      )
+                                    )
+                                  )
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple17Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TQ](msg: => (String, String))(f: => TQ): TQ =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple17: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple17Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+    }
+  }
+
+  implicit def tuple17Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR)(rc =>
+                                      Coder.beam(
+                                        new Tuple17Coder[
+                                          A,
+                                          B,
+                                          C,
+                                          D,
+                                          E,
+                                          G,
+                                          H,
+                                          I,
+                                          J,
+                                          K,
+                                          L,
+                                          M,
+                                          N,
+                                          O,
+                                          P,
+                                          Q,
+                                          R
+                                        ](
+                                          ac,
+                                          bc,
+                                          cc,
+                                          dc,
+                                          ec,
+                                          gc,
+                                          hc,
+                                          ic,
+                                          jc,
+                                          kc,
+                                          lc,
+                                          mc,
+                                          nc,
+                                          oc,
+                                          pc,
+                                          qc,
+                                          rc
+                                        )
+                                      )
+                                    )
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple18Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R],
+    sc: BCoder[S]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TR](msg: => (String, String))(f: => TR): TR =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple18: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+      onErrorMsg("encode" -> "_18")(sc.encode(value._18, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is)),
+        onErrorMsg("decode" -> "_18")(sc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple18Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc, _18 -> $sc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc,
+        "_18" -> sc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals() && sc.consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17),
+          sc.structuralValue(value._18)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17) && sc.isRegisterByteSizeObserverCheap(
+        value._18
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+      sc.registerByteSizeObserver(value._18, observer)
+    }
+  }
+
+  implicit def tuple18Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R],
+    CS: Coder[S]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR) { rc =>
+                                      Coder.transform(CS)(sc =>
+                                        Coder.beam(
+                                          new Tuple18Coder[
+                                            A,
+                                            B,
+                                            C,
+                                            D,
+                                            E,
+                                            G,
+                                            H,
+                                            I,
+                                            J,
+                                            K,
+                                            L,
+                                            M,
+                                            N,
+                                            O,
+                                            P,
+                                            Q,
+                                            R,
+                                            S
+                                          ](
+                                            ac,
+                                            bc,
+                                            cc,
+                                            dc,
+                                            ec,
+                                            gc,
+                                            hc,
+                                            ic,
+                                            jc,
+                                            kc,
+                                            lc,
+                                            mc,
+                                            nc,
+                                            oc,
+                                            pc,
+                                            qc,
+                                            rc,
+                                            sc
+                                          )
+                                        )
+                                      )
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple19Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R],
+    sc: BCoder[S],
+    tc: BCoder[T]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TS](msg: => (String, String))(f: => TS): TS =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple19: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+      onErrorMsg("encode" -> "_18")(sc.encode(value._18, os))
+      onErrorMsg("encode" -> "_19")(tc.encode(value._19, os))
+    }
+    override def decode(
+      is: InputStream
+    ): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is)),
+        onErrorMsg("decode" -> "_18")(sc.decode(is)),
+        onErrorMsg("decode" -> "_19")(tc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple19Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc, _18 -> $sc, _19 -> $tc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc,
+        "_18" -> sc,
+        "_19" -> tc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals() && sc.consistentWithEquals() && tc
+        .consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17),
+          sc.structuralValue(value._18),
+          tc.structuralValue(value._19)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17) && sc.isRegisterByteSizeObserverCheap(
+        value._18
+      ) && tc.isRegisterByteSizeObserverCheap(value._19)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+      sc.registerByteSizeObserver(value._18, observer)
+      tc.registerByteSizeObserver(value._19, observer)
+    }
+  }
+
+  implicit def tuple19Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R],
+    CS: Coder[S],
+    CT: Coder[T]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR) { rc =>
+                                      Coder.transform(CS) { sc =>
+                                        Coder.transform(CT)(tc =>
+                                          Coder.beam(
+                                            new Tuple19Coder[
+                                              A,
+                                              B,
+                                              C,
+                                              D,
+                                              E,
+                                              G,
+                                              H,
+                                              I,
+                                              J,
+                                              K,
+                                              L,
+                                              M,
+                                              N,
+                                              O,
+                                              P,
+                                              Q,
+                                              R,
+                                              S,
+                                              T
+                                            ](
+                                              ac,
+                                              bc,
+                                              cc,
+                                              dc,
+                                              ec,
+                                              gc,
+                                              hc,
+                                              ic,
+                                              jc,
+                                              kc,
+                                              lc,
+                                              mc,
+                                              nc,
+                                              oc,
+                                              pc,
+                                              qc,
+                                              rc,
+                                              sc,
+                                              tc
+                                            )
+                                          )
+                                        )
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple20Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R],
+    sc: BCoder[S],
+    tc: BCoder[T],
+    uc: BCoder[U]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TT](msg: => (String, String))(f: => TT): TT =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple20: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+      onErrorMsg("encode" -> "_18")(sc.encode(value._18, os))
+      onErrorMsg("encode" -> "_19")(tc.encode(value._19, os))
+      onErrorMsg("encode" -> "_20")(uc.encode(value._20, os))
+    }
+    override def decode(
+      is: InputStream
+    ): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is)),
+        onErrorMsg("decode" -> "_18")(sc.decode(is)),
+        onErrorMsg("decode" -> "_19")(tc.decode(is)),
+        onErrorMsg("decode" -> "_20")(uc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple20Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc, _18 -> $sc, _19 -> $tc, _20 -> $uc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc,
+        "_18" -> sc,
+        "_19" -> tc,
+        "_20" -> uc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals() && sc.consistentWithEquals() && tc
+        .consistentWithEquals() && uc.consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17),
+          sc.structuralValue(value._18),
+          tc.structuralValue(value._19),
+          uc.structuralValue(value._20)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17) && sc.isRegisterByteSizeObserverCheap(
+        value._18
+      ) && tc.isRegisterByteSizeObserverCheap(value._19) && uc.isRegisterByteSizeObserverCheap(
+        value._20
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+      sc.registerByteSizeObserver(value._18, observer)
+      tc.registerByteSizeObserver(value._19, observer)
+      uc.registerByteSizeObserver(value._20, observer)
+    }
+  }
+
+  implicit def tuple20Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R],
+    CS: Coder[S],
+    CT: Coder[T],
+    CU: Coder[U]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR) { rc =>
+                                      Coder.transform(CS) { sc =>
+                                        Coder.transform(CT) { tc =>
+                                          Coder.transform(CU)(uc =>
+                                            Coder.beam(
+                                              new Tuple20Coder[
+                                                A,
+                                                B,
+                                                C,
+                                                D,
+                                                E,
+                                                G,
+                                                H,
+                                                I,
+                                                J,
+                                                K,
+                                                L,
+                                                M,
+                                                N,
+                                                O,
+                                                P,
+                                                Q,
+                                                R,
+                                                S,
+                                                T,
+                                                U
+                                              ](
+                                                ac,
+                                                bc,
+                                                cc,
+                                                dc,
+                                                ec,
+                                                gc,
+                                                hc,
+                                                ic,
+                                                jc,
+                                                kc,
+                                                lc,
+                                                mc,
+                                                nc,
+                                                oc,
+                                                pc,
+                                                qc,
+                                                rc,
+                                                sc,
+                                                tc,
+                                                uc
+                                              )
+                                            )
+                                          )
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple21Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R],
+    sc: BCoder[S],
+    tc: BCoder[T],
+    uc: BCoder[U],
+    vc: BCoder[V]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TU](msg: => (String, String))(f: => TU): TU =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple21: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+      onErrorMsg("encode" -> "_18")(sc.encode(value._18, os))
+      onErrorMsg("encode" -> "_19")(tc.encode(value._19, os))
+      onErrorMsg("encode" -> "_20")(uc.encode(value._20, os))
+      onErrorMsg("encode" -> "_21")(vc.encode(value._21, os))
+    }
+    override def decode(
+      is: InputStream
+    ): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is)),
+        onErrorMsg("decode" -> "_18")(sc.decode(is)),
+        onErrorMsg("decode" -> "_19")(tc.decode(is)),
+        onErrorMsg("decode" -> "_20")(uc.decode(is)),
+        onErrorMsg("decode" -> "_21")(vc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple21Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc, _18 -> $sc, _19 -> $tc, _20 -> $uc, _21 -> $vc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc,
+        "_18" -> sc,
+        "_19" -> tc,
+        "_20" -> uc,
+        "_21" -> vc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals() && sc.consistentWithEquals() && tc
+        .consistentWithEquals() && uc.consistentWithEquals() && vc.consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17),
+          sc.structuralValue(value._18),
+          tc.structuralValue(value._19),
+          uc.structuralValue(value._20),
+          vc.structuralValue(value._21)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17) && sc.isRegisterByteSizeObserverCheap(
+        value._18
+      ) && tc.isRegisterByteSizeObserverCheap(value._19) && uc.isRegisterByteSizeObserverCheap(
+        value._20
+      ) && vc.isRegisterByteSizeObserverCheap(value._21)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+      sc.registerByteSizeObserver(value._18, observer)
+      tc.registerByteSizeObserver(value._19, observer)
+      uc.registerByteSizeObserver(value._20, observer)
+      vc.registerByteSizeObserver(value._21, observer)
+    }
+  }
+
+  implicit def tuple21Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R],
+    CS: Coder[S],
+    CT: Coder[T],
+    CU: Coder[U],
+    CV: Coder[V]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR) { rc =>
+                                      Coder.transform(CS) { sc =>
+                                        Coder.transform(CT) { tc =>
+                                          Coder.transform(CU) { uc =>
+                                            Coder.transform(CV)(vc =>
+                                              Coder.beam(
+                                                new Tuple21Coder[
+                                                  A,
+                                                  B,
+                                                  C,
+                                                  D,
+                                                  E,
+                                                  G,
+                                                  H,
+                                                  I,
+                                                  J,
+                                                  K,
+                                                  L,
+                                                  M,
+                                                  N,
+                                                  O,
+                                                  P,
+                                                  Q,
+                                                  R,
+                                                  S,
+                                                  T,
+                                                  U,
+                                                  V
+                                                ](
+                                                  ac,
+                                                  bc,
+                                                  cc,
+                                                  dc,
+                                                  ec,
+                                                  gc,
+                                                  hc,
+                                                  ic,
+                                                  jc,
+                                                  kc,
+                                                  lc,
+                                                  mc,
+                                                  nc,
+                                                  oc,
+                                                  pc,
+                                                  qc,
+                                                  rc,
+                                                  sc,
+                                                  tc,
+                                                  uc,
+                                                  vc
+                                                )
+                                              )
+                                            )
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple22Coder[
+    A,
+    B,
+    C,
+    D,
+    E,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    T,
+    U,
+    V,
+    W
+  ](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R],
+    sc: BCoder[S],
+    tc: BCoder[T],
+    uc: BCoder[U],
+    vc: BCoder[V],
+    wc: BCoder[W]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TV](msg: => (String, String))(f: => TV): TV =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple22: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+      onErrorMsg("encode" -> "_18")(sc.encode(value._18, os))
+      onErrorMsg("encode" -> "_19")(tc.encode(value._19, os))
+      onErrorMsg("encode" -> "_20")(uc.encode(value._20, os))
+      onErrorMsg("encode" -> "_21")(vc.encode(value._21, os))
+      onErrorMsg("encode" -> "_22")(wc.encode(value._22, os))
+    }
+    override def decode(
+      is: InputStream
+    ): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is)),
+        onErrorMsg("decode" -> "_18")(sc.decode(is)),
+        onErrorMsg("decode" -> "_19")(tc.decode(is)),
+        onErrorMsg("decode" -> "_20")(uc.decode(is)),
+        onErrorMsg("decode" -> "_21")(vc.decode(is)),
+        onErrorMsg("decode" -> "_22")(wc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple22Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc, _18 -> $sc, _19 -> $tc, _20 -> $uc, _21 -> $vc, _22 -> $wc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc,
+        "_18" -> sc,
+        "_19" -> tc,
+        "_20" -> uc,
+        "_21" -> vc,
+        "_22" -> wc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals() && sc.consistentWithEquals() && tc
+        .consistentWithEquals() && uc.consistentWithEquals() && vc.consistentWithEquals() && wc
+        .consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17),
+          sc.structuralValue(value._18),
+          tc.structuralValue(value._19),
+          uc.structuralValue(value._20),
+          vc.structuralValue(value._21),
+          wc.structuralValue(value._22)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17) && sc.isRegisterByteSizeObserverCheap(
+        value._18
+      ) && tc.isRegisterByteSizeObserverCheap(value._19) && uc.isRegisterByteSizeObserverCheap(
+        value._20
+      ) && vc.isRegisterByteSizeObserverCheap(value._21) && wc.isRegisterByteSizeObserverCheap(
+        value._22
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+      sc.registerByteSizeObserver(value._18, observer)
+      tc.registerByteSizeObserver(value._19, observer)
+      uc.registerByteSizeObserver(value._20, observer)
+      vc.registerByteSizeObserver(value._21, observer)
+      wc.registerByteSizeObserver(value._22, observer)
+    }
+  }
+
+  implicit def tuple22Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](
+    implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R],
+    CS: Coder[S],
+    CT: Coder[T],
+    CU: Coder[U],
+    CV: Coder[V],
+    CW: Coder[W]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR) { rc =>
+                                      Coder.transform(CS) { sc =>
+                                        Coder.transform(CT) { tc =>
+                                          Coder.transform(CU) { uc =>
+                                            Coder.transform(CV) { vc =>
+                                              Coder.transform(CW)(wc =>
+                                                Coder.beam(
+                                                  new Tuple22Coder[
+                                                    A,
+                                                    B,
+                                                    C,
+                                                    D,
+                                                    E,
+                                                    G,
+                                                    H,
+                                                    I,
+                                                    J,
+                                                    K,
+                                                    L,
+                                                    M,
+                                                    N,
+                                                    O,
+                                                    P,
+                                                    Q,
+                                                    R,
+                                                    S,
+                                                    T,
+                                                    U,
+                                                    V,
+                                                    W
+                                                  ](
+                                                    ac,
+                                                    bc,
+                                                    cc,
+                                                    dc,
+                                                    ec,
+                                                    gc,
+                                                    hc,
+                                                    ic,
+                                                    jc,
+                                                    kc,
+                                                    lc,
+                                                    mc,
+                                                    nc,
+                                                    oc,
+                                                    pc,
+                                                    qc,
+                                                    rc,
+                                                    sc,
+                                                    tc,
+                                                    uc,
+                                                    vc,
+                                                    wc
+                                                  )
+                                                )
+                                              )
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+}

--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -499,8 +499,7 @@ object Coder
   implicit val noneCoder: Coder[None.type] = ScalaCoders.noneCoder
   implicit val bitSetCoder: Coder[BitSet] = ScalaCoders.bitSetCoder
   implicit def seqCoder[T: Coder]: Coder[Seq[T]] = ScalaCoders.seqCoder
-  import shapeless.Strict
-  implicit def pairCoder[A, B](implicit CA: Strict[Coder[A]], CB: Strict[Coder[B]]): Coder[(A, B)] =
+  implicit def pairCoder[A, B](implicit CA: Coder[A], CB: Coder[B]): Coder[(A, B)] =
     ScalaCoders.pairCoder
   implicit def iterableCoder[T: Coder]: Coder[Iterable[T]] = ScalaCoders.iterableCoder
   implicit def throwableCoder[T <: Throwable: ClassTag]: Coder[T] = ScalaCoders.throwableCoder

--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -499,8 +499,6 @@ object Coder
   implicit val noneCoder: Coder[None.type] = ScalaCoders.noneCoder
   implicit val bitSetCoder: Coder[BitSet] = ScalaCoders.bitSetCoder
   implicit def seqCoder[T: Coder]: Coder[Seq[T]] = ScalaCoders.seqCoder
-  implicit def pairCoder[A, B](implicit CA: Coder[A], CB: Coder[B]): Coder[(A, B)] =
-    ScalaCoders.pairCoder
   implicit def iterableCoder[T: Coder]: Coder[Iterable[T]] = ScalaCoders.iterableCoder
   implicit def throwableCoder[T <: Throwable: ClassTag]: Coder[T] = ScalaCoders.throwableCoder
   implicit def listCoder[T: Coder]: Coder[List[T]] = ScalaCoders.listCoder

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
@@ -527,10 +527,9 @@ trait ScalaCoders {
   implicit def seqCoder[T: Coder]: Coder[Seq[T]] =
     Coder.transform(Coder[T])(bc => Coder.beam(new SeqCoder[T](bc)))
 
-  import shapeless.Strict
-  implicit def pairCoder[A, B](implicit CA: Strict[Coder[A]], CB: Strict[Coder[B]]): Coder[(A, B)] =
-    Coder.transform(CA.value) { ac =>
-      Coder.transform(CB.value)(bc => Coder.beam(new PairCoder[A, B](ac, bc)))
+  implicit def pairCoder[A, B](implicit CA: Coder[A], CB: Coder[B]): Coder[(A, B)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB)(bc => Coder.beam(new PairCoder[A, B](ac, bc)))
     }
 
   // TODO: proper chunking implementation

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/TupleCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/TupleCoders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Spotify AB.
+ * Copyright 2020 Spotify AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,354 +21,90 @@
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 
-
-
-
-
-
-
 package com.spotify.scio.coders.instances
 
 import com.spotify.scio.coders.Coder
-import shapeless.Strict
 
 trait TupleCoders {
 
 
-    implicit def tuple3Coder[A, B, C](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]]): Coder[(A, B, C)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
+    implicit def tuple3Coder[A: Coder, B: Coder, C: Coder]: Coder[(A, B, C)] = {
       Coder.gen[(A, B, C)]
     }
 
-    implicit def tuple4Coder[A, B, C, D](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]]): Coder[(A, B, C, D)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
+    implicit def tuple4Coder[A: Coder, B: Coder, C: Coder, D: Coder]: Coder[(A, B, C, D)] = {
       Coder.gen[(A, B, C, D)]
     }
 
-    implicit def tuple5Coder[A, B, C, D, E](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]]): Coder[(A, B, C, D, E)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
+    implicit def tuple5Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder]: Coder[(A, B, C, D, E)] = {
       Coder.gen[(A, B, C, D, E)]
     }
 
-    implicit def tuple6Coder[A, B, C, D, E, G](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]]): Coder[(A, B, C, D, E, G)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
+    implicit def tuple6Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder]: Coder[(A, B, C, D, E, G)] = {
       Coder.gen[(A, B, C, D, E, G)]
     }
 
-    implicit def tuple7Coder[A, B, C, D, E, G, H](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]]): Coder[(A, B, C, D, E, G, H)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
+    implicit def tuple7Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder]: Coder[(A, B, C, D, E, G, H)] = {
       Coder.gen[(A, B, C, D, E, G, H)]
     }
 
-    implicit def tuple8Coder[A, B, C, D, E, G, H, I](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]]): Coder[(A, B, C, D, E, G, H, I)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
+    implicit def tuple8Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder]: Coder[(A, B, C, D, E, G, H, I)] = {
       Coder.gen[(A, B, C, D, E, G, H, I)]
     }
 
-    implicit def tuple9Coder[A, B, C, D, E, G, H, I, J](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]]): Coder[(A, B, C, D, E, G, H, I, J)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
+    implicit def tuple9Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder]: Coder[(A, B, C, D, E, G, H, I, J)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J)]
     }
 
-    implicit def tuple10Coder[A, B, C, D, E, G, H, I, J, K](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]]): Coder[(A, B, C, D, E, G, H, I, J, K)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
+    implicit def tuple10Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K)]
     }
 
-    implicit def tuple11Coder[A, B, C, D, E, G, H, I, J, K, L](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]]): Coder[(A, B, C, D, E, G, H, I, J, K, L)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
+    implicit def tuple11Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L)]
     }
 
-    implicit def tuple12Coder[A, B, C, D, E, G, H, I, J, K, L, M](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]], M: Strict[Coder[M]]): Coder[(A, B, C, D, E, G, H, I, J, K, L, M)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
-      implicit val xM = M.value
+    implicit def tuple12Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M)]
     }
 
-    implicit def tuple13Coder[A, B, C, D, E, G, H, I, J, K, L, M, N](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]], M: Strict[Coder[M]], N: Strict[Coder[N]]): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
-      implicit val xM = M.value
-      implicit val xN = N.value
+    implicit def tuple13Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N)]
     }
 
-    implicit def tuple14Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]], M: Strict[Coder[M]], N: Strict[Coder[N]], O: Strict[Coder[O]]): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
-      implicit val xM = M.value
-      implicit val xN = N.value
-      implicit val xO = O.value
+    implicit def tuple14Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O)]
     }
 
-    implicit def tuple15Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]], M: Strict[Coder[M]], N: Strict[Coder[N]], O: Strict[Coder[O]], P: Strict[Coder[P]]): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
-      implicit val xM = M.value
-      implicit val xN = N.value
-      implicit val xO = O.value
-      implicit val xP = P.value
+    implicit def tuple15Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)]
     }
 
-    implicit def tuple16Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]], M: Strict[Coder[M]], N: Strict[Coder[N]], O: Strict[Coder[O]], P: Strict[Coder[P]], Q: Strict[Coder[Q]]): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
-      implicit val xM = M.value
-      implicit val xN = N.value
-      implicit val xO = O.value
-      implicit val xP = P.value
-      implicit val xQ = Q.value
+    implicit def tuple16Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)]
     }
 
-    implicit def tuple17Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]], M: Strict[Coder[M]], N: Strict[Coder[N]], O: Strict[Coder[O]], P: Strict[Coder[P]], Q: Strict[Coder[Q]], R: Strict[Coder[R]]): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
-      implicit val xM = M.value
-      implicit val xN = N.value
-      implicit val xO = O.value
-      implicit val xP = P.value
-      implicit val xQ = Q.value
-      implicit val xR = R.value
+    implicit def tuple17Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)]
     }
 
-    implicit def tuple18Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]], M: Strict[Coder[M]], N: Strict[Coder[N]], O: Strict[Coder[O]], P: Strict[Coder[P]], Q: Strict[Coder[Q]], R: Strict[Coder[R]], S: Strict[Coder[S]]): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
-      implicit val xM = M.value
-      implicit val xN = N.value
-      implicit val xO = O.value
-      implicit val xP = P.value
-      implicit val xQ = Q.value
-      implicit val xR = R.value
-      implicit val xS = S.value
+    implicit def tuple18Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder, S: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)]
     }
 
-    implicit def tuple19Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]], M: Strict[Coder[M]], N: Strict[Coder[N]], O: Strict[Coder[O]], P: Strict[Coder[P]], Q: Strict[Coder[Q]], R: Strict[Coder[R]], S: Strict[Coder[S]], T: Strict[Coder[T]]): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
-      implicit val xM = M.value
-      implicit val xN = N.value
-      implicit val xO = O.value
-      implicit val xP = P.value
-      implicit val xQ = Q.value
-      implicit val xR = R.value
-      implicit val xS = S.value
-      implicit val xT = T.value
+    implicit def tuple19Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder, S: Coder, T: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)]
     }
 
-    implicit def tuple20Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]], M: Strict[Coder[M]], N: Strict[Coder[N]], O: Strict[Coder[O]], P: Strict[Coder[P]], Q: Strict[Coder[Q]], R: Strict[Coder[R]], S: Strict[Coder[S]], T: Strict[Coder[T]], U: Strict[Coder[U]]): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
-      implicit val xM = M.value
-      implicit val xN = N.value
-      implicit val xO = O.value
-      implicit val xP = P.value
-      implicit val xQ = Q.value
-      implicit val xR = R.value
-      implicit val xS = S.value
-      implicit val xT = T.value
-      implicit val xU = U.value
+    implicit def tuple20Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder, S: Coder, T: Coder, U: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)]
     }
 
-    implicit def tuple21Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]], M: Strict[Coder[M]], N: Strict[Coder[N]], O: Strict[Coder[O]], P: Strict[Coder[P]], Q: Strict[Coder[Q]], R: Strict[Coder[R]], S: Strict[Coder[S]], T: Strict[Coder[T]], U: Strict[Coder[U]], V: Strict[Coder[V]]): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
-      implicit val xM = M.value
-      implicit val xN = N.value
-      implicit val xO = O.value
-      implicit val xP = P.value
-      implicit val xQ = Q.value
-      implicit val xR = R.value
-      implicit val xS = S.value
-      implicit val xT = T.value
-      implicit val xU = U.value
-      implicit val xV = V.value
+    implicit def tuple21Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder, S: Coder, T: Coder, U: Coder, V: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)]
     }
 
-    implicit def tuple22Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](implicit A: Strict[Coder[A]], B: Strict[Coder[B]], C: Strict[Coder[C]], D: Strict[Coder[D]], E: Strict[Coder[E]], G: Strict[Coder[G]], H: Strict[Coder[H]], I: Strict[Coder[I]], J: Strict[Coder[J]], K: Strict[Coder[K]], L: Strict[Coder[L]], M: Strict[Coder[M]], N: Strict[Coder[N]], O: Strict[Coder[O]], P: Strict[Coder[P]], Q: Strict[Coder[Q]], R: Strict[Coder[R]], S: Strict[Coder[S]], T: Strict[Coder[T]], U: Strict[Coder[U]], V: Strict[Coder[V]], W: Strict[Coder[W]]): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)] = {
-      implicit val xA = A.value
-      implicit val xB = B.value
-      implicit val xC = C.value
-      implicit val xD = D.value
-      implicit val xE = E.value
-      implicit val xG = G.value
-      implicit val xH = H.value
-      implicit val xI = I.value
-      implicit val xJ = J.value
-      implicit val xK = K.value
-      implicit val xL = L.value
-      implicit val xM = M.value
-      implicit val xN = N.value
-      implicit val xO = O.value
-      implicit val xP = P.value
-      implicit val xQ = Q.value
-      implicit val xR = R.value
-      implicit val xS = S.value
-      implicit val xT = T.value
-      implicit val xU = U.value
-      implicit val xV = V.value
-      implicit val xW = W.value
+    implicit def tuple22Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder, S: Coder, T: Coder, U: Coder, V: Coder, W: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)] = {
       Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)]
     }
 }
-
-
-
-
-
-
-

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/TupleCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/TupleCoders.scala
@@ -20,91 +20,4612 @@
 // !! DO NOT EDIT MANUALLY
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-
 package com.spotify.scio.coders.instances
 
-import com.spotify.scio.coders.Coder
+import java.io.{InputStream, OutputStream}
+
+import com.spotify.scio.coders.{Coder, CoderStackTrace}
+import org.apache.beam.sdk.coders.Coder.NonDeterministicException
+import org.apache.beam.sdk.coders.{Coder => BCoder, _}
+import org.apache.beam.sdk.util.common.ElementByteSizeObserver
+
+import scala.jdk.CollectionConverters._
 
 trait TupleCoders {
 
+  final private class Tuple3Coder[A, B, C](ac: BCoder[A], bc: BCoder[B], cc: BCoder[C])
+      extends AtomicCoder[(A, B, C)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
 
-    implicit def tuple3Coder[A: Coder, B: Coder, C: Coder]: Coder[(A, B, C)] = {
-      Coder.gen[(A, B, C)]
+    @inline def onErrorMsg[TC](msg: => (String, String))(f: => TC): TC =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple3: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+    }
+    override def decode(is: InputStream): (A, B, C) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple3Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List("_1" -> ac, "_2" -> bc, "_3" -> cc)
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
     }
 
-    implicit def tuple4Coder[A: Coder, B: Coder, C: Coder, D: Coder]: Coder[(A, B, C, D)] = {
-      Coder.gen[(A, B, C, D)]
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (ac.structuralValue(value._1), bc.structuralValue(value._2), cc.structuralValue(value._3))
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+    }
+  }
+
+  implicit def tuple3Coder[A, B, C](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C]
+  ): Coder[(A, B, C)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC)(cc => Coder.beam(new Tuple3Coder[A, B, C](ac, bc, cc)))
+      }
     }
 
-    implicit def tuple5Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder]: Coder[(A, B, C, D, E)] = {
-      Coder.gen[(A, B, C, D, E)]
+  final private class Tuple4Coder[A, B, C, D](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D]
+  ) extends AtomicCoder[(A, B, C, D)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TD](msg: => (String, String))(f: => TD): TD =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple4: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple4Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List("_1" -> ac, "_2" -> bc, "_3" -> cc, "_4" -> dc)
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
     }
 
-    implicit def tuple6Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder]: Coder[(A, B, C, D, E, G)] = {
-      Coder.gen[(A, B, C, D, E, G)]
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+    }
+  }
+
+  implicit def tuple4Coder[A, B, C, D](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D]
+  ): Coder[(A, B, C, D)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD)(dc => Coder.beam(new Tuple4Coder[A, B, C, D](ac, bc, cc, dc)))
+        }
+      }
     }
 
-    implicit def tuple7Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder]: Coder[(A, B, C, D, E, G, H)] = {
-      Coder.gen[(A, B, C, D, E, G, H)]
+  final private class Tuple5Coder[A, B, C, D, E](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E]
+  ) extends AtomicCoder[(A, B, C, D, E)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TE](msg: => (String, String))(f: => TE): TE =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple5: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple5Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List("_1" -> ac, "_2" -> bc, "_3" -> cc, "_4" -> dc, "_5" -> ec)
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
     }
 
-    implicit def tuple8Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder]: Coder[(A, B, C, D, E, G, H, I)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I)]
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+    }
+  }
+
+  implicit def tuple5Coder[A, B, C, D, E](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E]
+  ): Coder[(A, B, C, D, E)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE)(ec =>
+              Coder.beam(new Tuple5Coder[A, B, C, D, E](ac, bc, cc, dc, ec))
+            )
+          }
+        }
+      }
     }
 
-    implicit def tuple9Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder]: Coder[(A, B, C, D, E, G, H, I, J)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J)]
+  final private class Tuple6Coder[A, B, C, D, E, G](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G]
+  ) extends AtomicCoder[(A, B, C, D, E, G)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TF](msg: => (String, String))(f: => TF): TF =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple6: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple6Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List("_1" -> ac, "_2" -> bc, "_3" -> cc, "_4" -> dc, "_5" -> ec, "_6" -> gc)
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
     }
 
-    implicit def tuple10Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K)]
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E, G)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+    }
+  }
+
+  implicit def tuple6Coder[A, B, C, D, E, G](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G]
+  ): Coder[(A, B, C, D, E, G)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG)(gc =>
+                Coder.beam(new Tuple6Coder[A, B, C, D, E, G](ac, bc, cc, dc, ec, gc))
+              )
+            }
+          }
+        }
+      }
     }
 
-    implicit def tuple11Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L)]
+  final private class Tuple7Coder[A, B, C, D, E, G, H](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TG](msg: => (String, String))(f: => TG): TG =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple7: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple7Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs =
+        List("_1" -> ac, "_2" -> bc, "_3" -> cc, "_4" -> dc, "_5" -> ec, "_6" -> gc, "_7" -> hc)
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
     }
 
-    implicit def tuple12Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M)]
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E, G, H)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+    }
+  }
+
+  implicit def tuple7Coder[A, B, C, D, E, G, H](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H]
+  ): Coder[(A, B, C, D, E, G, H)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH)(hc =>
+                  Coder.beam(new Tuple7Coder[A, B, C, D, E, G, H](ac, bc, cc, dc, ec, gc, hc))
+                )
+              }
+            }
+          }
+        }
+      }
     }
 
-    implicit def tuple13Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N)]
+  final private class Tuple8Coder[A, B, C, D, E, G, H, I](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TH](msg: => (String, String))(f: => TH): TH =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple8: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple8Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
     }
 
-    implicit def tuple14Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O)]
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E, G, H, I)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+    }
+  }
+
+  implicit def tuple8Coder[A, B, C, D, E, G, H, I](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I]
+  ): Coder[(A, B, C, D, E, G, H, I)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI)(ic =>
+                    Coder.beam(
+                      new Tuple8Coder[A, B, C, D, E, G, H, I](ac, bc, cc, dc, ec, gc, hc, ic)
+                    )
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
     }
 
-    implicit def tuple15Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)]
+  final private class Tuple9Coder[A, B, C, D, E, G, H, I, J](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TI](msg: => (String, String))(f: => TI): TI =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple9: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I, J), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple9Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
     }
 
-    implicit def tuple16Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)]
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E, G, H, I, J)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+    }
+  }
+
+  implicit def tuple9Coder[A, B, C, D, E, G, H, I, J](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J]
+  ): Coder[(A, B, C, D, E, G, H, I, J)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ)(jc =>
+                      Coder.beam(
+                        new Tuple9Coder[A, B, C, D, E, G, H, I, J](
+                          ac,
+                          bc,
+                          cc,
+                          dc,
+                          ec,
+                          gc,
+                          hc,
+                          ic,
+                          jc
+                        )
+                      )
+                    )
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
 
-    implicit def tuple17Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)]
+  final private class Tuple10Coder[A, B, C, D, E, G, H, I, J, K](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TJ](msg: => (String, String))(f: => TJ): TJ =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple10: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I, J, K), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple10Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
     }
 
-    implicit def tuple18Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder, S: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)]
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(value: (A, B, C, D, E, G, H, I, J, K)): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+    }
+  }
+
+  implicit def tuple10Coder[A, B, C, D, E, G, H, I, J, K](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK)(kc =>
+                        Coder.beam(
+                          new Tuple10Coder[A, B, C, D, E, G, H, I, J, K](
+                            ac,
+                            bc,
+                            cc,
+                            dc,
+                            ec,
+                            gc,
+                            hc,
+                            ic,
+                            jc,
+                            kc
+                          )
+                        )
+                      )
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
 
-    implicit def tuple19Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder, S: Coder, T: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)]
+  final private class Tuple11Coder[A, B, C, D, E, G, H, I, J, K, L](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TK](msg: => (String, String))(f: => TK): TK =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple11: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I, J, K, L), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple11Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
     }
 
-    implicit def tuple20Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder, S: Coder, T: Coder, U: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)]
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+    }
+  }
+
+  implicit def tuple11Coder[A, B, C, D, E, G, H, I, J, K, L](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL)(lc =>
+                          Coder.beam(
+                            new Tuple11Coder[A, B, C, D, E, G, H, I, J, K, L](
+                              ac,
+                              bc,
+                              cc,
+                              dc,
+                              ec,
+                              gc,
+                              hc,
+                              ic,
+                              jc,
+                              kc,
+                              lc
+                            )
+                          )
+                        )
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
 
-    implicit def tuple21Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder, S: Coder, T: Coder, U: Coder, V: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)]
+  final private class Tuple12Coder[A, B, C, D, E, G, H, I, J, K, L, M](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TL](msg: => (String, String))(f: => TL): TL =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple12: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I, J, K, L, M), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple12Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
     }
 
-    implicit def tuple22Coder[A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, G: Coder, H: Coder, I: Coder, J: Coder, K: Coder, L: Coder, M: Coder, N: Coder, O: Coder, P: Coder, Q: Coder, R: Coder, S: Coder, T: Coder, U: Coder, V: Coder, W: Coder]: Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)] = {
-      Coder.gen[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)]
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L, M)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+    }
+  }
+
+  implicit def tuple12Coder[A, B, C, D, E, G, H, I, J, K, L, M](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM)(mc =>
+                            Coder.beam(
+                              new Tuple12Coder[A, B, C, D, E, G, H, I, J, K, L, M](
+                                ac,
+                                bc,
+                                cc,
+                                dc,
+                                ec,
+                                gc,
+                                hc,
+                                ic,
+                                jc,
+                                kc,
+                                lc,
+                                mc
+                              )
+                            )
+                          )
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple13Coder[A, B, C, D, E, G, H, I, J, K, L, M, N](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TM](msg: => (String, String))(f: => TM): TM =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple13: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(value: (A, B, C, D, E, G, H, I, J, K, L, M, N), os: OutputStream): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple13Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L, M, N)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+    }
+  }
+
+  implicit def tuple13Coder[A, B, C, D, E, G, H, I, J, K, L, M, N](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN)(nc =>
+                              Coder.beam(
+                                new Tuple13Coder[A, B, C, D, E, G, H, I, J, K, L, M, N](
+                                  ac,
+                                  bc,
+                                  cc,
+                                  dc,
+                                  ec,
+                                  gc,
+                                  hc,
+                                  ic,
+                                  jc,
+                                  kc,
+                                  lc,
+                                  mc,
+                                  nc
+                                )
+                              )
+                            )
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple14Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TN](msg: => (String, String))(f: => TN): TN =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple14: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N, O) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple14Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+    }
+  }
+
+  implicit def tuple14Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO)(oc =>
+                                Coder.beam(
+                                  new Tuple14Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O](
+                                    ac,
+                                    bc,
+                                    cc,
+                                    dc,
+                                    ec,
+                                    gc,
+                                    hc,
+                                    ic,
+                                    jc,
+                                    kc,
+                                    lc,
+                                    mc,
+                                    nc,
+                                    oc
+                                  )
+                                )
+                              )
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple15Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TO](msg: => (String, String))(f: => TO): TO =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple15: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple15Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+    }
+  }
+
+  implicit def tuple15Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP)(pc =>
+                                  Coder.beam(
+                                    new Tuple15Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P](
+                                      ac,
+                                      bc,
+                                      cc,
+                                      dc,
+                                      ec,
+                                      gc,
+                                      hc,
+                                      ic,
+                                      jc,
+                                      kc,
+                                      lc,
+                                      mc,
+                                      nc,
+                                      oc,
+                                      pc
+                                    )
+                                  )
+                                )
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple16Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TP](msg: => (String, String))(f: => TP): TP =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple16: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple16Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals()
+
+    override def structuralValue(value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+    }
+  }
+
+  implicit def tuple16Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ)(qc =>
+                                    Coder.beam(
+                                      new Tuple16Coder[
+                                        A,
+                                        B,
+                                        C,
+                                        D,
+                                        E,
+                                        G,
+                                        H,
+                                        I,
+                                        J,
+                                        K,
+                                        L,
+                                        M,
+                                        N,
+                                        O,
+                                        P,
+                                        Q
+                                      ](
+                                        ac,
+                                        bc,
+                                        cc,
+                                        dc,
+                                        ec,
+                                        gc,
+                                        hc,
+                                        ic,
+                                        jc,
+                                        kc,
+                                        lc,
+                                        mc,
+                                        nc,
+                                        oc,
+                                        pc,
+                                        qc
+                                      )
+                                    )
+                                  )
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple17Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TQ](msg: => (String, String))(f: => TQ): TQ =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple17: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple17Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+    }
+  }
+
+  implicit def tuple17Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR)(rc =>
+                                      Coder.beam(
+                                        new Tuple17Coder[
+                                          A,
+                                          B,
+                                          C,
+                                          D,
+                                          E,
+                                          G,
+                                          H,
+                                          I,
+                                          J,
+                                          K,
+                                          L,
+                                          M,
+                                          N,
+                                          O,
+                                          P,
+                                          Q,
+                                          R
+                                        ](
+                                          ac,
+                                          bc,
+                                          cc,
+                                          dc,
+                                          ec,
+                                          gc,
+                                          hc,
+                                          ic,
+                                          jc,
+                                          kc,
+                                          lc,
+                                          mc,
+                                          nc,
+                                          oc,
+                                          pc,
+                                          qc,
+                                          rc
+                                        )
+                                      )
+                                    )
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple18Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R],
+    sc: BCoder[S]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TR](msg: => (String, String))(f: => TR): TR =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple18: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+      onErrorMsg("encode" -> "_18")(sc.encode(value._18, os))
+    }
+    override def decode(is: InputStream): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is)),
+        onErrorMsg("decode" -> "_18")(sc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple18Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc, _18 -> $sc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc,
+        "_18" -> sc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals() && sc.consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17),
+          sc.structuralValue(value._18)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17) && sc.isRegisterByteSizeObserverCheap(
+        value._18
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+      sc.registerByteSizeObserver(value._18, observer)
+    }
+  }
+
+  implicit def tuple18Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R],
+    CS: Coder[S]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR) { rc =>
+                                      Coder.transform(CS)(sc =>
+                                        Coder.beam(
+                                          new Tuple18Coder[
+                                            A,
+                                            B,
+                                            C,
+                                            D,
+                                            E,
+                                            G,
+                                            H,
+                                            I,
+                                            J,
+                                            K,
+                                            L,
+                                            M,
+                                            N,
+                                            O,
+                                            P,
+                                            Q,
+                                            R,
+                                            S
+                                          ](
+                                            ac,
+                                            bc,
+                                            cc,
+                                            dc,
+                                            ec,
+                                            gc,
+                                            hc,
+                                            ic,
+                                            jc,
+                                            kc,
+                                            lc,
+                                            mc,
+                                            nc,
+                                            oc,
+                                            pc,
+                                            qc,
+                                            rc,
+                                            sc
+                                          )
+                                        )
+                                      )
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple19Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R],
+    sc: BCoder[S],
+    tc: BCoder[T]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TS](msg: => (String, String))(f: => TS): TS =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple19: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+      onErrorMsg("encode" -> "_18")(sc.encode(value._18, os))
+      onErrorMsg("encode" -> "_19")(tc.encode(value._19, os))
+    }
+    override def decode(
+      is: InputStream
+    ): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is)),
+        onErrorMsg("decode" -> "_18")(sc.decode(is)),
+        onErrorMsg("decode" -> "_19")(tc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple19Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc, _18 -> $sc, _19 -> $tc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc,
+        "_18" -> sc,
+        "_19" -> tc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals() && sc.consistentWithEquals() && tc
+        .consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17),
+          sc.structuralValue(value._18),
+          tc.structuralValue(value._19)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17) && sc.isRegisterByteSizeObserverCheap(
+        value._18
+      ) && tc.isRegisterByteSizeObserverCheap(value._19)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+      sc.registerByteSizeObserver(value._18, observer)
+      tc.registerByteSizeObserver(value._19, observer)
+    }
+  }
+
+  implicit def tuple19Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R],
+    CS: Coder[S],
+    CT: Coder[T]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR) { rc =>
+                                      Coder.transform(CS) { sc =>
+                                        Coder.transform(CT)(tc =>
+                                          Coder.beam(
+                                            new Tuple19Coder[
+                                              A,
+                                              B,
+                                              C,
+                                              D,
+                                              E,
+                                              G,
+                                              H,
+                                              I,
+                                              J,
+                                              K,
+                                              L,
+                                              M,
+                                              N,
+                                              O,
+                                              P,
+                                              Q,
+                                              R,
+                                              S,
+                                              T
+                                            ](
+                                              ac,
+                                              bc,
+                                              cc,
+                                              dc,
+                                              ec,
+                                              gc,
+                                              hc,
+                                              ic,
+                                              jc,
+                                              kc,
+                                              lc,
+                                              mc,
+                                              nc,
+                                              oc,
+                                              pc,
+                                              qc,
+                                              rc,
+                                              sc,
+                                              tc
+                                            )
+                                          )
+                                        )
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple20Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R],
+    sc: BCoder[S],
+    tc: BCoder[T],
+    uc: BCoder[U]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TT](msg: => (String, String))(f: => TT): TT =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple20: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+      onErrorMsg("encode" -> "_18")(sc.encode(value._18, os))
+      onErrorMsg("encode" -> "_19")(tc.encode(value._19, os))
+      onErrorMsg("encode" -> "_20")(uc.encode(value._20, os))
+    }
+    override def decode(
+      is: InputStream
+    ): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is)),
+        onErrorMsg("decode" -> "_18")(sc.decode(is)),
+        onErrorMsg("decode" -> "_19")(tc.decode(is)),
+        onErrorMsg("decode" -> "_20")(uc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple20Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc, _18 -> $sc, _19 -> $tc, _20 -> $uc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc,
+        "_18" -> sc,
+        "_19" -> tc,
+        "_20" -> uc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals() && sc.consistentWithEquals() && tc
+        .consistentWithEquals() && uc.consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17),
+          sc.structuralValue(value._18),
+          tc.structuralValue(value._19),
+          uc.structuralValue(value._20)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17) && sc.isRegisterByteSizeObserverCheap(
+        value._18
+      ) && tc.isRegisterByteSizeObserverCheap(value._19) && uc.isRegisterByteSizeObserverCheap(
+        value._20
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+      sc.registerByteSizeObserver(value._18, observer)
+      tc.registerByteSizeObserver(value._19, observer)
+      uc.registerByteSizeObserver(value._20, observer)
+    }
+  }
+
+  implicit def tuple20Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R],
+    CS: Coder[S],
+    CT: Coder[T],
+    CU: Coder[U]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR) { rc =>
+                                      Coder.transform(CS) { sc =>
+                                        Coder.transform(CT) { tc =>
+                                          Coder.transform(CU)(uc =>
+                                            Coder.beam(
+                                              new Tuple20Coder[
+                                                A,
+                                                B,
+                                                C,
+                                                D,
+                                                E,
+                                                G,
+                                                H,
+                                                I,
+                                                J,
+                                                K,
+                                                L,
+                                                M,
+                                                N,
+                                                O,
+                                                P,
+                                                Q,
+                                                R,
+                                                S,
+                                                T,
+                                                U
+                                              ](
+                                                ac,
+                                                bc,
+                                                cc,
+                                                dc,
+                                                ec,
+                                                gc,
+                                                hc,
+                                                ic,
+                                                jc,
+                                                kc,
+                                                lc,
+                                                mc,
+                                                nc,
+                                                oc,
+                                                pc,
+                                                qc,
+                                                rc,
+                                                sc,
+                                                tc,
+                                                uc
+                                              )
+                                            )
+                                          )
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple21Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R],
+    sc: BCoder[S],
+    tc: BCoder[T],
+    uc: BCoder[U],
+    vc: BCoder[V]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TU](msg: => (String, String))(f: => TU): TU =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple21: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+      onErrorMsg("encode" -> "_18")(sc.encode(value._18, os))
+      onErrorMsg("encode" -> "_19")(tc.encode(value._19, os))
+      onErrorMsg("encode" -> "_20")(uc.encode(value._20, os))
+      onErrorMsg("encode" -> "_21")(vc.encode(value._21, os))
+    }
+    override def decode(
+      is: InputStream
+    ): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is)),
+        onErrorMsg("decode" -> "_18")(sc.decode(is)),
+        onErrorMsg("decode" -> "_19")(tc.decode(is)),
+        onErrorMsg("decode" -> "_20")(uc.decode(is)),
+        onErrorMsg("decode" -> "_21")(vc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple21Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc, _18 -> $sc, _19 -> $tc, _20 -> $uc, _21 -> $vc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc,
+        "_18" -> sc,
+        "_19" -> tc,
+        "_20" -> uc,
+        "_21" -> vc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals() && sc.consistentWithEquals() && tc
+        .consistentWithEquals() && uc.consistentWithEquals() && vc.consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17),
+          sc.structuralValue(value._18),
+          tc.structuralValue(value._19),
+          uc.structuralValue(value._20),
+          vc.structuralValue(value._21)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17) && sc.isRegisterByteSizeObserverCheap(
+        value._18
+      ) && tc.isRegisterByteSizeObserverCheap(value._19) && uc.isRegisterByteSizeObserverCheap(
+        value._20
+      ) && vc.isRegisterByteSizeObserverCheap(value._21)
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+      sc.registerByteSizeObserver(value._18, observer)
+      tc.registerByteSizeObserver(value._19, observer)
+      uc.registerByteSizeObserver(value._20, observer)
+      vc.registerByteSizeObserver(value._21, observer)
+    }
+  }
+
+  implicit def tuple21Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R],
+    CS: Coder[S],
+    CT: Coder[T],
+    CU: Coder[U],
+    CV: Coder[V]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR) { rc =>
+                                      Coder.transform(CS) { sc =>
+                                        Coder.transform(CT) { tc =>
+                                          Coder.transform(CU) { uc =>
+                                            Coder.transform(CV)(vc =>
+                                              Coder.beam(
+                                                new Tuple21Coder[
+                                                  A,
+                                                  B,
+                                                  C,
+                                                  D,
+                                                  E,
+                                                  G,
+                                                  H,
+                                                  I,
+                                                  J,
+                                                  K,
+                                                  L,
+                                                  M,
+                                                  N,
+                                                  O,
+                                                  P,
+                                                  Q,
+                                                  R,
+                                                  S,
+                                                  T,
+                                                  U,
+                                                  V
+                                                ](
+                                                  ac,
+                                                  bc,
+                                                  cc,
+                                                  dc,
+                                                  ec,
+                                                  gc,
+                                                  hc,
+                                                  ic,
+                                                  jc,
+                                                  kc,
+                                                  lc,
+                                                  mc,
+                                                  nc,
+                                                  oc,
+                                                  pc,
+                                                  qc,
+                                                  rc,
+                                                  sc,
+                                                  tc,
+                                                  uc,
+                                                  vc
+                                                )
+                                              )
+                                            )
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  final private class Tuple22Coder[
+    A,
+    B,
+    C,
+    D,
+    E,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    T,
+    U,
+    V,
+    W
+  ](
+    ac: BCoder[A],
+    bc: BCoder[B],
+    cc: BCoder[C],
+    dc: BCoder[D],
+    ec: BCoder[E],
+    gc: BCoder[G],
+    hc: BCoder[H],
+    ic: BCoder[I],
+    jc: BCoder[J],
+    kc: BCoder[K],
+    lc: BCoder[L],
+    mc: BCoder[M],
+    nc: BCoder[N],
+    oc: BCoder[O],
+    pc: BCoder[P],
+    qc: BCoder[Q],
+    rc: BCoder[R],
+    sc: BCoder[S],
+    tc: BCoder[T],
+    uc: BCoder[U],
+    vc: BCoder[V],
+    wc: BCoder[W]
+  ) extends AtomicCoder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)] {
+    private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+    @inline def onErrorMsg[TV](msg: => (String, String))(f: => TV): TV =
+      try {
+        f
+      } catch {
+        case e: Exception =>
+          // allow Flink memory management, see WrappedBCoder#catching comment.
+          throw CoderStackTrace.append(
+            e,
+            Some(
+              s"Exception while trying to `${msg._1}` an instance" +
+                s" of Tuple22: Can't decode field ${msg._2}"
+            ),
+            materializationStackTrace
+          )
+      }
+
+    override def encode(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W),
+      os: OutputStream
+    ): Unit = {
+      onErrorMsg("encode" -> "_1")(ac.encode(value._1, os))
+      onErrorMsg("encode" -> "_2")(bc.encode(value._2, os))
+      onErrorMsg("encode" -> "_3")(cc.encode(value._3, os))
+      onErrorMsg("encode" -> "_4")(dc.encode(value._4, os))
+      onErrorMsg("encode" -> "_5")(ec.encode(value._5, os))
+      onErrorMsg("encode" -> "_6")(gc.encode(value._6, os))
+      onErrorMsg("encode" -> "_7")(hc.encode(value._7, os))
+      onErrorMsg("encode" -> "_8")(ic.encode(value._8, os))
+      onErrorMsg("encode" -> "_9")(jc.encode(value._9, os))
+      onErrorMsg("encode" -> "_10")(kc.encode(value._10, os))
+      onErrorMsg("encode" -> "_11")(lc.encode(value._11, os))
+      onErrorMsg("encode" -> "_12")(mc.encode(value._12, os))
+      onErrorMsg("encode" -> "_13")(nc.encode(value._13, os))
+      onErrorMsg("encode" -> "_14")(oc.encode(value._14, os))
+      onErrorMsg("encode" -> "_15")(pc.encode(value._15, os))
+      onErrorMsg("encode" -> "_16")(qc.encode(value._16, os))
+      onErrorMsg("encode" -> "_17")(rc.encode(value._17, os))
+      onErrorMsg("encode" -> "_18")(sc.encode(value._18, os))
+      onErrorMsg("encode" -> "_19")(tc.encode(value._19, os))
+      onErrorMsg("encode" -> "_20")(uc.encode(value._20, os))
+      onErrorMsg("encode" -> "_21")(vc.encode(value._21, os))
+      onErrorMsg("encode" -> "_22")(wc.encode(value._22, os))
+    }
+    override def decode(
+      is: InputStream
+    ): (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) =
+      (
+        onErrorMsg("decode" -> "_1")(ac.decode(is)),
+        onErrorMsg("decode" -> "_2")(bc.decode(is)),
+        onErrorMsg("decode" -> "_3")(cc.decode(is)),
+        onErrorMsg("decode" -> "_4")(dc.decode(is)),
+        onErrorMsg("decode" -> "_5")(ec.decode(is)),
+        onErrorMsg("decode" -> "_6")(gc.decode(is)),
+        onErrorMsg("decode" -> "_7")(hc.decode(is)),
+        onErrorMsg("decode" -> "_8")(ic.decode(is)),
+        onErrorMsg("decode" -> "_9")(jc.decode(is)),
+        onErrorMsg("decode" -> "_10")(kc.decode(is)),
+        onErrorMsg("decode" -> "_11")(lc.decode(is)),
+        onErrorMsg("decode" -> "_12")(mc.decode(is)),
+        onErrorMsg("decode" -> "_13")(nc.decode(is)),
+        onErrorMsg("decode" -> "_14")(oc.decode(is)),
+        onErrorMsg("decode" -> "_15")(pc.decode(is)),
+        onErrorMsg("decode" -> "_16")(qc.decode(is)),
+        onErrorMsg("decode" -> "_17")(rc.decode(is)),
+        onErrorMsg("decode" -> "_18")(sc.decode(is)),
+        onErrorMsg("decode" -> "_19")(tc.decode(is)),
+        onErrorMsg("decode" -> "_20")(uc.decode(is)),
+        onErrorMsg("decode" -> "_21")(vc.decode(is)),
+        onErrorMsg("decode" -> "_22")(wc.decode(is))
+      )
+
+    override def toString: String =
+      s"Tuple22Coder(_1 -> $ac, _2 -> $bc, _3 -> $cc, _4 -> $dc, _5 -> $ec, _6 -> $gc, _7 -> $hc, _8 -> $ic, _9 -> $jc, _10 -> $kc, _11 -> $lc, _12 -> $mc, _13 -> $nc, _14 -> $oc, _15 -> $pc, _16 -> $qc, _17 -> $rc, _18 -> $sc, _19 -> $tc, _20 -> $uc, _21 -> $vc, _22 -> $wc)"
+
+    // delegate methods for determinism and equality checks
+
+    override def verifyDeterministic(): Unit = {
+      val cs = List(
+        "_1" -> ac,
+        "_2" -> bc,
+        "_3" -> cc,
+        "_4" -> dc,
+        "_5" -> ec,
+        "_6" -> gc,
+        "_7" -> hc,
+        "_8" -> ic,
+        "_9" -> jc,
+        "_10" -> kc,
+        "_11" -> lc,
+        "_12" -> mc,
+        "_13" -> nc,
+        "_14" -> oc,
+        "_15" -> pc,
+        "_16" -> qc,
+        "_17" -> rc,
+        "_18" -> sc,
+        "_19" -> tc,
+        "_20" -> uc,
+        "_21" -> vc,
+        "_22" -> wc
+      )
+      val problems = cs.flatMap { case (label, c) =>
+        try {
+          c.verifyDeterministic()
+          Nil
+        } catch {
+          case e: NonDeterministicException =>
+            val reason = s"field $label is using non-deterministic $c"
+            List(reason -> e)
+        }
+      }
+
+      problems match {
+        case (_, e) :: _ =>
+          val reasons = problems.map { case (reason, _) => reason }
+          throw new NonDeterministicException(this, reasons.asJava, e)
+        case Nil =>
+      }
+    }
+
+    override def consistentWithEquals(): Boolean =
+      ac.consistentWithEquals() && bc.consistentWithEquals() && cc.consistentWithEquals() && dc
+        .consistentWithEquals() && ec.consistentWithEquals() && gc.consistentWithEquals() && hc
+        .consistentWithEquals() && ic.consistentWithEquals() && jc.consistentWithEquals() && kc
+        .consistentWithEquals() && lc.consistentWithEquals() && mc.consistentWithEquals() && nc
+        .consistentWithEquals() && oc.consistentWithEquals() && pc.consistentWithEquals() && qc
+        .consistentWithEquals() && rc.consistentWithEquals() && sc.consistentWithEquals() && tc
+        .consistentWithEquals() && uc.consistentWithEquals() && vc.consistentWithEquals() && wc
+        .consistentWithEquals()
+
+    override def structuralValue(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)
+    ): AnyRef =
+      if (consistentWithEquals()) {
+        value.asInstanceOf[AnyRef]
+      } else {
+        (
+          ac.structuralValue(value._1),
+          bc.structuralValue(value._2),
+          cc.structuralValue(value._3),
+          dc.structuralValue(value._4),
+          ec.structuralValue(value._5),
+          gc.structuralValue(value._6),
+          hc.structuralValue(value._7),
+          ic.structuralValue(value._8),
+          jc.structuralValue(value._9),
+          kc.structuralValue(value._10),
+          lc.structuralValue(value._11),
+          mc.structuralValue(value._12),
+          nc.structuralValue(value._13),
+          oc.structuralValue(value._14),
+          pc.structuralValue(value._15),
+          qc.structuralValue(value._16),
+          rc.structuralValue(value._17),
+          sc.structuralValue(value._18),
+          tc.structuralValue(value._19),
+          uc.structuralValue(value._20),
+          vc.structuralValue(value._21),
+          wc.structuralValue(value._22)
+        )
+      }
+
+    // delegate methods for byte size estimation
+    override def isRegisterByteSizeObserverCheap(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)
+    ): Boolean =
+      ac.isRegisterByteSizeObserverCheap(value._1) && bc.isRegisterByteSizeObserverCheap(
+        value._2
+      ) && cc.isRegisterByteSizeObserverCheap(value._3) && dc.isRegisterByteSizeObserverCheap(
+        value._4
+      ) && ec.isRegisterByteSizeObserverCheap(value._5) && gc.isRegisterByteSizeObserverCheap(
+        value._6
+      ) && hc.isRegisterByteSizeObserverCheap(value._7) && ic.isRegisterByteSizeObserverCheap(
+        value._8
+      ) && jc.isRegisterByteSizeObserverCheap(value._9) && kc.isRegisterByteSizeObserverCheap(
+        value._10
+      ) && lc.isRegisterByteSizeObserverCheap(value._11) && mc.isRegisterByteSizeObserverCheap(
+        value._12
+      ) && nc.isRegisterByteSizeObserverCheap(value._13) && oc.isRegisterByteSizeObserverCheap(
+        value._14
+      ) && pc.isRegisterByteSizeObserverCheap(value._15) && qc.isRegisterByteSizeObserverCheap(
+        value._16
+      ) && rc.isRegisterByteSizeObserverCheap(value._17) && sc.isRegisterByteSizeObserverCheap(
+        value._18
+      ) && tc.isRegisterByteSizeObserverCheap(value._19) && uc.isRegisterByteSizeObserverCheap(
+        value._20
+      ) && vc.isRegisterByteSizeObserverCheap(value._21) && wc.isRegisterByteSizeObserverCheap(
+        value._22
+      )
+
+    override def registerByteSizeObserver(
+      value: (A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W),
+      observer: ElementByteSizeObserver
+    ): Unit = {
+      ac.registerByteSizeObserver(value._1, observer)
+      bc.registerByteSizeObserver(value._2, observer)
+      cc.registerByteSizeObserver(value._3, observer)
+      dc.registerByteSizeObserver(value._4, observer)
+      ec.registerByteSizeObserver(value._5, observer)
+      gc.registerByteSizeObserver(value._6, observer)
+      hc.registerByteSizeObserver(value._7, observer)
+      ic.registerByteSizeObserver(value._8, observer)
+      jc.registerByteSizeObserver(value._9, observer)
+      kc.registerByteSizeObserver(value._10, observer)
+      lc.registerByteSizeObserver(value._11, observer)
+      mc.registerByteSizeObserver(value._12, observer)
+      nc.registerByteSizeObserver(value._13, observer)
+      oc.registerByteSizeObserver(value._14, observer)
+      pc.registerByteSizeObserver(value._15, observer)
+      qc.registerByteSizeObserver(value._16, observer)
+      rc.registerByteSizeObserver(value._17, observer)
+      sc.registerByteSizeObserver(value._18, observer)
+      tc.registerByteSizeObserver(value._19, observer)
+      uc.registerByteSizeObserver(value._20, observer)
+      vc.registerByteSizeObserver(value._21, observer)
+      wc.registerByteSizeObserver(value._22, observer)
+    }
+  }
+
+  implicit def tuple22Coder[A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](
+    implicit
+    CA: Coder[A],
+    CB: Coder[B],
+    CC: Coder[C],
+    CD: Coder[D],
+    CE: Coder[E],
+    CG: Coder[G],
+    CH: Coder[H],
+    CI: Coder[I],
+    CJ: Coder[J],
+    CK: Coder[K],
+    CL: Coder[L],
+    CM: Coder[M],
+    CN: Coder[N],
+    CO: Coder[O],
+    CP: Coder[P],
+    CQ: Coder[Q],
+    CR: Coder[R],
+    CS: Coder[S],
+    CT: Coder[T],
+    CU: Coder[U],
+    CV: Coder[V],
+    CW: Coder[W]
+  ): Coder[(A, B, C, D, E, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W)] =
+    Coder.transform(CA) { ac =>
+      Coder.transform(CB) { bc =>
+        Coder.transform(CC) { cc =>
+          Coder.transform(CD) { dc =>
+            Coder.transform(CE) { ec =>
+              Coder.transform(CG) { gc =>
+                Coder.transform(CH) { hc =>
+                  Coder.transform(CI) { ic =>
+                    Coder.transform(CJ) { jc =>
+                      Coder.transform(CK) { kc =>
+                        Coder.transform(CL) { lc =>
+                          Coder.transform(CM) { mc =>
+                            Coder.transform(CN) { nc =>
+                              Coder.transform(CO) { oc =>
+                                Coder.transform(CP) { pc =>
+                                  Coder.transform(CQ) { qc =>
+                                    Coder.transform(CR) { rc =>
+                                      Coder.transform(CS) { sc =>
+                                        Coder.transform(CT) { tc =>
+                                          Coder.transform(CU) { uc =>
+                                            Coder.transform(CV) { vc =>
+                                              Coder.transform(CW)(wc =>
+                                                Coder.beam(
+                                                  new Tuple22Coder[
+                                                    A,
+                                                    B,
+                                                    C,
+                                                    D,
+                                                    E,
+                                                    G,
+                                                    H,
+                                                    I,
+                                                    J,
+                                                    K,
+                                                    L,
+                                                    M,
+                                                    N,
+                                                    O,
+                                                    P,
+                                                    Q,
+                                                    R,
+                                                    S,
+                                                    T,
+                                                    U,
+                                                    V,
+                                                    W
+                                                  ](
+                                                    ac,
+                                                    bc,
+                                                    cc,
+                                                    dc,
+                                                    ec,
+                                                    gc,
+                                                    hc,
+                                                    ic,
+                                                    jc,
+                                                    kc,
+                                                    lc,
+                                                    mc,
+                                                    nc,
+                                                    oc,
+                                                    pc,
+                                                    qc,
+                                                    rc,
+                                                    sc,
+                                                    tc,
+                                                    uc,
+                                                    vc,
+                                                    wc
+                                                  )
+                                                )
+                                              )
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
 }

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sorter/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sorter/syntax/SCollectionSyntax.scala
@@ -86,7 +86,7 @@ final class SorterOps[K1, K2: SortingKey, V](self: SCollection[(K1, Iterable[(K2
           override def toString: String = "<iterable>"
         }
         (kv.getKey, iter)
-      }
+      }(Coder.beam(c.internal.getCoder))
   }
 }
 

--- a/scio-jmh/src/test/scala/com/spotify/scio/jmh/CoderBenchmark.scala
+++ b/scio-jmh/src/test/scala/com/spotify/scio/jmh/CoderBenchmark.scala
@@ -89,6 +89,25 @@ class CoderBenchmark {
     CoderMaterializer.beamWithDefault(Coder[List[String]])
   val stringListExample: List[String] = (1 to 1000).map(x => s"stringvalue$x").toList
 
+  val derivedTuple3Coder: BCoder[(Int, Int, Int)] =
+    CoderMaterializer.beamWithDefault(Coder[(Int, Int, Int)])
+  val tuple3Example: (Int, Int, Int) = (1, 10, 100)
+  val derivedTuple4Coder: BCoder[(Int, Int, Int, Int)] =
+    CoderMaterializer.beamWithDefault(Coder[(Int, Int, Int, Int)])
+  val tuple4Example: (Int, Int, Int, Int) = (1, 10, 100, 1000)
+
+  @Benchmark
+  def tuple3Encode(o: SerializedOutputSize): Array[Byte] =
+    Counter.track(o) {
+      CoderUtils.encodeToByteArray(derivedTuple3Coder, tuple3Example)
+    }
+
+  @Benchmark
+  def tuple4Encode(o: SerializedOutputSize): Array[Byte] =
+    Counter.track(o) {
+      CoderUtils.encodeToByteArray(derivedTuple4Coder, tuple4Example)
+    }
+
   @Benchmark
   def kryoEncode(o: SerializedOutputSize): Array[Byte] =
     Counter.track(o) {
@@ -159,6 +178,16 @@ class CoderBenchmark {
   val derivedMapEncoded: Array[Byte] = derivedMapEncode(new SerializedOutputSize)
   val kryoStringListEncoded: Array[Byte] = kryoStringListEncode(new SerializedOutputSize)
   val derivedStringListEncoded: Array[Byte] = derivedStringListEncode(new SerializedOutputSize)
+  val tuple3Encoded: Array[Byte] = tuple3Encode(new SerializedOutputSize)
+  val tuple4Encoded: Array[Byte] = tuple4Encode(new SerializedOutputSize)
+
+  @Benchmark
+  def tuple3Decode: (Int, Int, Int) =
+    CoderUtils.decodeFromByteArray(derivedTuple3Coder, tuple3Encoded)
+
+  @Benchmark
+  def tuple4Decode: (Int, Int, Int, Int) =
+    CoderUtils.decodeFromByteArray(derivedTuple4Coder, tuple4Encoded)
 
   @Benchmark
   def kryoDecode: User =

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -383,7 +383,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
       }
 
     val expectedMsg =
-      "PairCoder(_1 -> DoubleCoder, _2 -> DoubleCoder) is not deterministic"
+      "Tuple2Coder(_1 -> DoubleCoder, _2 -> DoubleCoder) is not deterministic"
 
     caught.getMessage should startWith(expectedMsg)
     caught.getMessage should include("field _1 is using non-deterministic DoubleCoder")

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -90,6 +90,8 @@ final case class SecondImplementationWithAnnotation(i: Int) extends TraitWithAnn
 
 final case class AnyValExample(value: String) extends AnyVal
 
+final case class NonDeterministic(a: Double, b: Double)
+
 final class CoderTest extends AnyFlatSpec with Matchers {
   val userId: UserId = UserId(Array[Byte](1, 2, 3, 4))
   val user: User = User(userId, "johndoe", "johndoe@spotify.com")
@@ -391,19 +393,18 @@ final class CoderTest extends AnyFlatSpec with Matchers {
   it should "have a nice verifyDeterministic exception for case classes" in {
     val caught =
       intercept[NonDeterministicException] {
-        val coder = Coder[(Double, Double, Double)]
+        val coder = Coder[NonDeterministic]
 
         materialize(coder).verifyDeterministic()
       }
 
     val expectedMsg =
-      "RecordCoder[scala.Tuple3](_1 -> DoubleCoder, _2 -> DoubleCoder, _3 -> DoubleCoder)" +
+      "RecordCoder[com.spotify.scio.coders.NonDeterministic](a -> DoubleCoder, b -> DoubleCoder)" +
         " is not deterministic"
 
     caught.getMessage should startWith(expectedMsg)
-    caught.getMessage should include("field _1 is using non-deterministic DoubleCoder")
-    caught.getMessage should include("field _2 is using non-deterministic DoubleCoder")
-    caught.getMessage should include("field _3 is using non-deterministic DoubleCoder")
+    caught.getMessage should include("field a is using non-deterministic DoubleCoder")
+    caught.getMessage should include("field b is using non-deterministic DoubleCoder")
   }
 
   it should "have a nice verifyDeterministic exception for disjunctions" in {

--- a/scripts/tuplecoders.py
+++ b/scripts/tuplecoders.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 #  Copyright 2016 Spotify AB.
 #
@@ -18,16 +18,13 @@
 import string
 import sys
 import textwrap
+import os
 
 
 # Utilities
 
 def mkVals(n):
-    return list(string.uppercase.replace('F', '')[:n])
-
-
-def mkTypes(n):
-    return ', '.join(mkVals(n))
+    return list(string.ascii_uppercase.replace('F', '')[:n])
 
 def mkBounds(n):
     return ', '.join(x + ': Coder' for x in mkVals(n))
@@ -35,15 +32,95 @@ def mkBounds(n):
 # Functions
 
 def tupleFns(out, n):
-    types = mkTypes(n)
-    print >> out, '''    
-    implicit def tuple{size}Coder[{bounds}]: Coder[({type_list})] = {{
-      Coder.gen[({type_list})]
-    }}'''.format(size=n, bounds=mkBounds(n), type_list=types)
+    t_type = f'T{string.ascii_uppercase[n-1]}'
+    types = mkVals(n)
+    bounds = mkBounds(n)
+
+    def coder_transform(a):
+        if len(a) == 1:
+            return f'''Coder.transform(C{a[0]})({a[0].lower()}c => Coder.beam(new Tuple{n}Coder[{','.join(types)}]({','.join(t.lower() + 'c' for t in types)})))'''
+        else:
+            return f'''Coder.transform(C{a[0]}) {{ {a[0].lower()}c =>''' + coder_transform(a[1:]) + "}"
+        
+    print(f'''    
+final private class Tuple{n}Coder[{','.join(types)}]({','.join(f'{t.lower()}c: BCoder[{t}]' for t in types)}) extends AtomicCoder[({','.join(types)})] {{
+  private[this] val materializationStackTrace: Array[StackTraceElement] = CoderStackTrace.prepare
+
+  @inline def onErrorMsg[{t_type}](msg: => (String, String))(f: => {t_type}): {t_type} =
+    try {{
+      f
+    }} catch {{
+      case e: Exception =>
+        // allow Flink memory management, see WrappedBCoder#catching comment.
+        throw CoderStackTrace.append(
+          e,
+          Some(
+            s"Exception while trying to `${{msg._1}}` an instance" +
+              s" of Tuple{n}: Can't decode field ${{msg._2}}"
+          ),
+          materializationStackTrace
+        )
+    }}
+
+  override def encode(value: ({','.join(types)}), os: OutputStream): Unit = {{
+    {os.linesep.join(f'onErrorMsg("encode" -> "_{idx}")({t.lower()}c.encode(value._{idx}, os))' for idx, t in enumerate(types, 1))}
+  }}
+  override def decode(is: InputStream): ({','.join(types)}) = {{
+    ({','.join(f'onErrorMsg("decode" -> "_{idx}")({t.lower()}c.decode(is))' for idx, t in enumerate(types, 1))})
+  }}
+
+  override def toString: String =
+    s"Tuple{n}Coder({', '.join(f'_{idx} -> ${t.lower()}c' for idx, t in enumerate(types, 1))})"
+
+  // delegate methods for determinism and equality checks
+
+  override def verifyDeterministic(): Unit = {{
+    val cs = List({', '.join(f'"_{idx}" -> {t.lower()}c' for idx, t in enumerate(types, 1))})
+    val problems = cs.flatMap {{ case (label, c) =>
+      try {{
+        c.verifyDeterministic()
+        Nil
+      }} catch {{
+        case e: NonDeterministicException =>
+          val reason = s"field $label is using non-deterministic $c"
+          List(reason -> e)
+      }}
+    }}
+
+    problems match {{
+      case (_, e) :: _ =>
+        val reasons = problems.map {{ case (reason, _) => reason }}
+        throw new NonDeterministicException(this, reasons.asJava, e)
+      case Nil =>
+    }}
+  }}
+
+  override def consistentWithEquals(): Boolean =
+    {' && '.join(f'{t.lower()}c.consistentWithEquals()' for t in types)}
+
+  override def structuralValue(value: ({','.join(types)})): AnyRef =
+    if (consistentWithEquals()) {{
+      value.asInstanceOf[AnyRef]
+    }} else {{
+        ({','.join(f'{t.lower()}c.structuralValue(value._{idx})' for idx, t in enumerate(types, 1))})
+    }}
+
+  // delegate methods for byte size estimation
+  override def isRegisterByteSizeObserverCheap(value: ({','.join(types)})): Boolean =
+    {' && '.join(f'{t.lower()}c.isRegisterByteSizeObserverCheap(value._{idx})' for idx, t in enumerate(types, 1))}
+
+  override def registerByteSizeObserver(value: ({','.join(types)}), observer: ElementByteSizeObserver): Unit = {{
+    {os.linesep.join(f'{t.lower()}c.registerByteSizeObserver(value._{idx}, observer)' for idx, t in enumerate(types, 1))}
+  }}
+}}
+    
+    implicit def tuple{n}Coder[{','.join(types)}](implicit {','.join(f'C{t}: Coder[{t}]' for t in types)}): Coder[({','.join(types)})] = {{
+    {coder_transform(types)}
+    }}''', file=out)
 
 
 def main(out):
-    print >> out, textwrap.dedent('''
+    print(textwrap.dedent('''
         /*
          * Copyright 2020 Spotify AB.
          *
@@ -69,16 +146,23 @@ def main(out):
     
         package com.spotify.scio.coders.instances
 
-        import com.spotify.scio.coders.Coder
+        import java.io.{InputStream, OutputStream}
+
+        import com.spotify.scio.coders.{Coder, CoderStackTrace}
+        import org.apache.beam.sdk.coders.Coder.NonDeterministicException
+        import org.apache.beam.sdk.coders.{Coder => BCoder, _}
+        import org.apache.beam.sdk.util.common.ElementByteSizeObserver
+
+        import scala.jdk.CollectionConverters._
 
         trait TupleCoders {
-        ''').replace('  # NOQA', '').lstrip('\n')
+        ''').replace('  # NOQA', '').lstrip('\n'), file=out)
 
     N = 22
-    for i in xrange(3, N + 1):
+    for i in range(3, N + 1):
         tupleFns(out, i)
 
-    print >> out, '}'
+    print('}', file=out)
 
 if __name__ == '__main__':
     main(sys.stdout)

--- a/scripts/tuplecoders.py
+++ b/scripts/tuplecoders.py
@@ -32,17 +32,14 @@ def mkTypes(n):
 def mkBounds(n):
     return ', '.join(x + ': Coder' for x in mkVals(n))
 
-def mkImplicits(n):
-    return '\n'.join('      implicit val x' + x + ' = ' + x for x in mkVals(n))
-
 # Functions
 
 def tupleFns(out, n):
     types = mkTypes(n)
-    print >> out, '''
-    implicit def tuple%sCoder[%s]: Coder[(%s)] = {
-      Coder.gen[(%s)]
-    }''' % (n, mkBounds(n), types, types)
+    print >> out, '''    
+    implicit def tuple{size}Coder[{bounds}]: Coder[({type_list})] = {{
+      Coder.gen[({type_list})]
+    }}'''.format(size=n, bounds=mkBounds(n), type_list=types)
 
 
 def main(out):

--- a/scripts/tuplecoders.py
+++ b/scripts/tuplecoders.py
@@ -30,20 +30,19 @@ def mkTypes(n):
     return ', '.join(mkVals(n))
 
 def mkBounds(n):
-    return ', '.join(x + ': Strict[Coder[' + x + ']]' for x in mkVals(n))
+    return ', '.join(x + ': Coder' for x in mkVals(n))
 
 def mkImplicits(n):
-    return '\n'.join('      implicit val x' + x + ' = ' + x + '.value' for x in mkVals(n))
+    return '\n'.join('      implicit val x' + x + ' = ' + x for x in mkVals(n))
 
 # Functions
 
 def tupleFns(out, n):
     types = mkTypes(n)
     print >> out, '''
-    implicit def tuple%sCoder[%s](implicit %s): Coder[(%s)] = {
-%s
+    implicit def tuple%sCoder[%s]: Coder[(%s)] = {
       Coder.gen[(%s)]
-    }''' % (n, types, mkBounds(n), types, mkImplicits(n), types)
+    }''' % (n, mkBounds(n), types, types)
 
 
 def main(out):
@@ -70,17 +69,10 @@ def main(out):
         // !! DO NOT EDIT MANUALLY
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-        
-        
-        
-        
-        
-        
-
+    
         package com.spotify.scio.coders.instances
 
         import com.spotify.scio.coders.Coder
-        import shapeless.Strict
 
         trait TupleCoders {
         ''').replace('  # NOQA', '').lstrip('\n')


### PR DESCRIPTION
I recently noticed that Tuple3 / Tuple4 are not that uncommon so decided to specialize them to save on serialization. Users should rarely rely on above then that but this adds for the other ones as well (bonus).

We should at some point ditch these python scripts and use either paiges or scalafix.