### PR TITLE
Support specifying tableDescription in saveAsTypedBigQueryTable

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -620,6 +620,7 @@ object BigQueryTyped {
       val createDisposition: CreateDisposition
       val timePartitioning: TimePartitioning
       val extendedErrorInfo: ExtendedErrorInfo
+      val tableDescription: String
       val insertErrorTransform: SCollection[extendedErrorInfo.Info] => Unit
     }
 
@@ -628,20 +629,23 @@ object BigQueryTyped {
         wd: WriteDisposition,
         cd: CreateDisposition,
         tp: TimePartitioning,
+        td: String,
         ei: ExtendedErrorInfo
       )(it: SCollection[ei.Info] => Unit): WriteParam = new WriteParam {
         val writeDisposition: WriteDisposition = wd
         val createDisposition: CreateDisposition = cd
         val timePartitioning: TimePartitioning = tp
         val extendedErrorInfo: ei.type = ei
+        val tableDescription: String = td
         val insertErrorTransform: SCollection[extendedErrorInfo.Info] => Unit = it
       }
 
       @inline final def apply(
         wd: WriteDisposition = DefaultWriteDisposition,
         cd: CreateDisposition = DefaultCreateDisposition,
-        tp: TimePartitioning = DefaultTimePartitioning
-      ): WriteParam = apply(wd, cd, tp, DefaultExtendedErrorInfo)(defaultInsertErrorTransform)
+        tp: TimePartitioning = DefaultTimePartitioning,
+        td: String = DefaultTableDescription
+      ): WriteParam = apply(wd, cd, tp, td, DefaultExtendedErrorInfo)(defaultInsertErrorTransform)
     }
 
   }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -175,9 +175,11 @@ final class SCollectionTypedOps[T <: HasAnnotation](private val self: SCollectio
     table: Table,
     timePartitioning: TimePartitioning = TableWriteParam.DefaultTimePartitioning,
     writeDisposition: WriteDisposition = TableWriteParam.DefaultWriteDisposition,
-    createDisposition: CreateDisposition = TableWriteParam.DefaultCreateDisposition
+    createDisposition: CreateDisposition = TableWriteParam.DefaultCreateDisposition,
+    tableDescription: String = TableWriteParam.DefaultTableDescription
   )(implicit tt: TypeTag[T], ct: ClassTag[T], coder: Coder[T]): ClosedTap[T] = {
-    val param = TableWriteParam(writeDisposition, createDisposition, timePartitioning)
+    val param =
+      TableWriteParam(writeDisposition, createDisposition, timePartitioning, tableDescription)
     self.write(BigQueryTyped.Table[T](table))(param)
   }
 }


### PR DESCRIPTION
The aim of this is to allow you to write the following and have it reflected in the description of the created BQ table:
```.saveAsTypedBigQueryTable(Table.Spec(tableSpec), tableDescription = "<some description>")```

Caveat: I am neither very knowledgeable about Scio nor Scala. This appears to be a straight-forward change based on patterns I've seen in the surrounding code, but it's very possible I'm missing something. Please let me know if that's the case.