### PR TITLE
Added documentation for typedBigQuery

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
@@ -124,6 +124,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
     newSource: Source
   ): SCollection[T] = typedBigQuery(Option(newSource))
 
+  /** Get a typed SCollection for BigQuery Table or a SELECT query using the Storage API. */
   def typedBigQuery[T <: HasAnnotation: ClassTag: TypeTag: Coder](
     newSource: Option[Source]
   ): SCollection[T] = {


### PR DESCRIPTION
closes #3208 

This PR adds documentation to an existing BigQuery API (_typedBigQuery_). Documentations for `Table` and `Query` type have been added as part of #3357.

**Question** 
Is this level of documentation adequate?