### PR TITLE
SortedBucketTransform lazily evaluates the inputs to transformFn

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -463,9 +463,11 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
                         ((List<Object>) values).add(v);
                       }
                     });
+                keyGroupSize += ((List<Object>) values).size();
               } else {
                 // Can't use predicate here as it acts on a List<Object>
                 values = () -> (Iterator<Object>) entry.getValue().getValue();
+                keyGroupSize = -1; // We can augment this in the transformFn maybe?
               }
               acceptKeyGroup = 1;
             } else {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -437,8 +437,6 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
             final TupleTag tupleTag = entry.getKey();
             int index = resultSchema.getIndex(tupleTag);
 
-            // final Iterable<Object> values;
-
             // Track the canonical # buckets of each source that the key is found in.
             // If we find it in a source with a # buckets >= the parallelism of the job,
             // we know that it doesn't need to be re-hashed as it's already in the right bucket.
@@ -458,7 +456,6 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
                 (Iterator<Object>) entry.getValue().getValue();
 
             if (emitKeyGroup && !materialize) {
-              acceptKeyGroup = 1;
               valueMap.add(
                   index,
                   () ->
@@ -468,6 +465,7 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
                             runningKeyGroupSize++;
                             return value;
                           }));
+              acceptKeyGroup = 1;
             } else if (emitKeyGroup) {
               final List<Object> values = (List<Object>) valueMap.get(index);
               keyGroupIterator.forEachRemaining(

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -456,7 +456,7 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
                 (Iterator<Object>) entry.getValue().getValue();
 
             if (emitKeyGroup && !materialize) {
-              valueMap.add(
+              valueMap.set(
                   index,
                   () ->
                       Iterators.transform(

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -395,19 +395,6 @@ public class SortedBucketSource<FinalKeyT> extends BoundedSource<KV<FinalKeyT, C
         if (runningKeyGroupSize != 0) { // If it's 0, that means we haven't started reading
           keyGroupSize.update(runningKeyGroupSize);
           runningKeyGroupSize = 0;
-          if (!materializeKeyGroup) { // Key groups must be exhausted before moving on to the next
-                                      // one
-            tupleTags
-                .getAll()
-                .forEach(
-                    tupleTag -> {
-                      final Iterable<?> maybeUnfinishedIt = next.getValue().getAll(tupleTag);
-                      if (TraversableOnceIterable.class.isAssignableFrom(
-                          maybeUnfinishedIt.getClass())) {
-                        ((TraversableOnceIterable<?>) maybeUnfinishedIt).ensureExhausted();
-                      }
-                    });
-          }
         }
 
         int completedSources = 0;

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -404,7 +404,8 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
             KV<FinalKeyT, CoGbkResult> mergedKeyGroup = keyGroupReader.getCurrent();
             transformFn.writeTransform(mergedKeyGroup, outputCollector);
 
-            // exhaust iterators if necessary before moving on to the next key group
+            // exhaust iterators if necessary before moving on to the next key group:
+            // for example, if not every element was needed in the transformFn
             sources.forEach(
                 source ->
                     mergedKeyGroup

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -41,6 +41,7 @@ import org.apache.beam.sdk.extensions.smb.SortedBucketSink.RenameBuckets;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSink.WriteResult;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.MergeBucketsReader;
+import org.apache.beam.sdk.extensions.smb.SortedBucketSource.TraversableOnceIterable;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.io.fs.ResourceId;
@@ -407,12 +408,14 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
             // exhaust iterators if necessary before moving on to the next key group:
             // for example, if not every element was needed in the transformFn
             sources.forEach(
-                source ->
-                    mergedKeyGroup
-                        .getValue()
-                        .getAll(source.getTupleTag())
-                        .iterator()
-                        .forEachRemaining(x -> {}));
+                source -> {
+                  final Iterable<?> maybeUnfinishedIt =
+                      mergedKeyGroup.getValue().getAll(source.getTupleTag());
+                  if (TraversableOnceIterable.class.isAssignableFrom(
+                      maybeUnfinishedIt.getClass())) {
+                    ((TraversableOnceIterable<?>) maybeUnfinishedIt).ensureExhausted();
+                  }
+                });
 
             // Return 1 non-null value for the entire bucket
             if (!started) {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -41,7 +41,6 @@ import org.apache.beam.sdk.extensions.smb.SortedBucketSink.RenameBuckets;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSink.WriteResult;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.MergeBucketsReader;
-import org.apache.beam.sdk.extensions.smb.SortedBucketSource.TraversableOnceIterable;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.io.fs.ResourceId;
@@ -404,18 +403,6 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
           try {
             KV<FinalKeyT, CoGbkResult> mergedKeyGroup = keyGroupReader.getCurrent();
             transformFn.writeTransform(mergedKeyGroup, outputCollector);
-
-            // exhaust iterators if necessary before moving on to the next key group:
-            // for example, if not every element was needed in the transformFn
-            sources.forEach(
-                source -> {
-                  final Iterable<?> maybeUnfinishedIt =
-                      mergedKeyGroup.getValue().getAll(source.getTupleTag());
-                  if (TraversableOnceIterable.class.isAssignableFrom(
-                      maybeUnfinishedIt.getClass())) {
-                    ((TraversableOnceIterable<?>) maybeUnfinishedIt).ensureExhausted();
-                  }
-                });
 
             // Return 1 non-null value for the entire bucket
             if (!started) {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -378,7 +378,7 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
         public boolean start() throws IOException {
           keyGroupReader =
               new MergeBucketsReader<>(
-                  sources, bucketOffsetId, effectiveParallelism, sourceSpec, null, keyGroupSize);
+                  sources, bucketOffsetId, effectiveParallelism, sourceSpec, null, keyGroupSize, false);
 
           bucketId = bucketOffsetId;
           dst = fileAssignment.forBucket(BucketShardId.of(bucketId, 0), effectiveParallelism, 1);

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -404,7 +404,7 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
             KV<FinalKeyT, CoGbkResult> mergedKeyGroup = keyGroupReader.getCurrent();
             transformFn.writeTransform(mergedKeyGroup, outputCollector);
 
-            // exhaust iterators if necessary
+            // exhaust iterators if necessary before moving on to the next key group
             sources.forEach(
                 source ->
                     mergedKeyGroup

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -476,6 +476,16 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     toR: CoGbkResult => R
   ) extends Serializable {
 
+    /**
+     * Defines the transforming function applied to each key group, where the output(s) are sent to
+     * the provided consumer via its `accept` function.
+     *
+     * The key group is defined as a key K and records R, where R represents the unpacked [[CoGbkResult]]
+     * converted to Scala Iterables. Note that, unless a [[org.apache.beam.sdk.extensions.smb.SortedBucketSource.Predicate]]
+     * is provided to the PTransform, the Scala Iterable is backed by a lazy iterator, and will only
+     * materialize if .toList or similar function is used in the transformFn. If you have extremely
+     * large key groups, take care to only materialize as much of the Iterable as is needed.
+     */
     def via(
       transformFn: (K, R, SortedBucketTransform.SerializableConsumer[W]) => Unit
     ): ClosedTap[Nothing] = {

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
@@ -46,8 +46,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Unit tests for {@link SortedBucketTransform}. */
 public class SortedBucketTransformTest {
@@ -64,7 +62,6 @@ public class SortedBucketTransformTest {
   private static final Set<String> expected = ImmutableSet.of("c1-c2", "d1-d2", "e1-e2");
 
   private static List<BucketedInput<?, ?>> sources;
-  private static final Logger LOG = LoggerFactory.getLogger(SortedBucketTransform.class);
 
   private static final TransformFn<String, String> mergeFunction =
       (keyGroup, outputConsumer) ->
@@ -78,7 +75,6 @@ public class SortedBucketTransformTest {
                         .getAll(new TupleTag<String>("rhs"))
                         .forEach(
                             rhs -> {
-                              LOG.error("Enumerating pair" + lhs + " + " + rhs);
                               outputConsumer.accept(lhs + "-" + rhs);
                             });
                   });

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
@@ -46,6 +46,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Unit tests for {@link SortedBucketTransform}. */
 public class SortedBucketTransformTest {
@@ -62,6 +64,7 @@ public class SortedBucketTransformTest {
   private static final Set<String> expected = ImmutableSet.of("c1-c2", "d1-d2", "e1-e2");
 
   private static List<BucketedInput<?, ?>> sources;
+  private static final Logger LOG = LoggerFactory.getLogger(SortedBucketTransform.class);
 
   private static final TransformFn<String, String> mergeFunction =
       (keyGroup, outputConsumer) ->
@@ -75,6 +78,7 @@ public class SortedBucketTransformTest {
                         .getAll(new TupleTag<String>("rhs"))
                         .forEach(
                             rhs -> {
+                              LOG.error("Enumerating pair" + lhs + " + " + rhs);
                               outputConsumer.accept(lhs + "-" + rhs);
                             });
                   });


### PR DESCRIPTION
`CoGbkResult`s are backed by `Iterable<Object>`s , which until now we've always fully materialized as lists. However, for the SortedBucketTransform, we can actually lazily read those records as we're feeding them into the user's `transformFn`, so they have the choice to fully materialize it, or not. In the case of extremely large key groups this could help the user avoid an OOM as long as they reduce it properly (i.e. not calling `toList()`, `size()` etc).

If the user supplies a `Predicate` though, we have to materialize, since the Predicate operates on a `List` of buffered results.