### PR TITLE
scio-parquet to support dynamic destinations for windowed scollections

### DIFF
--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/package.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/package.scala
@@ -25,6 +25,7 @@ import com.spotify.scio.parquet.avro.ParquetAvroIO.WriteParam
 import org.apache.avro.Schema
 import org.apache.avro.specific.SpecificRecordBase
 import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, PaneInfo}
+import org.apache.beam.sdk.values.WindowingStrategy
 import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.slf4j.LoggerFactory
@@ -143,42 +144,46 @@ package object avro {
     /**
      * Save this SCollection of Avro records as a Parquet files written to dynamic destinations.
      * @param path output location of the write operation
+     * @param filenameFunction an Either representing one of two functions which generates a filename. The Either must
+     *                         be a Left when writing dynamic files from windowed SCollections, or a Right when writing
+     *                         dynamic files from un-windowed SCollections. When the Either is a Left, the function's
+     *                         arguments represent
+     *                            (the shard number,
+     *                            the total number of shards,
+     *                            the bounded window,
+     *                            the pane info for the window)
+     *                         When the Either is a Right, the function's arguments represent
+     *                            (the shard number,
+     *                            the total number of shards)
      * @param schema must be not null if `T` is of type
      *               [[org.apache.avro.generic.GenericRecord GenericRecord]].
      * @param numShards number of shards per output directory
      * @param suffix defaults to .parquet
      * @param compression defaults to snappy
-     * @param windowFilenameFunction a function which generates a filename for windowed data, whose arguments represent
-     *                                (the shard number,
-     *                                the total number of shards,
-     *                                the bounded window,
-     *                                the pane info for the window)
-     * @param filenameFunction a function which generates a filename, whose arguments represent
-     *                         (the shard number,
-     *                         the total number of shards)
      */
     def saveAsDynamicParquetAvroFile(
       path: String,
+      filenameFunction: Either[(Int, Int, BoundedWindow, PaneInfo) => String, (Int, Int) => String],
       schema: Schema = WriteParam.DefaultSchema,
       numShards: Int = WriteParam.DefaultNumShards,
       suffix: String = WriteParam.DefaultSuffix,
-      compression: CompressionCodecName = WriteParam.DefaultCompression,
-      windowFilenameFunction: (Int, Int, BoundedWindow, PaneInfo) => String =
-        WriteParam.DefaultWindowedFilenameFunction,
-      filenameFunction: (Int, Int) => String = WriteParam.DefaultFilenameFunction
+      compression: CompressionCodecName = WriteParam.DefaultCompression
     )(implicit ct: ClassTag[T], coder: Coder[T]): ClosedTap[T] = {
 
       if (
-        windowFilenameFunction == WriteParam.DefaultWindowedFilenameFunction &&
-        filenameFunction == WriteParam.DefaultFilenameFunction
+        (self.internal.getWindowingStrategy != WindowingStrategy
+          .globalDefault() && filenameFunction.isRight) ||
+        (self.internal.getWindowingStrategy == WindowingStrategy
+          .globalDefault() && filenameFunction.isLeft)
       ) {
         throw new NotImplementedError(
-          "A file name function must be defined whe using saveAsDynamicParquetAvroFile"
+          "The filenameFunction value passed to saveAsDynamicParquetAvroFile does not" +
+            " support the window strategy applied to the SCollection."
         )
       }
 
       val param =
-        WriteParam(schema, numShards, suffix, compression, windowFilenameFunction, filenameFunction)
+        WriteParam(schema, numShards, suffix, compression, Some(filenameFunction))
       self.write(ParquetAvroIO[T](path))(param)
     }
   }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/package.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/package.scala
@@ -163,10 +163,20 @@ package object avro {
       numShards: Int = WriteParam.DefaultNumShards,
       suffix: String = WriteParam.DefaultSuffix,
       compression: CompressionCodecName = WriteParam.DefaultCompression,
-      windowFilenameFunction: Option[(Int, Int, BoundedWindow, PaneInfo) => String] =
+      windowFilenameFunction: (Int, Int, BoundedWindow, PaneInfo) => String =
         WriteParam.DefaultWindowedFilenameFunction,
-      filenameFunction: Option[(Int, Int) => String] = WriteParam.DefaultFilenameFunction
+      filenameFunction: (Int, Int) => String = WriteParam.DefaultFilenameFunction
     )(implicit ct: ClassTag[T], coder: Coder[T]): ClosedTap[T] = {
+
+      if (
+        windowFilenameFunction == WriteParam.DefaultWindowedFilenameFunction &&
+        filenameFunction == WriteParam.DefaultFilenameFunction
+      ) {
+        throw new NotImplementedError(
+          "A file name function must be defined whe using saveAsDynamicParquetAvroFile"
+        )
+      }
+
       val param =
         WriteParam(schema, numShards, suffix, compression, windowFilenameFunction, filenameFunction)
       self.write(ParquetAvroIO[T](path))(param)

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
@@ -17,13 +17,19 @@
 
 package com.spotify.scio.parquet.avro
 
+import java.io.File
+
 import com.spotify.scio._
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.avro._
 import com.spotify.scio.io.TapSpec
 import com.spotify.scio.testing._
+import com.spotify.scio.values.WindowOptions
 import org.apache.avro.generic.GenericRecord
+import org.apache.beam.sdk.options.PipelineOptionsFactory
+import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, IntervalWindow, PaneInfo}
 import org.apache.commons.io.FileUtils
