### PR TITLE
Only allow accesor methods for BigQuery fields in case classes

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/MacroUtil.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/MacroUtil.scala
@@ -34,7 +34,7 @@ private[types] object MacroUtil {
         .forall(b => t.baseClasses.contains(b.typeSymbol))
 
   def isField(s: Symbol): Boolean =
-    s.isPublic && s.isMethod && !s.isSynthetic && !s.isConstructor
+    s.isPublic && s.isMethod && s.asMethod.isAccessor && !s.isSynthetic && !s.isConstructor
 
   // Case class helpers for macros
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/MacroUtil.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/MacroUtil.scala
@@ -34,7 +34,7 @@ private[types] object MacroUtil {
         .forall(b => t.baseClasses.contains(b.typeSymbol))
 
   def isField(s: Symbol): Boolean =
-    s.isPublic && s.isMethod && s.asMethod.isAccessor && !s.isSynthetic && !s.isConstructor
+    s.isPublic && s.isMethod && s.asMethod.isCaseAccessor && !s.isSynthetic && !s.isConstructor
 
   // Case class helpers for macros
 
@@ -46,7 +46,7 @@ private[types] object MacroUtil {
   }
 
   def isField(c: blackbox.Context)(s: c.Symbol): Boolean =
-    s.isPublic && s.isMethod && !s.isSynthetic && !s.isConstructor
+    s.isPublic && s.isMethod && s.asMethod.isCaseAccessor && !s.isSynthetic && !s.isConstructor
   def getFields(c: blackbox.Context)(t: c.Type): Iterable[c.Symbol] = {
     import c.universe._
     val fields = t.decls.filter(isField(c))

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
@@ -183,4 +183,14 @@ final class ConverterProviderSpec
       EqDerivation[RepeatedNested].eqv(r1, r2) shouldBe true
     }
   }
+
+  property("round trip case class with method nested types") {
+    forAll { r1: CaseClassWithMethods =>
+      val r2 =
+        BigQueryType.fromTableRow[CaseClassWithMethods](
+          BigQueryType.toTableRow[CaseClassWithMethods](r1)
+        )
+      EqDerivation[CaseClassWithMethods].eqv(r1, r2) shouldBe true
+    }
+  }
 }

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -45,6 +45,11 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
     RequiredGeo.fromTableRow(TableRow("a" -> wkt)) shouldBe RequiredGeo(Geography(wkt))
     BigQueryType.toTableRow[RequiredGeo](RequiredGeo(Geography(wkt))) shouldBe TableRow("a" -> wkt)
   }
+
+  it should "handle case classes with methods" in {
+    RequiredWithMethod.fromTableRow(TableRow("a" -> "")) shouldBe RequiredWithMethod("")
+    BigQueryType.toTableRow[RequiredWithMethod](RequiredWithMethod("")) shouldBe TableRow("a" -> "")
+  }
 }
 
 object ConverterProviderTest {
@@ -60,4 +65,11 @@ object ConverterProviderTest {
 
   @BigQueryType.toTable
   case class Repeated(a: List[String])
+
+  @BigQueryType.toTable
+  case class RequiredWithMethod(a: String) {
+    val caseClassPublicValue: String = ""
+    def accessorMethod: String = ""
+    def method(x: String): String = x
+  }
 }

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/SchemaProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/SchemaProviderTest.scala
@@ -108,4 +108,8 @@ class SchemaProviderTest extends AnyFlatSpec with Matchers {
     // The description annotation should be serializable.
     SerializableUtils.ensureSerializable(new description(value = "this a field description"))
   }
+
+  it should "ignore methods in case classes" in {
+    SchemaProvider.schemaOf[CaseClassWithMethods] shouldBe parseSchema(recordFields("REQUIRED"))
+  }
 }

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/Schemas.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/Schemas.scala
@@ -89,4 +89,10 @@ object Schemas {
     @description("account user") user: User,
     @description("in USD") balance: Double
   )
+
+  case class CaseClassWithMethods(required: Required, optional: Optional, repeated: Repeated) {
+    val innerAccessorValue: String = ""
+    def accessorMethod: String = ""
+    def nonAccessorMethod(x: String): String = x
+  }
 }


### PR DESCRIPTION
This commit fixes an issue we detected with a case class that contained a method in it where the code wouldn't compile if it had the `@BigQueryType` annotation.

If methods were defined, the macro would treat them as fields in the table and attempt to construct the case class with it, leading to extra arguments in the constructor