### PR TITLE
Fix SMBTransform callsite name for Dataflow graph

### DIFF
--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -514,8 +514,11 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
       }
 
       val t = transform.via(fn)
+      sortMergeTransform(t)
+    }
 
-      self.applyInternal(t)
+    private def sortMergeTransform(t: SortedBucketIO.CoGbkTransform[K, W]): ClosedTap[Nothing] = {
+      self.applyInternal("sortMergeTransform", t)
       ClosedTap[Nothing](EmptyTap)
     }
   }

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -514,11 +514,7 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
       }
 
       val t = transform.via(fn)
-      sortMergeTransform(t)
-    }
-
-    private def sortMergeTransform(t: SortedBucketIO.CoGbkTransform[K, W]): ClosedTap[Nothing] = {
-      self.applyInternal(t)
+      self.applyInternal(self.tfName(Some("sortMergeTransform")), t)
       ClosedTap[Nothing](EmptyTap)
     }
   }

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -518,7 +518,7 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     }
 
     private def sortMergeTransform(t: SortedBucketIO.CoGbkTransform[K, W]): ClosedTap[Nothing] = {
-      self.applyInternal("sortMergeTransform", t)
+      self.applyInternal(t)
       ClosedTap[Nothing](EmptyTap)
     }
   }

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -514,7 +514,8 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
       }
 
       val t = transform.via(fn)
-      self.applyInternal(self.tfName(Some("sortMergeTransform")), t)
+      val tfName = self.tfName(Some("sortMergeTransform"))
+      self.applyInternal(tfName, t)
       ClosedTap[Nothing](EmptyTap)
     }
   }


### PR DESCRIPTION
Fixes the callsite name of the top-level SMB Transform from "via" to "sortMergeTransform" so it's less confusing in the Dataflow job graph.

before:
<img width="191" alt="Screen Shot 2021-12-09 at 11 30 04 AM" src="https://user-images.githubusercontent.com/1360529/145436707-2eaa4f6d-ebf5-411f-a5d6-f00646170dff.png">

after:
<img width="191" alt="Screen Shot 2021-12-09 at 11 30 12 AM" src="https://user-images.githubusercontent.com/1360529/145436723-1941610f-b75f-4fcd-9ba5-e6756db965d2.png">

