### PR TITLE
Remove deprecated BigQueryTable

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/syntax/SCollectionSyntax.scala
@@ -19,8 +19,8 @@ package com.spotify.scio.extra.bigquery.syntax
 
 import com.google.api.services.bigquery.model.TableReference
 import com.spotify.scio.annotations.experimental
-import com.spotify.scio.bigquery.BigQueryTable.WriteParam
-import com.spotify.scio.bigquery.{BigQueryTable, Table, TableRow}
+import com.spotify.scio.bigquery.BigQueryTypedTable.WriteParam
+import com.spotify.scio.bigquery.{BigQueryTypedTable, Table, TableRow}
 import com.spotify.scio.io.ClosedTap
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
@@ -29,6 +29,7 @@ import org.apache.avro.generic.IndexedRecord
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.{CreateDisposition, WriteDisposition}
 
 import scala.reflect.ClassTag
+import com.spotify.scio.bigquery.BigQueryTypedTable.Format
 
 trait SCollectionSyntax {
   implicit def toAvroToBigQuerySCollection[T <: IndexedRecord: ClassTag](
@@ -70,6 +71,6 @@ final class AvroToBigQuerySCollectionOps[T <: IndexedRecord: ClassTag](
       WriteParam(toTableSchema(schema), writeDisposition, createDisposition, tableDescription)
     self
       .map(toTableRow(_))
-      .write(BigQueryTable(Table.Ref(table)))(params)
+      .write(BigQueryTypedTable(Table.Ref(table), Format.TableRow))(params)
   }
 }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -22,13 +22,7 @@ import com.spotify.scio.bigquery.BigQueryTyped.Table.{WriteParam => TableWritePa
 import com.spotify.scio.bigquery.BigQueryTyped.BeamSchema.{WriteParam => TypedWriteParam}
 import com.spotify.scio.bigquery.TableRowJsonIO.{WriteParam => TableRowJsonWriteParam}
 import com.spotify.scio.bigquery.types.BigQueryType.HasAnnotation
-import com.spotify.scio.bigquery.{
-  BigQueryTable,
-  BigQueryTyped,
-  TableRow,
-  TableRowJsonIO,
-  TimePartitioning
-}
+import com.spotify.scio.bigquery.{BigQueryTyped, TableRow, TableRowJsonIO, TimePartitioning}
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.io._
 import com.spotify.scio.values.SCollection
@@ -53,14 +47,14 @@ final class SCollectionTableRowOps[T <: TableRow](private val self: SCollection[
    */
   def saveAsBigQueryTable(
     table: Table,
-    schema: TableSchema = BigQueryTable.WriteParam.DefaultSchema,
-    writeDisposition: WriteDisposition = BigQueryTable.WriteParam.DefaultWriteDisposition,
-    createDisposition: CreateDisposition = BigQueryTable.WriteParam.DefaultCreateDisposition,
-    tableDescription: String = BigQueryTable.WriteParam.DefaultTableDescription,
-    timePartitioning: TimePartitioning = BigQueryTable.WriteParam.DefaultTimePartitioning
+    schema: TableSchema = BigQueryTypedTable.WriteParam.DefaultSchema,
+    writeDisposition: WriteDisposition = BigQueryTypedTable.WriteParam.DefaultWriteDisposition,
+    createDisposition: CreateDisposition = BigQueryTypedTable.WriteParam.DefaultCreateDisposition,
+    tableDescription: String = BigQueryTypedTable.WriteParam.DefaultTableDescription,
+    timePartitioning: TimePartitioning = BigQueryTypedTable.WriteParam.DefaultTimePartitioning
   ): ClosedTap[TableRow] = {
     val param =
-      BigQueryTable.WriteParam(
+      BigQueryTypedTable.WriteParam(
         schema,
         writeDisposition,
         createDisposition,
@@ -97,14 +91,14 @@ final class SCollectionGenericRecordOps[T <: GenericRecord](private val self: SC
    */
   def saveAsBigQueryTable(
     table: Table,
-    schema: TableSchema = BigQueryTable.WriteParam.DefaultSchema,
-    writeDisposition: WriteDisposition = BigQueryTable.WriteParam.DefaultWriteDisposition,
-    createDisposition: CreateDisposition = BigQueryTable.WriteParam.DefaultCreateDisposition,
-    tableDescription: String = BigQueryTable.WriteParam.DefaultTableDescription,
-    timePartitioning: TimePartitioning = BigQueryTable.WriteParam.DefaultTimePartitioning
+    schema: TableSchema = BigQueryTypedTable.WriteParam.DefaultSchema,
+    writeDisposition: WriteDisposition = BigQueryTypedTable.WriteParam.DefaultWriteDisposition,
+    createDisposition: CreateDisposition = BigQueryTypedTable.WriteParam.DefaultCreateDisposition,
+    tableDescription: String = BigQueryTypedTable.WriteParam.DefaultTableDescription,
+    timePartitioning: TimePartitioning = BigQueryTypedTable.WriteParam.DefaultTimePartitioning
   ): ClosedTap[GenericRecord] = {
     val param =
-      BigQueryTable.WriteParam(
+      BigQueryTypedTable.WriteParam(
         schema,
         writeDisposition,
         createDisposition,

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/taps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/taps.scala
@@ -96,7 +96,7 @@ final case class BigQueryTaps(self: Taps) {
     mkTap(
       s"BigQuery Table: $table",
       () => bqc.tables.exists(table),
-      () => BigQueryTable(Table.Ref(table)).tap(())
+      () => BigQueryTypedTable(Table.Ref(table), Format.TableRow).tap(())
     )
 
   /** Get a `Future[Tap[TableRow]]` for BigQuery table. */


### PR DESCRIPTION
Users should now be using `BigQueryTypedTable` if they use the IO directly