### PR TITLE
Clarify ParquetExample inputs and outputs

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
@@ -104,7 +104,7 @@ object ParquetExample {
   }
 
   private def avroGenericIn(sc: ScioContext, args: Args): ClosedTap[String] =
-    // We can also passed an Avro schema directly to project into Avro GenericRecords.
+    // We can also pass an Avro schema directly to project into Avro GenericRecords.
     sc.parquetAvroFile[GenericRecord](args("input"), Account.getClassSchema)
 
       // Map out projected fields into something type safe

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
@@ -15,17 +15,16 @@
  * under the License.
  */
 
-// Example: Read and Write specific and generic Avro records
+// Example: Read and write Parquet in Avro and Typed formats
 // Usage:
 // `sbt "runMain com.spotify.scio.examples.extra.ParquetExample
-// --project=[PROJECT] --runner=DataflowRunner --region=[ZONE]
-// --input=[INPUT].parquet --output=[OUTPUT].parquet --method=[METHOD]"`
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION]
+// --input=[INPUT]/*.parquet --output=[OUTPUT] --method=[METHOD]"`
 package com.spotify.scio.examples.extra
 
 import com.spotify.scio._
 import com.spotify.scio.parquet.avro._
 import com.spotify.scio.parquet.types._
-import com.spotify.scio.values.SCollection
 import com.spotify.scio.avro.Account
 import com.spotify.scio.io.ClosedTap
 import org.apache.hadoop.conf.Configuration
