### PR TITLE
Adds a Parquet example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -976,7 +976,8 @@ lazy val `scio-examples`: Project = project
     `scio-sql`,
     `scio-test` % "compile->test",
     `scio-smb`,
-    `scio-redis`
+    `scio-redis`,
+    `scio-parquet`
   )
 
 lazy val `scio-repl`: Project = project

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
@@ -74,7 +74,7 @@ object ParquetExample {
 
       // The result Account records are not complete Avro objects. Only the projected columns are present while the rest are null.
       // These objects may fail serialization and it’s recommended that you map them out to tuples or case classes right after reading.
-      .map(x => AccountOutput(x.getId(), x.getName().toString()))
+      .map(x => AccountOutput(x.getId(), x.getName.toString))
 
       // This case class can now be saved as a parquet file
       // numShards should be explicitly set so that the size of each output file is smaller than

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Example: Read and Write specific and generic Avro records
+// Usage:
+
+// `sbt "runMain com.spotify.scio.examples.extra.ParquetExample
+// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --input=[INPUT].parquet --output=[OUTPUT].parquet --method=[METHOD]"`
+package com.spotify.scio.examples.extra
+
+import com.spotify.scio._
+import com.spotify.scio.parquet.avro._
+import com.spotify.scio.parquet.types._
+import com.spotify.scio.avro.Account
+import com.spotify.scio.io.ClosedTap
+import org.apache.hadoop.conf.Configuration
+import org.apache.avro.generic.GenericRecord
+
+object ParquetExample {
+
+  case class AccountInput(id: Int, `type`: String, name: String, amount: Double)
+
+  case class AccountOutput(id: Int, name: String)
+
+  def main(cmdlineArgs: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(cmdlineArgs)
+
+    val m = args("method")
+    m match {
+      // Read Parquet files as Specific Avro Records
+      case "avroSpecific" => avroSpecific(sc, args)
+
+      // Read Parquet files as Generic Avro Records
+      case "avroGeneric" => avroGeneric(sc, args)
+
+      // Read Parquet files as Scala Case Classes
+      case "caseClass" => caseClass(sc, args)
+
+      case _ => throw new RuntimeException(s"Invalid method $m")
+    }
+
+    sc.run()
+    ()
+  }
+
+  private def avroSpecific(sc: ScioContext, args: Args): ClosedTap[AccountOutput] = {
+    
+    // Account is an Avro Specific record. The avsc schema for the same can be found in scio-schemas/src/main/avro/schema.avsc
+    // Macros for generating column projections and row predicates
+    val projection = Projection[Account](_.getId, _.getName, _.getAmount) // Only these columns will be projected
+    val predicate = Predicate.build[Account](x => x.getAmount > 0) // Will skip row groups where this column value check is not satisfied
+
+    sc.parquetAvroFile[Account](args("input"), projection, predicate.parquet)
+      // filter natively with the same logic in case of mock input in tests
+      .filter(predicate.native)
+
+      // The result Account records are not complete Avro objects. Only the projected columns are present while the rest are null. 
+      // These objects may fail serialization and it’s recommended that you map them out to tuples or case classes right after reading.
+      .map(x => AccountOutput(x.getId(), x.getName().toString()))
+
+      // This case class can now be saved as a parquet file
+      .saveAsTypedParquetFile(args("output"), conf = fineTunedParquetWriterConfig())
+  }
+
+  private def avroGeneric(sc: ScioContext, args: Args): ClosedTap[AccountOutput] = {
+
+    // Now the fields in Account's schema act as our projection
+    sc.parquetAvroFile[GenericRecord](args("input"), Account.getClassSchema)
+
+      // GenericRecord objects are also not Serializable.
+      // Map out projected fields into something type safe
+      .map(r => AccountOutput(r.get("id").asInstanceOf[Int], r.get("name").toString))
+      // This case class can now be saved as a parquet file
+      .saveAsTypedParquetFile(args("output")) // passing writer configuration is optional but recommended
+  }
+
+  private def caseClass(sc: ScioContext, args: Args): ClosedTap[Account] = {
+    
+    // All fields in the case class definition act as our projection
+    sc.typedParquetFile[AccountInput](args("input"))
+
+      // We can also save the result as Parquet Avro files
+      .map(x => Account.newBuilder()
+                  .setId(x.id)
+                  .setType(x.`type`)
+                  .setName(x.name)
+                  .setAmount(x.amount)
+                  .build())
+      .saveAsParquetAvroFile(args("output"))
+    
+  }
+
+  // See this link for parquet writer tuning https://spotify.github.io/scio/io/Parquet.html#performance-tuning
+  private def fineTunedParquetWriterConfig(): Configuration = {
+    val conf: Configuration = new Configuration()
+    conf.setInt("parquet.block.size", 1073741824) // 1 * 1024 * 1024 * 1024 = 1 GiB
+    conf.set("fs.gs.inputstream.fadvise", "RANDOM")
+    conf
+  }
+}

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
@@ -68,7 +68,7 @@ object ParquetExample {
       case _ => throw new RuntimeException(s"Invalid method $m")
     }
 
-    sc.run().waitUntilDone()
+    sc.run()
     ()
   }
 
