### PR TITLE
Add parameters for passing retry settings to Jdbc write

### DIFF
--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcIO.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcIO.scala
@@ -21,7 +21,6 @@ import com.spotify.scio.values.SCollection
 import com.spotify.scio.ScioContext
 import com.spotify.scio.io.{EmptyTap, EmptyTapOf, ScioIO, Tap, TestIO}
 import org.apache.beam.sdk.io.{jdbc => beam}
-
 import java.sql.{PreparedStatement, ResultSet}
 
 import com.spotify.scio.coders.{Coder, CoderMaterializer}
@@ -38,7 +37,7 @@ object JdbcIO {
 
   private[jdbc] def jdbcIoId(opts: JdbcIoOptions): String = opts match {
     case JdbcReadOptions(connOpts, query, _, _, _) => jdbcIoId(connOpts, query)
-    case JdbcWriteOptions(connOpts, statement, _, _) =>
+    case JdbcWriteOptions(connOpts, statement, _, _, _, _) =>
       jdbcIoId(connOpts, statement)
   }
 
@@ -128,6 +127,11 @@ final case class JdbcWrite[T](writeOptions: JdbcWriteOptions[T]) extends JdbcIO[
       // override default batch size.
       transform = transform.withBatchSize(writeOptions.batchSize)
     }
+
+    transform = transform
+      .withRetryConfiguration(writeOptions.retryConfiguration)
+      .withRetryStrategy(writeOptions.retryStrategy.apply)
+
     data.applyInternal(transform)
     EmptyTap
   }

--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcOptions.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcOptions.scala
@@ -17,7 +17,9 @@
 
 package com.spotify.scio.jdbc
 
-import java.sql.{Driver, PreparedStatement, ResultSet}
+import java.sql.{Driver, PreparedStatement, ResultSet, SQLException}
+
+import org.apache.beam.sdk.io.jdbc.JdbcIO.{DefaultRetryStrategy, RetryConfiguration}
 
 /**
  * Options for a JDBC connection.
@@ -37,6 +39,14 @@ final case class JdbcConnectionOptions(
 object JdbcIoOptions {
   private[jdbc] val BeamDefaultBatchSize = -1L
   private[jdbc] val BeamDefaultFetchSize = -1
+  private[jdbc] val BeamDefaultMaxRetryAttempts = 5
+  private[jdbc] val BeamDefaultInitialRetryDelay = org.joda.time.Duration.ZERO
+  private[jdbc] val BeamDefaultMaxRetryDelay = org.joda.time.Duration.ZERO
+  private[jdbc] val BeamDefaultRetryConfiguration = RetryConfiguration.create(
+    BeamDefaultMaxRetryAttempts,
+    BeamDefaultMaxRetryDelay,
+    BeamDefaultInitialRetryDelay
+  )
 }
 
 sealed trait JdbcIoOptions
@@ -65,10 +75,14 @@ final case class JdbcReadOptions[T](
  * @param statement               query statement
  * @param preparedStatementSetter function to set values in a [[java.sql.PreparedStatement]]
  * @param batchSize               use apache beam default batch size if the value is -1
+ * @param retryConfiguration      [[org.apache.beam.sdk.io.jdbc.JdbcIO.RetryConfiguration]] for specifying retry behavior
+ * @param retryStrategy           A predicate of [[java.sql.SQLException]] indicating a failure to retry
  */
 final case class JdbcWriteOptions[T](
   connectionOptions: JdbcConnectionOptions,
   statement: String,
   preparedStatementSetter: (T, PreparedStatement) => Unit = null,
-  batchSize: Long = JdbcIoOptions.BeamDefaultBatchSize
+  batchSize: Long = JdbcIoOptions.BeamDefaultBatchSize,
+  retryConfiguration: RetryConfiguration = JdbcIoOptions.BeamDefaultRetryConfiguration,
+  retryStrategy: (SQLException => Boolean) = new DefaultRetryStrategy().apply
 ) extends JdbcIoOptions

--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcOptions.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcOptions.scala
@@ -84,5 +84,5 @@ final case class JdbcWriteOptions[T](
   preparedStatementSetter: (T, PreparedStatement) => Unit = null,
   batchSize: Long = JdbcIoOptions.BeamDefaultBatchSize,
   retryConfiguration: RetryConfiguration = JdbcIoOptions.BeamDefaultRetryConfiguration,
-  retryStrategy: (SQLException => Boolean) = new DefaultRetryStrategy().apply
+  retryStrategy: SQLException => Boolean = new DefaultRetryStrategy().apply
 ) extends JdbcIoOptions


### PR DESCRIPTION
Beam's underlying `JdbcIo` allows for passing a set of parameters to set how failures should be retried in write operations, including backoff settings and a strategy for retries given an instance of `SQLException`

The relevant beam classes are [RetryConfiguration](https://beam.apache.org/releases/javadoc/2.23.0/org/apache/beam/sdk/io/jdbc/JdbcIO.RetryConfiguration.html) and [RetryStrategy](https://beam.apache.org/releases/javadoc/2.3.0/org/apache/beam/sdk/io/jdbc/JdbcIO.RetryStrategy.html)

It appears at present there are no Scio variants, and without access to the underlying transform instance, these settings cannot be set.

This PR adds a case-class representation of these settings, with the `RetryStrategy` accepted as a lambda, since it extends `FunctionalInterface`.  [Defaults are set equivalent to the settings in Beam's JdbcIO](https://github.com/apache/beam/blob/master/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java#L966-L985).

Could use some ideas on how to cover this with tests:  noticed the `batchSize` setting for WriteOptions also similarly isn't covered, likely because it's hard to expose the underlying transform to the test suite.