### PR TITLE
Force Queries to use the BigQuery Storage API 

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -73,7 +73,7 @@ private object Reads {
       .newQueryJob(sqlQuery, flattenResults, labels)
       .map { job =>
         sc.onClose(_ => bigQueryClient.waitForJobs(job))
-        typedRead.from(job.table).withoutValidation()
+        typedRead.from(job.table).withoutValidation().withMethod(Method.DIRECT_READ)
       }
 
     sc.applyTransform(read.get)


### PR DESCRIPTION
It seems that scio is rightfully using the default method in BigQueryIO for reading the results of the query.

Unfortunately, this method is fairly expensive and unnecessary in recent versions of Beam as we can use the Storage API for this and entirely omit the Avro Export process of the table.

This PR thus forces the reading method to be the `DIRECT_READ` one for queries. This should improve startup times and costs as extra GCS and BigQuery Export costs will not be born by the jobs.