### PR TITLE
(fix #3913) parquet-avro TestIO includes map function

### DIFF
--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
@@ -42,7 +42,7 @@ class ParquetExampleTest extends PipelineSpec {
       Seq(new Account(1, "checking", "Alice", 1000.0), new Account(2, "checking", "Bob", 1500.0))
 
     val expected = input
-      // .map(x => AccountOutput(x.getId(), x.getName.toString))
+      .map(x => AccountOutput(x.getId(), x.getName.toString))
       .map(_.toString)
 
     JobTest[com.spotify.scio.examples.extra.ParquetExample.type]

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
@@ -21,7 +21,7 @@ import java.io.File
 import com.spotify.scio._
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.avro._
-import com.spotify.scio.io.TapSpec
+import com.spotify.scio.io.{TapSpec, TextIO}
 import com.spotify.scio.testing._
 import com.spotify.scio.values.{SCollection, WindowOptions}
 import org.apache.avro.generic.GenericRecord
@@ -274,5 +274,27 @@ class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
       sc.run()
     }
 
+  }
+
+  it should "apply map functions to test input" in {
+    JobTest[ParquetTestJob.type]
+      .args("--input=input", "--output=output")
+      .input(
+        ParquetAvroIO[Account]("input"),
+        List(Account.newBuilder().setId(1).setName("foo").setType("bar").setAmount(2.0).build())
+      )
+      .output(TextIO("output"))(_ should containSingleValue(("foo", 10.0).toString))
+      .run()
+  }
+}
+
+object ParquetTestJob {
+  def main(cmdLineArgs: Array[String]): Unit = {
+    val (sc, args) = ContextAndArgs(cmdLineArgs)
+    sc
+      .parquetAvroFile[Account](args("input"), projection = Projection[Account](_.getName))
+      .map(a => (a.getName.toString, 10.0))
+      .saveAsTextFile(args("output"))
+    sc.run().waitUntilDone()
   }
 }

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
@@ -292,7 +292,10 @@ object ParquetTestJob {
   def main(cmdLineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdLineArgs)
     sc
-      .parquetAvroFile[Account](args("input"), projection = Projection[Account](_.getName, _.getAmount))
+      .parquetAvroFile[Account](
+        args("input"),
+        projection = Projection[Account](_.getName, _.getAmount)
+      )
       .map(a => (a.getName.toString, a.getAmount))
       .saveAsTextFile(args("output"))
     sc.run().waitUntilDone()

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
@@ -283,7 +283,7 @@ class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
         ParquetAvroIO[Account]("input"),
         List(Account.newBuilder().setId(1).setName("foo").setType("bar").setAmount(2.0).build())
       )
-      .output(TextIO("output"))(_ should containSingleValue(("foo", 10.0).toString))
+      .output(TextIO("output"))(_ should containSingleValue(("foo", 2.0).toString))
       .run()
   }
 }
@@ -292,8 +292,8 @@ object ParquetTestJob {
   def main(cmdLineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdLineArgs)
     sc
-      .parquetAvroFile[Account](args("input"), projection = Projection[Account](_.getName))
-      .map(a => (a.getName.toString, 10.0))
+      .parquetAvroFile[Account](args("input"), projection = Projection[Account](_.getName, _.getAmount))
+      .map(a => (a.getName.toString, a.getAmount))
       .saveAsTextFile(args("output"))
     sc.run().waitUntilDone()
   }


### PR DESCRIPTION
the way `ParquetAvroIO` is implemented incorporates the subsequently supplied `map` function into the ScioIO itself ([as the projection function](https://github.com/spotify/scio/blob/main/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/syntax/ScioContextSyntax.scala#L70)), so it gets ignored in `JobTest`, which can be confusing/counterintuitive for users. this PR overrides `readTest` to apply the mapping function directly to the test input.