### PR TITLE
Update BigtableExample to waitUntilDone

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BigtableExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BigtableExample.scala
@@ -87,7 +87,7 @@ object BigtableWriteExample {
       .map(kv => BigtableExample.toMutation(kv._1, kv._2))
       .saveAsBigtable(btProjectId, btInstanceId, btTableId)
 
-    sc.run()
+    sc.run().waitUntilDone()
 
     // Bring down the number of nodes after the job ends to save cost. There is no need to wait
     // after bumping the nodes down.


### PR DESCRIPTION
Per #3458 , `sc.run().waitUntilDone()` is the preferred way to run a task post completion, like updating the size of a Bigtable cluster. 
Update the example to wait for a run to complete before scaling down the Bigtable cluster, which would be necessary for a larger topology.