### PR TITLE
suport null-key records in smb writes

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -28,7 +28,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -180,6 +182,16 @@ public abstract class BucketMetadata<K, V> implements Serializable, HasDisplayDa
 
   public int getNumShards() {
     return numShards;
+  }
+
+  Set<BucketShardId> getAllBucketShardIds() {
+    final HashSet<BucketShardId> allBucketShardIds = new HashSet<>();
+    for (int shardId = 0; shardId < numShards; shardId++) {
+      for (int bucketId = 0; bucketId < numBuckets; bucketId++) {
+        allBucketShardIds.add(BucketShardId.of(bucketId, shardId));
+      }
+    }
+    return allBucketShardIds;
   }
 
   public Class<K> getKeyClass() {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketShardId.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketShardId.java
@@ -47,8 +47,8 @@ public abstract class BucketShardId {
     return new AutoValue_BucketShardId(bucketId, shardId);
   }
 
-  public static BucketShardId ofNullKey(int shardId) {
-    return new AutoValue_BucketShardId(NULL_KEYS_BUCKET_ID, shardId);
+  public static BucketShardId ofNullKey() {
+    return new AutoValue_BucketShardId(NULL_KEYS_BUCKET_ID, 0);
   }
 
   public boolean isNullKeyBucket() {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SMBFilenamePolicy.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SMBFilenamePolicy.java
@@ -145,7 +145,7 @@ public final class SMBFilenamePolicy implements Serializable {
       return directory.resolve(timestamp + METADATA_FILENAME, StandardResolveOptions.RESOLVE_FILE);
     }
 
-    /** Returns a ResourceId matching the */
+    /** Returns a ResourceId matching the null keys. */
     public ResourceId forNullKeys() {
       return directory.resolve(
           NULL_KEYS_BUCKET_TEMPLATE + "*" + filenameSuffix, StandardResolveOptions.RESOLVE_FILE);

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SMBFilenamePolicy.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SMBFilenamePolicy.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.extensions.smb;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.UUID;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
@@ -127,7 +128,7 @@ public final class SMBFilenamePolicy implements Serializable {
 
       final String timestamp = doTimestampFiles ? Instant.now().toString(TEMPFILE_TIMESTAMP) : "";
       String filename =
-          maxNumShards == 1
+          maxNumShards == 1 || id.isNullKeyBucket()
               ? String.format(bucketOnlyTemplate, bucketName, filenameSuffix)
               : String.format(
                   bucketShardTemplate, bucketName, id.getShardId(), maxNumShards, filenameSuffix);
@@ -142,6 +143,12 @@ public final class SMBFilenamePolicy implements Serializable {
     public ResourceId forMetadata() {
       String timestamp = doTimestampFiles ? Instant.now().toString(TEMPFILE_TIMESTAMP) : "";
       return directory.resolve(timestamp + METADATA_FILENAME, StandardResolveOptions.RESOLVE_FILE);
+    }
+
+    /** Returns a ResourceId matching the */
+    public ResourceId forNullKeys() {
+      return directory.resolve(
+          NULL_KEYS_BUCKET_TEMPLATE + "*" + filenameSuffix, StandardResolveOptions.RESOLVE_FILE);
     }
 
     public ResourceId getDirectory() {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSink.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSink.java
@@ -794,11 +794,9 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
                       public void processElement(ProcessContext c) throws Exception {
                         final K key = bucketMetadata.extractKey(c.element().getValue());
                         final Coder<K> kCoder = bucketMetadata.getKeyCoder();
-                        if (key == null
-                            ? c.element().getKey() != null
-                            : !Arrays.equals(
-                                CoderUtils.encodeToByteArray(kCoder, key),
-                                CoderUtils.encodeToByteArray(kCoder, c.element().getKey()))) {
+                        if (!Arrays.equals(
+                            CoderUtils.encodeToByteArray(kCoder, key),
+                            CoderUtils.encodeToByteArray(kCoder, c.element().getKey()))) {
                           throw new RuntimeException(
                               "BucketMetadata's extractKey fn did not match pre-keyed PCollection");
                         }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -181,13 +181,15 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
         }
         writtenBuckets.put(BucketShardId.of(bucket.bucketId, 0), bucket.destination);
       }
+
       RenameBuckets.moveFiles(
           bucketMetadata,
           writtenBuckets,
           dstFileAssignment,
           fileOperations,
           bucketDst -> c.output(BUCKETS_TAG, bucketDst),
-          metadataDst -> c.output(METADATA_TAG, metadataDst));
+          metadataDst -> c.output(METADATA_TAG, metadataDst),
+          false); // Don't include null-key bucket in output
     }
   }
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SMBFilenamePolicyTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SMBFilenamePolicyTest.java
@@ -66,8 +66,8 @@ public class SMBFilenamePolicyTest {
         resolveFile(destination, PREFIX + "-00005-of-00008-shard-00001-of-00003", SUFFIX));
 
     Assert.assertEquals(
-        fileAssignment.forBucket(BucketShardId.ofNullKey(1), metadata),
-        resolveFile(destination, PREFIX + "-null-keys-shard-00001-of-00003", SUFFIX));
+        fileAssignment.forBucket(BucketShardId.ofNullKey(), metadata),
+        resolveFile(destination, PREFIX + "-null-keys", SUFFIX));
 
     // Test single-shard combinations
     final BucketMetadata singleShardMetadata = TestBucketMetadata.of(8, 1);
@@ -77,7 +77,7 @@ public class SMBFilenamePolicyTest {
         resolveFile(destination, PREFIX + "-00005-of-00008", SUFFIX));
 
     Assert.assertEquals(
-        fileAssignment.forBucket(BucketShardId.ofNullKey(0), singleShardMetadata),
+        fileAssignment.forBucket(BucketShardId.ofNullKey(), singleShardMetadata),
         resolveFile(destination, PREFIX + "-null-keys", SUFFIX));
 
     // Test invalid shard-bucket combinations

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSinkTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSinkTest.java
@@ -150,10 +150,10 @@ public class SortedBucketSinkTest {
     final MatchResult outputFiles =
         FileSystems.match(
             TestUtils.fromFolder(output)
-                .resolve("*.txt", StandardResolveOptions.RESOLVE_FILE)
+                .resolve("*-of-*.txt", StandardResolveOptions.RESOLVE_FILE)
                 .toString());
 
-    Assert.assertEquals(2, outputFiles.metadata().size());
+    Assert.assertEquals(1, outputFiles.metadata().size());
     Assert.assertEquals(
         "custom-prefix-00000-of-00001.txt",
         outputFiles.metadata().get(0).resourceId().getFilename());

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -225,11 +225,11 @@ public class SortedBucketSourceTest {
   public void testNullKeysIgnored() throws Exception {
     test(
         ImmutableMap.of(
-            BucketShardId.ofNullKey(0), Lists.newArrayList(""),
+            BucketShardId.ofNullKey(), Lists.newArrayList(""),
             BucketShardId.of(0, 0), Lists.newArrayList("x1", "x2", "y1", "y2"),
             BucketShardId.of(1, 0), Lists.newArrayList("c1", "c2")),
         ImmutableMap.of(
-            BucketShardId.ofNullKey(0), Lists.newArrayList(""),
+            BucketShardId.ofNullKey(), Lists.newArrayList(""),
             BucketShardId.of(0, 0), Lists.newArrayList("x3", "x4", "z3", "z4"),
             BucketShardId.of(1, 0), Lists.newArrayList("c2", "c3")));
   }

--- a/site/src/paradox/extras/Sort-Merge-Bucket.md
+++ b/site/src/paradox/extras/Sort-Merge-Bucket.md
@@ -67,6 +67,12 @@ See API bindings in:
 - @javadoc[JsonSortedBucketIO](org.apache.beam.sdk.extensions.smb.JsonSortedBucketIO)
 - @javadoc[TensorFlowBucketIO](org.apache.beam.sdk.extensions.smb.TensorFlowBucketIO)
 
+## Null keys in SMB datasets
+
+If the key field of one or more PCollection elements is null, those elements will be diverted into a special
+bucket file, `bucket-null-keys.avro`. This file will be ignored in SMB reads and transforms and must
+be manually read by a downstream user.
+
 ## Tuning parameters for SMB transforms
 
 SMB reads should be more performant and less resource-intensive than regular joins or groupBys.


### PR DESCRIPTION
Records with null keys are diverted to a separate file, `bucket-null-keys.[avro|tfrecord|json]`. this completes a feature we started implementing in an earlier version and didn't finish.

I got rid of the sharding aspect of the null-key bucket -- I'm envisioning this would just be a small spillover of records, @nevillelyh wdyt? We could also add an optimization so that the null-key bucket skips the SortDoFn step but I don't think it matters too much.

this file is ignored in SMB reads/transforms, it's designed for regular file reads.

(the failing CircleCI test is from a transient bigtable integration test failure)