+import org.joda.time.{DateTimeFieldType, Duration, Instant}
 import org.scalatest.BeforeAndAfterAll
 
 class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
@@ -124,6 +130,98 @@ class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
 
     val files = dir.listFiles()
     files.length shouldBe 1
+
+    val params =
+      ParquetAvroIO.ReadParam[GenericRecord, GenericRecord](AvroUtils.schema, null, identity)
+    val tap = ParquetAvroTap(files.head.getAbsolutePath, params)
+    tap.value.toList should contain theSameElementsAs genericRecords
+
+    FileUtils.deleteDirectory(dir)
+  }
+
+  it should "write windowed generic records to dynamic destinations" in {
+    // This test follows the same pattern as com.spotify.scio.io.dynamic.DynamicFileTest
+
+    val dir = tmpDir
+
+    val genericRecords = (0 until 10).map(AvroUtils.newGenericRecord)
+    val options = PipelineOptionsFactory.fromArgs("--streaming=true").create()
+    val sc1 = ScioContext(options)
+    implicit val coder = Coder.avroGenericRecordCoder(AvroUtils.schema)
+    sc1
+      .parallelize(genericRecords)
+      // Explicit optional arguments `Duration.Zero` and `WindowOptions()` as a workaround for the
+      // mysterious "Could not find proxy for val sc1" compiler error
+      // take each records int value and multiply it by half hour, so we should have 2 records in each hour window
+      .timestampBy(x => new Instant(x.get("int_field").asInstanceOf[Int] * 1800000), Duration.ZERO)
+      .withFixedWindows(Duration.standardHours(1), Duration.ZERO, WindowOptions())
+      .saveAsDynamicParquetAvroFile(
+        dir.toString,
+        numShards = 1,
+        schema = AvroUtils.schema,
+        windowFilenameFunction =
+          Some { (shardNumber: Int, numShards: Int, window: BoundedWindow, paneInfo: PaneInfo) =>
+            val intervalWindow = window.asInstanceOf[IntervalWindow]
+            val year = intervalWindow.start().get(DateTimeFieldType.year())
+            val month = intervalWindow.start().get(DateTimeFieldType.monthOfYear())
+            val day = intervalWindow.start().get(DateTimeFieldType.dayOfMonth())
+            val hour = intervalWindow.start().get(DateTimeFieldType.hourOfDay())
+            "y=%02d/m=%02d/d=%02d/h=%02d/part-%s-of-%s"
+              .format(year, month, day, hour, shardNumber, numShards)
+          }
+      )
+    sc1.run()
+
+    def recursiveListFiles(directory: File): List[File] = {
+      val files = directory.listFiles()
+      files.filter(!_.isDirectory).toList ++ files.filter(_.isDirectory).flatMap(recursiveListFiles)
+    }
+
+    val files = recursiveListFiles(dir)
+    files.length shouldBe 5
+
+    val params =
+      ParquetAvroIO.ReadParam[GenericRecord, GenericRecord](AvroUtils.schema, null, identity)
+
+    (0 until 10)
+      .sliding(2, 2)
+      .zipWithIndex
+      .map(t =>
+        (
+          "y=1970/m=01/d=01/h=%02d/part-0-of-1.parquet".format(t._2),
+          t._1.map(AvroUtils.newGenericRecord)
+        )
+      )
+      .foreach({
+        case (filename, records) => {
+          val tap = ParquetAvroTap(s"$dir/$filename", params)
+          tap.value.toList should contain theSameElementsAs records
+        }
+      })
+
+    FileUtils.deleteDirectory(dir)
+  }
+
+  it should "write generic records to dynamic destinations" in {
+    val dir = tmpDir
+
+    val genericRecords = (1 to 100).map(AvroUtils.newGenericRecord)
+    val sc = ScioContext()
+    implicit val coder = Coder.avroGenericRecordCoder(AvroUtils.schema)
+    sc.parallelize(genericRecords)
+      .saveAsDynamicParquetAvroFile(
+        dir.toString,
+        numShards = 1,
+        schema = AvroUtils.schema,
+        filenameFunction = Some { (shardNumber: Int, numShards: Int) =>
+          "part-%s-of-%s-with-custom-naming".format(shardNumber, numShards)
+        }
+      )
+    sc.run()
+
+    val files = dir.listFiles()
+    files.length shouldBe 1
+    files.head.getAbsolutePath should include("part-0-of-1-with-custom-naming.parquet")
 
     val params =
       ParquetAvroIO.ReadParam[GenericRecord, GenericRecord](AvroUtils.schema, null, identity)


### PR DESCRIPTION
This is a draft PR to support https://github.com/spotify/scio/issues/2824; it provides an API for defining a custom filename based on the window associated with the SCollection (see https://spotify-foss.slack.com/archives/C015189TFDH/p1600776553015800). This differs from other dynamic file support implementations, which provide an API for defining the filename based on the SCollection object directly; it's unclear which functionality the original issue was requesting, but this PR addresses the functionality requested in the slack thread. 