### PR TITLE
update socco-ng to 0.1.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1226,7 +1226,7 @@ lazy val soccoSettings = if (sys.env.contains("SOCCO")) {
       "-P:socco:package_com.spotify.scio:https://spotify.github.io/scio/api"
     ),
     autoCompilerPlugins := true,
-    addCompilerPlugin(("io.regadas" %% "socco-ng" % "0.1.6").cross(CrossVersion.full)),
+    addCompilerPlugin(("io.regadas" %% "socco-ng" % "0.1.7").cross(CrossVersion.full)),
     // Generate scio-examples/target/site/index.html
     soccoIndex := SoccoIndex.generate(target.value / "site" / "index.html"),
     Compile / compile := {


### PR DESCRIPTION
socco-ng 0.1.7 has been published for scala 2.13.8: https://repo1.maven.org/maven2/io/regadas/socco-ng_2.13.8/0.1.7/