### PR TITLE
explicitly set coders.tableRowCoder in BQ write

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -23,6 +23,7 @@ import com.spotify.scio.bigquery.BigQueryTyped.BeamSchema.{WriteParam => TypedWr
 import com.spotify.scio.bigquery.TableRowJsonIO.{WriteParam => TableRowJsonWriteParam}
 import com.spotify.scio.bigquery.types.BigQueryType.HasAnnotation
 import com.spotify.scio.bigquery.{BigQueryTyped, TableRow, TableRowJsonIO, TimePartitioning}
+import com.spotify.scio.bigquery.coders
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.io._
 import com.spotify.scio.values.SCollection
@@ -61,13 +62,10 @@ final class SCollectionTableRowOps[T <: TableRow](private val self: SCollection[
         tableDescription,
         timePartitioning
       )
-
     self
       .covary[TableRow]
       .write(
-        BigQueryTypedTable(table, Format.TableRow)(
-          self.coder.asInstanceOf[Coder[TableRow]]
-        )
+        BigQueryTypedTable(table, Format.TableRow)(coders.tableRowCoder)
       )(param)
   }
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -62,6 +62,7 @@ final class SCollectionTableRowOps[T <: TableRow](private val self: SCollection[
         tableDescription,
         timePartitioning
       )
+
     self
       .covary[TableRow]
       .write(


### PR DESCRIPTION
What's happening is the implicit BQ coder instances are not in scope so a fallback `genericJsonCoder` is being selected over the specific, correct Beam `TableRowJsonCoder`. We do this in a few other places in Scio's BQ package, i.e. [here](https://github.com/spotify/scio/blob/be7166c58450bd59ae5d0048d39ef3ea0d5ed107/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala#L265): 

```scala
  private[this] def tableRow(table: Table): BigQueryTypedTable[TableRow] =
    BigQueryTypedTable(
      beam.BigQueryIO.readTableRows(),
      beam.BigQueryIO.writeTableRows(),
      table,
      BigQueryUtils.convertGenericRecordToTableRow(_, _)
    )(coders.tableRowCoder)
```