### PR TITLE
Add Sparkey-backed variants of hashJoin/hashIntersect/etc.

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/LargeHashSCollectionFunctions.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/LargeHashSCollectionFunctions.scala
@@ -1,0 +1,17 @@
+package com.spotify.scio.extra.sparkey
+
+import com.spotify.scio.coders.Coder
+import com.spotify.scio.extra.sparkey.instances.SparkeySet
+import com.spotify.scio.values.{SCollection, SideInput}
+
+/** Extra functions available on SCollections for Sparkey hash-based filtering. */
+class LargeHashSCollectionFunctions[T](val self: SCollection[T]) {
+
+  /**
+   * Return a new SCollection containing only elements that also exist in the `LargeSetSideInput`.
+   *
+   * @group transform
+   */
+  def hashFilter(sideInput: SideInput[SparkeySet[T]])(implicit coder: Coder[T]): SCollection[T] =
+    self.map((_, ())).hashIntersectByKey(sideInput).keys
+}

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/LargeHashSCollectionFunctions.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/LargeHashSCollectionFunctions.scala
@@ -5,7 +5,7 @@ import com.spotify.scio.extra.sparkey.instances.SparkeySet
 import com.spotify.scio.values.{SCollection, SideInput}
 
 /** Extra functions available on SCollections for Sparkey hash-based filtering. */
