### PR TITLE
Rework GHA pre-release job setup

### DIFF
--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -3,7 +3,6 @@ name: pre-release-check
 env:
   GOOGLE_PROJECT_ID: data-integration-test
   SBT_OPTS: -DbeamRunners=DataflowRunner
-  DEFAULT_DATAFLOW_ARGS: --runner=DataflowRunner --project=data-integration-test --region=europe-west1 --tempLocation=gs://dataflow-tmp-europe-west1/gha
 
 on:
   workflow_dispatch # Manually triggered
@@ -24,13 +23,5 @@ jobs:
           java-version: 11
       - name: set JVM opts
         run: scripts/gha_setup.sh
-      - name: (Dataflow) IO Writes
-        run: sbt ${{ env.SBT_OPTS }} "scio-examples/runMain ${{ matrix.io_write }} ${{ env.DEFAULT_DATAFLOW_ARGS }} "
-      - name: (Dataflow) IO Reads
-        run: sbt ${{ env.SBT_OPTS }} "scio-examples/runMain ${{ matrix.io_read }} ${{ env.DEFAULT_DATAFLOW_ARGS }}"
-    strategy:
-      matrix:
-        io_write:
-          - com.spotify.scio.examples.extra.AvroExample --method=specificOut --output=gs://data-integration-test-prerelease-it/AvroExample/Write/${{ github.run_id }}
-        io_read:
-          - com.spotify.scio.examples.extra.AvroExample --method=specificIn --input=gs://data-integration-test-prerelease-it/AvroExample/Write/${{ github.run_id }}/*.avro --output=gs://data-integration-test-eu/AvroExample/Read/${{ github.run_id }}
+      - name: Run Dataflow jobs
+        run: sbt ${{ env.SBT_OPTS }} "scio-examples/it:runMain com.spotify.scio.examples.RunPreReleaseIT --runId=${{ github.run_id }}"

--- a/build.sbt
+++ b/build.sbt
@@ -882,6 +882,7 @@ lazy val `scio-examples`: Project = project
   .in(file("scio-examples"))
   .settings(commonSettings)
   .settings(soccoSettings)
+  .settings(itSettings)
   .settings(beamRunnerSettings)
   .settings(macroSettings)
   .settings(
@@ -940,6 +941,7 @@ lazy val `scio-examples`: Project = project
       ForkOptions().withRunJVMOptions((Test / javaOptions).value.toVector)
     )
   )
+  .configs(IntegrationTest)
   .dependsOn(
     `scio-core`,
     `scio-google-cloud-platform`,

--- a/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
+++ b/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
@@ -34,7 +34,7 @@ object RunPreReleaseIT {
           parquet(runId) :+ avro(runId)
         )
         .map(_ => log.info("All Dataflow jobs ran successfully."))
-        .recover(e => log.error("At least one Dataflow job failed", e)),
+        .recover(e => throw new RuntimeException("At least one Dataflow job failed", e)),
       Duration(1, TimeUnit.HOURS)
     )
   }

--- a/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
+++ b/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2022 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.scio.examples
 
 import com.spotify.scio.ContextAndArgs

