### PR TITLE
Fix BigQuery implicit coder

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -142,6 +142,7 @@ object BigQueryIO {
         s"BigQueryIO($id, List(${selectedFields.mkString(",")}), $rowRestriction)"
     }
 }
+
 object BigQueryTypedSelect {
   object ReadParam {
     private[bigquery] val DefaultFlattenResults = false
@@ -189,7 +190,7 @@ final case class BigQuerySelect(sqlQuery: Query) extends BigQueryIO[TableRow] {
   override type WriteP = Nothing // ReadOnly
 
   private[this] lazy val underlying =
-    BigQueryTypedSelect(beam.BigQueryIO.readTableRows(), sqlQuery, identity)
+    BigQueryTypedSelect(beam.BigQueryIO.readTableRows(), sqlQuery, identity)(coders.tableRowCoder)
 
   override def testId: String = s"BigQueryIO(${sqlQuery.underlying})"
 
@@ -261,7 +262,7 @@ object BigQueryTypedTable {
       beam.BigQueryIO.writeTableRows(),
       table,
       BigQueryUtils.convertGenericRecordToTableRow(_, _)
-    )
+    )(coders.tableRowCoder)
 
   private[this] def genericRecord(
     table: Table
@@ -423,7 +424,7 @@ final case class BigQueryStorageSelect(sqlQuery: Query) extends BigQueryIO[Table
       beam.BigQueryIO.readTableRows().withMethod(Method.DIRECT_READ),
       sqlQuery,
       identity
-    )
+    )(coders.tableRowCoder)
 
   override def testId: String = s"BigQueryIO(${sqlQuery.underlying})"
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/coders/package.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/coders/package.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.bigquery
+
+import com.spotify.scio.bigquery.instances.CoderInstances
+
+package object coders extends CoderInstances

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/instances/CoderInstances.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/instances/CoderInstances.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.bigquery.instances
+
+import com.spotify.scio.coders.Coder
+import com.google.api.services.bigquery.model.TableRow
+import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder
+
+trait CoderInstances {
+  implicit def tableRowCoder: Coder[TableRow] = Coder.beam(TableRowJsonCoder.of())
+}

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -61,9 +61,14 @@ final class SCollectionTableRowOps[T <: TableRow](private val self: SCollection[
         tableDescription,
         timePartitioning
       )
+
     self
       .covary[TableRow]
-      .write(BigQueryTypedTable(table, Format.TableRow))(param)
+      .write(
+        BigQueryTypedTable(table, Format.TableRow)(
+          self.coder.asInstanceOf[Coder[TableRow]]
+        )
+      )(param)
   }
 
   /**

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
@@ -40,6 +40,7 @@ import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 import com.spotify.scio.bigquery.BigQueryTypedTable
 import com.spotify.scio.bigquery.BigQueryTypedTable.Format
+import com.spotify.scio.bigquery.coders.tableRowCoder
 
 /** Enhanced version of [[ScioContext]] with BigQuery methods. */
 final class ScioContextOps(private val self: ScioContext) extends AnyVal {
@@ -71,7 +72,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
 
   /** Get an SCollection for a BigQuery table. */
   def bigQueryTable(table: Table): SCollection[TableRow] =
-    bigQueryTable(table, BigQueryTypedTable.Format.TableRow)
+    bigQueryTable(table, BigQueryTypedTable.Format.TableRow)(tableRowCoder)
 
   /**
    * Get an SCollection for a BigQuery table using the specified [[Format]].


### PR DESCRIPTION
fixes #3606

In a follow-up PR, I'll update the migration notes for the new `scio-google-platform` module. We need users to be aware that some of the coders are not resolved implicitly anymore due to the dependency decoupling.