### PR TITLE
Do not unwrap a wrapped Beam coder to avoid NPE

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
@@ -28,6 +28,7 @@ private[scio] object BeamCoders {
   @tailrec
   private def unwrap[T](coder: beam.Coder[T]): beam.Coder[T] =
     coder match {
+      case WrappedBCoder(c)         => unwrap(c)
       case c: LazyCoder[T]          => unwrap(c.bcoder)
       case c: beam.NullableCoder[T] => c.getValueCoder
       case _                        => coder

--- a/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
@@ -28,7 +28,6 @@ private[scio] object BeamCoders {
   @tailrec
   private def unwrap[T](coder: beam.Coder[T]): beam.Coder[T] =
     coder match {
-      case WrappedBCoder(c)         => unwrap(c)
       case c: LazyCoder[T]          => unwrap(c.bcoder)
       case c: beam.NullableCoder[T] => c.getValueCoder
       case _                        => coder

--- a/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
@@ -69,7 +69,7 @@ object CoderMaterializer {
         WrappedBCoder.create(
           nullCoder(
             o,
-            new RecordCoder(
+            RecordCoder(
               typeName,
               coders.map(c => c._1 -> nullCoder(o, beamImpl(o, c._2))),
               construct,

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
@@ -511,8 +511,6 @@ trait ScalaCoders {
 
   implicit def sortedSetCoder[T: Coder: Ordering]: Coder[SortedSet[T]] =
     Coder.transform(Coder[T])(bc => Coder.beam(new SortedSetCoder[T](bc)))
-
-  // implicit def enumerationCoder[E <: Enumeration]: Coder[E#Value] = ???
 }
 
 private[coders] object ScalaCoders extends ScalaCoders

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -22,7 +22,7 @@ import java.lang.{Boolean => JBoolean, Double => JDouble, Iterable => JIterable}
 import java.util.concurrent.ThreadLocalRandom
 
 import com.spotify.scio.ScioContext
-import com.spotify.scio.coders.{AvroBytesUtil, BeamCoders, Coder, CoderMaterializer, WrappedBCoder}
+import com.spotify.scio.coders.{AvroBytesUtil, BeamCoders, Coder, CoderMaterializer}
 import com.spotify.scio.estimators.{
   ApproxDistinctCounter,
   ApproximateUniqueCounter,

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -144,10 +144,8 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   def name: String = internal.getName
 
   /** Assign a Coder to this SCollection. */
-  def setCoder(coder: org.apache.beam.sdk.coders.Coder[T]): SCollection[T] = coder match {
-    case wc: WrappedBCoder[T] => context.wrap(internal.setCoder(wc.u))
-    case _                    => context.wrap(internal.setCoder(coder))
-  }
+  def setCoder(coder: org.apache.beam.sdk.coders.Coder[T]): SCollection[T] =
+    context.wrap(internal.setCoder(coder))
 
   def setSchema(schema: Schema[T])(implicit ct: ClassTag[T]): SCollection[T] =
     if (!internal.hasSchema) {


### PR DESCRIPTION
[Unwrapping](https://github.com/spotify/scio/blob/9b96f2819f83a561450c2588166833bacfe859e3/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala#L148) the [Wrapped Beam coder](https://github.com/spotify/scio/blob/9b96f2819f83a561450c2588166833bacfe859e3/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala#L246) coder might lead to NPE because the whole idea of wrapping a Beam coder was to avoid the issue with Beam trying to extract type parameters from anonymous classes. 

An example from [this issue](https://github.com/spotify/scio/issues/3895) applies `xmap` which creates an [anonymous instance of the Beam coder](https://github.com/spotify/scio/blob/9b96f2819f83a561450c2588166833bacfe859e3/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala#L484). `CoderMaterializer` wraps this anonymous class beam coder which subsequently is passed to `SCollection.setCoder` which unwraps it again and it leads to the NPE on attempt of Beam to validate coder compatibility. 

As an alternative solution, we can try to avoid Beam coders defined using Scala anonymous classes. This would also fix the issue. For the xmap, we can extract the anonymous coder to a `XmapCoder`: 

```scala
final case class XmapCoder[A, B](bc: BCoder[A], f: A => B, t: B => A) extends AtomicCoder[B] {
  override def encode(value: B, os: OutputStream): Unit =
    bc.encode(t(value), os)
  override def decode(is: InputStream): B =
    f(bc.decode(is))

  // delegate methods for determinism and equality checks
  override def verifyDeterministic(): Unit = bc.verifyDeterministic()
  override def consistentWithEquals(): Boolean = bc.consistentWithEquals()
  override def structuralValue(value: B): AnyRef =
    if (consistentWithEquals()) {
      value.asInstanceOf[AnyRef]
    } else {
      bc.structuralValue(t(value))
    }

  // delegate methods for byte size estimation
  override def isRegisterByteSizeObserverCheap(value: B): Boolean =
    bc.isRegisterByteSizeObserverCheap(t(value))
  override def registerByteSizeObserver(value: B, observer: ElementByteSizeObserver): Unit =
    bc.registerByteSizeObserver(t(value), observer)
}
```

This might fix the problem with `xmap`, but the same issue might pop in a different place. 