### PR TITLE
Document ordering of selectedFields

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
@@ -91,7 +91,9 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
    *
    * @param selectedFields names of the fields in the table that should be read. If empty, all
    *                       fields will be read. If the specified field is a nested field, all the
-   *                       sub-fields in the field will be selected.
+   *                       sub-fields in the field will be selected. Fields will always appear in
+   *                       the generated class in the same order as they appear in the table,
+   *                       regardless of the order specified in selectedFields.
    * @param rowRestriction SQL text filtering statement, similar ti a WHERE clause in a query.
    *                       Currently, we support combinations of predicates that are a comparison
    *                       between a column and a constant value in SQL statement. Aggregates are

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
@@ -242,7 +242,9 @@ object BigQueryType {
    *
    * @param selectedFields names of the fields in the table that should be read. If empty, all
    *                       fields will be read. If the specified field is a nested field, all the
-   *                       sub-fields in the field will be selected.
+   *                       sub-fields in the field will be selected. Fields will always appear in
+   *                       the generated class in the same order as they appear in the table,
+   *                       regardless of the order specified in selectedFields.
    * @param rowRestriction SQL text filtering statement, similar ti a WHERE clause in a query.
    *                       Currently, we support combinations of predicates that are a comparison
    *                       between a column and a constant value in SQL statement. Aggregates are

--- a/site/src/main/paradox/migrations/v0.8.0-Migration-Guide.md
+++ b/site/src/main/paradox/migrations/v0.8.0-Migration-Guide.md
@@ -211,7 +211,7 @@ import com.spotify.scio.bigquery._
 class Example
 ```
 
-However if you don't want to pull everything, you can always specify which fields you want and even set some filtering.
+However if you don't want to pull everything, you can always specify which fields you want and even set some filtering. Note that the field names in `selectedFields` must appear in the same order as the columns appear in the table.
 
 ```scala
 import com.spotify.scio.bigquery._


### PR DESCRIPTION
I've found that the order of the fields specified to `selectedFields` doesn't seem to have any effect.

Say I have a Big Query table with 2 columns in the order `first_column, last_column`, and a single row `first_column: "foo", last_column: "bar"`, and I have the following code:

```scala
@BigQueryType.fromStorage("my-table", selectedFields = List("last_column", "first_column")
class MyClass

sc.typedBigQueryStorage[MyClass](Table.Spec(MyClass.table.format))
.map(r => println(s"first_column: %s, last_column: %s", r.first_column, r.last_column)
```

This prints out `first_column: bar, last_column: foo`

This PR updates Scio's documentation. I haven't been able to find any documentation about this upstream in Google's API Docs.