@@ -33,17 +32,37 @@ import org.apache.avro.generic.GenericRecord
 
 object ParquetExample {
 
-  case class AccountInput(id: Int, `type`: String, name: String, amount: Double)
+  /**
+   * These case classes represent both full and projected field mappings from the [[Account]] Avro
+   * record.
+   */
+  case class AccountFull(id: Int, `type`: String, name: String, amount: Double)
+  case class AccountProjection(id: Int, name: String)
 
-  case class AccountOutput(id: Int, name: String)
-
-  // See this link for parquet writer tuning https://spotify.github.io/scio/io/Parquet.html#performance-tuning
-  lazy val fineTunedParquetWriterConfig: Configuration = {
+  /**
+   * A Hadoop [[Configuration]] can optionally be passed for Parquet reads and writes to improve
+   * performance.
+   *
+   * See more here: https://spotify.github.io/scio/io/Parquet.html#performance-tuning
+   */
+  private val fineTunedParquetWriterConfig: Configuration = {
     val conf: Configuration = new Configuration()
     conf.setInt("parquet.block.size", 1073741824) // 1 * 1024 * 1024 * 1024 = 1 GiB
     conf.set("fs.gs.inputstream.fadvise", "RANDOM")
     conf
   }
+
+  private[extra] val fakeData: Iterable[Account] =
+    (1 to 100)
+      .map(i =>
+        Account
+          .newBuilder()
+          .setId(i)
+          .setType(if (i % 3 == 0) "current" else "checking")
+          .setName(s"account $i")
+          .setAmount(i.toDouble)
+          .build()
+      )
 
   def main(cmdlineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdlineArgs)
@@ -73,62 +92,40 @@ object ParquetExample {
   }
 
   private def avroSpecificIn(sc: ScioContext, args: Args): ClosedTap[String] = {
-
-    // Account is an Avro Specific record. The avsc schema for the same can be found in scio-schemas/src/main/avro/schema.avsc
     // Macros for generating column projections and row predicates
-    val projection =
-      Projection[Account](_.getId, _.getName, _.getAmount) // Only these columns will be projected
-    val predicate = Predicate[Account](x =>
-      x.getAmount > 0
-    ) // Will skip row groups where this column value check is not satisfied
+    val projection = Projection[Account](_.getId, _.getName, _.getAmount)
+    val predicate = Predicate[Account](x => x.getAmount > 0)
 
     sc.parquetAvroFile[Account](args("input"), projection, predicate)
       // The result Account records are not complete Avro objects. Only the projected columns are present while the rest are null.
       // These objects may fail serialization and it’s recommended that you map them out to tuples or case classes right after reading.
-      .map(x => AccountOutput(x.getId, x.getName.toString))
+      .map(x => AccountProjection(x.getId, x.getName.toString))
       .saveAsTextFile(args("output"))
   }
 
   private def avroGenericIn(sc: ScioContext, args: Args): ClosedTap[String] =
-    // Now the fields in Account's schema act as our projection
+    // We can also passed an Avro schema directly to project into Avro GenericRecords.
     sc.parquetAvroFile[GenericRecord](args("input"), Account.getClassSchema)
 
       // Map out projected fields into something type safe
-      .map(r => AccountOutput(r.get("id").asInstanceOf[Int], r.get("name").toString))
+      .map(r => AccountProjection(r.get("id").asInstanceOf[Int], r.get("name").toString))
       .saveAsTextFile(args("output"))
 
   private def typedIn(sc: ScioContext, args: Args): ClosedTap[String] =
-    // All fields in the case class definition act as our projection
-    sc.typedParquetFile[AccountInput](args("input"))
+    sc.typedParquetFile[AccountProjection](args("input"))
       .saveAsTextFile(args("output"))
 
-  private def dummyData(sc: ScioContext): SCollection[Account] =
-    // Generating some dummy data and creating an SCollection of spcific Avro records
-    sc.parallelize(1 to 100)
-      .map(i =>
-        Account
-          .newBuilder()
-          .setId(i)
-          .setType(if (i % 3 == 0) "current" else "checking")
-          .setName(s"account $i")
-          .setAmount(i.toDouble)
-          .build()
-      )
-
   private def avroOut(sc: ScioContext, args: Args): ClosedTap[Account] =
-    dummyData(sc)
-
+    sc.parallelize(fakeData)
       // numShards should be explicitly set so that the size of each output file is smaller than
       // but close to `parquet.block.size`, i.e. 1 GiB. This guarantees that each file contains 1 row group only and reduces seeks.
       .saveAsParquetAvroFile(args("output"), numShards = 1, conf = fineTunedParquetWriterConfig)
 
-  private def typedOut(sc: ScioContext, args: Args): ClosedTap[AccountOutput] =
-    dummyData(sc)
-      .map(x => AccountOutput(x.getId, x.getName.toString))
-
-      // This case class can now be saved as a parquet file
+  private def typedOut(sc: ScioContext, args: Args): ClosedTap[AccountFull] =
+    sc.parallelize(fakeData)
+      .map(x => AccountFull(x.getId, x.getType.toString, x.getName.toString, x.getAmount))
       .saveAsTypedParquetFile(
         args("output")
-      ) // passing writer configuration is optional but recommended
+      )
 
 }

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
@@ -18,74 +18,57 @@ package com.spotify.scio.examples.extra
  */
 
 import com.spotify.scio.avro.Account
-import com.spotify.scio.examples.extra.ParquetExample.{AccountInput, AccountOutput}
+import com.spotify.scio.examples.extra.ParquetExample.{AccountFull, AccountProjection}
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.parquet.avro._
 import com.spotify.scio.parquet.types._
