### PR TITLE
covary etc. should reset coder #3809

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -298,19 +298,19 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @tparam U The result underlying type.
    * @return The result SCollection with the changed underlying type.
    */
-  private def unsafeChangeUnderlyingType[U: Coder]: SCollection[U] = {
+  private def unsafeCastElement[U: Coder]: SCollection[U] = {
     val coder = CoderMaterializer.beam(context, Coder[U])
     ensureSerializable(coder).fold(throw _, this.asInstanceOf[SCollection[U]].setCoder)
   }
 
   /** lifts this [[SCollection]] to the specified type */
-  def covary[U >: T: Coder]: SCollection[U] = unsafeChangeUnderlyingType[U]
+  def covary[U >: T: Coder]: SCollection[U] = unsafeCastElement[U]
 
   /** lifts this [[SCollection]] to the specified type */
-  def covary_[U: Coder](implicit ev: T <:< U): SCollection[U] = unsafeChangeUnderlyingType[U]
+  def covary_[U: Coder](implicit ev: T <:< U): SCollection[U] = unsafeCastElement[U]
 
   /** lifts this [[SCollection]] to the specified type */
-  def contravary[U <: T: Coder]: SCollection[U] = unsafeChangeUnderlyingType[U]
+  def contravary[U <: T: Coder]: SCollection[U] = unsafeCastElement[U]
 
   /**
    * Convert this SCollection to an [[SCollectionWithFanout]] that uses an intermediate node to

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/pubsub/PubsubIO.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/pubsub/PubsubIO.scala
@@ -292,7 +292,7 @@ final private case class PubSubMessagePubsubIOWithoutAttributes[T <: beam.Pubsub
 ) extends PubsubIOWithoutAttributes[T] {
   override protected def read(sc: ScioContext, params: ReadP): SCollection[T] = {
     val t = setup(beam.PubsubIO.readMessages(), params)
-    sc.applyTransform(t).contravary[T]
+    sc.applyTransform(t).unsafeContravary[T]
   }
 
   override protected def write(data: SCollection[T], params: WriteP): Tap[Nothing] = {

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/pubsub/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/pubsub/syntax/SCollectionSyntax.scala
@@ -76,10 +76,11 @@ trait SCollectionSyntax {
       maxBatchSize: Option[Int] = None,
       maxBatchBytesSize: Option[Int] = None
     )(implicit ev: T <:< (V, Map[String, String])): ClosedTap[Nothing] = {
-      implicit val vCoder = BeamCoders.getTupleCoders(coll.covary_[(V, Map[String, String])])._1
+      implicit val vCoder =
+        BeamCoders.getTupleCoders(coll.unsafeCovary_[(V, Map[String, String])])._1
       val io = PubsubIO.withAttributes[V](topic, idAttribute, timestampAttribute)
       coll
-        .covary_[(V, Map[String, String])]
+        .unsafeCovary_[(V, Map[String, String])]
         .write(io)(PubsubIO.WriteParam(maxBatchSize, maxBatchBytesSize))
     }
   }

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -39,10 +39,18 @@ import org.joda.time.{DateTimeConstants, Duration, Instant}
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
-import com.spotify.scio.coders.Coder
+import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.schemas.Schema
+import org.apache.beam.sdk.util.CoderUtils
+
+object SCollectionTest {
+  class TestA(val l: Long)
+  case class TestB(override val l: Long, s: String) extends TestA(l)
+}
 
 class SCollectionTest extends PipelineSpec {
+  import com.spotify.scio.values.SCollectionTest._
+
   "SCollection" should "support applyTransform()" in {
     runWithContext { sc =>
       val p =
@@ -807,6 +815,24 @@ class SCollectionTest extends PipelineSpec {
     runWithContext { sc =>
       val coll = sc.empty[Int]().reifyAsListInGlobalWindow
       coll should containInAnyOrder(Seq(Seq.empty[Int]))
+    }
+  }
+
+  it should "reset coder after covary is applied" in {
+    runWithContext { sc =>
+      val coll1 = sc.parallelize(Seq(new TestA(0)))
+      val coll2 = sc.parallelize(Seq(TestB(1, "1")))
+      val coll = coll2.covary[TestA] ++ coll1
+
+      // The test fails if covary doesn't reset the coder to the Coder[TestA],
+      // because the result collection is a mix of TestA and TestB and Coder[TestB]
+      // won't be able to decode an instance of TestA from coll1.
+      val beamCoder = CoderMaterializer.beamWithDefault(coll.coder, sc.options)
+      val testAInstance = new TestA(0)
+      val bytes = CoderUtils.encodeToByteArray(beamCoder, testAInstance)
+      val result = CoderUtils.decodeFromByteArray(beamCoder, bytes)
+
+      result.l shouldBe testAInstance.l
     }
   }
 


### PR DESCRIPTION
The PR fixes the issue with `covary`/`contravary` not resetting the coder to the target underlying type. More details about the issue [here](https://github.com/spotify/scio/issues/3809).

The fix introduces the new function `unsafeCastElement` which casts the underlying type and sets the coder to the type `covary`/`contravary` is changing it to. 

Also added a unit test which mimics the original issue by concatenating two SCollections of type B and A and covarying the first to the second. It fails w/o the fix.