### PR TITLE
Redis lookup Do Fn #3331

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
@@ -72,10 +72,11 @@ object RedisLookUpStringsExample {
 
   private def lookupFn(connectionOptions: RedisConnectionOptions) =
     new RedisLookupDoFn[String, Option[String]](connectionOptions) {
-      override def asyncLookup(client: ThreadLocal[Jedis],
-                               input: String): ListenableFuture[Option[String]] = {
+      override def asyncLookup(
+        client: ThreadLocal[Jedis],
+        input: String
+      ): ListenableFuture[Option[String]] =
         Futures.immediateFuture(Option(client.get.get(input)))
-      }
     }
 
   def main(cmdlineArgs: Array[String]): Unit = {

--- a/scio-redis/src/main/scala/com/spotify/scio/redis/lookup/RedisLookupDoFn.scala
+++ b/scio-redis/src/main/scala/com/spotify/scio/redis/lookup/RedisLookupDoFn.scala
@@ -10,11 +10,10 @@ import redis.clients.jedis.Jedis
  * @tparam I Type of the input element.
  * @tparam O Type of the lookup result.
  */
-abstract class RedisLookupDoFn[I, O](connectionOptions: RedisConnectionOptions,
-                                     maxPendingRequests: Int =
-                                     RedisLookupDoFn.DEFAULT_MAX_PENDING_REQUEST)
-  extends GuavaAsyncLookupDoFn[I, O, ThreadLocal[Jedis]](maxPendingRequests) {
-
+abstract class RedisLookupDoFn[I, O](
+  connectionOptions: RedisConnectionOptions,
+  maxPendingRequests: Int = RedisLookupDoFn.DEFAULT_MAX_PENDING_REQUEST
+) extends GuavaAsyncLookupDoFn[I, O, ThreadLocal[Jedis]](maxPendingRequests) {
 
   override protected def newClient(): ThreadLocal[Jedis] = {
     val connectionConfig = RedisConnectionOptions.toConnectionConfig(connectionOptions)

--- a/scio-redis/src/main/scala/com/spotify/scio/redis/lookup/RedisLookupDoFn.scala
+++ b/scio-redis/src/main/scala/com/spotify/scio/redis/lookup/RedisLookupDoFn.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2020 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.scio.redis.lookup
 
 import com.spotify.scio.redis.RedisConnectionOptions

--- a/scio-redis/src/main/scala/com/spotify/scio/redis/lookup/RedisLookupDoFn.scala
+++ b/scio-redis/src/main/scala/com/spotify/scio/redis/lookup/RedisLookupDoFn.scala
@@ -1,0 +1,33 @@
+package com.spotify.scio.redis.lookup
+
+import com.spotify.scio.redis.RedisConnectionOptions
+import com.spotify.scio.transforms.GuavaAsyncLookupDoFn
+import redis.clients.jedis.Jedis
+
+/**
+ * A [[org.apache.beam.sdk.transforms.DoFn]] that performs asynchronous Redis lookup.
+ *
+ * @tparam I Type of the input element.
+ * @tparam O Type of the lookup result.
+ */
+abstract class RedisLookupDoFn[I, O](connectionOptions: RedisConnectionOptions,
+                                     maxPendingRequests: Int =
+                                     RedisLookupDoFn.DEFAULT_MAX_PENDING_REQUEST)
+  extends GuavaAsyncLookupDoFn[I, O, ThreadLocal[Jedis]](maxPendingRequests) {
+
+
+  override protected def newClient(): ThreadLocal[Jedis] = {
+    val connectionConfig = RedisConnectionOptions.toConnectionConfig(connectionOptions)
+
+    new ThreadLocal[Jedis] {
+      override def initialValue(): Jedis = connectionConfig.connect()
+    }
+  }
+
+}
+
+object RedisLookupDoFn {
+
+  val DEFAULT_MAX_PENDING_REQUEST = 1000
+
+}


### PR DESCRIPTION
Adding Lookup Do Fn for Redis. It just simply extends `GuavaAsyncLookupDoFn`. The client in this case is an instance of [Jedis client](https://github.com/xetorthio/jedis/blob/master/src/main/java/redis/clients/jedis/Jedis.java). 

There is one issue with the client which complicates its integration with the `BaseAsyncLookupDoFn`: Jedis client isn't thread safe. It has to be be created and used in the same thread. `BaseAsyncLookupDoFn` allocates clients per lookup fn instance and even though it isn't possible for multiple threads to access the client simultaneously, it is possible that different threads will access it on after another because Beam/Dataflow might re-cycle a thread after a bundle is processed (this is based on my observations). I have done some testing both on my local and on DataFlow and was able to re-produce the issue. To mitigate the issue I am wrapping the client into `ThreadLocal` so that every thread gets its own copy of the Jedis client. Jedis client allocation should be relatively lightweight operation. My main concern is that it isn't possible to explicitly close the client after a bundle is processed or/and after the thread is getting re-cycled. A better solution would be to add support for per-bundle clients to the `BaseAsyncLookupDoFn`. This would allow to properly create and dispose clients on each bundle and I believe Beam/DataFlow uses a single thread to process a single bundle (but I am not sure here).

I tested this implementation with a batch and a streaming job and seems to work fine. We can use this as a P0 implementation, but re-visit it if there will be resource management issues.