### PR TITLE
Set max heap size for the docs generating workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,7 @@ jobs:
         run: sbt scio-examples/compile site/makeSite
         env:
           SOCCO: true
+          _JAVA_OPTIONS: "-Xmx1500m"
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:


### PR DESCRIPTION
The `deploy` workflow [has been failing](https://github.com/spotify/scio/runs/3505211764?check_suite_focus=true) on the step generating docs site with the OOM. Let's try to cap the max heap size and see if it will work.