### PR TITLE
Remove internal release steps from the How-to-Release.md

### DIFF
--- a/site/src/main/paradox/dev/How-to-Release.md
+++ b/site/src/main/paradox/dev/How-to-Release.md
@@ -52,10 +52,8 @@ git push origin vX.Y.Z
 ## After successfully published artifacts
 
 - Run @github[scripts/bump_scio.sh](/scripts/bump_scio.sh) to update [homebrew formula](https://github.com/spotify/homebrew-public/blob/master/scio.rb) and `scioVersion` in downstream repos including [scio.g8](https://github.com/spotify/scio.g8), [featran](https://github.com/spotify/featran), etc.
-- Bump version in the internal `scio-cookie` and monorepo
-- Send internal announcement to scio-users@spotify.com and flatmap-announce@spotify.com
 - Send external announcement to scio-users@googlegroups.com and user@beam.apache.org
-- Announce on internal and public [Slack](https://slackin.spotify.com/)
+- Announce on public [Slack](https://slackin.spotify.com/)
 - Announce on Twitter
 
 <sup>*</sup>Starting with `0.4.0` all release names are scientific names of animals with genus and species starting with the same letter, in ascending alphabetical order; Harry Potter spells starting with `0.8.0`; Latin names of cities in ascending alphabetical order starting `0.10.0`.


### PR DESCRIPTION
Internal steps were moved to the internal documentation.