### PR TITLE
add serializeToByteArray

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/hll/zetasketch/ZetaSketchHLL.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/hll/zetasketch/ZetaSketchHLL.scala
@@ -67,6 +67,9 @@ final class ZetaSketchHll[T](arrOpt: Option[Array[Byte]], elemOpt: Option[T] = N
     new ZetaSketchHll[T](Option(nhll.serializeToByteArray()))
   }
 
+  /** @return the byte array representation of the hll */
+  def serializeToByteArray(): Array[Byte] = hll.serializeToByteArray()
+
   /** @return the estimated distinct count */
   def estimateSize(): Long = hll.result()
 


### PR DESCRIPTION
Adding a function `serializeToByteArray` to `ZetasketchHLL` to allow for storage of the `ByteArray` representation of the HLL.