--- a/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
+++ b/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
@@ -13,7 +13,7 @@ import scala.util.{Failure, Success, Try}
 
 object RunPreReleaseIT {
 
-  implicit val ec: ExecutionContext = ExecutionContext.global
+  implicit private val ec: ExecutionContext = ExecutionContext.global
 
   private val defaultArgs = Array(
     "--runner=DataflowRunner",
@@ -39,7 +39,7 @@ object RunPreReleaseIT {
     )
   }
 
-  def avro(runId: String): Future[Unit] = {
+  private def avro(runId: String): Future[Unit] = {
     val out1 = gcsPath[AvroExample.type]("specificOut", runId)
     val out2 = gcsPath[AvroExample.type]("specificIn", runId)
 
@@ -51,7 +51,7 @@ object RunPreReleaseIT {
       )
   }
 
-  def parquet(runId: String): List[Future[Unit]] = {
+  private def parquet(runId: String): List[Future[Unit]] = {
     val out1 = gcsPath[ParquetExample.type]("avroOut", runId)
     val out2 = gcsPath[ParquetExample.type]("typedIn", runId)
     val out3 = gcsPath[ParquetExample.type]("avroSpecificIn", runId)
@@ -74,11 +74,11 @@ object RunPreReleaseIT {
     )
   }
 
-  def invokeJob[T: ClassTag](args: String*): Future[Unit] =
+  private def invokeJob[T: ClassTag](args: String*): Future[Unit] =
     Future {
       val cls = ScioUtil.classOf[T]
       val jobObjName = cls.getName.replaceAll("\\$$", "")
-      log.info(s"Running Dataflow job ${cls.getName}")
+      log.info(s"Running Dataflow job ${cls.getName}...")
       Try(
         Class
           .forName(jobObjName)

--- a/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
+++ b/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
@@ -1,0 +1,96 @@
+package com.spotify.scio.examples
+
+import com.spotify.scio.ContextAndArgs
+import com.spotify.scio.examples.extra.{AvroExample, ParquetExample}
+import com.spotify.scio.util.ScioUtil
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
+
+object RunPreReleaseIT {
+
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  private val defaultArgs = Array(
+    "--runner=DataflowRunner",
+    "--project=data-integration-test",
+    "--region=europe-west1",
+    "--tempLocation=gs://dataflow-tmp-europe-west1/gha"
+  )
+
+  private val log = LoggerFactory.getLogger(getClass)
+
+  def main(cmdLineArgs: Array[String]): Unit = {
+    val (_, args) = ContextAndArgs(cmdLineArgs)
+    val runId = args("runId")
+
+    Await.result(
+      Future
+        .sequence(
+          parquet(runId) :+ avro(runId)
+        )
+        .map(_ => log.info("All Dataflow jobs ran successfully."))
+        .recover(e => log.error("At least one Dataflow job failed", e)),
+      Duration(1, TimeUnit.HOURS)
+    )
+  }
+
+  def avro(runId: String): Future[Unit] = {
+    val out1 = gcsPath[AvroExample.type]("specificOut", runId)
+    val out2 = gcsPath[AvroExample.type]("specificIn", runId)
+
+    Future
+      .successful(log.info("Starting Avro IO tests... "))
+      .flatMap(_ => invokeJob[AvroExample.type]("--method=specificOut", s"--output=$out1"))
+      .flatMap(_ =>
+        invokeJob[AvroExample.type]("--method=specificIn", s"--input=$out1", s"--output=$out2")
+      )
+  }
+
+  def parquet(runId: String): List[Future[Unit]] = {
+    val out1 = gcsPath[ParquetExample.type]("avroOut", runId)
+    val out2 = gcsPath[ParquetExample.type]("typedIn", runId)
+    val out3 = gcsPath[ParquetExample.type]("avroSpecificIn", runId)
+
+    val write = Future
+      .successful(log.info("Starting Parquet IO tests... "))
+      .flatMap(_ => invokeJob[ParquetExample.type]("--method=avroOut", s"--output=$out1"))
+
+    List(
+      write.flatMap(_ =>
+        invokeJob[ParquetExample.type]("--method=typedIn", s"--input=$out1", s"--output=$out2")
+      ),
+      write.flatMap(_ =>
+        invokeJob[ParquetExample.type](
+          "--method=avroSpecificIn",
+          s"--input=$out1",
+          s"--output=$out3"
+        )
+      )
+    )
+  }
+
+  def invokeJob[T: ClassTag](args: String*): Future[Unit] =
+    Future {
+      val cls = ScioUtil.classOf[T]
+      val jobObjName = cls.getName.replaceAll("\\$$", "")
+      log.info(s"Running Dataflow job ${cls.getName}")
+      Try(
+        Class
+          .forName(jobObjName)
+          .getMethod("main", classOf[Array[String]])
+          .invoke(null, defaultArgs ++ Array(args: _*))
+      ) match {
+        case Success(_) => log.info(s"Dataflow job ${cls.getName} ran successfully.")
+        case Failure(e) =>
+          throw new RuntimeException(s"Dataflow job ${cls.getName} failed with ${e.getClass}", e)
+      }
+    }
+
+  private def gcsPath[T: ClassTag](methodName: String, runId: String): String =
+    s"gs://data-integration-test-prerelease-it/${ScioUtil.classOf[T].getSimpleName}/$methodName/$runId"
+}

--- a/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
+++ b/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
@@ -47,7 +47,7 @@ object RunPreReleaseIT {
       .successful(log.info("Starting Avro IO tests... "))
       .flatMap(_ => invokeJob[AvroExample.type]("--method=specificOut", s"--output=$out1"))
       .flatMap(_ =>
-        invokeJob[AvroExample.type]("--method=specificIn", s"--input=$out1", s"--output=$out2")
+        invokeJob[AvroExample.type]("--method=specificIn", s"--input=$out1/*", s"--output=$out2")
       )
   }
 
@@ -62,12 +62,12 @@ object RunPreReleaseIT {
 
     List(
       write.flatMap(_ =>
-        invokeJob[ParquetExample.type]("--method=typedIn", s"--input=$out1", s"--output=$out2")
+        invokeJob[ParquetExample.type]("--method=typedIn", s"--input=$out1/*", s"--output=$out2")
       ),
       write.flatMap(_ =>
         invokeJob[ParquetExample.type](
           "--method=avroSpecificIn",
-          s"--input=$out1",
+          s"--input=$out1/*",
           s"--output=$out3"
         )
       )

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
@@ -87,7 +87,7 @@ object ParquetExample {
       case _ => throw new RuntimeException(s"Invalid method $m")
     }
 
-    sc.run()
+    sc.run().waitUntilDone()
     ()
   }
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
@@ -29,31 +29,35 @@ package com.spotify.scio.examples.extra
 import com.spotify.scio.ContextAndArgs
 import com.spotify.scio.avro.Account
 import com.spotify.scio.coders.Coder
-import org.apache.avro.Schema.Field
+import org.apache.avro.Schema
 import org.apache.avro.file.CodecFactory
 import org.apache.avro.generic.{GenericData, GenericRecord}
-import org.apache.avro.{JsonProperties, Schema}
-import org.apache.beam.sdk.extensions.smb.AvroSortedBucketIO
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType
-import org.apache.beam.sdk.extensions.smb.TargetParallelism
+import org.apache.beam.sdk.extensions.smb.{AvroSortedBucketIO, TargetParallelism}
 import org.apache.beam.sdk.values.TupleTag
 
-import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 object SortMergeBucketExample {
-  lazy val UserDataSchema: Schema = Schema.createRecord(
-    "UserData",
-    "doc",
-    "com.spotify.scio.examples.extra",
-    false,
-    List(
-      new Field("userId", Schema.create(Schema.Type.INT), "doc", JsonProperties.NULL_VALUE),
-      new Field("age", Schema.create(Schema.Type.INT), "doc", JsonProperties.NULL_VALUE)
-    ).asJava
+  lazy val UserDataSchema: Schema = new Schema.Parser().parse(
+    """
+      |{
+      |    "name": "UserData",
+      |    "namespace": "com.spotify.examples.extra",
+      |    "type": "record",
+      |    "fields": [
+      |        {
+      |            "name": "userId",
+      |            "type": ["null", {"type": "string", "avro.java.string": "String"}]
+      |        },
+      |        {
+      |          "name": "age", "type": "int"
+      |        }
+      |    ]}
+      |""".stripMargin
   )
 
-  def user(id: Int, age: Int): GenericRecord = {
+  def user(id: String, age: Int): GenericRecord = {
     val gr = new GenericData.Record(UserDataSchema)
     gr.put("userId", id)
     gr.put("age", age)
@@ -72,10 +76,10 @@ object SortMergeBucketWriteExample {
     val (sc, args) = ContextAndArgs(cmdLineArgs)
 
     sc.parallelize(0 until 500)
-      .map(i => SortMergeBucketExample.user(i, i % 100))
+      .map(i => SortMergeBucketExample.user(i.toString, i % 100))
       .saveAsSortedBucket(
         AvroSortedBucketIO
-          .write(classOf[Integer], "userId", SortMergeBucketExample.UserDataSchema)
+          .write(classOf[String], "userId", SortMergeBucketExample.UserDataSchema)
           .to(args("users"))
           .withTempDirectory(sc.options.getTempLocation)
           .withCodec(CodecFactory.snappyCodec())
@@ -91,14 +95,14 @@ object SortMergeBucketWriteExample {
         Account
           .newBuilder()
           .setId(i)
-          .setName(s"user$i")
+          .setName(i.toString)
           .setType(s"type${i % 5}")
           .setAmount(Random.nextDouble() * 1000)
           .build()
       }
       .saveAsSortedBucket(
         AvroSortedBucketIO
-          .write[Integer, Account](classOf[Integer], "id", classOf[Account])
+          .write[String, Account](classOf[String], "name", classOf[Account])
           .to(args("accounts"))
           .withSorterMemoryMb(128)
           .withTempDirectory(sc.options.getTempLocation)
@@ -120,21 +124,21 @@ object SortMergeBucketJoinExample {
   implicit val coder: Coder[GenericRecord] =
     Coder.avroGenericRecordCoder(SortMergeBucketExample.UserDataSchema)
 
-  case class UserAccountData(userId: Int, age: Int, balance: Double) {
+  case class UserAccountData(userId: String, age: Int, balance: Double) {
     override def toString: String = s"$userId\t$age\t$balance"
   }
 
   def main(cmdLineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdLineArgs)
 
-    val mapFn: ((Integer, (GenericRecord, Account))) => UserAccountData = {
+    val mapFn: ((String, (GenericRecord, Account))) => UserAccountData = {
       case (userId, (userData, account)) =>
         UserAccountData(userId, userData.get("age").toString.toInt, account.getAmount)
     }
 
     // #SortMergeBucketExample_join
     sc.sortMergeJoin(
-      classOf[Integer],
+      classOf[String],
       AvroSortedBucketIO
         .read(new TupleTag[GenericRecord]("lhs"), SortMergeBucketExample.UserDataSchema)
         // 1. Only 1 user per user ID
@@ -171,21 +175,21 @@ object SortMergeBucketTransformExample {
     )
 
     sc.sortMergeTransform(
-      classOf[Integer],
+      classOf[String],
       readLhs,
       readRhs,
       TargetParallelism.auto()
     ).to(
       AvroSortedBucketIO
-        .transformOutput(classOf[Integer], "id", classOf[Account])
+        .transformOutput(classOf[String], "name", classOf[Account])
         .to(args("output"))
     ).via { case (key, (users, accounts), outputCollector) =>
       users.foreach { user =>
         outputCollector.accept(
           Account
             .newBuilder()
-            .setId(key)
-            .setName(user.get("userId").toString)
+            .setId(key.toInt)
+            .setName(key)
             .setType("combinedAmount")
             .setAmount(accounts.foldLeft(0.0)(_ + _.getAmount))
             .build()

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
@@ -184,7 +184,7 @@ object SortMergeBucketTransformExample {
         .transformOutput(classOf[String], "name", classOf[Account])
         .to(args("output"))
     ).via { case (key, (users, accounts), outputCollector) =>
-      users.foreach { user =>
+      users.foreach { _ =>
         outputCollector.accept(
           Account
             .newBuilder()

--- a/scio-schemas/src/main/avro/schema.avsc
+++ b/scio-schemas/src/main/avro/schema.avsc
@@ -6,7 +6,7 @@
     "fields": [
         {"name": "id", "type": "int"},
         {"name": "type", "type": "string"},
-        {"name": "name", "type": "string"},
+        {"name": "name", "type": ["null", "string"]},
         {"name": "amount", "type": "double"}
     ]
 }, {


### PR DESCRIPTION
this re-organizes the pre-release GHA setup to optimize the amount of concurrency and minimize dead time on the GHA worker. GHA doesn't have great built-in support for concurrent execution of tasks, so I created a Scala runnable class that uses vanilla Scala Futures to express this task graph (i.e. Avro read example depends on Avro write example). Also, I added Parquet jobs.

a downside of it is that you can't run individual jobs/parts of the workflow...you have to run the whole thing every time

Tested this out on GHA to verify it works as expected! lmk what you think.