### PR TITLE
add unit test for Avro Source+PTransform serialization

### DIFF
--- a/scio-schemas/src/main/avro/schema.avsc
+++ b/scio-schemas/src/main/avro/schema.avsc
@@ -58,4 +58,19 @@
         {"name": "string_field", "type": ["null", "string"], "default": null},
         {"name": "array_field", "type": {"type": "array", "items": "string"}, "default": null}
     ]
+},
+{
+    "name": "StringFieldTest",
+    "namespace": "com.spotify.scio.avro",
+    "type": "record",
+    "doc": "Record for testing string decoding",
+    "fields": [
+        {"name": "strField", "type": ["null", "string"]},
+        {"name": "mapField", "type": [
+            "null", {"type": "map", "values": "string"}
+        ], "default": null},
+        {"name": "arrayField", "type": [
+            "null", {"type": "array", "items": "string"}
+        ], "default": null}
+    ]
 }]

--- a/scio-test/src/test/scala/com/spotify/scio/coders/AvroCoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/AvroCoderTest.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.coders
+
+import com.google.common.collect.{ImmutableList, ImmutableMap}
+import com.spotify.scio.ScioContext
+import com.spotify.scio.avro._
+import com.spotify.scio.avro.StringFieldTest
+import com.spotify.scio.testing.PipelineSpec
+import com.spotify.scio.values.SCollection
+import org.scalatest.BeforeAndAfterAll
+
+import java.nio.file.Files
+import scala.jdk.CollectionConverters._
+
+class AvroCoderTest extends PipelineSpec with BeforeAndAfterAll {
+
+  private lazy val tempFolder = {
+    val dir = Files.createTempDirectory(getClass.getSimpleName)
+    dir.toFile.deleteOnExit()
+    dir
+  }
+
+  // Write Avro source to local file system
+  override protected def beforeAll(): Unit = {
+    val sc = ScioContext()
+    sc
+      .parallelize(1 to 10)
+      .map(_ =>
+        StringFieldTest
+          .newBuilder()
+          .setStrField("someStr")
+          .setMapField(ImmutableMap.of("someKey", "someVal"))
+          .setArrayField(ImmutableList.of("someListVal"))
+          .build()
+      )
+      .saveAsAvroFile(tempFolder.toString)
+    sc.run()
+  }
+
+  // Verifies fix for BEAM-12628 Avro string encoding issue
+  "Avro SpecificRecords" should "be read and serialized using java String field representations" in {
+    def isJavaStr(t: Any): Boolean = {
+      t match {
+        case (k, v) =>
+          k.getClass == classOf[java.lang.String] && v.getClass == classOf[java.lang.String]
+        case v: Iterable[Any] => v.forall(isJavaStr)
+        case _                => t.getClass == classOf[java.lang.String]
+      }
+    }
+
+    val sc = ScioContext()
+    val data: SCollection[StringFieldTest] = sc
+      .avroFile[StringFieldTest](tempFolder.resolve("*.avro").toString)
+      .map(identity)
+
+    data should satisfy[StringFieldTest] { mappedData =>
+      mappedData.forall { record =>
+        isJavaStr(record.getStrField) &&
+        isJavaStr(record.getArrayField.asScala) && isJavaStr(record.getMapField.asScala)
+      }
+    }
+
+    sc.run()
+  }
+}

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -605,22 +605,6 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     new Moments(0.0, 0.0, 0.0, 0.0, 0.0) coderShould roundtrip()
     Moments(12) coderShould roundtrip()
   }
-
-  it should "deserialize Avro string fields as java.lang.Strings by default" in {
-    implicit val hasJavaStringType: Equality[Account] =
-      (roundtripped: Account, _: Any) =>
-        roundtripped.getName.getClass == classOf[
-          String
-        ] && roundtripped.getType.getClass == classOf[String]
-
-    Account
-      .newBuilder()
-      .setId(0)
-      .setType("foo")
-      .setName("bar")
-      .setAmount(1.0)
-      .build() coderShould roundtrip()
-  }
 }
 
 object RecursiveCase {

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -33,7 +33,6 @@ import scala.collection.{mutable => mut}
 import java.io.ByteArrayInputStream
 import org.apache.beam.sdk.testing.CoderProperties
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
-import com.spotify.scio.avro.Account
 import com.twitter.algebird.Moments
 
 final case class UserId(bytes: Seq[Byte])


### PR DESCRIPTION
Tests fixes from BEAM-12628.

The reason I didn't put it in the `CoderTest` suite is bc we encountered this bug not just in the `Coder#encode`/`Coder#decode` that happens between `PTransform`s, but also when reading from `AvroSource` as it [manually sets an AvroCoder](https://github.com/apache/beam/blob/243128a8fc52798e1b58b0cf1a271d95ee7aa241/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java#L195) (rather than use one from the coder registry). So even after adding the shaded `AvroCoder` fix for Beam < 2.33.0, the bug was still occurring when reading from Avro source.

Verified that this test does fail for Beam < 2.33.0.

I'm not sure about the test naming/package placement; wdyt?