### PR TITLE
Fix for the non serializable Redis IO DoFn summoned execution context

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
@@ -137,7 +137,6 @@ object RedisWriteStreamingExample {
 // --redisHost=[REDIS_HOST]
 // --redisPort=[REDIS_PORT]
 object RedisLookUpStringsExample {
-  import scala.concurrent.ExecutionContext.Implicits.global
 
   def main(cmdlineArgs: Array[String]): Unit = {
 

--- a/scio-redis/src/main/scala/com/spotify/scio/redis/RedisDoFn.scala
+++ b/scio-redis/src/main/scala/com/spotify/scio/redis/RedisDoFn.scala
@@ -33,11 +33,19 @@ import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters._
 
+object RedisDoFn {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  implicit val ec: ExecutionContext = global
+}
+
 abstract class RedisDoFn[I, O](
   connectionConfig: RedisConnectionConfiguration,
   batchSize: Int
-)(implicit ec: ExecutionContext)
+)
     extends DoFn[I, O] {
+
+   @transient implicit lazy val ec: ExecutionContext = RedisDoFn.ec
 
   @transient private var jedis: Jedis = _
   @transient private var pipeline: Pipeline = _

--- a/scio-redis/src/main/scala/com/spotify/scio/redis/RedisDoFn.scala
+++ b/scio-redis/src/main/scala/com/spotify/scio/redis/RedisDoFn.scala
@@ -35,18 +35,15 @@ import scala.jdk.CollectionConverters._
 
 object RedisDoFn {
   import scala.concurrent.ExecutionContext.Implicits.global
-
   implicit val ec: ExecutionContext = global
 }
 
 abstract class RedisDoFn[I, O](
   connectionConfig: RedisConnectionConfiguration,
   batchSize: Int
-)
-    extends DoFn[I, O] {
+) extends DoFn[I, O] {
 
-   @transient implicit lazy val ec: ExecutionContext = RedisDoFn.ec
-
+  @transient implicit lazy val ec: ExecutionContext = RedisDoFn.ec
   @transient private var jedis: Jedis = _
   @transient private var pipeline: Pipeline = _
   private val results: ConcurrentLinkedQueue[Future[Result]] = new ConcurrentLinkedQueue()

--- a/scio-redis/src/main/scala/com/spotify/scio/redis/RedisDoFn.scala
+++ b/scio-redis/src/main/scala/com/spotify/scio/redis/RedisDoFn.scala
@@ -33,17 +33,13 @@ import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters._
 
-object RedisDoFn {
-  import scala.concurrent.ExecutionContext.Implicits.global
-  implicit val ec: ExecutionContext = global
-}
-
 abstract class RedisDoFn[I, O](
   connectionConfig: RedisConnectionConfiguration,
   batchSize: Int
 ) extends DoFn[I, O] {
 
-  @transient implicit lazy val ec: ExecutionContext = RedisDoFn.ec
+  @transient implicit lazy val ec: ExecutionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
   @transient private var jedis: Jedis = _
   @transient private var pipeline: Pipeline = _
   private val results: ConcurrentLinkedQueue[Future[Result]] = new ConcurrentLinkedQueue()
@@ -64,7 +60,7 @@ abstract class RedisDoFn[I, O](
     }
   }
 
-  def this(opts: RedisConnectionOptions, batchSize: Int)(implicit ec: ExecutionContext) =
+  def this(opts: RedisConnectionOptions, batchSize: Int) =
     this(RedisConnectionOptions.toConnectionConfig(opts), batchSize)
 
   private def flush(fn: Result => Unit): Unit = {

--- a/scio-redis/src/main/scala/com/spotify/scio/redis/RedisIO.scala
+++ b/scio-redis/src/main/scala/com/spotify/scio/redis/RedisIO.scala
@@ -30,7 +30,6 @@ import org.apache.beam.sdk.io.redis.{RedisConnectionConfiguration, RedisIO => Be
 import org.joda.time.Duration
 
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 
 sealed trait RedisIO[T] extends ScioIO[T] {
   final override val tapT: TapT.Aux[T, Nothing] = EmptyTapOf[T]


### PR DESCRIPTION
`RedisDoFn` implicitly summons global execution context which isn't serializable. The following exception is raised on attempt to save to Redis: 

```
Exception in thread "main" java.lang.IllegalArgumentException: unable to serialize DoFnWithExecutionInformation{doFn=com.spotify.scio.redis.RedisWrite$Writer$$anon$1@144ab54, mainOutputTag=Tag<output>, sideInputMapping={}, schemaInformation=DoFnSchemaInformation{elementConverters=[]}}
	at org.apache.beam.sdk.util.SerializableUtils.serializeToByteArray(SerializableUtils.java:59)
	at org.apache.beam.repackaged.direct_java.runners.core.construction.ParDoTranslation.translateDoFn(ParDoTranslation.java:695)
	at org.apache.beam.repackaged.direct_java.runners.core.construction.ParDoTranslation$1.translateDoFn(ParDoTranslation.java:253)
	at org.apache.beam.repackaged.direct_java.runners.core.construction.ParDoTranslation.payloadForParDoLike(ParDoTranslation.java:817)
	at org.apache.beam.repackaged.direct_java.runners.core.construction.ParDoTranslation.translateParDo(ParDoTranslation.java:249)
	at org.apache.beam.repackaged.direct_java.runners.core.construction.ParDoTranslation.translateParDo(ParDoTranslation.java:210)
	at org.apache.beam.repackaged.direct_java.runners.core.construction.ParDoTranslation$ParDoTranslator.translate(ParDoTranslation.java:176)
	at org.apache.beam.repackaged.direct_java.runners.core.construction.PTransformTranslation.toProto(PTransformTranslation.java:248)
	at org.apache.beam.repackaged.direct_java.runners.core.construction.ParDoTranslation.getParDoPayload(ParDoTranslation.java:746)
	at org.apache.beam.repackaged.direct_java.runners.core.construction.ParDoTranslation.isSplittable(ParDoTranslation.java:761)
	at org.apache.beam.repackaged.direct_java.runners.core.construction.PTransformMatchers$6.matches(PTransformMatchers.java:274)
	at org.apache.beam.sdk.Pipeline$2.visitPrimitiveTransform(Pipeline.java:289)
	at org.apache.beam.sdk.runners.TransformHierarchy$Node.visit(TransformHierarchy.java:587)
	at org.apache.beam.sdk.runners.TransformHierarchy$Node.visit(TransformHierarchy.java:579)
	at org.apache.beam.sdk.runners.TransformHierarchy$Node.visit(TransformHierarchy.java:579)
	at org.apache.beam.sdk.runners.TransformHierarchy$Node.visit(TransformHierarchy.java:579)
	at org.apache.beam.sdk.runners.TransformHierarchy$Node.access$500(TransformHierarchy.java:239)
	at org.apache.beam.sdk.runners.TransformHierarchy.visit(TransformHierarchy.java:213)
	at org.apache.beam.sdk.Pipeline.traverseTopologically(Pipeline.java:468)
	at org.apache.beam.sdk.Pipeline.replace(Pipeline.java:267)
	at org.apache.beam.sdk.Pipeline.replaceAll(Pipeline.java:217)
	at org.apache.beam.runners.direct.DirectRunner.performRewrites(DirectRunner.java:255)
	at org.apache.beam.runners.direct.DirectRunner.run(DirectRunner.java:175)
	at org.apache.beam.runners.direct.DirectRunner.run(DirectRunner.java:67)
	at org.apache.beam.sdk.Pipeline.run(Pipeline.java:322)
	at org.apache.beam.sdk.Pipeline.run(Pipeline.java:308)
	at com.spotify.scio.ScioContext.execute(ScioContext.scala:651)
	at com.spotify.scio.ScioContext$$anonfun$run$1.apply(ScioContext.scala:639)
	at com.spotify.scio.ScioContext$$anonfun$run$1.apply(ScioContext.scala:627)
	at com.spotify.scio.ScioContext.requireNotClosed(ScioContext.scala:717)
	at com.spotify.scio.ScioContext.run(ScioContext.scala:627)
	at com.spotify.test.redis.example.RedisLoaderJob$.main(RedisLoaderJob.scala:31)
	at com.spotify.test.redis.example.RedisLoaderJob.main(RedisLoaderJob.scala)
Caused by: java.io.NotSerializableException: scala.concurrent.impl.ExecutionContextImpl$$anon$3
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at org.apache.beam.sdk.util.SerializableUtils.serializeToByteArray(SerializableUtils.java:55)
	... 32 more
```

The fix is just to make the execution context lazy/transient to avoid its ser-de.