### PR TITLE
Revert "Update zoltar-api, zoltar-core, ... to 0.6.0-M4"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,7 @@ val slf4jVersion = "1.7.32"
 val sparkeyVersion = "3.2.1"
 val sparkVersion = "2.4.6"
 val tensorFlowVersion = "0.3.3"
-val zoltarVersion = "0.6.0-M4"
+val zoltarVersion = "0.6.0-M2"
 val scalaCollectionCompatVersion = "2.5.0"
 
 ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)


### PR DESCRIPTION
Reverts spotify/scio#4068

Forgot that this version relies on TF 0.4.0-snapshot; we should not include it in scio just yet.