### PR TITLE
Parquet schema evolution doc: no need to append new fields to the end of a record.

### DIFF
--- a/site/src/main/paradox/io/Parquet.md
+++ b/site/src/main/paradox/io/Parquet.md
@@ -176,7 +176,7 @@ Add the following import to handle typed Parquet in a way compatible with Parque
 import magnolify.parquet.ParquetArray.AvroCompat._
 ```
 
-The same Avro schema evolution principles apply to Parquet, i.e. only append `OPTIONAL` or `REPEATED` fields at the end of a record with default `null` or `[]`. See this [test](https://github.com/spotify/magnolify/blob/master/parquet/src/test/scala/magnolify/parquet/test/SchemaEvolutionSuite.scala) for some common scenarios w.r.t. Parquet schema evolution.
+The same Avro schema evolution principles apply to Parquet, i.e. only append `OPTIONAL` or `REPEATED` fields with default `null` or `[]`. See this [test](https://github.com/spotify/magnolify/blob/master/parquet/src/test/scala/magnolify/parquet/test/SchemaEvolutionSuite.scala) for some common scenarios w.r.t. Parquet schema evolution.
 
 ## Performance Tuning
 


### PR DESCRIPTION
New fields could be added to any position in a record. The only requirement for them is to be nullable or []. See the [magnolify](https://github.com/spotify/magnolify/blob/main/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala#L88-L90) test as a proof. 