### PR TITLE
Propagate coder and simplify Bigquery Format type

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -113,7 +113,11 @@ final class SCollectionGenericRecordOps[T <: GenericRecord](private val self: SC
       )
     self
       .covary[GenericRecord]
-      .write(BigQueryTypedTable(table, Format.GenericRecord))(param)
+      .write(
+        BigQueryTypedTable(table, Format.GenericRecord)(
+          self.coder.asInstanceOf[Coder[GenericRecord]]
+        )
+      )(param)
   }
 
 }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
@@ -82,7 +82,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
    * Note: When using `Format.GenericRecord` Bigquery types DATE, TIME and DATETIME
    *       are read as STRING.
    */
-  def bigQueryTable(table: Table, format: Format): SCollection[format.F] =
+  def bigQueryTable[F: Coder](table: Table, format: Format[F]): SCollection[F] =
     self.read(BigQueryTypedTable(table, format))
 
   /**


### PR DESCRIPTION
Right now this is only needed for `Format.GenericRecord`. 

For performance reasons users are recommended to supply their own `Coder` through:

```scala
val schema: org.apache.avro.Schema = ???
implicit val coder = Coder.avroGenericRecordCoder(schema)
```

Fixes #3399