### PR TITLE
Remove java8 steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
     strategy:
       matrix:
         java:
-          - graalvm-ce-java8@21.0.0
           - graalvm-ce-java11@21.0.0
         scala:
           - 2.12.13
@@ -71,7 +70,6 @@ jobs:
     strategy:
       matrix:
         java:
-          - graalvm-ce-java8@21.0.0
           - graalvm-ce-java11@21.0.0
         scala:
           - 2.12.13
@@ -90,7 +88,6 @@ jobs:
     strategy:
       matrix:
         java:
-          - graalvm-ce-java8@21.0.0
           - graalvm-ce-java11@21.0.0
         scala:
           - 2.12.13


### PR DESCRIPTION
Tbh we don't really need them. why? Build is being done with `-release 8` and `-source 8`, `-target 8` which targets scala/java to java8. Adding java11 specific features will fail.

Because we now have less steps ... this should:tm: reduce some stress on GHA, which in the majority of cases seems to be the reason for failures.