### PR TITLE
simplify tempDirectory setting in SMB write

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -946,6 +946,7 @@ lazy val `scio-examples`: Project = project
         HiddenFileFilter || "TypedBigQueryTornadoes*.scala" || "TypedStorageBigQueryTornadoes*.scala"
       }
     },
+    fork in run := true,
     sources in doc in Compile := List(),
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     Test / testGrouping := splitTests(

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
@@ -290,7 +290,7 @@ public class AvroSortedBucketIO {
           .build();
     }
 
-    /** Specifies the temporary directory for writing. */
+    /** Specifies the temporary directory for writing. Defaults to --tempLocation if not set. */
     public Write<K, T> withTempDirectory(String tempDirectory) {
       return toBuilder()
           .setTempDirectory(FileSystems.matchNewResource(tempDirectory, true))
@@ -407,7 +407,7 @@ public class AvroSortedBucketIO {
           .build();
     }
 
-    /** Specifies the temporary directory for writing. */
+    /** Specifies the temporary directory for writing. Defaults to --tempLocation if not set. */
     public TransformOutput<K, T> withTempDirectory(String tempDirectory) {
       return toBuilder()
           .setTempDirectory(FileSystems.matchNewResource(tempDirectory, true))

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
@@ -212,7 +212,7 @@ public class JsonSortedBucketIO {
           .build();
     }
 
-    /** Specifies the temporary directory for writing. */
+    /** Specifies the temporary directory for writing. Defaults to --tempLocation if not set. */
     public Write<K> withTempDirectory(String tempDirectory) {
       return toBuilder()
           .setTempDirectory(FileSystems.matchNewResource(tempDirectory, true))
@@ -310,7 +310,7 @@ public class JsonSortedBucketIO {
           .build();
     }
 
-    /** Specifies the temporary directory for writing. */
+    /** Specifies the temporary directory for writing. Defaults to --tempLocation if not set. */
     public TransformOutput<K> withTempDirectory(String tempDirectory) {
       return toBuilder()
           .setTempDirectory(FileSystems.matchNewResource(tempDirectory, true))

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSink.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSink.java
@@ -539,7 +539,8 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
                 writer.write(CoderUtils.decodeFromByteArray(valueCoder, kv.getValue()));
               } catch (IOException e) {
                 cleanupTempFiles(e, Collections.singleton(tmpFile));
-                throw new RuntimeException("Failed to write sorted-bucket file", e);
+                throw new RuntimeException(
+                    "Failed to write sorted-bucket file " + bucketShardId, e);
               }
             });
       }
@@ -649,7 +650,7 @@ public class SortedBucketSink<K, V> extends PTransform<PCollection<V>, WriteResu
         }
       }
 
-      LOG.info("Renaming bucket files");
+      LOG.info("Moving {} bucket files into {}", srcFiles.size(), dstFileAssignment.getDirectory());
       try {
         FileSystems.rename(srcFiles, dstFiles);
       } catch (IOException e) {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
@@ -224,7 +224,7 @@ public class TensorFlowBucketIO {
           .build();
     }
 
-    /** Specifies the temporary directory for writing. */
+    /** Specifies the temporary directory for writing. Defaults to --tempLocation if not set. */
     public Write<K> withTempDirectory(String tempDirectory) {
       return toBuilder()
           .setTempDirectory(FileSystems.matchNewResource(tempDirectory, true))
@@ -322,7 +322,7 @@ public class TensorFlowBucketIO {
           .build();
     }
 
-    /** Specifies the temporary directory for writing. */
+    /** Specifies the temporary directory for writing. Defaults to --tempLocation if not set. */
     public TransformOutput<K> withTempDirectory(String tempDirectory) {
       return toBuilder()
           .setTempDirectory(FileSystems.matchNewResource(tempDirectory, true))


### PR DESCRIPTION
this makes temp file handling more like Beam's; instead of users having to specify a temp directory in the builder options, it's optional and will default to the value of the `--tempLocation` option instead (this should never be null).

Also added a some test to check temp file cleanup.