### PR TITLE
update GcsConnectorUtil to remove deprecated auth & search for ADC

### DIFF
--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/GcsConnectorUtil.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/GcsConnectorUtil.scala
@@ -17,20 +17,39 @@
 
 package com.spotify.scio.parquet
 
+import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import com.spotify.scio.ScioContext
 import com.spotify.scio.util.ScioUtil
 import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
+import org.slf4j.LoggerFactory
+
+import java.io.File
+import java.util.Locale
+import scala.util.Try
 
 private[parquet] object GcsConnectorUtil {
-  def setCredentials(job: Job): Unit =
+  private lazy val log = LoggerFactory.getLogger(getClass)
+
+  def setCredentials(job: Job): Unit = {
     // These are needed since `FileInputFormat.setInputPaths` validates paths locally and
     // requires the user's GCP credentials.
-    sys.env.get("GOOGLE_APPLICATION_CREDENTIALS") match {
-      case Some(json) =>
-        job.getConfiguration
-          .set("fs.gs.auth.service.account.json.keyfile", json)
+    val keyFile = sys.env
+      .get("GOOGLE_APPLICATION_CREDENTIALS")
+      .filter(_.nonEmpty)
+      .orElse {
+        Try(GoogleCredentials.getApplicationDefault()).toOption match {
+          case Some(_: ServiceAccountCredentials) => getWellKnownCredentialFile.map(_.toString)
+          case _ => None // ADC was not set, or was a personal user credential
+        }
+      }
+
+    keyFile match {
+      case Some(path) => job.getConfiguration.set("fs.gs.auth.service.account.json.keyfile", path)
       case None =>
+        log.warn(
+          "Application default credentials could not be resolved, using default Cloud SDK credentials"
+        )
         // Client id/secret of Google-managed project associated with the Cloud SDK
         job.getConfiguration
           .setBoolean("fs.gs.auth.service.account.enable", false)
@@ -38,11 +57,13 @@ private[parquet] object GcsConnectorUtil {
         job.getConfiguration
           .set("fs.gs.auth.client.secret", "ZmssLNjJy2998hD4CTg2ejr2")
     }
+  }
 
   def unsetCredentials(job: Job): Unit = {
     job.getConfiguration.unset("fs.gs.auth.service.account.json.keyfile")
     job.getConfiguration.unset("fs.gs.auth.service.account.enable")
-    job.getConfiguration.unset("fs.gs.auth.client.id")
+    job.getConfiguration.unset("fs.gs.auth.service.account.enable")
+    job.getConfiguration.unset("fs.gs.auth.null.enable")
     job.getConfiguration.unset("fs.gs.auth.client.secret")
   }
 
@@ -57,5 +78,19 @@ private[parquet] object GcsConnectorUtil {
     if (!ScioUtil.isLocalRunner(sc.options.getRunner)) {
       GcsConnectorUtil.unsetCredentials(job)
     }
+  }
+
+  // Adapted from com.google.auth.oauth2.DefaultCredentialsProvider
+  private def getWellKnownCredentialFile: Option[File] = {
+    val os = sys.props.getOrElse("os.name", "").toLowerCase(Locale.US)
+    val cloudRootPath = if (os.contains("windows")) {
+      new File(sys.env("APPDATA"))
+    } else {
+      new File(sys.props.getOrElse("user.home", ""), ".config")
+    }
+    val credentialFilePath =
+      new File(cloudRootPath, "gcloud/application_default_credentials.json")
+
+    if (credentialFilePath.exists()) Some(credentialFilePath) else None
   }
 }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/GcsConnectorUtil.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/GcsConnectorUtil.scala
@@ -52,16 +52,17 @@ private[parquet] object GcsConnectorUtil {
           "com.spotify.scio.parquet.ApplicationDefaultTokenProvider"
         )
       case _ =>
-        throw new IllegalStateException(
-          "No valid Google credentials were found. " +
-            "Check that application default is set."
-        )
+        job.getConfiguration
+          .setBoolean("fs.gs.auth.service.account.enable", false)
+        job.getConfiguration.unset("fs.gs.auth.null.enable")
     }
   }
 
   def unsetCredentials(job: Job): Unit = {
     job.getConfiguration.unset("fs.gs.auth.service.account.json.keyfile")
     job.getConfiguration.unset("fs.gs.auth.access.token.provider.impl")
+    job.getConfiguration.unset("fs.gs.auth.null.enable")
+    job.getConfiguration.unset("fs.gs.auth.service.account.enable")
   }
 
   def setInputPaths(sc: ScioContext, job: Job, path: String): Unit = {

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/GcsConnectorUtil.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/GcsConnectorUtil.scala
@@ -27,34 +27,36 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 
 import java.io.File
 import java.util.Locale
-import scala.util.Try
+import scala.util.{Success, Try}
 
 private[parquet] object GcsConnectorUtil {
-  def setCredentials(job: Job): Unit = {
-    // These are needed since `FileInputFormat.setInputPaths` validates paths locally and
-    // requires the user's GCP credentials.
-    lazy val applicationDefault = Try(GoogleCredentials.getApplicationDefault())
 
-    sys.env
-      .get("GOOGLE_APPLICATION_CREDENTIALS")
-      .filter(_.nonEmpty)
-      .orElse {
-        applicationDefault.toOption match {
-          case Some(_: ServiceAccountCredentials) => getWellKnownCredentialFile.map(_.toString)
-          case _                                  => None
-        }
-      } match {
-      case Some(serviceAccountKeyFile) =>
-        job.getConfiguration.set("fs.gs.auth.service.account.json.keyfile", serviceAccountKeyFile)
-      case _ if applicationDefault.isSuccess => // ADC exists but isn't a service account
+  /**
+   * Attempts to set Hadoop credential configuration when running locally. This is needed since
+   * [[FileInputFormat.setInputPaths]] validates paths locally and requires the user's GCP
+   * credentials.
+   *
+   * In order of precedence, credentials will be searched for: (1) in the
+   * GOOGLE_APPLICATION_CREDENTIALS environment variable (2) in user's home
+   * .config/gcloud/application_default_credentials.json file
+   *
+   * If neither of these paths exist, `fs.gs.auth.null.enable` will be set (to enable unit testing).
+   */
+  def setCredentials(job: Job): Unit = {
+    Try(GoogleCredentials.getApplicationDefault()).map {
+      case _: ServiceAccountCredentials => getWellKnownCredentialFile.map(_.toString)
+      case _                            => None
+    } match {
+      case Success(Some(sa)) =>
+        job.getConfiguration.set("fs.gs.auth.service.account.json.keyfile", sa)
+      case Success(None) =>
         job.getConfiguration.set(
           "fs.gs.auth.access.token.provider.impl",
           "com.spotify.scio.parquet.ApplicationDefaultTokenProvider"
         )
       case _ =>
-        job.getConfiguration
-          .setBoolean("fs.gs.auth.service.account.enable", false)
-        job.getConfiguration.unset("fs.gs.auth.null.enable")
+        job.getConfiguration.setBoolean("fs.gs.auth.service.account.enable", false)
+        job.getConfiguration.setBoolean("fs.gs.auth.null.enable", true)
     }
   }
 
@@ -80,16 +82,21 @@ private[parquet] object GcsConnectorUtil {
 
   // Adapted from com.google.auth.oauth2.DefaultCredentialsProvider
   private def getWellKnownCredentialFile: Option[File] = {
-    val os = sys.props.getOrElse("os.name", "").toLowerCase(Locale.US)
-    val cloudRootPath = if (os.contains("windows")) {
-      new File(sys.env("APPDATA"))
-    } else {
-      new File(sys.props.getOrElse("user.home", ""), ".config")
-    }
-    val credentialFilePath =
-      new File(cloudRootPath, "gcloud/application_default_credentials.json")
-
-    if (credentialFilePath.exists()) Some(credentialFilePath) else None
+    sys.env
+      .get("GOOGLE_APPLICATION_CREDENTIALS")
+      .map(new File(_))
+      .filter(_.exists())
+      .orElse {
+        val os = sys.props.getOrElse("os.name", "").toLowerCase(Locale.US)
+        val cloudRootPath = if (os.contains("windows")) {
+          new File(sys.env("APPDATA"))
+        } else {
+          new File(sys.props.getOrElse("user.home", ""), ".config")
+        }
+        Some(
+          new File(cloudRootPath, "gcloud/application_default_credentials.json")
+        ).filter(_.exists())
+      }
   }
 }
 


### PR DESCRIPTION
the PR updates a couple things in `setCredentials` (this is called for reads on `DirectRunner` only; it doesn't affect Dataflow).

- If `GOOGLE_APPLICATION_CREDENTIALS` is not set, instead of giving up, using google's oAuth library to find if `~/.config/gcloud/application_default_credentials.json` exists and whether it contains service account credentials.
- If a service account ADC cannot be found use `fs.gs.auth.access.token.provider.impl`, as described in GCS connector's [CONFIGURATION.md](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/CONFIGURATION.md#authentication). I feel iffy about this because I had to define my own `AccessTokenProvider` class using Google credentials; but I verified it works. 
- the "fallback" option of using the default CLOUDSDK_PROJECT client id/secret no longer works and the configuration is now invalid; support was removed in https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/511 .
