### PR TITLE
first draft of a Dataflow pre-release check

### DIFF
--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -1,0 +1,40 @@
+name: pre-release-check
+
+env:
+  ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
+  GOOGLE_APPLICATION_CREDENTIALS: scripts/data-integration-test-key.json
+  GOOGLE_PROJECT_ID: data-integration-test
+  SBT_OPTS: -DbeamRunners=DataflowRunner
+  DEFAULT_DATAFLOW_ARGS: --runner=DataflowRunner --project=data-integration-test --region=europe-west1
+
+on:
+  workflow_dispatch # Manually triggered
+jobs:
+  test-dataflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: cache SBT
+        uses: coursier/cache-action@v6
+      - name: Java setup
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: ${{matrix.java}}
+      - name: Setup project
+        run: scripts/gha_setup.sh
+      - name: (Dataflow) IO Writes
+        run: sbt ${{ env.SBT_OPTS }} "++${{ matrix.scala }} scio-examples/runMain ${{ matrix.io_write }} ${{ env.DEFAULT_DATAFLOW_ARGS }} "
+      - name: (Dataflow) IO Reads
+        run: sbt ${{ env.SBT_OPTS }} "++${{ matrix.scala }} scio-examples/runMain ${{ matrix.io_read }} ${{ env.DEFAULT_DATAFLOW_ARGS }}"
+    strategy:
+      matrix:
+        java:
+          - 8
+          - 11
+        scala:
+          - 2.13.6
+        io_write:
+          - com.spotify.scio.examples.extra.AvroExample --method=specificOut --output=gs://data-integration-test-eu/AvroExample/Write/${{ env.GITHUB_RUN_ID }}
+        io_read:
+          - com.spotify.scio.examples.extra.AvroExample --method=specificIn --input=gs://data-integration-test-eu/AvroExample/Write/${{ env.GITHUB_RUN_ID }}/*.avro --output=gs://data-integration-test-eu/AvroExample/Read/${{ env.GITHUB_RUN_ID }}

--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -20,20 +20,15 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: adopt
-          java-version: ${{matrix.java}}
+          java-version: 11
       - name: Setup project
         run: scripts/gha_setup.sh
       - name: (Dataflow) IO Writes
-        run: sbt ${{ env.SBT_OPTS }} "++${{ matrix.scala }} scio-examples/runMain ${{ matrix.io_write }} ${{ env.DEFAULT_DATAFLOW_ARGS }} "
+        run: sbt ${{ env.SBT_OPTS }} "scio-examples/runMain ${{ matrix.io_write }} ${{ env.DEFAULT_DATAFLOW_ARGS }} "
       - name: (Dataflow) IO Reads
-        run: sbt ${{ env.SBT_OPTS }} "++${{ matrix.scala }} scio-examples/runMain ${{ matrix.io_read }} ${{ env.DEFAULT_DATAFLOW_ARGS }}"
+        run: sbt ${{ env.SBT_OPTS }} "scio-examples/runMain ${{ matrix.io_read }} ${{ env.DEFAULT_DATAFLOW_ARGS }}"
     strategy:
       matrix:
-        java:
-          - 8
-          - 11
-        scala:
-          - 2.13.6
         io_write:
           - com.spotify.scio.examples.extra.AvroExample --method=specificOut --output=gs://data-integration-test-eu/AvroExample/Write/${{ env.GITHUB_RUN_ID }}
         io_read:

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroExample.scala
@@ -77,7 +77,7 @@ object AvroExample {
       case _ => throw new RuntimeException(s"Invalid method $m")
     }
 
-    sc.run()
+    sc.run().waitUntilDone()
     ()
   }
 


### PR DESCRIPTION
the idea is to add a step that we can trigger before releasing that runs some sample jobs in Dataflow, so we can have increased confidence in the release - similar to what Beam does. The jobs use small, fake datasets and only take about 5 min....but it is still a blocking operation for the GHA task, unfortunately. For now I just picked a job from scio-examples to run; eventually we might want to write custom jobs to test (i.e for popular/frequently-evolving IOs like SMB or Parquet). I validated the yaml for this with [act](https://github.com/nektos/act).
