### PR TITLE
remove dangling sentence in Coders.md

### DIFF
--- a/site/src/main/paradox/internals/Coders.md
+++ b/site/src/main/paradox/internals/Coders.md
@@ -1,7 +1,5 @@
 # Coder Typeclass
 
-Starting from Scio 0.7.0,
-
 ## `Coder` in Apache Beam
 
 As per [Beam's documentation](https://beam.apache.org/documentation/programming-guide/#specifying-coders)


### PR DESCRIPTION
I noticed this was present from the first commit of this file in 234cd0dd76c3a52b8665bbd643267ef2baaa59be when the docs were ported from the Github wiki to the repo contents. I can't tell if this was a copy and paste error or there used to be more after the comma, but it seems to not really say anything any longer.