### PR TITLE
update nodes by cluster name

### DIFF
--- a/scio-google-cloud-platform/src/main/java/com/spotify/scio/bigtable/BigtableUtil.java
+++ b/scio-google-cloud-platform/src/main/java/com/spotify/scio/bigtable/BigtableUtil.java
@@ -93,7 +93,7 @@ public final class BigtableUtil {
           .getClustersList()
           .stream()
           // if no clusters specified then apply to all clusters in the instance.
-          .filter(c -> clusterNames.isEmpty() || clusterNames.contains(simplify(c.getName())))
+          .filter(c -> clusterNames.isEmpty() || clusterNames.contains(shorterName(c.getName())))
           .collect(Collectors.toList());
 
       // For each cluster update the number of nodes
@@ -137,7 +137,7 @@ public final class BigtableUtil {
     }
   }
 
-  static String simplify(String name) {
+  static String shorterName(String name) {
     if (name.lastIndexOf('/') != -1) {
       return name.substring(name.lastIndexOf('/') + 1, name.length());
     } else {

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigtable/syntax/ScioContextSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigtable/syntax/ScioContextSyntax.scala
@@ -29,11 +29,11 @@ import org.apache.beam.sdk.io.range.ByteKeyRange
 import org.joda.time.Duration
 
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOption
 
 object ScioContextOps {
   private val DefaultSleepDuration = Duration.standardMinutes(20)
-  // Empty set means all clusters.
-  private val DefaultClusterNames: Set[String] = Set.empty
+  private val DefaultClusterNames: Option[Set[String]] = None
 }
 
 /** Enhanced version of [[ScioContext]] with Bigtable methods. */
@@ -117,7 +117,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
     projectId: String,
     instanceId: String,
     numberOfNodes: Int,
-    clusterNames: Set[String],
+    clusterNames: Option[Set[String]],
     sleepDuration: Duration
   ): Unit = {
     val bigtableOptions = BigtableOptions
@@ -163,7 +163,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   def updateNumberOfBigtableNodes(
     bigtableOptions: BigtableOptions,
     numberOfNodes: Int,
-    clusterNames: Set[String],
+    clusterNames: Option[Set[String]],
     sleepDuration: Duration
   ): Unit =
     if (!self.isTest) {
@@ -172,7 +172,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
         bigtableOptions,
         numberOfNodes,
         sleepDuration,
-        clusterNames.asJava
+        clusterNames.map(_.asJava).toJava
       )
     }
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigtable/syntax/ScioContextSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigtable/syntax/ScioContextSyntax.scala
@@ -28,8 +28,8 @@ import com.spotify.scio.values.SCollection
 import org.apache.beam.sdk.io.range.ByteKeyRange
 import org.joda.time.Duration
 
+import java.util.Optional
 import scala.jdk.CollectionConverters._
-import scala.jdk.OptionConverters.RichOption
 
 object ScioContextOps {
   private val DefaultSleepDuration = Duration.standardMinutes(20)
@@ -172,7 +172,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
         bigtableOptions,
         numberOfNodes,
         sleepDuration,
-        clusterNames.map(_.asJava).toJava
+        Optional.ofNullable(clusterNames.map(_.asJava).orNull)
       )
     }
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigtable/syntax/ScioContextSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigtable/syntax/ScioContextSyntax.scala
@@ -168,12 +168,20 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   ): Unit =
     if (!self.isTest) {
       // No need to update the number of nodes in a test
-      BigtableUtil.updateNumberOfBigtableNodes(
-        bigtableOptions,
-        numberOfNodes,
-        sleepDuration,
-        Optional.ofNullable(clusterNames.map(_.asJava).orNull)
-      )
+      if (clusterNames.isDefined) {
+        BigtableUtil.updateNumberOfBigtableNodes(
+          bigtableOptions,
+          numberOfNodes,
+          sleepDuration
+        )
+      } else {
+        BigtableUtil.updateNumberOfBigtableNodes(
+          bigtableOptions,
+          numberOfNodes,
+          sleepDuration,
+          clusterNames.map(_.asJava).get
+        )
+      }
     }
 
   /**

--- a/scio-google-cloud-platform/src/test/java/com/spotify/scio/bigtable/BigtableUtilTest.java
+++ b/scio-google-cloud-platform/src/test/java/com/spotify/scio/bigtable/BigtableUtilTest.java
@@ -1,0 +1,20 @@
+package com.spotify.scio.bigtable;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BigtableUtilTest {
+
+  @Test
+  public void simplifyTest() {
+    Assert.assertEquals(
+        BigtableUtil.simplify("/projects/scio-test/instances/test-instance/clusters/sample-cluster"),
+        "sample-cluster"
+    );
+
+    Assert.assertEquals(
+        BigtableUtil.simplify("simple-name-cluster"),
+        "simple-name-cluster"
+    );
+  }
+}

--- a/scio-google-cloud-platform/src/test/java/com/spotify/scio/bigtable/BigtableUtilTest.java
+++ b/scio-google-cloud-platform/src/test/java/com/spotify/scio/bigtable/BigtableUtilTest.java
@@ -6,14 +6,14 @@ import org.junit.Test;
 public class BigtableUtilTest {
 
   @Test
-  public void simplifyTest() {
+  public void shorterNameTest() {
     Assert.assertEquals(
-        BigtableUtil.simplify("/projects/scio-test/instances/test-instance/clusters/sample-cluster"),
+        BigtableUtil.shorterName("/projects/scio-test/instances/test-instance/clusters/sample-cluster"),
         "sample-cluster"
     );
 
     Assert.assertEquals(
-        BigtableUtil.simplify("simple-name-cluster"),
+        BigtableUtil.shorterName("simple-name-cluster"),
         "simple-name-cluster"
     );
   }


### PR DESCRIPTION
This allows users to update node counts per cluster or set of clusters of a given instance. 

Fixes: https://github.com/spotify/scio/issues/3541