### PR TITLE
Add support for additional read sources in smb cogroup

### DIFF
--- a/scio-smb/src/it/scala/com/spotify/scio/smb/SortMergeBucketParityIT.scala
+++ b/scio-smb/src/it/scala/com/spotify/scio/smb/SortMergeBucketParityIT.scala
@@ -18,10 +18,10 @@
 package com.spotify.scio.smb
 
 import java.nio.file.{Files, Path}
-
 import com.spotify.scio.ScioContext
 import com.spotify.scio.avro._
 import com.spotify.scio.coders.Coder
+import com.spotify.scio.util.MultiJoin
 import com.spotify.scio.values.SCollection
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Field
@@ -143,6 +143,69 @@ class SortMergeBucketParityIT extends AnyFlatSpec with Matchers {
       )
 
       avroA.keyBy(keyFn).cogroup(avroB.keyBy(keyFn), avroC.keyBy(keyFn), avroD.keyBy(keyFn))
+    }
+  }
+
+  it should "have parity with a 5-way CoGroup" in withNumSources(5) { inputs =>
+    compareResults(
+      _.sortMergeCoGroup(
+        classOf[Integer],
+        mkRead(inputs(0)),
+        mkRead(inputs(1)),
+        mkRead(inputs(2)),
+        mkRead(inputs(3)),
+        mkRead(inputs(4)),
+        TargetParallelism.auto()
+      )
+    ) { sc =>
+      val (avroA, avroB, avroC, avroD, avroE) = (
+        sc.avroFile(s"${inputs(0)}/*.avro", schema),
+        sc.avroFile(s"${inputs(1)}/*.avro", schema),
+        sc.avroFile(s"${inputs(2)}/*.avro", schema),
+        sc.avroFile(s"${inputs(3)}/*.avro", schema),
+        sc.avroFile(s"${inputs(4)}/*.avro", schema)
+      )
+
+      MultiJoin.cogroup(
+        avroA.keyBy(keyFn),
+        avroB.keyBy(keyFn),
+        avroC.keyBy(keyFn),
+        avroD.keyBy(keyFn),
+        avroE.keyBy(keyFn)
+      )
+    }
+  }
+
+  it should "have parity with a 6-way CoGroup" in withNumSources(6) { inputs =>
+    compareResults(
+      _.sortMergeCoGroup(
+        classOf[Integer],
+        mkRead(inputs(0)),
+        mkRead(inputs(1)),
+        mkRead(inputs(2)),
+        mkRead(inputs(3)),
+        mkRead(inputs(4)),
+        mkRead(inputs(5)),
+        TargetParallelism.auto()
+      )
+    ) { sc =>
+      val (avroA, avroB, avroC, avroD, avroE, avroF) = (
+        sc.avroFile(s"${inputs(0)}/*.avro", schema),
+        sc.avroFile(s"${inputs(1)}/*.avro", schema),
+        sc.avroFile(s"${inputs(2)}/*.avro", schema),
+        sc.avroFile(s"${inputs(3)}/*.avro", schema),
+        sc.avroFile(s"${inputs(4)}/*.avro", schema),
+        sc.avroFile(s"${inputs(5)}/*.avro", schema)
+      )
+
+      MultiJoin.cogroup(
+        avroA.keyBy(keyFn),
+        avroB.keyBy(keyFn),
+        avroC.keyBy(keyFn),
+        avroD.keyBy(keyFn),
+        avroE.keyBy(keyFn),
+        avroF.keyBy(keyFn)
+      )
     }
   }
 

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -331,6 +331,159 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     sortMergeCoGroup(keyClass, a, b, c, d, TargetParallelism.auto())
 
   /**
+   * For each key K in `a` or `b` or `c` or `d` or `e`, return a resulting SCollection that contains a
+   * tuple with the list of values for that key in a`, `b`, `c`, `d` and `e`.
+   *
+   * See note on [[SortedBucketScioContext.sortMergeJoin()]] for information on how an SMB cogroup
+   * differs from a regular [[org.apache.beam.sdk.transforms.join.CoGroupByKey]] operation.
+   *
+   * @group cogroup
+   *
+   * @param keyClass cogroup key class. Must have a Coder in Beam's default
+   *                 [[org.apache.beam.sdk.coders.CoderRegistry]] as custom key coders are not
+   *                 supported yet.
+   * @param targetParallelism the desired parallelism of the job. See
+   *                 [[org.apache.beam.sdk.extensions.smb.TargetParallelism]] for more information.
+   */
+  @experimental
+  def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder, D: Coder, E: Coder](
+    keyClass: Class[K],
+    a: SortedBucketIO.Read[A],
+    b: SortedBucketIO.Read[B],
+    c: SortedBucketIO.Read[C],
+    d: SortedBucketIO.Read[D],
+    e: SortedBucketIO.Read[E],
+    targetParallelism: TargetParallelism
+  ): SCollection[(K, (Iterable[A], Iterable[B], Iterable[C], Iterable[D], Iterable[E]))] = {
+    val t = SortedBucketIO
+      .read(keyClass)
+      .of(a)
+      .and(b)
+      .and(c)
+      .and(d)
+      .and(e)
+      .withTargetParallelism(targetParallelism)
+    val (tupleTagA, tupleTagB, tupleTagC, tupleTagD, tupleTagE) = (
+      a.getTupleTag,
+      b.getTupleTag,
+      c.getTupleTag,
+      d.getTupleTag,
+      e.getTupleTag
+    )
+    val tfName = self.tfName
+
+    self
+      .wrap(self.pipeline.apply(s"SMB CoGroupByKey@$tfName", t))
+      .withName(tfName)
+      .map { kv =>
+        val cgbkResult = kv.getValue
+
+        (
+          kv.getKey,
+          (
+            cgbkResult.getAll(tupleTagA).asScala,
+            cgbkResult.getAll(tupleTagB).asScala,
+            cgbkResult.getAll(tupleTagC).asScala,
+            cgbkResult.getAll(tupleTagD).asScala,
+            cgbkResult.getAll(tupleTagE).asScala
+          )
+        )
+      }
+  }
+
+  @experimental
+  def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder, D: Coder, E: Coder](
+    keyClass: Class[K],
+    a: SortedBucketIO.Read[A],
+    b: SortedBucketIO.Read[B],
+    c: SortedBucketIO.Read[C],
+    d: SortedBucketIO.Read[D],
+    e: SortedBucketIO.Read[E]
+  ): SCollection[(K, (Iterable[A], Iterable[B], Iterable[C], Iterable[D], Iterable[E]))] =
+    sortMergeCoGroup(keyClass, a, b, c, d, e, TargetParallelism.auto())
+
+  /**
+   * For each key K in `a` or `b` or `c` or `d` or `e` or `f`, return a resulting SCollection that contains a
+   * tuple with the list of values for that key in a`, `b`, `c`, `d`, `e` and `f`.
+   *
+   * See note on [[SortedBucketScioContext.sortMergeJoin()]] for information on how an SMB cogroup
+   * differs from a regular [[org.apache.beam.sdk.transforms.join.CoGroupByKey]] operation.
+   *
+   * @group cogroup
+   *
+   * @param keyClass cogroup key class. Must have a Coder in Beam's default
+   *                 [[org.apache.beam.sdk.coders.CoderRegistry]] as custom key coders are not
+   *                 supported yet.
+   * @param targetParallelism the desired parallelism of the job. See
+   *                 [[org.apache.beam.sdk.extensions.smb.TargetParallelism]] for more information.
+   */
+  @experimental
+  def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, F: Coder](
+    keyClass: Class[K],
+    a: SortedBucketIO.Read[A],
+    b: SortedBucketIO.Read[B],
+    c: SortedBucketIO.Read[C],
+    d: SortedBucketIO.Read[D],
+    e: SortedBucketIO.Read[E],
+    f: SortedBucketIO.Read[F],
+    targetParallelism: TargetParallelism
+  ): SCollection[
+    (K, (Iterable[A], Iterable[B], Iterable[C], Iterable[D], Iterable[E], Iterable[F]))
+  ] = {
+    val t = SortedBucketIO
+      .read(keyClass)
+      .of(a)
+      .and(b)
+      .and(c)
+      .and(d)
+      .and(e)
+      .and(f)
+      .withTargetParallelism(targetParallelism)
+    val (tupleTagA, tupleTagB, tupleTagC, tupleTagD, tupleTagE, tupleTagF) = (
+      a.getTupleTag,
+      b.getTupleTag,
+      c.getTupleTag,
+      d.getTupleTag,
+      e.getTupleTag,
+      f.getTupleTag
+    )
+    val tfName = self.tfName
+
+    self
+      .wrap(self.pipeline.apply(s"SMB CoGroupByKey@$tfName", t))
+      .withName(tfName)
+      .map { kv =>
+        val cgbkResult = kv.getValue
+
+        (
+          kv.getKey,
+          (
+            cgbkResult.getAll(tupleTagA).asScala,
+            cgbkResult.getAll(tupleTagB).asScala,
+            cgbkResult.getAll(tupleTagC).asScala,
+            cgbkResult.getAll(tupleTagD).asScala,
+            cgbkResult.getAll(tupleTagE).asScala,
+            cgbkResult.getAll(tupleTagF).asScala
+          )
+        )
+      }
+  }
+
+  @experimental
+  def sortMergeCoGroup[K: Coder, A: Coder, B: Coder, C: Coder, D: Coder, E: Coder, F: Coder](
+    keyClass: Class[K],
+    a: SortedBucketIO.Read[A],
+    b: SortedBucketIO.Read[B],
+    c: SortedBucketIO.Read[C],
+    d: SortedBucketIO.Read[D],
+    e: SortedBucketIO.Read[E],
+    f: SortedBucketIO.Read[F]
+  ): SCollection[
+    (K, (Iterable[A], Iterable[B], Iterable[C], Iterable[D], Iterable[E], Iterable[F]))
+  ] =
+    sortMergeCoGroup(keyClass, a, b, c, d, e, f, TargetParallelism.auto())
+
+  /**
    * Perform a [[SortedBucketScioContext.sortMergeGroupByKey()]] operation, then immediately apply
    * a transformation function to the merged groups and re-write using the same bucketing key and
    * hashing scheme. By applying the write, transform, and write in the same transform, an extra


### PR DESCRIPTION
Adding support for reading 5 and 6 sources with smb cogroup. 

See [issue](https://github.com/spotify/scio/issues/3555). The original issue was filed for 8 sources but we have identified that we only need support for 6 sources for the time being.
