### PR TITLE
make GZIP default for Parquet

### DIFF
--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -208,7 +208,7 @@ object ParquetAvroIO {
     private[avro] val DefaultSchema = null
     private[avro] val DefaultNumShards = 0
     private[avro] val DefaultSuffix = ".parquet"
-    private[avro] val DefaultCompression = CompressionCodecName.SNAPPY
+    private[avro] val DefaultCompression = CompressionCodecName.GZIP
     private[avro] val DefaultFilenameFunction = None
   }
 

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -116,7 +116,7 @@ object ParquetExampleIO {
   object WriteParam {
     private[tensorflow] val DefaultNumShards = 0
     private[tensorflow] val DefaultSuffix = ".parquet"
-    private[tensorflow] val DefaultCompression = CompressionCodecName.SNAPPY
+    private[tensorflow] val DefaultCompression = CompressionCodecName.GZIP
   }
 
   final case class WriteParam private (

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -101,7 +101,7 @@ object ParquetTypeIO {
   object WriteParam {
     private[types] val DefaultNumShards = 0
     private[types] val DefaultSuffix = ".parquet"
-    private[types] val DefaultCompression = CompressionCodecName.SNAPPY
+    private[types] val DefaultCompression = CompressionCodecName.GZIP
   }
 
   final case class WriteParam[T] private (


### PR DESCRIPTION
Empirically GZIP has much better compression ratio and seem to perform
just as well as SNAPPY on blob storage like GCS.