### PR TITLE
(fix #4082) numBuckets should be a required SMB param

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
@@ -78,7 +78,6 @@ public class AvroSortedBucketIO {
   private static <K, T extends GenericRecord> Write.Builder<K, T> newBuilder(
       Class<K> keyClass, String keyField) {
     return new AutoValue_AvroSortedBucketIO_Write.Builder<K, T>()
-        .setNumBuckets(SortedBucketIO.DEFAULT_NUM_BUCKETS)
         .setNumShards(SortedBucketIO.DEFAULT_NUM_SHARDS)
         .setHashType(SortedBucketIO.DEFAULT_HASH_TYPE)
         .setSorterMemoryMb(SortedBucketIO.DEFAULT_SORTER_MEMORY_MB)

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
@@ -53,7 +53,6 @@ public class JsonSortedBucketIO {
   /** Returns a new {@link Write} for BigQuery {@link TableRow} JSON records. */
   public static <K> Write<K> write(Class<K> keyClass, String keyField) {
     return new AutoValue_JsonSortedBucketIO_Write.Builder<K>()
-        .setNumBuckets(SortedBucketIO.DEFAULT_NUM_BUCKETS)
         .setNumShards(SortedBucketIO.DEFAULT_NUM_SHARDS)
         .setHashType(SortedBucketIO.DEFAULT_HASH_TYPE)
         .setFilenamePrefix(SortedBucketIO.DEFAULT_FILENAME_PREFIX)

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroSortedBucketIO.java
@@ -83,7 +83,6 @@ public class ParquetAvroSortedBucketIO {
   private static <K, T extends GenericRecord> Write.Builder<K, T> newBuilder(
       Class<K> keyClass, String keyField) {
     return new AutoValue_ParquetAvroSortedBucketIO_Write.Builder<K, T>()
-        .setNumBuckets(SortedBucketIO.DEFAULT_NUM_BUCKETS)
         .setNumShards(SortedBucketIO.DEFAULT_NUM_SHARDS)
         .setHashType(SortedBucketIO.DEFAULT_HASH_TYPE)
         .setSorterMemoryMb(SortedBucketIO.DEFAULT_SORTER_MEMORY_MB)

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SortedBucketIO {
 
-  static final int DEFAULT_NUM_BUCKETS = 128;
+  static final int DEFAULT_NUM_BUCKETS = 0;
   static final int DEFAULT_NUM_SHARDS = 1;
   static final HashType DEFAULT_HASH_TYPE = HashType.MURMUR3_128;
   static final int DEFAULT_SORTER_MEMORY_MB = 1024;
@@ -304,6 +304,7 @@ public class SortedBucketIO {
     @Override
     public WriteResult expand(PCollection<V> input) {
       Preconditions.checkNotNull(getOutputDirectory(), "outputDirectory is not set");
+      Preconditions.checkArgument(getNumBuckets() > 0, "numBuckets must be set to a nonzero value");
 
       return input.apply(
           new SortedBucketSink<>(

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
  */
 public class SortedBucketIO {
 
-  static final int DEFAULT_NUM_BUCKETS = 0;
   static final int DEFAULT_NUM_SHARDS = 1;
   static final HashType DEFAULT_HASH_TYPE = HashType.MURMUR3_128;
   static final int DEFAULT_SORTER_MEMORY_MB = 1024;
@@ -258,7 +257,8 @@ public class SortedBucketIO {
   }
 
   public abstract static class Write<K, V> extends PTransform<PCollection<V>, WriteResult> {
-    abstract int getNumBuckets();
+    @Nullable
+    abstract Integer getNumBuckets();
 
     abstract int getNumShards();
 
@@ -304,7 +304,9 @@ public class SortedBucketIO {
     @Override
     public WriteResult expand(PCollection<V> input) {
       Preconditions.checkNotNull(getOutputDirectory(), "outputDirectory is not set");
-      Preconditions.checkArgument(getNumBuckets() > 0, "numBuckets must be set to a nonzero value");
+      Preconditions.checkArgument(
+          getNumBuckets() != null && getNumBuckets() > 0,
+          "numBuckets must be set to a nonzero value");
 
       return input.apply(
           new SortedBucketSink<>(
@@ -333,6 +335,9 @@ public class SortedBucketIO {
     @Override
     public WriteResult expand(PCollection<KV<K, V>> input) {
       Preconditions.checkNotNull(write.getOutputDirectory(), "outputDirectory is not set");
+      Preconditions.checkArgument(
+          write.getNumBuckets() != null && write.getNumBuckets() > 0,
+          "numBuckets must be set to a nonzero value");
 
       final ResourceId outputDirectory = write.getOutputDirectory();
       ResourceId tempDirectory = write.getTempDirectory();

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
@@ -58,7 +58,6 @@ public class TensorFlowBucketIO {
    */
   public static <K> Write<K> write(Class<K> keyClass, String keyField) {
     return new AutoValue_TensorFlowBucketIO_Write.Builder<K>()
-        .setNumBuckets(SortedBucketIO.DEFAULT_NUM_BUCKETS)
         .setNumShards(SortedBucketIO.DEFAULT_NUM_SHARDS)
         .setHashType(SortedBucketIO.DEFAULT_HASH_TYPE)
         .setSorterMemoryMb(SortedBucketIO.DEFAULT_SORTER_MEMORY_MB)

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIO.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIO.scala
@@ -84,7 +84,7 @@ object ParquetTypeSortedBucketIO {
     keyField: String,
     compression: CompressionCodecName = ParquetTypeFileOperations.DefaultCompression,
     configuration: Configuration = new Configuration(),
-    numBuckets: Int = SortedBucketIO.DEFAULT_NUM_BUCKETS,
+    numBuckets: Integer = null,
     numShards: Int = SortedBucketIO.DEFAULT_NUM_SHARDS,
     filenamePrefix: String = SortedBucketIO.DEFAULT_FILENAME_PREFIX,
     hashType: HashType = SortedBucketIO.DEFAULT_HASH_TYPE,
@@ -130,7 +130,7 @@ object ParquetTypeSortedBucketIO {
     def withConfiguration(configuration: Configuration): Write[K, T] =
       this.copy(configuration = configuration)
 
-    override def getNumBuckets: Int = numBuckets
+    override def getNumBuckets: Integer = numBuckets
     override def getNumShards: Int = numShards
     override def getFilenamePrefix: String = filenamePrefix
     override def getKeyClass: Class[K] = keyClass

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIOTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIOTest.java
@@ -93,4 +93,15 @@ public class AvroSortedBucketIOTest {
     Assert.assertEquals(tempDirectory, write.getTempDirectoryOrDefault(pipeline));
     Assert.assertEquals(tempDirectory, transform.getTempDirectoryOrDefault(pipeline));
   }
+
+  @Test
+  public void testNumBucketsRequiredParam() {
+    Throwable t = Assert.assertThrows(
+        IllegalArgumentException.class, () ->
+        AvroSortedBucketIO.write(String.class, "name", AvroGeneratedUser.class)
+            .to(folder.toString())
+            .expand(null)
+        );
+    Assert.assertEquals("numBuckets must be set to a nonzero value", t.getMessage());
+  }
 }

--- a/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIOTest.scala
+++ b/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIOTest.scala
@@ -88,4 +88,13 @@ class ParquetTypeSortedBucketIOTest extends AnyFlatSpec with Matchers {
     write.getTempDirectoryOrDefault(pipeline).toString shouldBe tempDir
     transform.getTempDirectoryOrDefault(pipeline).toString shouldBe tempDir
   }
+
+  it should "check that numBuckets is set" in {
+    the[IllegalArgumentException] thrownBy {
+      ParquetTypeSortedBucketIO
+        .write[String, User]("name")
+        .to("/output")
+        .expand(null)
+    } should have message "numBuckets must be set to a nonzero value"
+  }
 }

--- a/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIOTest.scala
+++ b/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIOTest.scala
@@ -68,7 +68,10 @@ class ParquetTypeSortedBucketIOTest extends AnyFlatSpec with Matchers {
     val tempDir = s"/tmp/temp-${UUID.randomUUID().toString}/"
     pipeline.getOptions.setTempLocation(tempDir)
 
-    val write = ParquetTypeSortedBucketIO.write[String, User]("name").to("/output")
+    val write = ParquetTypeSortedBucketIO
+      .write[String, User]("name")
+      .to("/output")
+      .withNumBuckets(1)
     val transform = SortedBucketIO
       .read(classOf[String])
       .of(


### PR DESCRIPTION
I don't find this to be a particularly elegant solution (making `getNumBuckets` a boxed `@Nullable` to comply with AutoValue limitations, as we do [a lot of intermediate building](https://github.com/spotify/scio/blob/main/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java#L75) before the final `expand` call) but I think it's workable enough and has little user impact. although it's technically a breaking change, I don't expect there are many cases where this is not set!