### PR TITLE
Upgrade Beam to 2.34

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ val autoServiceVersion = "1.0"
 val autoValueVersion = "1.8.2"
 val avroVersion = "1.8.2"
 val beamVendorVersion = "0.1"
-val beamVersion = "2.33.0"
+val beamVersion = "2.34.0"
 val bigdataossVersion = "2.2.2"
 val bigQueryStorageVersion = "1.21.1"
 val bigtableClientVersion = "1.19.1"
@@ -439,6 +439,7 @@ lazy val `scio-core`: Project = project
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
       "org.apache.commons" % "commons-compress" % commonsCompressVersion,
       "org.apache.commons" % "commons-math3" % commonsMath3Version,
+      "org.apache.commons" % "commons-lang3" % commonsLang3Version,
       "org.scalatest" %% "scalatest" % scalatestVersion % Test,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.typelevel" %% "algebra" % algebraVersion,

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/BeamTypeCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/BeamTypeCoders.scala
@@ -45,7 +45,7 @@ trait BeamTypeCoders {
 
   implicit def beamKVCoder[K: Coder, V: Coder]: Coder[KV[K, V]] = Coder.kv(Coder[K], Coder[V])
 
-  implicit def readableFileCoder: Coder[ReadableFile] = Coder.beam(new ReadableFileCoder())
+  implicit def readableFileCoder: Coder[ReadableFile] = Coder.beam(ReadableFileCoder.of())
 
   implicit def matchResultMetadataCoder: Coder[MatchResult.Metadata] =
     Coder.beam(MetadataCoderV2.of())

--- a/scio-google-cloud-platform/src/main/java/com/spotify/scio/bigtable/ChannelPoolCreator.java
+++ b/scio-google-cloud-platform/src/main/java/com/spotify/scio/bigtable/ChannelPoolCreator.java
@@ -51,6 +51,6 @@ public class ChannelPoolCreator {
     final ClientInterceptor[] interceptors = getClientInterceptors(options);
 
     return new ChannelPool(
-        () -> BigtableSession.createNettyChannel(options.getAdminHost(), options, interceptors), 1);
+        () -> BigtableSession.createNettyChannel(options.getAdminHost(), options, false, interceptors), 1);
   }
 }


### PR DESCRIPTION
Beam 2.33 depends on a older version of the BQ client which does not RST_STREAM errors correctly when using the BQ storage API.  Depending on the runner, this could either cause *a lot* of bundles to be retried (Dataflow) and generate a ton of error logs or it can completely prevent the job to execute properly (Flink).

Beam 2.34 ships with an updated version of BQ which should fix the issue.  