-class LargeHashSCollectionFunctions[T](val self: SCollection[T]) {
+class LargeHashSCollectionFunctions[T](private val self: SCollection[T]) {
 
   /**
    * Return a new SCollection containing only elements that also exist in the `LargeSetSideInput`.

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/LargeHashSCollectionFunctions.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/LargeHashSCollectionFunctions.scala
@@ -1,17 +1,35 @@
+/*
+ * Copyright 2021 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.scio.extra.sparkey
 
-import com.spotify.scio.coders.Coder
 import com.spotify.scio.extra.sparkey.instances.SparkeySet
 import com.spotify.scio.values.{SCollection, SideInput}
 
 /** Extra functions available on SCollections for Sparkey hash-based filtering. */
 class LargeHashSCollectionFunctions[T](private val self: SCollection[T]) {
 
+  implicit val coder = self.coder
+
   /**
    * Return a new SCollection containing only elements that also exist in the `LargeSetSideInput`.
    *
    * @group transform
    */
-  def hashFilter(sideInput: SideInput[SparkeySet[T]])(implicit coder: Coder[T]): SCollection[T] =
+  def hashFilter(sideInput: SideInput[SparkeySet[T]]): SCollection[T] =
     self.map((_, ())).hashIntersectByKey(sideInput).keys
 }

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/LargeHashSCollectionFunctions.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/LargeHashSCollectionFunctions.scala
@@ -23,13 +23,13 @@ import com.spotify.scio.values.{SCollection, SideInput}
 /** Extra functions available on SCollections for Sparkey hash-based filtering. */
 class LargeHashSCollectionFunctions[T](private val self: SCollection[T]) {
 
-  implicit val coder = self.coder
-
   /**
    * Return a new SCollection containing only elements that also exist in the `LargeSetSideInput`.
    *
    * @group transform
    */
-  def hashFilter(sideInput: SideInput[SparkeySet[T]]): SCollection[T] =
+  def hashFilter(sideInput: SideInput[SparkeySet[T]]): SCollection[T] = {
+    implicit val coder = self.coder
     self.map((_, ())).hashIntersectByKey(sideInput).keys
+  }
 }

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctions.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctions.scala
@@ -34,12 +34,7 @@ class PairLargeHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     compressionBlockSize: Int = DefaultCompressionBlockSize
   ): SCollection[(K, (V, W))] = {
     implicit val wCoder: Coder[W] = rhs.valueCoder
-    hashJoin(
-      rhs.asLargeMultiMapSideInput(numShards, compressionType, compressionBlockSize)(
-        Coder[K],
-        Coder[Iterable[W]]
-      )
-    )
+    hashJoin(rhs.asLargeMultiMapSideInput(numShards, compressionType, compressionBlockSize))
   }
 
   /**

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctions.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctions.scala
@@ -1,0 +1,240 @@
+package com.spotify.scio.extra.sparkey
+
+import com.spotify.scio.coders.Coder
+import com.spotify.scio.extra.sparkey.instances.{SparkeyMap, SparkeySet}
+import com.spotify.scio.values.{SCollection, SideInput}
+import com.spotify.sparkey.CompressionType
+
+/**
+ * Extra functions available on SCollections of (key, value) pairs for hash based joins
+ * through an implicit conversion, using the Sparkey-backed LargeMapSideInput for dramatic speed
+ * increases over the in-memory versions for datasets >100MB. As long as the RHS fits on disk,
+ * these functions are usually much much faster than regular joins and save on shuffling.
+ *
+ * Note that these are nearly identical to the functions in PairHashSCollectionFunctions.scala,
+ * but we can't reuse the implementations there as SideInput[T] is not covariant over T.
+ *
+ * @groupname join Join Operations
+ */
+class PairLargeHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
+
+  implicit private[this] val (keyCoder, valueCoder): (Coder[K], Coder[V]) =
+    (self.keyCoder, self.valueCoder)
+
+  /**
+   * Perform an inner join by replicating `rhs` to all workers.
+   * The right side should be <<10x smaller than the left side, and must fit on disk.
+   *
+   * @group join
+   */
+  def largeHashJoin[W](
+    rhs: SCollection[(K, W)],
+    numShards: Short = DefaultSideInputNumShards,
+    compressionType: CompressionType = DefaultCompressionType,
+    compressionBlockSize: Int = DefaultCompressionBlockSize
+  ): SCollection[(K, (V, W))] = {
+    implicit val wCoder: Coder[W] = rhs.valueCoder
+    hashJoin(
+      rhs.asLargeMultiMapSideInput(numShards, compressionType, compressionBlockSize)(
+        Coder[K],
+        Coder[Iterable[W]]
+      )
+    )
+  }
+
+  /**
+   * Perform an inner join with a MultiMap `SideInput[SparkeyMap[K, Iterable[V]]`
+   *
+   * The right side must fit on disk. The SideInput can be used reused for multiple joins.
+   *
+   * @example
+   * {{{
+   *   val si = pairSCollRight.asLargeMultiMapSideInput
+   *   val joined1 = pairSColl1Left.hashJoin(si)
+   *   val joined2 = pairSColl2Left.hashJoin(si)
+   * }}}
+   *
+   * @group join
+   */
+  def hashJoin[W: Coder](
+    sideInput: SideInput[SparkeyMap[K, Iterable[W]]]
+  ): SCollection[(K, (V, W))] =
+    self.transform { in =>
+      in.withSideInputs(sideInput)
+        .flatMap[(K, (V, W))] { (kv, sideInputCtx) =>
+          sideInputCtx(sideInput)
+            .getOrElse(kv._1, Iterable.empty[W])
+            .iterator
+            .map(w => (kv._1, (kv._2, w)))
+        }
+        .toSCollection
+    }
+
+  /**
+   * Perform a left outer join by replicating `rhs` to all workers.
+   * The right side must fit on disk.
+   *
+   * @example
+   * {{{
+   *   val si = pairSCollRight
+   *   val joined = pairSColl1Left.largeHashLeftOuterJoin(pairSCollRight)
+   * }}}
+   * @group join
+   * @param rhs The SCollection[(K, W)] treated as right side of the join.
+   */
+  def largeHashLeftOuterJoin[W](
+    rhs: SCollection[(K, W)],
+    numShards: Short = DefaultSideInputNumShards,
+    compressionType: CompressionType = DefaultCompressionType,
+    compressionBlockSize: Int = DefaultCompressionBlockSize
+  ): SCollection[(K, (V, Option[W]))] = {
+    implicit val wCoder: Coder[W] = rhs.valueCoder
+    hashLeftOuterJoin(
+      rhs.asLargeMultiMapSideInput(numShards, compressionType, compressionBlockSize)
+    )
+  }
+
+  /**
+   * Perform a left outer join with a MultiMap `SideInput[SparkeyMap[K, Iterable[V]]`
+   *
+   * @example
+   * {{{
+   *   val si = pairSCollRight.asLargeMultiMapSideInput
+   *   val joined1 = pairSColl1Left.hashLeftOuterJoin(si)
+   *   val joined2 = pairSColl2Left.hashLeftOuterJoin(si)
+   * }}}
+   * @group join
+   */
+  def hashLeftOuterJoin[W: Coder](
+    sideInput: SideInput[SparkeyMap[K, Iterable[W]]]
+  ): SCollection[(K, (V, Option[W]))] = {
+    self.transform { in =>
+      in.withSideInputs(sideInput)
+        .flatMap[(K, (V, Option[W]))] { case ((k, v), sideInputCtx) =>
+          // Using .get here instead of if/else to avoid calling .get twice on a disk-based map.
+          sideInputCtx(sideInput)
+            .get(k)
+            .map(_.iterator.map(w => (k, (v, Some(w)))))
+            .getOrElse(Iterator((k, (v, None))))
+        }
+        .toSCollection
+    }
+  }
+
+  /**
+   * Perform a full outer join by replicating `rhs` to all workers. The right side must fit on disk.
+   *
+   * @group join
+   */
+  def largeHashFullOuterJoin[W](
+    rhs: SCollection[(K, W)],
+    numShards: Short = DefaultSideInputNumShards,
+    compressionType: CompressionType = DefaultCompressionType,
+    compressionBlockSize: Int = DefaultCompressionBlockSize
+  ): SCollection[(K, (Option[V], Option[W]))] = {
+    implicit val wCoder = rhs.valueCoder
+    hashFullOuterJoin(
+      rhs.asLargeMultiMapSideInput(numShards, compressionType, compressionBlockSize)
+    )
+  }
+
+  /**
+   * Perform a full outer join with a `SideInput[SparkeyMap[K, Iterable[W]]]`.
+   *
+   * @example
+   * {{{
+   *   val si = pairSCollRight.asLargeMultiMapSideInput
+   *   val joined1 = pairSColl1Left.hashFullOuterJoin(si)
+   *   val joined2 = pairSColl2Left.hashFullOuterJoin(si)
+   * }}}
+   *
+   * @group join
+   */
+  def hashFullOuterJoin[W: Coder](
+    sideInput: SideInput[SparkeyMap[K, Iterable[W]]]
+  ): SCollection[(K, (Option[V], Option[W]))] =
+    self.transform { in =>
+      val leftHashed = in
+        .withSideInputs(sideInput)
+        .flatMap { case ((k, v), sideInputCtx) =>
+          val rhsSideMap = sideInputCtx(sideInput)
+          if (rhsSideMap.contains(k)) {
+            rhsSideMap(k).iterator
+              .map[(K, (Option[V], Option[W]), Boolean)](w => (k, (Some(v), Some(w)), true))
+          } else {
+            Iterator((k, (Some(v), None), false))
+          }
+        }
+        .toSCollection
+
+      val rightHashed = leftHashed
+        .filter(_._3)
+        .map(_._1)
+        .aggregate(Set.empty[K])(_ + _, _ ++ _)
+        .withSideInputs(sideInput)
+        .flatMap { (mk, sideInputCtx) =>
+          val m = sideInputCtx(sideInput)
+          (m.keySet diff mk)
+            .flatMap(k => m(k).iterator.map[(K, (Option[V], Option[W]))](w => (k, (None, Some(w)))))
+        }
+        .toSCollection
+
+      leftHashed.map(x => (x._1, x._2)) ++ rightHashed
+    }
+
+  /**
+   * Return an SCollection with the pairs from `this` whose keys are in `rhs`
+   * given `rhs` is small enough to fit on disk.
+   *
+   * Unlike [[SCollection.intersection]] this preserves duplicates in `this`.
+   *
+   * @group per key
+   */
+  def largeHashIntersectByKey(
+    rhs: SCollection[K],
+    numShards: Short = DefaultSideInputNumShards,
+    compressionType: CompressionType = DefaultCompressionType,
+    compressionBlockSize: Int = DefaultCompressionBlockSize
+  ): SCollection[(K, V)] =
+    hashIntersectByKey(rhs.asLargeSetSideInput(numShards, compressionType, compressionBlockSize))
+
+  /**
+   * Return an SCollection with the pairs from `this` whose keys are in the SideSet `rhs`.
+   *
+   * Unlike [[SCollection.intersection]] this preserves duplicates in `this`.
+   *
+   * @group per key
+   */
+  def hashIntersectByKey(sideInput: SideInput[SparkeySet[K]]): SCollection[(K, V)] =
+    self
+      .withSideInputs(sideInput)
+      .filter { case ((k, _), sideInputCtx) => sideInputCtx(sideInput).contains(k) }
+      .toSCollection
+
+  /**
+   * Return an SCollection with the pairs from `this` whose keys are not in SCollection[V] `rhs`.
+   *
+   * Rhs must be small enough to fit on disk.
+   *
+   * @group per key
+   */
+  def largeHashSubtractByKey(
+    rhs: SCollection[K],
+    numShards: Short = DefaultSideInputNumShards,
+    compressionType: CompressionType = DefaultCompressionType,
+    compressionBlockSize: Int = DefaultCompressionBlockSize
+  ): SCollection[(K, V)] =
+    hashSubtractByKey(rhs.asLargeSetSideInput(numShards, compressionType, compressionBlockSize))
+
+  /**
+   * Return an SCollection with the pairs from `this` whose keys are not in SideInput[Set] `rhs`.
+   *
+   * @group per key
+   */
+  def hashSubtractByKey(sideInput: SideInput[SparkeySet[K]]): SCollection[(K, V)] =
+    self
+      .withSideInputs(sideInput)
+      .filter { case ((k, _), sideInputCtx) => !sideInputCtx(sideInput).contains(k) }
+      .toSCollection
+
+}

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctions.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctions.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2021 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.scio.extra.sparkey
 
 import com.spotify.scio.coders.Coder

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctions.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctions.scala
@@ -16,7 +16,7 @@ import com.spotify.sparkey.CompressionType
  *
  * @groupname join Join Operations
  */
