### PR TITLE
Fix JavaAsyncLookupDoFn doc link

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/JavaAsyncLookupDoFn.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/JavaAsyncLookupDoFn.java
@@ -32,7 +32,7 @@ public abstract class JavaAsyncLookupDoFn<A, B, C>
     extends BaseAsyncLookupDoFn<A, B, C, CompletableFuture<B>, BaseAsyncLookupDoFn.Try<B>>
     implements FutureHandlers.Java<B> {
 
-  /** Create a {@link GuavaAsyncLookupDoFn} instance. */
+  /** Create a {@link JavaAsyncLookupDoFn} instance. */
   public JavaAsyncLookupDoFn() {
     super();
   }


### PR DESCRIPTION
I believe `GuavaAsyncLookupDoFn` doc link was left accidentally. 