### PR TITLE
Fix getRecord should not throw on a missing field

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/TableRowSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/TableRowSyntax.scala
@@ -77,7 +77,7 @@ final class TableRowOps(private val r: TableRow) extends AnyVal {
     this.getValue(name, x => x.asInstanceOf[java.util.List[AnyRef]].iterator().asScala.toSeq, null)
 
   def getRecord(name: AnyRef): Map[String, AnyRef] =
-    r.get(name).asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap
+    this.getValue(name, x => x.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap, null)
 
   private def getValue[T](name: AnyRef, fn: AnyRef => T, default: T): T = {
     val o = r.get(name)

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/TableRowSyntaxTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/TableRowSyntaxTest.scala
@@ -27,4 +27,11 @@ class TableRowSyntaxTest extends AnyFlatSpec with Matchers {
     val expected = Map("foo" -> "bar")
     row.getRecord("record") shouldBe expected
   }
+
+  it should "#3378: not throw an NPE on a non-existent subrecord" in {
+    val dummy = List(("a", 1), ("b", 2))
+    val row = TableRow(dummy: _*)
+    val result = row.getRecord("c")
+    result shouldBe null
+  }
 }


### PR DESCRIPTION
Use getValue[T] inside of getRecord a la getRepeated to avoid a NullPointerException if a non-existent field was requested.