-import com.spotify.scio.io.TextIO
+import com.spotify.scio.io.{TextIO, TextTap}
 
 class ParquetExampleTest extends PipelineSpec {
 
-  lazy val dummyData: IndexedSeq[Account] = (1 to 100)
-    .map(i =>
-      Account
-        .newBuilder()
-        .setId(i)
-        .setType(if (i % 3 == 0) "current" else "checking")
-        .setName(s"account $i")
-        .setAmount(i.toDouble)
-        .build()
-    )
-
   "ParquetExample" should "work for specific input" in {
-    val input =
-      Seq(new Account(1, "checking", "Alice", 1000.0), new Account(2, "checking", "Bob", 1500.0))
-
-    val expected = input
-      .map(x => AccountOutput(x.getId(), x.getName.toString))
+    val expected = ParquetExample.fakeData
+      .map(x => AccountProjection(x.getId, x.getName.toString))
       .map(_.toString)
 
     JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
       .args("--input=in.parquet", "--output=out.txt", "--method=avroSpecificIn")
-      .input(ParquetAvroIO[Account]("in.parquet"), input)
+      .input(ParquetAvroIO[Account]("in.parquet"), ParquetExample.fakeData)
       .output(TextIO("out.txt"))(coll => coll should containInAnyOrder(expected))
       .run()
   }
 
-  "ParquetExample" should "work for typed input" in {
-    val input =
-      Seq(AccountInput(1, "checking", "Alice", 1000.0), AccountInput(2, "checking", "Bob", 1500.0))
+  it should "work for typed input" in {
+    val input = ParquetExample.fakeData
+      .map(x => AccountProjection(x.getId, x.getName.toString))
 
     val expected = input.map(_.toString)
 
     JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
       .args("--input=in.parquet", "--output=out.txt", "--method=typedIn")
-      .input(ParquetTypeIO[AccountInput]("in.parquet"), input)
+      .input(ParquetTypeIO[AccountProjection]("in.parquet"), input)
       .output(TextIO("out.txt"))(coll => coll should containInAnyOrder(expected))
       .run()
   }
 
-  "ParquetExample" should "work for specific output" in {
-    val expected = dummyData
-
+  it should "work for specific output" in {
     JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
       .args("--output=out.parquet", "--method=avroOut")
       .output(ParquetAvroIO[Account]("out.parquet"))(coll =>
-        coll should containInAnyOrder(expected)
+        coll should containInAnyOrder(ParquetExample.fakeData)
       )
       .run()
   }
 
-  "ParquetExample" should "work for typed output" in {
-    val expected = dummyData
-      .map(x => AccountOutput(x.getId, x.getName.toString))
+  it should "work for typed output" in {
+    val expected = ParquetExample.fakeData
+      .map(a => AccountFull(a.getId, a.getType.toString, a.getName.toString, a.getAmount))
 
     JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
       .args("--output=out.parquet", "--method=typedOut")
-      .output(ParquetTypeIO[AccountOutput]("out.parquet"))(coll =>
+      .output(ParquetTypeIO[AccountFull]("out.parquet"))(coll =>
         coll should containInAnyOrder(expected)
       )
       .run()
   }
-
 }

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
@@ -26,7 +26,7 @@ import com.spotify.scio.io.TextIO
 
 class ParquetExampleTest extends PipelineSpec {
 
-  "ParquetExample" should "work for specific input" in {
+  "ParquetExample" should "work for SpecificRecord input" in {
     val expected = ParquetExample.fakeData
       .map(x => AccountProjection(x.getId, x.getName.toString))
       .map(_.toString)
@@ -51,7 +51,7 @@ class ParquetExampleTest extends PipelineSpec {
       .run()
   }
 
-  it should "work for specific output" in {
+  it should "work for SpecificRecord output" in {
     JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
       .args("--output=out.parquet", "--method=avroOut")
       .output(ParquetAvroIO[Account]("out.parquet"))(coll =>

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
@@ -22,7 +22,7 @@ import com.spotify.scio.examples.extra.ParquetExample.{AccountFull, AccountProje
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.parquet.avro._
 import com.spotify.scio.parquet.types._
-import com.spotify.scio.io.{TextIO, TextTap}
+import com.spotify.scio.io.TextIO
 
 class ParquetExampleTest extends PipelineSpec {
 


### PR DESCRIPTION
when I was running the `ParquetExample`s in Dataflow I noticed that the `--typedOut` job doesn't create a valid input for `--typedIn`. I cleaned up the input/output types and added some clarifying comments so that the `--{avroSpecific|avroGeneric|typed}In` jobs have valid dependencies on the `--{avro|typed}Out ` jobs.