-class PairLargeHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
+class PairLargeHashSCollectionFunctions[K, V](private val self: SCollection[(K, V)]) {
 
   implicit private[this] val (keyCoder, valueCoder): (Coder[K], Coder[V]) =
     (self.keyCoder, self.valueCoder)

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -451,14 +451,8 @@ package object sparkey extends SparkeyReaderInstances {
       numShards: Short = DefaultSideInputNumShards,
       compressionType: CompressionType = DefaultCompressionType,
       compressionBlockSize: Int = DefaultCompressionBlockSize
-    )(implicit
-      koder: Coder[K],
-      voder: Coder[Iterable[V]]
     ): SideInput[SparkeyMap[K, Iterable[V]]] =
-      self.groupByKey.asLargeMapSideInput(numShards, compressionType, compressionBlockSize)(
-        koder,
-        voder
-      )
+      self.groupByKey.asLargeMapSideInput(numShards, compressionType, compressionBlockSize)
 
     /**
      * Convert this SCollection to a SideInput, mapping key-value pairs of each window to a

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -408,8 +408,8 @@ package object sparkey extends SparkeyReaderInstances {
       compressionType: CompressionType = DefaultCompressionType,
       compressionBlockSize: Int = DefaultCompressionBlockSize
     ): SideInput[SparkeyMap[K, V]] = {
-      val beamKoder = CoderMaterializer.beam(self.context.options, keyCoder)
-      val beamVoder = CoderMaterializer.beam(self.context.options, valueCoder)
+      val beamKoder = CoderMaterializer.beam(self.context.options, Coder[K])
+      val beamVoder = CoderMaterializer.beam(self.context.options, Coder[V])
 
       new LargeMapSideInput[K, V](
         self
@@ -509,7 +509,7 @@ package object sparkey extends SparkeyReaderInstances {
       compressionType: CompressionType = DefaultCompressionType,
       compressionBlockSize: Int = DefaultCompressionBlockSize
     ): SideInput[SparkeySet[T]] = {
-      val beamKoder = CoderMaterializer.beam(self.context.options, coder)
+      val beamKoder = CoderMaterializer.beam(self.context.options, Coder[T])
 
       new LargeSetSideInput[T](
         self

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -204,7 +204,7 @@ package object sparkey extends SparkeyReaderInstances {
   }
 
   /** Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with Sparkey methods. */
-  implicit class SparkeyPairSCollection[K, V](private val self: SCollection[(K, V)])
+  implicit class SparkeyPairSCollection[K, V](@transient private val self: SCollection[(K, V)])
       extends Serializable {
 
     import SparkeyPairSCollection._

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/LargeHashSCollectionFunctionsTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/LargeHashSCollectionFunctionsTest.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.extra.sparkey
+
+import com.spotify.scio.testing.PipelineSpec
+
+class LargeHashSCollectionFunctionsTest extends PipelineSpec {
+  it should "support hashFilter() with asLargeSetSideInput" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq("a", "b", "c", "b"))
+      val p2 = sc.parallelize(Seq[String]("a", "a", "b", "e")).asLargeSetSideInput
+      val p = p1.hashFilter(p2)
+      p should containInAnyOrder(Seq("a", "b", "b"))
+    }
+  }
+}

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctionsTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctionsTest.scala
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2021 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.extra.sparkey
+
+import com.spotify.scio.options.ScioOptions
+import com.spotify.scio.testing.PipelineSpec
+
+class PairLargeHashSCollectionFunctionsTest extends PipelineSpec {
+  "PairSCollection" should "support largeHashJoin()" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
+      val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("d", 14)))
+      val p = p1.largeHashJoin(p2)
+      p should containInAnyOrder(Seq(("a", (1, 11)), ("b", (2, 12))))
+    }
+  }
+
+  it should "support largeHashJoin() with nulls" in {
+    runWithContext { sc =>
+      sc.optionsAs[ScioOptions].setNullableCoders(true)
+
+      val p1 = sc.parallelize(Seq((null, "1"), (null, "2"), ("b", "3")))
+      val p2 = sc.parallelize(Seq((null, "11"), ("b", null), ("b", "13")))
+      val p = p1.largeHashJoin(p2)
+      p should
+        containInAnyOrder(
+          Seq((null, ("1", "11")), (null, ("2", "11")), ("b", ("3", null)), ("b", ("3", "13")))
+        )
+    }
+  }
+
+  it should "support largeHashJoin() with duplicate keys" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("a", 2), ("b", 3)))
+      val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("b", 13)))
+      val p = p1.largeHashJoin(p2)
+      p should
+        containInAnyOrder(Seq(("a", (1, 11)), ("a", (2, 11)), ("b", (3, 12)), ("b", (3, 13))))
+    }
+  }
+
+  it should "support largeHashJoin() with empty RHS" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
+      val p2 = sc.parallelize(Seq.empty[(String, Int)])
+      val p = p1.largeHashJoin(p2)
+      p should haveSize(0)
+    }
+  }
+
+  it should "support hashJoin() with .asLargeMultiMapSideInput" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("a", 2), ("b", 3)))
+      val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("b", 13))).asLargeMultiMapSideInput
+      val p = p1.hashJoin(p2)
+      p should
+        containInAnyOrder(Seq(("a", (1, 11)), ("a", (2, 11)), ("b", (3, 12)), ("b", (3, 13))))
+    }
+  }
+
+  it should "support hashJoin() with empty .asLargeMultiMapSideInput" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("a", 2), ("b", 3)))
+      val p2 = sc.parallelize[(String, Int)](Map.empty).asLargeMultiMapSideInput
+      val p = p1.hashJoin(p2)
+      p should
+        containInAnyOrder(Seq.empty[(String, (Int, Int))])
+    }
+  }
+
+  it should "support largeHashLeftOuterJoin()" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
+      val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("d", 14)))
+      val p = p1.largeHashLeftOuterJoin(p2)
+      p should containInAnyOrder(Seq(("a", (1, Some(11))), ("b", (2, Some(12))), ("c", (3, None))))
+    }
+  }
+
+  it should "support largeHashLeftOuterJoin() with empty RHS" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
+      val p2 = sc.parallelize(Seq.empty[(String, Int)])
+      val p = p1.largeHashLeftOuterJoin(p2)
+      val empty = Option.empty[Int]
+      p should containInAnyOrder(Seq(("a", (1, empty)), ("b", (2, empty)), ("c", (3, empty))))
+    }
+  }
+
+  it should "support largeHashLeftOuterJoin() with duplicate keys" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("a", 2), ("b", 3), ("c", 4)))
+      val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("b", 13)))
+      val p = p1.largeHashLeftOuterJoin(p2)
+      p should containInAnyOrder(
+        Seq(
+          ("a", (1, Some(11))),
+          ("a", (2, Some(11))),
+          ("b", (3, Some(12))),
+          ("b", (3, Some(13))),
+          ("c", (4, None))
+        )
+      )
+    }
+  }
+
+  it should "support largeHashLeftOuterJoin() with asLargeMultiMapSideInput" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
+      val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("d", 14))).asLargeMultiMapSideInput
+      val p = p1.hashLeftOuterJoin(p2)
+      p should containInAnyOrder(Seq(("a", (1, Some(11))), ("b", (2, Some(12))), ("c", (3, None))))
+    }
+  }
+
+  it should "support largeHashFullOuterJoin()" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2)))
+      val p2 = sc.parallelize(Seq(("a", 11), ("c", 13)))
+      val p = p1.largeHashFullOuterJoin(p2)
+      p should containInAnyOrder(
+        Seq(("a", (Some(1), Some(11))), ("b", (Some(2), None)), ("c", (None, Some(13))))
+      )
+    }
+  }
+
+  it should "support largeHashFullOuterJoin() with empty RHS" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2)))
+      val p2 = sc.parallelize(Seq.empty[(String, Int)])
+      val p = p1.largeHashFullOuterJoin(p2)
+      val empty = Option.empty[Int]
+      val some = Option[Int] _
+      p should containInAnyOrder(Seq(("a", (some(1), empty)), ("b", (some(2), empty))))
+    }
+  }
+
+  it should "support largeHashFullOuterJoin() with duplicate keys" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("a", 2), ("b", 3), ("c", 4)))
+      val p2 = sc.parallelize(Seq(("a", 11), ("b", 12), ("b", 13), ("d", 14)))
+      val p = p1.largeHashFullOuterJoin(p2)
+      p should containInAnyOrder(
+        Seq(
+          ("a", (Some(1), Some(11))),
+          ("a", (Some(2), Some(11))),
+          ("b", (Some(3), Some(12))),
+          ("b", (Some(3), Some(13))),
+          ("c", (Some(4), None)),
+          ("d", (None, Some(14)))
+        )
+      )
+    }
+  }
+
+  it should "support largeHashFullOuterJoin() with no overlap" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1)))
+      val p2 = sc.parallelize(Seq(("b", 2)))
+      val p = p1.largeHashFullOuterJoin(p2)
+      p should containInAnyOrder(Seq(("a", (Some(1), None)), ("b", (None, Some(2)))))
+    }
+  }
+
+  it should "support hashFullOuterJoin() with asLargeMultiMapSideInput" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2)))
+      val p2 = sc.parallelize(Seq(("a", 11), ("c", 13))).asLargeMultiMapSideInput
+      val p = p1.hashFullOuterJoin(p2)
+      p should containInAnyOrder(
+        Seq(("a", (Some(1), Some(11))), ("b", (Some(2), None)), ("c", (None, Some(13))))
+      )
+    }
+  }
+
+  it should "support largeHashIntersectByKey()" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
+      val p2 = sc.parallelize(Seq("a", "b", "d"))
+      val p = p1.largeHashIntersectByKey(p2)
+      p should containInAnyOrder(Seq(("a", 1), ("b", 2)))
+    }
+  }
+
+  it should "support largeHashIntersectByKey() with duplicate keys" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3), ("b", 4)))
+      val p2 = sc.parallelize(Seq("a", "b", "b", "d"))
+      val p = p1.largeHashIntersectByKey(p2)
+      p should containInAnyOrder(Seq(("a", 1), ("b", 2), ("b", 4)))
+    }
+  }
+
+  it should "support largeHashIntersectByKey() with empty LHS" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq[(String, Unit)]())
+      val p2 = sc.parallelize(Seq("a", "b", "d"))
+      val p = p1.largeHashIntersectByKey(p2)
+      p should beEmpty
+    }
+  }
+
+  it should "support largeHashIntersectByKey() with empty RHS" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3), ("b", 4)))
+      val p2 = sc.parallelize(Seq[String]())
+      val p = p1.largeHashIntersectByKey(p2)
+      p should beEmpty
+    }
+  }
+
+  it should "support hashIntersectByKey() with asLargeSetSideInput" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3), ("b", 4)))
+      val p2 = sc.parallelize(Seq[String]("a", "b", "d")).asLargeSetSideInput
+      val p = p1.hashIntersectByKey(p2)
+      p should containInAnyOrder(Seq(("a", 1), ("b", 2), ("b", 4)))
+    }
+  }
+
+  it should "support largeHashSubtractByKey() with empty RHS" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2)))
+      val p2 = sc.parallelize(Seq.empty[String])
+      val output = p1.largeHashSubtractByKey(p2)
+      output should haveSize(2)
+      output should containInAnyOrder(Seq(("a", 1), ("b", 2)))
+    }
+  }
+
+  it should "support largeHashSubtractByKey() with empty LHS" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq.empty[(String, Any)])
+      val p2 = sc.parallelize(Seq("1", "2", "3"))
+      val output = p1.largeHashSubtractByKey(p2)
+      output should beEmpty
+    }
+  }
+
+  it should "support largeHashSubtractByKey() with non-empty RHS / LHS and no duplicates" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3), ("d", 3)))
+      val p2 = sc.parallelize(Seq("a", "d"))
+      val output = p1.largeHashSubtractByKey(p2)
+      output should haveSize(2)
+      output should containInAnyOrder(Seq(("b", 2), ("c", 3)))
+    }
+  }
+
+  it should "support largeHashSubtractByKey() with duplicate keys in LHS" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3), ("b", 4), ("d", 5)))
+      val p2 = sc.parallelize(Seq("a", "c"))
+      val output = p1.largeHashSubtractByKey(p2)
+      output should haveSize(3)
+      output should containInAnyOrder(Seq(("b", 2), ("b", 4), ("d", 5)))
+    }
+  }
+
+  it should "support hashSubtractByKey() with asLargeSetSideInput RHS" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("b", 3), ("c", 4)))
+      val p2 = sc.parallelize(Seq[String]("a", "b")).asLargeSetSideInput
+      val output = p1.hashSubtractByKey(p2)
+      output should haveSize(1)
+      output should containInAnyOrder(Seq(("c", 4)))
+    }
+  }
+
+  it should "support hashFilter() with asLargeSetSideInput" in {
+    runWithContext { sc =>
+      val p1 = sc.parallelize(Seq("a", "b", "c", "b"))
+      val p2 = sc.parallelize(Seq[String]("a", "a", "b", "e")).asLargeSetSideInput
+      val p = p1.hashFilter(p2)
+      p should containInAnyOrder(Seq("a", "b", "b"))
+    }
+  }
+}

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctionsTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctionsTest.scala
@@ -245,7 +245,7 @@ class PairLargeHashSCollectionFunctionsTest extends PipelineSpec {
 
   it should "support largeHashSubtractByKey() with empty LHS" in {
     runWithContext { sc =>
-      val p1 = sc.parallelize(Seq.empty[(String, Any)])
+      val p1 = sc.parallelize(Seq.empty[(String, Int)])
       val p2 = sc.parallelize(Seq("1", "2", "3"))
       val output = p1.largeHashSubtractByKey(p2)
       output should beEmpty

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
@@ -415,12 +415,12 @@ class SparkeyTest extends PipelineSpec {
     val typedSideData = Seq(("ab", Seq(1, 2)), ("bc", Seq(2, 3)), ("cd", Seq(3, 4)))
     val typedSideDataMap = typedSideData.toMap
 
-    val cache = TestCache[String, AnyRef]()
+    val cache = TestCache[String, Seq[Int]]()
 
     val sparkey = sc.parallelize(typedSideData).mapValues(_.mkString(",")).asSparkey
     val sparkeyMaterialized = sparkey.materialize
 
-    val si = sparkey.asTypedSparkeySideInput[Object](cache) { b: Array[Byte] =>
+    val si = sparkey.asTypedSparkeySideInput[Seq[Int]](cache) { b: Array[Byte] =>
       new String(b).split(",").map(_.toInt).toSeq
     }
 
@@ -478,12 +478,12 @@ class SparkeyTest extends PipelineSpec {
     val input = Seq("1")
     val typedSideData = Seq(("ab", Seq(1, 2)), ("bc", Seq(2, 3)), ("cd", Seq(3, 4)))
 
-    val cache = TestCache[String, AnyRef]()
+    val cache = TestCache[String, Seq[Int]]()
 
     val sparkey = sc.parallelize(typedSideData).mapValues(_.mkString(",")).asSparkey
     val sparkeyMaterialized = sparkey.materialize
 
-    val si = sparkey.asTypedSparkeySideInput[Object](cache) { b: Array[Byte] =>
+    val si = sparkey.asTypedSparkeySideInput[Seq[Int]](cache) { b: Array[Byte] =>
       new String(b).split(",").map(_.toInt).toSeq
     }
 
@@ -512,12 +512,12 @@ class SparkeyTest extends PipelineSpec {
     val input = Seq("1")
     val typedSideData = Seq(("ab", Seq(1, 2)), ("bc", Seq(2, 3)), ("cd", Seq(3, 4)))
 
-    val cache = TestCache[String, AnyRef]()
+    val cache = TestCache[String, Seq[Int]]()
 
     val sparkey = sc.parallelize(typedSideData).mapValues(_.mkString(",")).asSparkey(numShards = 2)
     val sparkeyMaterialized = sparkey.materialize
 
-    val si = sparkey.asTypedSparkeySideInput[Object](cache) { b: Array[Byte] =>
+    val si = sparkey.asTypedSparkeySideInput[Seq[Int]](cache) { b: Array[Byte] =>
       new String(b).split(",").map(_.toInt).toSeq
     }
 

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairHashSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairHashSCollectionFunctionsTest.scala
@@ -245,7 +245,7 @@ class PairHashSCollectionFunctionsTest extends PipelineSpec {
 
   it should "support hashSubtractByKey() with empty LHS" in {
     runWithContext { sc =>
-      val p1 = sc.parallelize(Seq.empty[(String, Any)])
+      val p1 = sc.parallelize(Seq.empty[(String, Int)])
       val p2 = sc.parallelize(Seq("1", "2", "3"))
       val output = p1.hashSubtractByKey(p2)
       output should beEmpty


### PR DESCRIPTION
This PR builds on https://github.com/spotify/scio/pull/3678 and finishes off the "speed things up with Sparkey" effort by adding `.largeHashJoin` equivalents for the existing `hashJoin` family of methods. Tests included. The anecdotal pipeline that was speed up by a factor of 2x (mentioned in https://github.com/spotify/scio/pull/3677) was using the `largeHashLeftOuterJoin` method from this PR.