### PR TITLE
Add helper methods for org.scalacheck.Gen to PipelineSpec 

### DIFF
--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
@@ -220,10 +220,10 @@ trait PipelineTestUtils {
         )
         None
       case Some(a) =>
-        val r = Try(fn(a))
+        val r = Try(fn(a)).map(Some(_))
         if (r.isFailure)
           logger.error(s"Failure at ${name.value}:${line.value}. Seed: ${seed.toBase64}")
-        r.map(Option(_)).get
+        r.get
     }
   }
 }

--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
@@ -21,9 +21,15 @@ import org.apache.beam.sdk.options._
 import com.spotify.scio._
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.values.SCollection
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+import org.slf4j.LoggerFactory
+
+import scala.util.Try
 
 /** Trait with utility methods for unit testing pipelines. */
 trait PipelineTestUtils {
+  private[this] val logger = LoggerFactory.getLogger(this.getClass)
 
   /**
    * Test pipeline components with a [[ScioContext]].
@@ -172,5 +178,43 @@ trait PipelineTestUtils {
     val f = fn(sc).materialize
     val result: ScioResult = sc.run().waitUntilFinish() // block non-test runner
     (result, result.tap(f).value.toSeq)
+  }
+
+  /**
+   * @param genA
+   * @param fn
+   * @param line
+   * @param name
+   * @tparam A
+   * @tparam T
+   * @return
+   */
+  def withGen[A, T](genA: Gen[A])(
+    fn: A => T
+  )(implicit line: sourcecode.Line, name: sourcecode.Name): Option[T] =
+    withGen(genA, Seed.random())(fn)(line, name)
+
+  def withGen[A, T](genA: Gen[A], base64Seed: String)(
+    fn: A => T
+  )(implicit line: sourcecode.Line, name: sourcecode.Name): Option[T] =
+    withGen(genA, Seed.fromBase64(base64Seed).get)(fn)(line, name)
+
+  def withGen[A, T](genA: Gen[A], seed: Seed)(
+    fn: A => T
+  )(implicit line: sourcecode.Line, name: sourcecode.Name): Option[T] = {
+    genA.apply(Gen.Parameters.default, seed) match {
+      case None =>
+        logger.error(
+          s"Failed to generate a valid value at ${name.value}:${line.value}. " +
+            s"Consider rewriting Gen instances to be less failure-prone. " +
+            s"Seed: ${seed.toBase64}"
+        )
+        None
+      case Some(a) =>
+        val r = Try(fn(a))
+        if (r.isFailure)
+          logger.error(s"Failure at ${name.value}:${line.value}. Seed: ${seed.toBase64}")
+        r.map(Option(_)).get
+    }
   }
 }

--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
@@ -181,24 +181,33 @@ trait PipelineTestUtils {
   }
 
   /**
-   * @param genA
-   * @param fn
-   * @param line
-   * @param name
-   * @tparam A
-   * @tparam T
+   * Generate an instance of `A` from `genA` using a random seed.
+   *
    * @return
+   *   The result of `fn` applied to the generated `A`, or `None` on generation failure.
    */
   def withGen[A, T](genA: Gen[A])(
     fn: A => T
   )(implicit line: sourcecode.Line, name: sourcecode.Name): Option[T] =
     withGen(genA, Seed.random())(fn)(line, name)
 
+  /**
+   * Generate an instance of `A` from `genA` using a the seed specified by `base64Seed`.
+   *
+   * @return
+   *   The result of `fn` applied to the generated `A`, or `None` on generation failure.
+   */
   def withGen[A, T](genA: Gen[A], base64Seed: String)(
     fn: A => T
   )(implicit line: sourcecode.Line, name: sourcecode.Name): Option[T] =
     withGen(genA, Seed.fromBase64(base64Seed).get)(fn)(line, name)
 
