### PR TITLE
Support $LATEST replacement for Query

### DIFF
--- a/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/types/BigQueryTypeIT.scala
+++ b/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/types/BigQueryTypeIT.scala
@@ -173,7 +173,9 @@ class BigQueryTypeIT extends AnyFlatSpec with Matchers {
 
   it should "format and return query as source" in {
     LegacyLatestT.queryAsSource("TABLE") shouldBe Query(legacyLatestQuery.format("TABLE"))
+    LegacyLatestT.queryAsSource("$LATEST").latest(bq) shouldBe Query(legacyLatestQuery.format("$LATEST")).latest(bq)
     SqlLatestT.queryAsSource("TABLE") shouldBe Query(sqlLatestQuery.format("TABLE"))
+    SqlLatestT.queryAsSource("$LATEST").latest(bq) shouldBe Query(sqlLatestQuery.format("$LATEST")).latest(bq)
   }
 
   it should "type check annotation arguments" in {

--- a/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/types/StorageIT.scala
+++ b/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/types/StorageIT.scala
@@ -316,6 +316,7 @@ object StorageIT {
   @BigQueryType.fromStorage("data-integration-test:partition_a.table_%s", List("$LATEST"))
   class StorageLatest
 
+  // Require setting default project to allow this work locally. Use command `gcloud config set project data-integration-test`.
   @BigQueryType.fromStorage("partition_a.table_%s", List("$LATEST"))
   class StorageEnvProject
 

--- a/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/types/StorageIT.scala
+++ b/scio-bigquery/src/it/scala/com/spotify/scio/bigquery/types/StorageIT.scala
@@ -316,7 +316,6 @@ object StorageIT {
   @BigQueryType.fromStorage("data-integration-test:partition_a.table_%s", List("$LATEST"))
   class StorageLatest
 
-  // Require setting default project to allow this work locally. Use command `gcloud config set project data-integration-test`.
   @BigQueryType.fromStorage("partition_a.table_%s", List("$LATEST"))
   class StorageEnvProject
 

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
@@ -39,7 +39,7 @@ sealed trait Source
 final case class Query(underlying: String) extends Source {
 
   /**
-   *  A helper method to replace the "$LATEST" laceholder in query to the latest common partition.
+   *  A helper method to replace the "$LATEST" placeholder in query to the latest common partition.
    *  For example:
    *  {{{
    *  @BigQueryType.fromQuery("SELECT ... FROM `project.data.foo_%s`", "$LATEST")

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
@@ -19,23 +19,26 @@ package com.spotify.scio.bigquery
 import java.math.MathContext
 import java.nio.ByteBuffer
 
-import com.spotify.scio.ScioContext
-import com.spotify.scio.values.SCollection
 import com.google.api.services.bigquery.model.{
+  TableReference => GTableReference,
   TableRow => GTableRow,
-  TimePartitioning => GTimePartitioning,
-  TableReference => GTableReference
+  TimePartitioning => GTimePartitioning
 }
-import org.apache.beam.sdk.io.gcp.bigquery.{BigQueryHelpers, BigQueryInsertError, WriteResult}
+import com.spotify.scio.ScioContext
+import com.spotify.scio.bigquery.client.BigQuery
+import com.spotify.scio.values.SCollection
 import org.apache.avro.Conversions.DecimalConversion
 import org.apache.avro.LogicalTypes
+import org.apache.beam.sdk.io.gcp.bigquery.{BigQueryHelpers, BigQueryInsertError, WriteResult}
+import org.joda.time._
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatterBuilder}
-import org.joda.time.DateTimeZone
-import org.joda.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 
 sealed trait Source
 
-final case class Query(underlying: String) extends Source
+final case class Query(underlying: String) extends Source {
+  def latest(bq: BigQuery): Query =
+    Query(BigQueryPartitionUtil.latestQuery(bq, this.underlying))
+}
 
 sealed trait Table extends Source {
   def spec: String

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
@@ -35,9 +35,31 @@ import org.joda.time.format.{DateTimeFormat, DateTimeFormatterBuilder}
 
 sealed trait Source
 
+/** A wrapper type [[Query]] which wraps a SQL String. */
 final case class Query(underlying: String) extends Source {
+
+  /**
+   *  A helper method to replace the "$LATEST" laceholder in query to the latest common partition.
+   *  For example:
+   *  {{{
+   *  @BigQueryType.fromQuery("SELECT ... FROM `project.data.foo_%s`", "$LATEST")
+   *  class Foo
+   *
+   *  val bq: BigQuery = BigQuery.defaultInstance()
+   *  scioContext.bigQuerySelect(Foo.queryAsSource("$LATEST").latest(bq))
+   *  }}}
+   *
+   *  Or, if your query string is a dynamic value which uses a "$LATEST" placeholder,
+   *  {{{
+   *  val dynamicSQLStr = "SELECT ... FROM some_table_$LATEST"
+   *  scioContext.bigQuerySelect(Query(dynamicSQLStr).latest(bq))
+   *  }}}
+   *
+   * @param bq [[BigQuery]] client
+   * @return [[Query]] with "$LATEST" replaced
+   */
   def latest(bq: BigQuery): Query =
-    Query(BigQueryPartitionUtil.latestQuery(bq, this.underlying))
+    Query(BigQueryPartitionUtil.latestQuery(bq, underlying))
 }
 
 sealed trait Table extends Source {

--- a/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
+++ b/scio-bigquery/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
@@ -60,6 +60,8 @@ final case class Query(underlying: String) extends Source {
    */
   def latest(bq: BigQuery): Query =
     Query(BigQueryPartitionUtil.latestQuery(bq, underlying))
+
+  def latest(): Query = latest(BigQuery.defaultInstance())
 }
 
 sealed trait Table extends Source {


### PR DESCRIPTION
So to support Bigtable queries containing `$LATEST` in the table name.