### PR TITLE
Fix parquet avro generic records read

### DIFF
--- a/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
+++ b/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
@@ -77,6 +77,7 @@ object RunPreReleaseIT {
     val out1 = gcsPath[ParquetExample.type]("avroOut", runId)
     val out2 = gcsPath[ParquetExample.type]("typedIn", runId)
     val out3 = gcsPath[ParquetExample.type]("avroSpecificIn", runId)
+    val out4 = gcsPath[ParquetExample.type]("avroGenericIn", runId)
 
     val write = Future
       .successful(log.info("Starting Parquet IO tests... "))
@@ -91,6 +92,13 @@ object RunPreReleaseIT {
           "--method=avroSpecificIn",
           s"--input=$out1/*",
           s"--output=$out3"
+        )
+      ),
+      write.flatMap(_ =>
+        invokeJob[ParquetExample.type](
+          "--method=avroGenericIn",
+          s"--input=$out1/*",
+          s"--output=$out4"
         )
       )
     )

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroInOut.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroInOut.scala
@@ -43,6 +43,7 @@ object AvroInOut {
           .setType("checking")
           .setName(r.getStringField)
           .setAmount(r.getDoubleField)
+          .setAccountStatus(AccountStatus.Active)
           .build()
       }
       // Save result as Avro files

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroExampleTest.scala
@@ -25,7 +25,10 @@ import com.spotify.scio.testing._
 class AvroExampleTest extends PipelineSpec {
   "AvroExample" should "work for specific input" in {
     val input =
-      Seq(new Account(1, "checking", "Alice", 1000.0), new Account(2, "checking", "Bob", 1500.0))
+      Seq(
+        new Account(1, "checking", "Alice", 1000.0, AccountStatus.Active),
+        new Account(2, "checking", "Bob", 1500.0, AccountStatus.Active)
+      )
 
     val expected = input.map(_.toString)
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroInOutTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroInOutTest.scala
@@ -29,7 +29,10 @@ class AvroInOutTest extends PipelineSpec {
   )
 
   val expected: Seq[Account] =
-    Seq(new Account(1, "checking", "Alice", 1000.0), new Account(2, "checking", "Bob", 1500.0))
+    Seq(
+      new Account(1, "checking", "Alice", 1000.0, AccountStatus.Active),
+      new Account(2, "checking", "Bob", 1500.0, AccountStatus.Active)
+    )
 
   "AvroInOut" should "work" in {
     JobTest[com.spotify.scio.examples.extra.AvroInOut.type]

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
@@ -21,7 +21,7 @@ import com.spotify.scio.testing.PipelineSpec
 import com.google.protobuf.Message
 import org.apache.beam.sdk.io.gcp.{pubsub => beam}
 import com.spotify.scio._
-import com.spotify.scio.avro.Account
+import com.spotify.scio.avro.{Account, AccountStatus}
 import com.spotify.scio.proto.Track.TrackPB
 import com.spotify.scio.testing._
 import com.spotify.scio.pubsub._
@@ -62,7 +62,7 @@ class PubsubIOTest extends PipelineSpec with ScioIOSpec {
   }
 
   it should "support deprecated readAvro" in {
-    val xs = (1 to 100).map(x => new Account(x, "", "", x.toDouble))
+    val xs = (1 to 100).map(x => new Account(x, "", "", x.toDouble, AccountStatus.Active))
     testJobTest(xs)(PubsubIO.readAvro[Account](_))(_.pubsubSubscription(_))(_.saveAsPubsub(_))
   }
 

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
@@ -99,7 +99,7 @@ class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
 
     val sc1 = ScioContext()
     val nestedRecords =
-      (1 to 10).map(x => new Account(x, x.toString, x.toString, x.toDouble))
+      (1 to 10).map(x => new Account(x, x.toString, x.toString, x.toDouble, AccountStatus.Active))
     sc1
       .parallelize(nestedRecords)
       .saveAsParquetAvroFile(dir.toString)

--- a/scio-schemas/src/main/avro/schema.avsc
+++ b/scio-schemas/src/main/avro/schema.avsc
@@ -7,7 +7,15 @@
         {"name": "id", "type": "int"},
         {"name": "type", "type": "string"},
         {"name": "name", "type": ["null", "string"]},
-        {"name": "amount", "type": "double"}
+        {"name": "amount", "type": "double"},
+        {
+         "name": "account_status",
+         "type": [
+              "null",
+              {"type": "enum", "name": "AccountStatus", "symbols": ["Active", "Inactive"]}
+           ],
+         "default": null
+        }
     ]
 }, {
     "type": "record",

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -219,7 +219,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
   object Avro {
     import com.spotify.scio.avro.{Account, Address, User => AvUser}
 
-    val accounts: List[Account] = List(new Account(1, "type", "name", 12.5, AccountStatus.Active))
+    val accounts: List[Account] = List(new Account(1, "type", "name", 12.5, null))
     val address =
       new Address("street1", "street2", "city", "state", "01234", "Sweden")
     val user = new AvUser(1, "lastname", "firstname", "email@foobar.com", accounts.asJava, address)

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -33,6 +33,7 @@ import scala.collection.{mutable => mut}
 import java.io.ByteArrayInputStream
 import org.apache.beam.sdk.testing.CoderProperties
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
+import com.spotify.scio.avro.AccountStatus
 import com.twitter.algebird.Moments
 
 final case class UserId(bytes: Seq[Byte])
@@ -218,7 +219,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
   object Avro {
     import com.spotify.scio.avro.{Account, Address, User => AvUser}
 
-    val accounts: List[Account] = List(new Account(1, "tyoe", "name", 12.5))
+    val accounts: List[Account] = List(new Account(1, "type", "name", 12.5, AccountStatus.Active))
     val address =
       new Address("street1", "street2", "city", "state", "01234", "Sweden")
     val user = new AvUser(1, "lastname", "firstname", "email@foobar.com", accounts.asJava, address)

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -33,7 +33,6 @@ import scala.collection.{mutable => mut}
 import java.io.ByteArrayInputStream
 import org.apache.beam.sdk.testing.CoderProperties
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
-import com.spotify.scio.avro.AccountStatus
 import com.twitter.algebird.Moments
 
 final case class UserId(bytes: Seq[Byte])


### PR DESCRIPTION
The following primitive job reading Avro Parquet: 

```scala
val schema: Schema = ...
implicit val genericRecordCoder: Coder[GenericRecord] = Coder.avroGenericRecordCoder(schema)
sc.parquetAvroFile[GenericRecord](args("input"), schema)
      .map(identity)
      .count
```

would fail with the following error:

```
Exception in thread "main" org.apache.avro.AvroTypeException: Not an enum: <***EnumVariant***>
	at org.apache.avro.generic.GenericDatumWriter.writeEnum(GenericDatumWriter.java:177)
	at org.apache.avro.generic.GenericDatumWriter.writeWithoutConversion(GenericDatumWriter.java:119)
	at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:75)
	at org.apache.avro.generic.GenericDatumWriter.writeField(GenericDatumWriter.java:166)
	at org.apache.avro.generic.GenericDatumWriter.writeRecord(GenericDatumWriter.java:156)
	at org.apache.avro.generic.GenericDatumWriter.writeWithoutConversion(GenericDatumWriter.java:118)
	at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:75)
	at org.apache.avro.generic.GenericDatumWriter.writeField(GenericDatumWriter.java:166)
	at org.apache.avro.generic.GenericDatumWriter.writeRecord(GenericDatumWriter.java:156)
	at org.apache.avro.generic.GenericDatumWriter.writeWithoutConversion(GenericDatumWriter.java:118)
	at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:75)
	at org.apache.avro.generic.GenericDatumWriter.write(GenericDatumWriter.java:62)
	at org.apache.beam.sdk.coders.AvroCoder.encode(AvroCoder.java:363)
	at org.apache.beam.sdk.coders.Coder.encode(Coder.java:136)
	at org.apache.beam.sdk.util.CoderUtils.encodeToSafeStream(CoderUtils.java:85)
	at org.apache.beam.sdk.util.CoderUtils.encodeToByteArray(CoderUtils.java:69)
	at org.apache.beam.sdk.util.CoderUtils.encodeToByteArray(CoderUtils.java:54)
	at org.apache.beam.sdk.util.CoderUtils.clone(CoderUtils.java:144)
	at org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO$HadoopInputFormatBoundedSource$HadoopInputFormatReader.cloneIfPossiblyMutable(HadoopFormatIO.java:983)
	at org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO$HadoopInputFormatBoundedSource$HadoopInputFormatReader.transformKeyOrValue(HadoopFormatIO.java:972)
	at org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO$HadoopInputFormatBoundedSource$HadoopInputFormatReader.getCurrent(HadoopFormatIO.java:946)
	at org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO$HadoopInputFormatBoundedSource$HadoopInputFormatReader.getCurrent(HadoopFormatIO.java:856)
	at org.apache.beam.runners.direct.BoundedReadEvaluatorFactory$BoundedReadEvaluator.processElement(BoundedReadEvaluatorFactory.java:156)
	at org.apache.beam.runners.direct.DirectTransformExecutor.processElements(DirectTransformExecutor.java:165)
```

Root cause: Beam's AvroCoder expects GenericRecords to be encoded using Avro GenericData model, but `parquet-avro` uses `SpecificData` model unless it is configured to use `GenericData` explicitly.

Fix: infer case when GenericRecord is read and apply Parquet specific configs to switch `parquet-avro` to `GenericData` model so it produces GenericData records compatible with Beam's AvroCoder. To configure Parquet two [read config params](https://github.com/apache/parquet-mr/tree/master/parquet-avro) are used: 
 - `parquet.avro.compatible=false`
 -  `parquet.avro.data.supplier=org.apache.parquet.avro.GenericDataSupplier `. 
 
The former forces Parquet to use [AvroRecordConverter](https://github.com/apache/parquet-mr/blob/master/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java) instead of [AvroIndexedRecordConverter](https://github.com/apache/parquet-mr/blob/master/parquet-avro/src/main/java/org/apache/parquet/avro/AvroIndexedRecordConverter.java) and needed because AvroIndexedRecordConverter doesn't support `GenericData` at all. The latter instructs parquet to use `GenericData` model by forcing it to use `org.apache.parquet.avro.GenericDataSupplier`.

The issue was observed for Avro enums: specific data model would deserialize enums as an instance of Java enum, but AvroCoder expects it to be wrapped into [EnumSymbol](https://github.com/apache/avro/blob/master/lang/java/avro/src/main/java/org/apache/avro/generic/GenericData.java#L511) and fails during runtime.

