### PR TITLE
improve smb auto-splittability

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -218,14 +218,15 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
     final int adjustedParallelism =
         getFanout(
-            getOrComputeSourceSpec(),
-            effectiveParallelism,
-            targetParallelism,
-            getEstimatedSizeBytes(options),
-            desiredBundleSizeBytes,
-            DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR);
+                getOrComputeSourceSpec(),
+                effectiveParallelism,
+                targetParallelism,
+                getEstimatedSizeBytes(options),
+                desiredBundleSizeBytes,
+                DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR)
+            * effectiveParallelism;
 
-    LOG.info("Parallelism was adjusted to " + adjustedParallelism);
+    LOG.info("Parallelism was adjusted from %d to %d", effectiveParallelism, adjustedParallelism);
 
     final long estSplitSize = estimatedSizeBytes / adjustedParallelism;
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -226,9 +226,14 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
                 DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR)
             * effectiveParallelism;
 
-    LOG.info("Parallelism was adjusted from %d to %d", effectiveParallelism, adjustedParallelism);
-
     final long estSplitSize = estimatedSizeBytes / adjustedParallelism;
+
+    LOG.info(
+        "Parallelism was adjusted from %d source(s) of size %d MB to %d source(s) of size %d MB",
+        effectiveParallelism,
+        getEstimatedSizeBytes(options) / 1000000.0,
+        adjustedParallelism,
+        estSplitSize / 1000000.0);
 
     return IntStream.range(0, adjustedParallelism)
         .boxed()

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -228,12 +230,13 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
 
     final long estSplitSize = estimatedSizeBytes / adjustedParallelism;
 
+    final DecimalFormat sizeFormat = new DecimalFormat("0.00");
     LOG.info(
-        "Parallelism was adjusted from %d source(s) of size %d MB to %d source(s) of size %d MB",
+        "Parallelism was adjusted from {} source(s) of size {} MB to {} source(s) of size {} MB",
         effectiveParallelism,
-        getEstimatedSizeBytes(options) / 1000000.0,
+        sizeFormat.format((getEstimatedSizeBytes(options) / 1000000.0)),
         adjustedParallelism,
-        estSplitSize / 1000000.0);
+        sizeFormat.format(estSplitSize / 1000000.0));
 
     return IntStream.range(0, adjustedParallelism)
         .boxed()

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -235,7 +235,8 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
 
     final DecimalFormat sizeFormat = new DecimalFormat("0.00");
     LOG.info(
-        "Parallelism was adjusted by splitting source of size {} MB into {} source(s) of size {} MB",
+        "Parallelism was adjusted by {}splitting source of size {} MB into {} source(s) of size {} MB",
+        effectiveParallelism > 1 ? "further " : "",
         sizeFormat.format(estimatedSizeBytes / 1000000.0),
         numSplits,
         sizeFormat.format(estSplitSize / 1000000.0));

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -224,7 +223,7 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
   public List<? extends BoundedSource<KV<FinalKeyT, CoGbkResult>>> split(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
     final int numSplits =
-        getFanout(
+        getNumSplits(
             getOrComputeSourceSpec(),
             effectiveParallelism,
             targetParallelism,
@@ -257,7 +256,7 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
         .collect(Collectors.toList());
   }
 
-  static int getFanout(
+  static int getNumSplits(
       SourceSpec sourceSpec,
       int effectiveParallelism,
       TargetParallelism targetParallelism,

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -20,7 +20,6 @@ package org.apache.beam.sdk.extensions.smb;
 import java.io.IOException;
 import java.io.Serializable;
 import java.text.DecimalFormat;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -313,7 +312,7 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
 
       final int numSplits =
-          SortedBucketSource.getFanout(
+          SortedBucketSource.getNumSplits(
               sourceSpec,
               effectiveParallelism,
               targetParallelism,

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -324,7 +324,8 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
 
       final DecimalFormat sizeFormat = new DecimalFormat("0.00");
       LOG.info(
-          "Parallelism was adjusted by splitting source of size {} MB into {} source(s) of size {} MB",
+          "Parallelism was adjusted by {}splitting source of size {} MB into {} source(s) of size {} MB",
+          effectiveParallelism > 1 ? "further " : "",
           sizeFormat.format(estimatedSizeBytes / 1000000.0),
           numSplits,
           sizeFormat.format(estSplitSize / 1000000.0));


### PR DESCRIPTION
we were getting some reports of Dataflow splitting the source multiple times, with confusing log messages about what's happening. this fixes the bucket allocation in case of multiple splits (which buckets are processed per split source) and makes the log a lot clearer what's going on.