### PR TITLE
Fix RedisDoFn ExecutionContext

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
@@ -25,7 +25,7 @@ import com.spotify.scio.redis.types._
 import com.spotify.scio.redis.coders._
 import org.apache.beam.examples.common.ExampleUtils
 import org.apache.beam.sdk.options.{PipelineOptions, StreamingOptions}
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 // ## Redis Read Strings example
 // Read strings from Redis by a key pattern
@@ -148,7 +148,9 @@ object RedisLookUpStringsExample {
     sc.parallelize(Seq("key1", "key2", "unknownKey"))
       .parDo(
         new RedisDoFn[String, (String, Option[String])](connectionOptions, 1000) {
-          override def request(value: String, client: Client): Future[(String, Option[String])] =
+          override def request(value: String, client: Client)(implicit
+            ec: ExecutionContext
+          ): Future[(String, Option[String])] =
             client
               .request(p => p.get(value) :: Nil)
               .map { case r: List[String @unchecked] => (value, r.headOption) }

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
@@ -137,7 +137,6 @@ object RedisWriteStreamingExample {
 // --redisHost=[REDIS_HOST]
 // --redisPort=[REDIS_PORT]
 object RedisLookUpStringsExample {
-  import scala.concurrent.ExecutionContext.Implicits.global
 
   def main(cmdlineArgs: Array[String]): Unit = {
 

--- a/scio-redis/src/main/scala/com/spotify/scio/redis/RedisDoFn.scala
+++ b/scio-redis/src/main/scala/com/spotify/scio/redis/RedisDoFn.scala
@@ -36,9 +36,10 @@ import scala.jdk.CollectionConverters._
 abstract class RedisDoFn[I, O](
   connectionConfig: RedisConnectionConfiguration,
   batchSize: Int
-)(implicit ec: ExecutionContext)
-    extends DoFn[I, O] {
+) extends DoFn[I, O] {
 
+  @transient implicit lazy val ec: ExecutionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
   @transient private var jedis: Jedis = _
   @transient private var pipeline: Pipeline = _
   private val results: ConcurrentLinkedQueue[Future[Result]] = new ConcurrentLinkedQueue()
@@ -59,7 +60,7 @@ abstract class RedisDoFn[I, O](
     }
   }
 
-  def this(opts: RedisConnectionOptions, batchSize: Int)(implicit ec: ExecutionContext) =
+  def this(opts: RedisConnectionOptions, batchSize: Int) =
     this(RedisConnectionOptions.toConnectionConfig(opts), batchSize)
 
   private def flush(fn: Result => Unit): Unit = {

--- a/scio-redis/src/main/scala/com/spotify/scio/redis/RedisIO.scala
+++ b/scio-redis/src/main/scala/com/spotify/scio/redis/RedisIO.scala
@@ -30,7 +30,6 @@ import org.apache.beam.sdk.io.redis.{RedisConnectionConfiguration, RedisIO => Be
 import org.joda.time.Duration
 
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 
 sealed trait RedisIO[T] extends ScioIO[T] {
   final override val tapT: TapT.Aux[T, Nothing] = EmptyTapOf[T]


### PR DESCRIPTION
This is an alternative approach to #3841 while still allowing users to provide their own `ExecutionContex`.

@stormy-ua please take a look, wdyt?