### PR TITLE
Include which user is authenticated in BQ 403 exceptions

### DIFF
--- a/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/PopulateTestData.scala
+++ b/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/PopulateTestData.scala
@@ -124,7 +124,7 @@ object PopulateTestData {
       .setDatasetReference(new DatasetReference().setProjectId(projectId).setDatasetId(datasetId))
       .setLocation(location)
     try {
-      bq.client.underlying.datasets().insert(projectId, ds).execute()
+      bq.client.execute(_.datasets().insert(projectId, ds))
     } catch {
       case e: GoogleJsonResponseException
           if e.getStatusCode == 409 && e.getDetails.getMessage.contains("Already Exists") =>

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQuerySysProps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQuerySysProps.scala
@@ -53,4 +53,9 @@ object BigQuerySysProps {
     "Timeout in milliseconds to read data from an established connection. " +
       "Default is 20000 (20 seconds). 0 for an infinite timeout."
   )
+
+  val DebugAuth: SysProp = SysProp(
+    "bigquery.debug_auth",
+    "System property key to enable logging active BigQuery user information on auth errors"
+  )
 }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
@@ -243,9 +243,9 @@ object BigQuery {
             new HttpResponseException.Builder(e.getStatusCode, e.getStatusMessage, e.getHeaders)
               .setContent(e.getContent)
               .setMessage(s"""
-                   |[${getClass.getName}] Authenticated ${adc._1} was ${adc._2}
-                   |
                    |${e.getMessage}
+                   |
+                   |[${getClass.getName}] Authenticated ${adc._1}: ${adc._2}
                    |""".stripMargin),
             e.getDetails
           )

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
@@ -239,14 +239,16 @@ object BigQuery {
         case Success(response) => response
         case Failure(e: GoogleJsonResponseException) if e.getStatusCode == 403 =>
           val adc = getAuthenticatedUser
-          throw new HttpResponseException.Builder(e.getStatusCode, e.getStatusMessage, e.getHeaders)
-            .setContent(e.getContent)
-            .setMessage(s"""
+          throw new GoogleJsonResponseException(
+            new HttpResponseException.Builder(e.getStatusCode, e.getStatusMessage, e.getHeaders)
+              .setContent(e.getContent)
+              .setMessage(s"""
                    |[${getClass.getName}] Authenticated ${adc._1} was ${adc._2}
                    |
                    |${e.getMessage}
-                   |""".stripMargin)
-            .build()
+                   |""".stripMargin),
+            e.getDetails
+          )
         case Failure(e) =>
           throw e
       }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQueryConfig.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQueryConfig.scala
