### PR TITLE
Fix removed dependency

### DIFF
--- a/site/src/main/paradox/migrations/v0.10.0-Migration-Guide.md
+++ b/site/src/main/paradox/migrations/v0.10.0-Migration-Guide.md
@@ -20,7 +20,7 @@ Update your `build.sbt` accordingly, for example:
       "com.spotify" %% "scio-core" % scioVersion,
 -     "com.spotify" %% "scio-bigquery" % scioVersion,
 -     "com.spotify" %% "scio-bigtable" % scioVersion,
--     "com.spotify" %% "scio-bigquery" % scioVersion,
+-     "com.spotify" %% "scio-spanner" % scioVersion,
 +     "com.spotify" %% "scio-google-cloud-platform" % scioVersion,
       "com.spotify" %% "scio-test" % scioVersion % Test
     )


### PR DESCRIPTION
Documentation contains `scio-bigquery` instead of `scio-spanner`