### PR TITLE
(fix #3912) fix unionAll withName issue

### DIFF
--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -21,6 +21,7 @@ import java.io.PrintStream
 import java.nio.file.Files
 
 import com.google.api.client.util.Charsets
+import com.spotify.scio.ScioContext
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.util.MockedPrintStream
 import com.spotify.scio.util.random.RandomSamplerUtils
@@ -833,6 +834,27 @@ class SCollectionTest extends PipelineSpec {
       val result = CoderUtils.decodeFromByteArray(beamCoder, bytes)
 
       result.l shouldBe testAInstance.l
+    }
+  }
+
+  it should "name unionAll transforms" in {
+    val input1: List[Int] = (1 to 10).toList
+    val input2: List[Int] = (11 to 20).toList
+    val sc = ScioContext.forTest()
+
+    noException shouldBe thrownBy {
+      sc
+        .withName("Test Union Name")
+        .unionAll(
+          Seq(
+            sc
+              .withName("Input A")
+              .parallelize(input1),
+            sc
+              .withName("Input B")
+              .parallelize(input2)
+          )
+        )
     }
   }
 

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -121,6 +121,25 @@ class SCollectionTest extends PipelineSpec {
     runWithContext(sc => sc.unionAll(List[SCollection[Unit]]()) should beEmpty)
   }
 
+  it should "support unionAll() with named transforms" in {
+    val sc = ScioContext.forTest()
+
+    noException shouldBe thrownBy {
+      sc
+        .withName("Test Union Name")
+        .unionAll(
+          Seq(
+            sc
+              .withName("Input A")
+              .parallelize(1 to 10),
+            sc
+              .withName("Input B")
+              .parallelize(11 to 20)
+          )
+        )
+    }
+  }
+
   it should "support ++ operator" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq("a", "b", "c"))
@@ -834,27 +853,6 @@ class SCollectionTest extends PipelineSpec {
       val result = CoderUtils.decodeFromByteArray(beamCoder, bytes)
 
       result.l shouldBe testAInstance.l
-    }
-  }
-
-  it should "name unionAll transforms" in {
-    val input1: List[Int] = (1 to 10).toList
-    val input2: List[Int] = (11 to 20).toList
-    val sc = ScioContext.forTest()
-
-    noException shouldBe thrownBy {
-      sc
-        .withName("Test Union Name")
-        .unionAll(
-          Seq(
-            sc
-              .withName("Input A")
-              .parallelize(input1),
-            sc
-              .withName("Input B")
-              .parallelize(input2)
-          )
-        )
     }
   }
 


### PR DESCRIPTION
because of the order of evaluation, @sisidra 's example from #3912 was effectively calling multiple `.withName`s in a row and leading to a conflict:

```scala
sc.withName("Input/union")
  .unionAll(
      Seq(
        sc.withName("Input/a").textFile("a.txt"),
         sc.withName("Input/b").textFile("b.txt")
      )
  )

=>
java.lang.IllegalArgumentException: requirement failed: withName() has already been used to set 'Input/union' as the name for the next transform.
  at scala.Predef$.require(Predef.scala:281)
  at com.spotify.scio.values.TransformNameable.withName(TransformNameable.scala:41)
  at com.spotify.scio.values.TransformNameable.withName$(TransformNameable.scala:38)
  at com.spotify.scio.ScioContext.withName(ScioContext.scala:496)
  ... 31 elided
```

 It's also resolvable by just extracting the sequence of unioned inputs:

```scala
val inputs = Seq(sc.withName("Input/a").textFile("a.txt"), sc.withName("Input/b").textFile("b.txt"))
sc.withName("Input/union")
  .unionAll(inputs)
```

Because this is a pretty common use case for `unionAll` I thought it was reasonable enough to fix the issue by making its `Iterable[SCollection[T]` argument lazily evaluated. 🤷‍♀️ 