### PR TITLE
Clarify extra.csv.CsvIO docs

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/csv/CsvIO.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/csv/CsvIO.scala
@@ -61,8 +61,11 @@ import org.apache.beam.sdk.values.PCollection
  * [[https://nrinaudo.github.io/kantan.csv/rows_as_arbitrary_types.html Kantan docs]]
  * {{{
  *  case class User(name: String, age: Int)
- *  implicit val decoder = HeaderDecoder.ordered { (name: String, age: Int) => User(name, age) }
- *  val users: SCollection[User] = scioContext.csvFile(path)
+ *  implicit val decoder = RowDecoder.ordered { (name: String, age: Int) => User(name, age) }
+ *  val csvConfiguration = CsvIO.DefaultReadParams.copy(
+ *    csvConfiguration = CsvIO.DefaultCsvConfig.copy(header = CsvConfiguration.Header.None)
+ *  )
+ *  val users: SCollection[User] = scioContext.csvFile(path, csvConfiguration)
  * }}}
  *
  * =Writing=

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/csv/CsvIO.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/csv/CsvIO.scala
@@ -62,9 +62,7 @@ import org.apache.beam.sdk.values.PCollection
  * {{{
  *  case class User(name: String, age: Int)
  *  implicit val decoder = RowDecoder.ordered { (name: String, age: Int) => User(name, age) }
- *  val csvConfiguration = CsvIO.DefaultReadParams.copy(
- *    csvConfiguration = CsvIO.DefaultCsvConfig.copy(header = CsvConfiguration.Header.None)
- *  )
+ *  val csvConfiguration = CsvIO.ReadParam(csvConfiguration = CsvIO.DefaultCsvConfig.withoutHeader)
  *  val users: SCollection[User] = scioContext.csvFile(path, csvConfiguration)
  * }}}
  *


### PR DESCRIPTION
- Clarify Encoder to use when reading headerless file (`HeaderEncoder.ordered` doesn't exist, `RowDecoder.ordered` is used in the linked docs)
- Add explicit configuration parameter that ignores the header.  If not included, kantan.csv will silently skip the first row of the csv file