### PR TITLE
Remove printstacktrace in Coders

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -623,7 +623,6 @@ private[coders] object CoderStackTrace {
     additionalMessage: Option[String],
     baseStack: Array[StackTraceElement]
   ): T = {
-    cause.printStackTrace()
     val messageItem = additionalMessage.map { msg =>
       new StackTraceElement(s"Due to $msg", "", "", 0)
     }


### PR DESCRIPTION
There's no reason to print a stacktrace here.