### PR TITLE
Fix logging in ApproxFilter

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/hash/ApproxFilter.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/hash/ApproxFilter.scala
@@ -276,9 +276,10 @@ sealed trait ApproxFilterCompanion {
     } else {
       val settings = partitionSettings(expectedInsertions, fpp, 100 * 1024 * 1024)
       logger.info(
-        s"Partition settings for approximate filter side input of $expectedInsertions keys: " +
-          s"partitions=${settings.partitions}, expectedInsertions=${settings.expectedInsertions}," +
-          "sizeBytes=$settings.sizeBytes"
+        s"""Partition settings for approximate filter side input of $expectedInsertions keys:
+           |partitions=${settings.partitions}
+           |expectedInsertions=${settings.expectedInsertions}
+           |sizeBytes=${settings.sizeBytes}""".stripMargin
       )
       elems
         .hashPartition(settings.partitions)

--- a/scio-core/src/main/scala/com/spotify/scio/hash/ApproxFilter.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/hash/ApproxFilter.scala
@@ -276,12 +276,9 @@ sealed trait ApproxFilterCompanion {
     } else {
       val settings = partitionSettings(expectedInsertions, fpp, 100 * 1024 * 1024)
       logger.info(
-        "Partition settings for approximate filter side input of {} keys: " +
-          "partitions={}, expectedInsertions={}, sizeBytes={}",
-         expectedInsertions,
-         settings.partitions,
-         settings.expectedInsertions,
-         settings.sizeBytes
+        s"Partition settings for approximate filter side input of $expectedInsertions keys: " +
+          "partitions=$settings.partitions, expectedInsertions=$settings.expectedInsertions," +
+          "sizeBytes=$settings.sizeBytes"
       )
       elems
         .hashPartition(settings.partitions)

--- a/scio-core/src/main/scala/com/spotify/scio/hash/ApproxFilter.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/hash/ApproxFilter.scala
@@ -278,12 +278,10 @@ sealed trait ApproxFilterCompanion {
       logger.info(
         "Partition settings for approximate filter side input of {} keys: " +
           "partitions={}, expectedInsertions={}, sizeBytes={}",
-        Seq(
-          expectedInsertions,
-          settings.partitions,
-          settings.expectedInsertions,
-          settings.sizeBytes
-        )
+         expectedInsertions,
+         settings.partitions,
+         settings.expectedInsertions,
+         settings.sizeBytes
       )
       elems
         .hashPartition(settings.partitions)

--- a/scio-core/src/main/scala/com/spotify/scio/hash/ApproxFilter.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/hash/ApproxFilter.scala
@@ -277,7 +277,7 @@ sealed trait ApproxFilterCompanion {
       val settings = partitionSettings(expectedInsertions, fpp, 100 * 1024 * 1024)
       logger.info(
         s"Partition settings for approximate filter side input of $expectedInsertions keys: " +
-          "partitions=$settings.partitions, expectedInsertions=$settings.expectedInsertions," +
+          s"partitions=${settings.partitions}, expectedInsertions=${settings.expectedInsertions}," +
           "sizeBytes=$settings.sizeBytes"
       )
       elems


### PR DESCRIPTION
Fixing the logging of the partition setting in ApproxFilter since it logged the sequence in the first placeholder.