### PR TITLE
Add parameter to skip cloning in typedParquetFile

### DIFF
--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -21,7 +21,6 @@ import java.lang.{Boolean => JBoolean}
 import com.spotify.scio.ScioContext
 import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.io.{ScioIO, Tap, TapOf, TapT}
-import com.spotify.scio.parquet.types.ParquetTypeIO.ReadParam.DefaultSkipClone
 import com.spotify.scio.parquet.{BeamInputFile, GcsConnectorUtil}
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -116,8 +116,8 @@ object ParquetTypeIO {
   }
   final case class ReadParam[T] private (
     predicate: FilterPredicate = null,
-    skipClone: Boolean = ReadParam.DefaultSkipClone,
-    conf: Configuration = ReadParam.DefaultConfiguration
+    conf: Configuration = ReadParam.DefaultConfiguration,
+    skipClone: Boolean = ReadParam.DefaultSkipClone
   )
 
   object WriteParam {

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -26,7 +26,13 @@ import com.spotify.scio.parquet.{BeamInputFile, GcsConnectorUtil}
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
 import magnolify.parquet.ParquetType
-import org.apache.beam.sdk.io.{DefaultFilenamePolicy, DynamicFileDestinations, FileBasedSink, FileSystems, WriteFiles}
+import org.apache.beam.sdk.io.{
+  DefaultFilenamePolicy,
+  DynamicFileDestinations,
+  FileBasedSink,
+  FileSystems,
+  WriteFiles
+}
 import org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider
 import org.apache.beam.sdk.transforms.SimpleFunction

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -45,7 +45,10 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
-final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](path: String) extends ScioIO[T] {
+final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
+  path: String,
+  skipClone: Boolean
+) extends ScioIO[T] {
   override type ReadP = ParquetTypeIO.ReadParam[T]
   override type WriteP = ParquetTypeIO.WriteParam[T]
   override val tapT: TapT.Aux[T, T] = TapOf[T]
@@ -79,6 +82,7 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](path: String) ex
         CoderMaterializer.beam(sc, Coder[T])
       )
       .withConfiguration(job.getConfiguration)
+      .withSkipValueClone(skipClone)
     sc.applyTransform(source).map(_.getValue)
   }
 
@@ -109,6 +113,7 @@ object ParquetTypeIO {
   object ReadParam {
     private[types] val DefaultPredicate = null
     private[types] val DefaultConfiguration = new Configuration()
+    private[types] val DefaultSkipClone = true
   }
   final case class ReadParam[T] private (
     predicate: FilterPredicate = null,

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/syntax/ScioContextSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/syntax/ScioContextSyntax.scala
@@ -34,11 +34,11 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   /** Get an SCollection for a Parquet file as case classes `T`. */
   def typedParquetFile[T: ClassTag: Coder: ParquetType](
     path: String,
-    skipClone: Boolean = ReadParam.DefaultSkipClone,
     predicate: FilterPredicate = ReadParam.DefaultPredicate,
-    conf: Configuration = ReadParam.DefaultConfiguration
+    conf: Configuration = ReadParam.DefaultConfiguration,
+    skipClone: Boolean = ReadParam.DefaultSkipClone
   ): SCollection[T] =
-    self.read(ParquetTypeIO[T](path))(ParquetTypeIO.ReadParam(predicate, skipClone, conf))
+    self.read(ParquetTypeIO[T](path))(ParquetTypeIO.ReadParam(predicate, conf, skipClone))
 }
 trait ScioContextSyntax {
   implicit def parquetTypeScioContext(c: ScioContext): ScioContextOps = new ScioContextOps(c)

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/syntax/ScioContextSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/syntax/ScioContextSyntax.scala
@@ -38,7 +38,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
     predicate: FilterPredicate = ReadParam.DefaultPredicate,
     conf: Configuration = ReadParam.DefaultConfiguration
   ): SCollection[T] =
-    self.read(ParquetTypeIO[T](path, skipClone))(ParquetTypeIO.ReadParam(predicate, conf))
+    self.read(ParquetTypeIO[T](path))(ParquetTypeIO.ReadParam(predicate, skipClone, conf))
 }
 trait ScioContextSyntax {
   implicit def parquetTypeScioContext(c: ScioContext): ScioContextOps = new ScioContextOps(c)

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/syntax/ScioContextSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/syntax/ScioContextSyntax.scala
@@ -34,10 +34,11 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   /** Get an SCollection for a Parquet file as case classes `T`. */
   def typedParquetFile[T: ClassTag: Coder: ParquetType](
     path: String,
+    skipClone: Boolean = ReadParam.DefaultSkipClone,
     predicate: FilterPredicate = ReadParam.DefaultPredicate,
     conf: Configuration = ReadParam.DefaultConfiguration
   ): SCollection[T] =
-    self.read(ParquetTypeIO[T](path))(ParquetTypeIO.ReadParam(predicate, conf))
+    self.read(ParquetTypeIO[T](path, skipClone))(ParquetTypeIO.ReadParam(predicate, conf))
 }
 trait ScioContextSyntax {
   implicit def parquetTypeScioContext(c: ScioContext): ScioContextOps = new ScioContextOps(c)

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/types/ParquetTypeIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/types/ParquetTypeIOTest.scala
@@ -63,6 +63,14 @@ class ParquetTypeIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
     ()
   }
 
+  it should "read case classes with skip clone disabled" in {
+    val sc = ScioContext()
+    val data = sc.typedParquetFile[Wide](s"$dir/*.parquet", skipClone = false)
+    data should containInAnyOrder(records)
+    sc.run()
+    ()
+  }
+
   it should "read case classes with projection" in {
     val sc = ScioContext()
     val data = sc.typedParquetFile[Narrow](s"$dir/*.parquet")


### PR DESCRIPTION
This adds a parameter to `typedParquetFile` toggling skipValueCoder of the underlying `HadoopIO` and enables skipping by default. Disabling cloning spares us from encoding and decoding every element read with the input. 
> **.withSkipValueClone(true)**:
> Hadoop formats typically work with Writable data structures which are mutable and instances
> are reused by the input format reader. Therefore, to not to have elements which can change value
> after they are emitted from read, this IO will clone each key value read from underlying hadoop
> input format (unless they are in the list of well known immutable types). However, in cases where
> used input format does not reuse instances for key/value or translation functions are used which
> already output immutable types, such clone of values can be needless penalty. In these cases IO
> can be instructed to skip key/value cloning. 

Setting it to `true` by default in contrast to the Apache Beam default should be fine, because we are working with immutable case classes.

## Benchmark

### Not skipping clone:
` val parquetInput = sc.typedParquetFile[CaseClass]("gs://bucket/path/*.parquet", skipClone = false)`
<img width="418" alt="Screenshot 2022-01-18 at 21 55 35" src="https://user-images.githubusercontent.com/7419376/150017301-1ef8f398-b9ed-430a-81b5-12577f462ec8.png">

### Skipping clone:
`val parquetInput = sc.typedParquetFile[CaseClass]("gs://bucket/path/*.parquet", skipClone = true)`
<img width="418" alt="Screenshot 2022-01-18 at 21 55 51" src="https://user-images.githubusercontent.com/7419376/150017544-73e7d32c-4b82-4e54-b77f-7f59af7855c7.png">


