### PR TITLE
Add outputParallelization for JdbcReadOptions

### DIFF
--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcIO.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcIO.scala
@@ -36,7 +36,7 @@ object JdbcIO {
     }
 
   private[jdbc] def jdbcIoId(opts: JdbcIoOptions): String = opts match {
-    case JdbcReadOptions(connOpts, query, _, _, _) => jdbcIoId(connOpts, query)
+    case JdbcReadOptions(connOpts, query, _, _, _, _) => jdbcIoId(connOpts, query)
     case JdbcWriteOptions(connOpts, statement, _, _, _, _) =>
       jdbcIoId(connOpts, statement)
   }
@@ -80,6 +80,8 @@ final case class JdbcSelect[T: Coder](readOptions: JdbcReadOptions[T]) extends J
         override def mapRow(resultSet: ResultSet): T =
           readOptions.rowMapper(resultSet)
       })
+      .withOutputParallelization(readOptions.outputParallelization)
+
     if (readOptions.statementPreparator != null) {
       transform = transform
         .withStatementPreparator(new beam.JdbcIO.StatementPreparator {

--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcOptions.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcOptions.scala
@@ -17,9 +17,9 @@
 
 package com.spotify.scio.jdbc
 
-import java.sql.{Driver, PreparedStatement, ResultSet, SQLException}
-
 import org.apache.beam.sdk.io.jdbc.JdbcIO.{DefaultRetryStrategy, RetryConfiguration}
+
+import java.sql.{Driver, PreparedStatement, ResultSet, SQLException}
 
 /**
  * Options for a JDBC connection.
@@ -47,6 +47,7 @@ object JdbcIoOptions {
     BeamDefaultMaxRetryDelay,
     BeamDefaultInitialRetryDelay
   )
+  private[jdbc] val DefaultOutputParallelization = true
 }
 
 sealed trait JdbcIoOptions
@@ -54,18 +55,20 @@ sealed trait JdbcIoOptions
 /**
  * Options for reading from a JDBC source.
  *
- * @param connectionOptions   connection options
- * @param query               query string
- * @param statementPreparator function to prepare a [[java.sql.PreparedStatement]]
- * @param rowMapper           function to map from a SQL [[java.sql.ResultSet]] to `T`
- * @param fetchSize           use apache beam default fetch size if the value is -1
+ * @param connectionOptions     connection options
+ * @param query                 query string
+ * @param statementPreparator   function to prepare a [[java.sql.PreparedStatement]]
+ * @param rowMapper             function to map from a SQL [[java.sql.ResultSet]] to `T`
+ * @param fetchSize             use apache beam default fetch size if the value is -1
+ * @param outputParallelization reshuffle result to distribute it to all workers. Default to true.
  */
 final case class JdbcReadOptions[T](
   connectionOptions: JdbcConnectionOptions,
   query: String,
   statementPreparator: PreparedStatement => Unit = null,
   rowMapper: ResultSet => T,
-  fetchSize: Int = JdbcIoOptions.BeamDefaultFetchSize
+  fetchSize: Int = JdbcIoOptions.BeamDefaultFetchSize,
+  outputParallelization: Boolean = JdbcIoOptions.DefaultOutputParallelization
 ) extends JdbcIoOptions
 
 /**


### PR DESCRIPTION
### What
Be able to set `outputParallelization` to false
 https://github.com/apache/beam/pull/7956

### Why
In some cases, reshuffling step after a JDBC read is not necessary: very small dataset or we know that a shuffle will occur right after the JDBC read.

