### PR TITLE
Get rid of an Iterable re-iteration twice in the asMapSingletonSideInput

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -1013,8 +1013,10 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
       .transform(
         _.groupByKey
           .map { kv =>
-            require(kv._2.size == 1, s"Multiple values for key ${kv._1}")
-            (kv._1, kv._2.head)
+            val iter = kv._2.iterator
+            val head = iter.next()
+            require(iter.isEmpty, s"Multiple values for key ${kv._1}")
+            (kv._1, head)
           }
           .groupBy(_ => ())
           .map(_._2.toMap)


### PR DESCRIPTION
The current implementation of the `asMapSingletonSideInput` iterates the same `Iterable` in the `groupBy` twice by calling `size` first and then subsequently `head`. While this works just fine with Dataflow it miserable fails on Flink with the following exception:

```
Caused by: java.lang.IllegalStateException: GBK result is not re-iterable. You can enable re-iterations by setting '--reIterableGroupByKeyResult'.
	at org.apache.beam.runners.flink.translation.functions.FlinkNonMergingReduceFunction$OnceIterable.iterator(FlinkNonMergingReduceFunction.java:64)
	at scala.collection.convert.Wrappers$JIterableWrapper.iterator(Wrappers.scala:55)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at scala.collection.TraversableOnce.size(TraversableOnce.scala:139)
	at scala.collection.TraversableOnce.size$(TraversableOnce.scala:129)
	at scala.collection.AbstractTraversable.size(Traversable.scala:108)
	at com.spotify.data.example.BrownieRecsJob$.$anonfun$asMapSingletonSideInput$2(BrownieRecsJob.scala:42)
	at com.spotify.scio.util.Functions$$anon$7.processElement(Functions.scala:263)
```

Effectively this blocks usage of the `asMapSingletonSideInput` on Flink.