### PR TITLE
Support `verifyDeterministic` and `consistentWithEquals` in recursive coders

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
@@ -45,6 +45,7 @@ private object NothingCoder extends AtomicCoder[Nothing] {
   override def decode(is: InputStream): Nothing =
     // can't possibly happen
     throw new IllegalStateException("Trying to decode a value of type Nothing is impossible")
+  override def consistentWithEquals(): Boolean = true
 }
 
 abstract private class BaseSeqLikeCoder[M[_], T](val elemCoder: BCoder[T])

--- a/scio-test/src/main/scala/com/spotify/scio/testing/CoderAssertions.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/CoderAssertions.scala
@@ -76,6 +76,22 @@ object CoderAssertions {
       }
     }
 
+  def beConsistentWithEquals[T: ClassTag](opts: PipelineOptions = DefaultPipelineOptions): CoderAssertion[T] =
+    new CoderAssertion[T] {
+      override def assert(value: T)(implicit c: Coder[T], eq: Equality[T]): Assertion = {
+        val beamCoder = CoderMaterializer.beamWithDefault(c, o = opts)
+        beamCoder.consistentWithEquals() shouldBe true
+      }
+    }
+
+  def beDeterministic[T: ClassTag](opts: PipelineOptions = DefaultPipelineOptions): CoderAssertion[T] =
+    new CoderAssertion[T] {
+      override def assert(value: T)(implicit c: Coder[T], eq: Equality[T]): Assertion = {
+        val beamCoder = CoderMaterializer.beamWithDefault(c, o = opts)
+        noException should be thrownBy beamCoder.verifyDeterministic()
+      }
+    }
+
   def coderIsSerializable[A](implicit c: Coder[A]): Assertion =
     coderIsSerializable(CoderMaterializer.beamWithDefault(c))
 

--- a/scio-test/src/main/scala/com/spotify/scio/testing/CoderAssertions.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/CoderAssertions.scala
@@ -76,7 +76,9 @@ object CoderAssertions {
       }
     }
 
-  def beConsistentWithEquals[T: ClassTag](opts: PipelineOptions = DefaultPipelineOptions): CoderAssertion[T] =
+  def beConsistentWithEquals[T: ClassTag](
+    opts: PipelineOptions = DefaultPipelineOptions
+  ): CoderAssertion[T] =
     new CoderAssertion[T] {
       override def assert(value: T)(implicit c: Coder[T], eq: Equality[T]): Assertion = {
         val beamCoder = CoderMaterializer.beamWithDefault(c, o = opts)
@@ -84,7 +86,9 @@ object CoderAssertions {
       }
     }
 
-  def beDeterministic[T: ClassTag](opts: PipelineOptions = DefaultPipelineOptions): CoderAssertion[T] =
+  def beDeterministic[T: ClassTag](
+    opts: PipelineOptions = DefaultPipelineOptions
+  ): CoderAssertion[T] =
     new CoderAssertion[T] {
       override def assert(value: T)(implicit c: Coder[T], eq: Equality[T]): Assertion = {
         val beamCoder = CoderMaterializer.beamWithDefault(c, o = opts)

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -549,6 +549,10 @@ final class CoderTest extends AnyFlatSpec with Matchers {
 
     SampleField("hello", StringType) coderShould roundtrip()
 
+    // https://github.com/spotify/scio/issues/3707
+    SampleField("hello", StringType) coderShould beConsistentWithEquals()
+    SampleField("hello", StringType) coderShould beDeterministic()
+
     SampleField(
       "hello",
       RecordType(


### PR DESCRIPTION
fixes #3707 