@@ -37,6 +37,9 @@ object BigQueryConfig {
   /** Default cache behavior is enabled. */
   private[this] val CacheEnabledDefault: Boolean = true
 
+  /** Default debug auth behavior is disabled. */
+  private[this] val DebugAuthEnabledDefault: Boolean = false
+
   /** Default priority is batch. */
   private[this] val PriorityDefault: QueryPriority = QueryPriority.BATCH
 
@@ -52,6 +55,11 @@ object BigQueryConfig {
     BigQuerySysProps.CacheEnabled.valueOption
       .flatMap(x => Try(x.toBoolean).toOption)
       .getOrElse(CacheEnabledDefault)
+
+  def isDebugAuthEnabled: Boolean =
+    BigQuerySysProps.DebugAuth.valueOption
+      .flatMap(x => Try(x.toBoolean).toOption)
+      .getOrElse(DebugAuthEnabledDefault)
 
   def cacheDirectory: Path =
     BigQuerySysProps.CacheDirectory.valueOption.map(Paths.get(_)).getOrElse(CacheDirectoryDefault)

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/ExtractOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/ExtractOps.scala
@@ -125,7 +125,7 @@ final private[client] class ExtractOps(client: Client, jobService: JobOps) {
 
     Logger.info(s"Extracting table $sourceTable to ${destinationUris.mkString(", ")}")
 
-    client.underlying.jobs().insert(client.project, job).execute()
+    client.execute(_.jobs().insert(client.project, job))
 
     val extractJob = ExtractJob(destinationUris, Some(jobReference), tableRef)
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/JobOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/JobOps.scala
@@ -91,11 +91,11 @@ final private[client] class JobOps(client: Client) {
       val remainingJobs = pendingJobs.filter { case (bqJob, jobReference) =>
         val jobId = jobReference.getJobId
         try {
-          val poll = client.underlying
-            .jobs()
-            .get(client.project, jobId)
-            .setLocation(jobReference.getLocation)
-            .execute()
+          val poll = client.execute(
+            _.jobs()
+              .get(client.project, jobId)
+              .setLocation(jobReference.getLocation)
+          )
           val error = poll.getStatus.getErrorResult
           if (error != null) {
             throw new RuntimeException(s"${bqJob.show} failed with error: $error")

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/LoadOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/LoadOps.scala
@@ -158,7 +158,7 @@ final private[client] class LoadOps(client: Client, jobService: JobOps) {
 
     Logger.info(s"Loading data into $destinationTable from ${sources.mkString(", ")}")
 
-    client.underlying.jobs().insert(client.project, job).execute()
+    client.execute(_.jobs().insert(client.project, job))
 
     val loadJob = LoadJob(sources, Some(jobReference), tableRef)
 


### PR DESCRIPTION
A common BQ-related complaint is about the vagueness of Google's 403 exception: `User does not have permission to query table` doesn't contain the relevant info about which user is _actually_ making the call and this can get confusing with the bigquery permissions setup. This PR updates the exception error message to actually include the name of the credentialed user, for example:

```bash
[error] /scio/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BigqueryExample.scala:10:4: exception during macro expansion: 
[error] com.google.api.client.googleapis.json.GoogleJsonResponseException: 
[error] 403 Forbidden
[error] POST https://bigquery.googleapis.com/bigquery/v2/projects/scio-playground/jobs
[error] {
[error]   "code" : 403,
[error]   "errors" : [ {
[error]     "domain" : "global",
[error]     "message" : "Access Denied: Table ****:***.***.**: User does not have permission to query table ***.***.**.",
[error]     "reason" : "accessDenied"
[error]   } ],
[error]   "message" : "Access Denied: Table ***.***.**: User does not have permission to query table ***.***.**.",
[error]   "status" : "PERMISSION_DENIED"
[error] }
[error]
[error] [com.spotify.scio.bigquery.client.BigQuery$bigquery.debug_auth] Active credential was service account claire@*****.iam.gserviceaccount.com
[error] 
[error] 	at com.spotify.scio.bigquery.client.BigQuery$Client.execute(BigQuery.scala:250)
[error] 	at com.spotify.scio.bigquery.client.QueryOps$$anonfun$com$spotify$scio$bigquery$client$QueryOps$$run$1$1.apply(QueryOps.scala:258)
[error] 	at com.spotify.scio.bigquery.client.QueryOps$$anonfun$com$spotify$scio$bigquery$client$QueryOps$$run$1$1.apply(QueryOps.scala:232)
[error] 	at scala.util.Try$.apply(Try.scala:210)
[error] 	at com.spotify.scio.bigquery.client.QueryOps.com$spotify$scio$bigquery$client$QueryOps$$run$1(QueryOps.scala:232)
[error] 	at com.spotify.scio.bigquery.client.QueryOps$$anonfun$com$spotify$scio$bigquery$client$QueryOps$$run$1.apply(QueryOps.scala:266)
[error] 	at com.spotify.scio.bigquery.client.QueryOps$$anonfun$com$spotify$scio$bigquery$client$QueryOps$$run$1.apply(QueryOps.scala:266)
[error] 	at scala.collection.mutable.HashMap.getOrElseUpdate(HashMap.scala:454)
[error] 	at com.spotify.scio.bigquery.client.QueryOps.com$spotify$scio$bigquery$client$QueryOps$$run(QueryOps.scala:266)
[error] 	at com.spotify.scio.bigquery.client.QueryOps.isLegacySql(QueryOps.scala:294)
[error] 	at com.spotify.scio.bigquery.client.QueryOps$$anonfun$schema$1.apply(QueryOps.scala:62)
[error] 	at com.spotify.scio.bigquery.client.QueryOps$$anonfun$schema$1.apply(QueryOps.scala:62)
[error] 	at com.spotify.scio.bigquery.client.Cache$.getOrElse(Cache.scala:86)
[error] 	at com.spotify.scio.bigquery.client.QueryOps.schema(QueryOps.scala:61)
[error] 	at com.spotify.scio.bigquery.types.TypeProvider$.queryImpl(TypeProvider.scala:128)
[error]   @BigQueryType.fromQuery("*******")
```

I feel like I put it in kind of an awkward place... lmk if you can think of a better location for this message 😅  Maybe upon instantiation of the client even? Or just logged? 

also, trying to brainstorm whether this would raise any GDPR/privacy issues 🤔 