### PR TITLE
(fix #3944) ToTable implements selectedFields

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -195,6 +195,14 @@ private[types] object TypeProvider {
           desc.headOption.map(d => q"override def tableDescription: _root_.java.lang.String = $d")
         val defToPrettyString =
           q"override def toPrettyString(indent: Int = 0): String = ${p(c, s"$SBQ.types.SchemaUtil")}.toPrettyString(this.schema, ${cName.toString}, indent)"
+
+        val fieldValNames = fields.flatMap {
+          case ValDef(_, name, _, _) => Some(name.toString)
+          case _                     => None
+        }
+        val defSelectedFields =
+          q"def selectedFields: _root_.scala.List[_root_.java.lang.String] = $fieldValNames"
+
         val fnTrait =
           tq"${TypeName(s"Function${fields.size}")}[..${fields.map(_.children.head)}, $cName]"
         val traits = (if (fields.size <= 22) Seq(fnTrait) else Seq()) ++ defTblDesc
@@ -225,7 +233,7 @@ private[types] object TypeProvider {
             ${companion(c)(
             cName,
             traits,
-            Seq(defSchema, defAvroSchema, defToPrettyString) ++ defTblDesc,
+            Seq(defSchema, defAvroSchema, defToPrettyString, defSelectedFields) ++ defTblDesc,
             taggedFields.asInstanceOf[Seq[Tree]].size,
             maybeCompanion
           )}

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -196,12 +196,10 @@ private[types] object TypeProvider {
         val defToPrettyString =
           q"override def toPrettyString(indent: Int = 0): String = ${p(c, s"$SBQ.types.SchemaUtil")}.toPrettyString(this.schema, ${cName.toString}, indent)"
 
-        val fieldValNames = fields.flatMap {
-          case ValDef(_, name, _, _) => Some(name.toString)
-          case _                     => None
-        }
         val defSelectedFields =
-          q"def selectedFields: _root_.scala.List[_root_.java.lang.String] = $fieldValNames"
+          q"def selectedFields: _root_.scala.List[_root_.java.lang.String] = ${fields.map {
+            case ValDef(_, fname, _, _) => fname.toString
+          }}"
 
         val fnTrait =
           tq"${TypeName(s"Function${fields.size}")}[..${fields.map(_.children.head)}, $cName]"

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
@@ -32,6 +32,9 @@ object TypeProviderTest {
   @BigQueryType.toTable
   case class RefinedClass(a1: Int)
 
+  @BigQueryType.toTable
+  case class ToTable(f1: Long, f2: Double, f3: Boolean, f4: String, f5: Instant)
+
   @BigQueryType.fromSchema("""
       |{"fields": [{"mode": "REQUIRED", "name": "f1", "type": "INTEGER"}]}
       |""".stripMargin)
@@ -319,9 +322,6 @@ class TypeProviderTest extends AnyFlatSpec with Matchers {
   }
 
   @BigQueryType.toTable
-  case class ToTable(f1: Long, f2: Double, f3: Boolean, f4: String, f5: Instant)
-
-  @BigQueryType.toTable
   case class Record(f1: Int, f2: String)
 
   "BigQueryType.toTable" should "support .tupled in companion object" in {
@@ -343,7 +343,7 @@ class TypeProviderTest extends AnyFlatSpec with Matchers {
   }
 
   it should "support .selectedFields in companion object" in {
-    BigQueryType[RefinedClass].selectedFields shouldBe Some(List("a1"))
+    BigQueryType[ToTable].selectedFields shouldBe Some(List("f1", "f2", "f3", "f4", "f5"))
   }
 
   it should "create companion object that is a Function subtype" in {

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
@@ -342,6 +342,10 @@ class TypeProviderTest extends AnyFlatSpec with Matchers {
     (classOf[ToTable => TableRow] isAssignableFrom ToTable.toTableRow.getClass) shouldBe true
   }
 
+  it should "support .selectedFields in companion object" in {
+    BigQueryType[RefinedClass].selectedFields shouldBe Some(List("a1"))
+  }
+
   it should "create companion object that is a Function subtype" in {
     val cls5 =
       classOf[Function5[Long, Double, Boolean, String, Instant, ToTable]]


### PR DESCRIPTION
spotify/scio#3944

offers limited BQ Storage support for `BigQueryType.ToTable` for users who don't want to use the credential-required `BigQueryType.FromStorage`. it's limited in that it simply limits the data returned by the API call to the fields specified in the case class; doesn't support row restriction; since as-is, users can already use `typedBigQueryStorage` with a `BigQueryType.ToTable`-annotated class, I think this is reasonable to add as it just makes an already-existing functionality more efficient.

verified with a unit test & by running scio-examples jobs on real BQ data, to verify that only the selected fields are getting read.