@@ -86,7 +86,6 @@ object ParquetExample {
       // The result Account records are not complete Avro objects. Only the projected columns are present while the rest are null.
       // These objects may fail serialization and it’s recommended that you map them out to tuples or case classes right after reading.
       .map(x => AccountOutput(x.getId, x.getName.toString))
-      .map(_.toString)
       .saveAsTextFile(args("output"))
   }
 
@@ -94,16 +93,13 @@ object ParquetExample {
     // Now the fields in Account's schema act as our projection
     sc.parquetAvroFile[GenericRecord](args("input"), Account.getClassSchema)
 
-      // GenericRecord objects are also not Serializable.
       // Map out projected fields into something type safe
       .map(r => AccountOutput(r.get("id").asInstanceOf[Int], r.get("name").toString))
-      .map(_.toString)
       .saveAsTextFile(args("output"))
 
   private def typedIn(sc: ScioContext, args: Args): ClosedTap[String] =
     // All fields in the case class definition act as our projection
     sc.typedParquetFile[AccountInput](args("input"))
-      .map(_.toString)
       .saveAsTextFile(args("output"))
 
   private def dummyData(sc: ScioContext): SCollection[Account] =

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Spotify AB.
+ * Copyright 2021 Spotify AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@
 
 // Example: Read and Write specific and generic Avro records
 // Usage:
-
 // `sbt "runMain com.spotify.scio.examples.extra.ParquetExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[ZONE]
 // --input=[INPUT].parquet --output=[OUTPUT].parquet --method=[METHOD]"`
 package com.spotify.scio.examples.extra
 
 import com.spotify.scio._
 import com.spotify.scio.parquet.avro._
 import com.spotify.scio.parquet.types._
+import com.spotify.scio.values.SCollection
 import com.spotify.scio.avro.Account
 import com.spotify.scio.io.ClosedTap
 import org.apache.hadoop.conf.Configuration
@@ -37,19 +37,33 @@ object ParquetExample {
 
   case class AccountOutput(id: Int, name: String)
 
+  // See this link for parquet writer tuning https://spotify.github.io/scio/io/Parquet.html#performance-tuning
+  lazy val fineTunedParquetWriterConfig: Configuration = {
+    val conf: Configuration = new Configuration()
+    conf.setInt("parquet.block.size", 1073741824) // 1 * 1024 * 1024 * 1024 = 1 GiB
+    conf.set("fs.gs.inputstream.fadvise", "RANDOM")
+    conf
+  }
+
   def main(cmdlineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdlineArgs)
 
     val m = args("method")
     m match {
       // Read Parquet files as Specific Avro Records
-      case "avroSpecific" => avroSpecific(sc, args)
+      case "avroSpecificIn" => avroSpecificIn(sc, args)
 
       // Read Parquet files as Generic Avro Records
-      case "avroGeneric" => avroGeneric(sc, args)
+      case "avroGenericIn" => avroGenericIn(sc, args)
 
       // Read Parquet files as Scala Case Classes
-      case "caseClass" => caseClass(sc, args)
+      case "typedIn" => typedIn(sc, args)
+
+      // Write dummy Parquet Avro records
+      case "avroOut" => avroOut(sc, args)
+
+      // Write dummy Parquet records using case classes
+      case "typedOut" => typedOut(sc, args)
 
       case _ => throw new RuntimeException(s"Invalid method $m")
     }
@@ -58,7 +72,7 @@ object ParquetExample {
     ()
   }
 
-  private def avroSpecific(sc: ScioContext, args: Args): ClosedTap[AccountOutput] = {
+  private def avroSpecificIn(sc: ScioContext, args: Args): ClosedTap[String] = {
 
     // Account is an Avro Specific record. The avsc schema for the same can be found in scio-schemas/src/main/avro/schema.avsc
     // Macros for generating column projections and row predicates
@@ -75,51 +89,53 @@ object ParquetExample {
       // The result Account records are not complete Avro objects. Only the projected columns are present while the rest are null.
       // These objects may fail serialization and it’s recommended that you map them out to tuples or case classes right after reading.
       .map(x => AccountOutput(x.getId(), x.getName.toString))
-
-      // This case class can now be saved as a parquet file
-      // numShards should be explicitly set so that the size of each output file is smaller than
-      // but close to `parquet.block.size`, i.e. 1 GiB. This guarantees that each file contains 1 row group only and reduces seeks.
-      .saveAsTypedParquetFile(args("output"), numShards = 5, conf = fineTunedParquetWriterConfig())
+      .map(_.toString)
+      .saveAsTextFile(args("output"))
   }
 
-  private def avroGeneric(sc: ScioContext, args: Args): ClosedTap[AccountOutput] = {
-
+  private def avroGenericIn(sc: ScioContext, args: Args): ClosedTap[String] =
     // Now the fields in Account's schema act as our projection
     sc.parquetAvroFile[GenericRecord](args("input"), Account.getClassSchema)
 
       // GenericRecord objects are also not Serializable.
       // Map out projected fields into something type safe
       .map(r => AccountOutput(r.get("id").asInstanceOf[Int], r.get("name").toString))
+      .map(_.toString)
+      .saveAsTextFile(args("output"))
+
+  private def typedIn(sc: ScioContext, args: Args): ClosedTap[String] =
+    // All fields in the case class definition act as our projection
+    sc.typedParquetFile[AccountInput](args("input"))
+      .map(_.toString)
+      .saveAsTextFile(args("output"))
+
+  private def dummyData(sc: ScioContext): SCollection[Account] =
+    // Generating some dummy data and creating an SCollection of spcific Avro records
+    sc.parallelize(1 to 100)
+      .map(i =>
+        Account
+          .newBuilder()
+          .setId(i)
+          .setType(if (i % 3 == 0) "current" else "checking")
+          .setName(s"account $i")
+          .setAmount(i.toDouble)
+          .build()
+      )
+
+  private def avroOut(sc: ScioContext, args: Args): ClosedTap[Account] =
+    dummyData(sc)
+
+      // numShards should be explicitly set so that the size of each output file is smaller than
+      // but close to `parquet.block.size`, i.e. 1 GiB. This guarantees that each file contains 1 row group only and reduces seeks.
+      .saveAsParquetAvroFile(args("output"), numShards = 1, conf = fineTunedParquetWriterConfig)
+
+  private def typedOut(sc: ScioContext, args: Args): ClosedTap[AccountOutput] =
+    dummyData(sc)
+      .map(x => AccountOutput(x.getId, x.getName.toString))
+
       // This case class can now be saved as a parquet file
       .saveAsTypedParquetFile(
         args("output")
       ) // passing writer configuration is optional but recommended
-  }
 
-  private def caseClass(sc: ScioContext, args: Args): ClosedTap[Account] = {
-
-    // All fields in the case class definition act as our projection
-    sc.typedParquetFile[AccountInput](args("input"))
-
-      // We can also save the result as Parquet Avro files
-      .map(x =>
-        Account
-          .newBuilder()
-          .setId(x.id)
-          .setType(x.`type`)
-          .setName(x.name)
-          .setAmount(x.amount)
-          .build()
-      )
-      .saveAsParquetAvroFile(args("output"))
-
-  }
-
-  // See this link for parquet writer tuning https://spotify.github.io/scio/io/Parquet.html#performance-tuning
-  private def fineTunedParquetWriterConfig(): Configuration = {
-    val conf: Configuration = new Configuration()
-    conf.setInt("parquet.block.size", 1073741824) // 1 * 1024 * 1024 * 1024 = 1 GiB
-    conf.set("fs.gs.inputstream.fadvise", "RANDOM")
-    conf
-  }
 }

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
@@ -42,7 +42,7 @@ class ParquetExampleTest extends PipelineSpec {
       Seq(new Account(1, "checking", "Alice", 1000.0), new Account(2, "checking", "Bob", 1500.0))
 
     val expected = input
-      .map(x => AccountOutput(x.getId(), x.getName.toString))
+      // .map(x => AccountOutput(x.getId(), x.getName.toString))
       .map(_.toString)
 
     JobTest[com.spotify.scio.examples.extra.ParquetExample.type]

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
@@ -28,7 +28,7 @@ class ParquetExampleTest extends PipelineSpec {
     val input =
       Seq(new Account(1, "checking", "Alice", 1000.0), new Account(2, "checking", "Bob", 1500.0))
 
-    val expected = input.map(_.toString)
+    val expected = input.map(x => AccountOutput(x.getId(), x.getName.toString))
 
     JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
       .args("--input=in.parquet", "--output=out.parquet", "--method=avroSpecific")

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
@@ -1,0 +1,41 @@
+package com.spotify.scio.examples.extra
+
+/*
+ * Copyright 2019 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.spotify.scio.avro.Account
+import com.spotify.scio.examples.extra.ParquetExample.AccountOutput
+import com.spotify.scio.testing.PipelineSpec
+import com.spotify.scio.parquet.avro.ParquetAvroIO
+import com.spotify.scio.parquet.types.ParquetTypeIO
+
+class ParquetExampleTest extends PipelineSpec {
+  "ParquetExample" should "work for specific input" in {
+    val input =
+      Seq(new Account(1, "checking", "Alice", 1000.0), new Account(2, "checking", "Bob", 1500.0))
+
+    val expected = input.map(_.toString)
+
+    JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
+      .args("--input=in.parquet", "--output=out.parquet", "--method=avroSpecific")
+      .input(ParquetAvroIO[Account]("in.parquet"), input)
+      .output(ParquetTypeIO[AccountOutput]("out.parquet"))(coll =>
+        coll should containInAnyOrder(expected)
+      )
+      .run()
+  }
+}

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
@@ -18,24 +18,74 @@ package com.spotify.scio.examples.extra
  */
 
 import com.spotify.scio.avro.Account
-import com.spotify.scio.examples.extra.ParquetExample.AccountOutput
+import com.spotify.scio.examples.extra.ParquetExample.{AccountInput, AccountOutput}
 import com.spotify.scio.testing.PipelineSpec
-import com.spotify.scio.parquet.avro.ParquetAvroIO
-import com.spotify.scio.parquet.types.ParquetTypeIO
+import com.spotify.scio.parquet.avro._
+import com.spotify.scio.parquet.types._
+import com.spotify.scio.io.TextIO
 
 class ParquetExampleTest extends PipelineSpec {
+
+  lazy val dummyData: IndexedSeq[Account] = (1 to 100)
+    .map(i =>
+      Account
+        .newBuilder()
+        .setId(i)
+        .setType(if (i % 3 == 0) "current" else "checking")
+        .setName(s"account $i")
+        .setAmount(i.toDouble)
+        .build()
+    )
+
   "ParquetExample" should "work for specific input" in {
     val input =
       Seq(new Account(1, "checking", "Alice", 1000.0), new Account(2, "checking", "Bob", 1500.0))
 
-    val expected = input.map(x => AccountOutput(x.getId(), x.getName.toString))
+    val expected = input
+      .map(x => AccountOutput(x.getId(), x.getName.toString))
+      .map(_.toString)
 
     JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
-      .args("--input=in.parquet", "--output=out.parquet", "--method=avroSpecific")
+      .args("--input=in.parquet", "--output=out.txt", "--method=avroSpecificIn")
       .input(ParquetAvroIO[Account]("in.parquet"), input)
+      .output(TextIO("out.txt"))(coll => coll should containInAnyOrder(expected))
+      .run()
+  }
+
+  "ParquetExample" should "work for typed input" in {
+    val input =
+      Seq(AccountInput(1, "checking", "Alice", 1000.0), AccountInput(2, "checking", "Bob", 1500.0))
+
+    val expected = input.map(_.toString)
+
+    JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
+      .args("--input=in.parquet", "--output=out.txt", "--method=typedIn")
+      .input(ParquetTypeIO[AccountInput]("in.parquet"), input)
+      .output(TextIO("out.txt"))(coll => coll should containInAnyOrder(expected))
+      .run()
+  }
+
+  "ParquetExample" should "work for specific output" in {
+    val expected = dummyData
+
+    JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
+      .args("--output=out.parquet", "--method=avroOut")
+      .output(ParquetAvroIO[Account]("out.parquet"))(coll =>
+        coll should containInAnyOrder(expected)
+      )
+      .run()
+  }
+
+  "ParquetExample" should "work for typed output" in {
+    val expected = dummyData
+      .map(x => AccountOutput(x.getId, x.getName.toString))
+
+    JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
+      .args("--output=out.parquet", "--method=typedOut")
       .output(ParquetTypeIO[AccountOutput]("out.parquet"))(coll =>
         coll should containInAnyOrder(expected)
       )
       .run()
   }
+
 }


### PR DESCRIPTION
This serves as an example for Reading and Writing `parquet` files.
- Followed [this documentation](https://spotify.github.io/scio/io/Parquet.html)
- Corresponding issue: #3851 