+  /**
+   * Generate an instance of `A` from `genA` using a the seed specified by `seed`.
+   *
+   * @return
+   *   The result of `fn` applied to the generated `A`, or `None` on generation failure.
+   */
   def withGen[A, T](genA: Gen[A], seed: Seed)(
     fn: A => T
   )(implicit line: sourcecode.Line, name: sourcecode.Name): Option[T] = {

--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
@@ -188,7 +188,7 @@ trait PipelineTestUtils {
    */
   def withGen[A, T](genA: Gen[A])(
     fn: A => T
-  )(implicit line: sourcecode.Line, name: sourcecode.Name): Option[T] =
+  )(implicit line: sourcecode.Line, name: sourcecode.FileName): Option[T] =
     withGen(genA, Seed.random())(fn)(line, name)
 
   /**
@@ -199,7 +199,7 @@ trait PipelineTestUtils {
    */
   def withGen[A, T](genA: Gen[A], base64Seed: String)(
     fn: A => T
-  )(implicit line: sourcecode.Line, name: sourcecode.Name): Option[T] =
+  )(implicit line: sourcecode.Line, name: sourcecode.FileName): Option[T] =
     withGen(genA, Seed.fromBase64(base64Seed).get)(fn)(line, name)
 
   /**
@@ -210,7 +210,7 @@ trait PipelineTestUtils {
    */
   def withGen[A, T](genA: Gen[A], seed: Seed)(
     fn: A => T
-  )(implicit line: sourcecode.Line, name: sourcecode.Name): Option[T] = {
+  )(implicit line: sourcecode.Line, name: sourcecode.FileName): Option[T] = {
     genA.apply(Gen.Parameters.default, seed) match {
       case None =>
         logger.error(

--- a/scio-test/src/test/scala/com/spotify/scio/testing/PipelineTestUtilsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/PipelineTestUtilsTest.scala
@@ -1,0 +1,39 @@
+package com.spotify.scio.testing
+
+import org.scalacheck.Gen
+import org.scalacheck.rng.Seed
+
+class PipelineTestUtilsTest extends PipelineSpec {
+  "PipelineTestUtils" should "generate a test case and have an optional return value" in {
+    val xxx = withGen(Gen.const(1))(i => i)
+    assert(xxx.contains(1))
+  }
+
+  it should "return None on test case generation failure, not throw" in {
+    val xxx = withGen(Gen.const(1).suchThat(_ => false))(_ => ())
+    assert(xxx.isEmpty)
+  }
+
+  it should "propagate errors" in {
+    assertThrows[RuntimeException] {
+      withGen(Gen.const(1)) { _ =>
+        throw new RuntimeException("xxx")
+      }
+    }
+  }
+
+  it should "accept a static seed" in {
+    val seed = Seed.random()
+    val xxx = withGen(Gen.choose(1, 10), seed)(i => i)
+    val yyy = withGen(Gen.choose(1, 10), seed)(i => i)
+    assert(xxx == yyy)
+  }
+
+  it should "accept a base64 string seed" in {
+    val seed = Seed.random().toBase64
+    val xxx = withGen(Gen.choose(1, 10), seed)(i => i)
+    val yyy = withGen(Gen.choose(1, 10), seed)(i => i)
+    assert(xxx == yyy)
+  }
+
+}

--- a/scio-test/src/test/scala/com/spotify/scio/testing/PipelineTestUtilsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/PipelineTestUtilsTest.scala
@@ -4,14 +4,14 @@ import org.scalacheck.Gen
 import org.scalacheck.rng.Seed
 
 class PipelineTestUtilsTest extends PipelineSpec {
-  "PipelineTestUtils" should "generate a test case and have an optional return value" in {
-    val xxx = withGen(Gen.const(1))(i => i)
-    assert(xxx.contains(1))
+  "PipelineTestUtils.withGen" should "generate a test case and have an optional return value" in {
+    val x = withGen(Gen.const(1))(i => i)
+    assert(x.contains(1))
   }
 
   it should "return None on test case generation failure, not throw" in {
-    val xxx = withGen(Gen.const(1).suchThat(_ => false))(_ => ())
-    assert(xxx.isEmpty)
+    val x = withGen(Gen.const(1).suchThat(_ => false))(_ => ())
+    assert(x.isEmpty)
   }
 
   it should "propagate errors" in {
@@ -24,16 +24,16 @@ class PipelineTestUtilsTest extends PipelineSpec {
 
   it should "accept a static seed" in {
     val seed = Seed.random()
-    val xxx = withGen(Gen.choose(1, 10), seed)(i => i)
-    val yyy = withGen(Gen.choose(1, 10), seed)(i => i)
-    assert(xxx == yyy)
+    val x = withGen(Gen.choose(1, 10), seed)(i => i)
+    val y = withGen(Gen.choose(1, 10), seed)(i => i)
+    assert(x == y)
   }
 
   it should "accept a base64 string seed" in {
     val seed = Seed.random().toBase64
-    val xxx = withGen(Gen.choose(1, 10), seed)(i => i)
-    val yyy = withGen(Gen.choose(1, 10), seed)(i => i)
-    assert(xxx == yyy)
+    val x = withGen(Gen.choose(1, 10), seed)(i => i)
+    val y = withGen(Gen.choose(1, 10), seed)(i => i)
+    assert(x == y)
   }
 
 }

--- a/site/src/main/paradox/Scio-Unit-Tests.md
+++ b/site/src/main/paradox/Scio-Unit-Tests.md
@@ -83,6 +83,21 @@ To run the test, we use the `runWithContext`, this will run calculateTeamScores 
 
 Scio provides more `SCollection` assertions such as `inWindow`, `inCombinedNonLatePanes`, `inFinalPane`, and `inOnlyPane`. You can find the full list [here](https://spotify.github.io/scio/api/com/spotify/scio/testing/SCollectionMatchers.html). More information on testing unbounded pipelines can be found [here](https://beam.apache.org/blog/2016/10/20/test-stream.html).
 
+### Test using scalacheck generators
 
+When using `org.scalacheck.Gen` to create test data in a pipeline test, use `withGen` to capture the random seed and print it on failure:
+```scala mdoc
+val inputGen = Gen.listOfN(10, Gen.choose(1, 10))
+withGen(inputGen) { input =>
+  throw new RuntimeException("woops")
+}
+// will log:
+// Failure at MyTest:3. Seed: m82pUlOaHUcyWDadIbOIdEOR7GW4ebmN1oR0a0vbLpG=
+```
 
-
+To reproduce a test failure, a static seed can be passed as either a base-64 string or an `org.scalacheck.rng.Seed`:
+```scala mdoc
+withGen(inputGen, "m82pUlOaHUcyWDadIbOIdEOR7GW4ebmN1oR0a0vbLpG=") { input =>
+  // ...
+}
+```


### PR DESCRIPTION
Provides a standard way to log the seed on test failure and to handle generation failure.