### PR TITLE
Add support for tearing down the resources automatically if the resource is AutoCloseable

### DIFF
--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
@@ -106,7 +106,7 @@ sealed trait PredictDoFn[T, V, M <: Model[_]]
   }
 
   @Teardown
-  def teardown(): Unit = {
+  override def teardown(): Unit = {
     Log.info(s"Tearing down predict DoFn $this")
     val (running, m) = getResource().get(modelId)
     if (running.decrementAndGet() == 0) {


### PR DESCRIPTION
Hi, I was looking at some of our pipelines and discovered that the resources weren't being released. This normally isn't a problem as the teardown implies the machine is shutting down, but in our use-case it led to an ever-increasing amount of threads being created, which polluted the logs with warnings.

Instead of doing so from our codebase I thought it would be better if the DoFnWithResource automatically closed them based on whether the resource is AutoCloseable or not, liberating the users from that mental overhead.

The algorithm is adapted from the TensorflowDoFn test as it already had to solve this issue. 