### PR TITLE
Fix snapshot version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
       - name: cache SBT
         uses: coursier/cache-action@v6
       - name: Java 11 setup


### PR DESCRIPTION
`checkout` action by default now fetchs repos with depth 1. Tags are not fetched on merge to `main` so snpashot version get's release with `0.0.0`.

This issue does not affect tag releases since tag will be available.