### PR TITLE
Adding a warning message to groupBy

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/util/CallSites.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/CallSites.scala
@@ -43,7 +43,7 @@ private[scio] object CallSites {
   private def isPCollectionApply(e: StackTraceElement): Boolean =
     e.getClassName == s"$beamNs.sdk.values.PCollection" && e.getMethodName == "apply"
 
-  def thisWasCalledExternally: Boolean = {
+  def wasCalledExternally: Boolean = {
     val className = Thread
       .currentThread()
       .getStackTrace

--- a/scio-core/src/main/scala/com/spotify/scio/util/CallSites.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/CallSites.scala
@@ -43,6 +43,17 @@ private[scio] object CallSites {
   private def isPCollectionApply(e: StackTraceElement): Boolean =
     e.getClassName == s"$beamNs.sdk.values.PCollection" && e.getMethodName == "apply"
 
+  def thisWasCalledExternally: Boolean = {
+    val className = Thread
+      .currentThread()
+      .getStackTrace
+      .drop(3) // drop `getStackTrace`, `isInternalCall` and the frame/method where this method is called from
+      .head
+      .getClass
+      .getName
+    isExternalClass(className)
+  }
+
   def getAppName: String =
     Thread
       .currentThread()

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -645,7 +645,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @group transform
    */
   def groupBy[K: Coder](f: T => K): SCollection[(K, Iterable[T])] = {
-    if (!context.isTest && CallSites.thisWasCalledExternally) {
+    if (!context.isTest && CallSites.wasCalledExternally) {
       SCollection.logger.warn(
         "groupBy will materialize all values for a key to a single worker," +
           " which is a very common cause of memory issues." +

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -31,10 +31,8 @@ import com.spotify.scio.estimators.{
 import com.spotify.scio.io._
 import com.spotify.scio.schemas.{Schema, SchemaMaterializer, To}
 import com.spotify.scio.testing.TestDataManager
-import com.spotify.scio.util.CallSites.thisWasCalledExternally
 import com.spotify.scio.util._
 import com.spotify.scio.util.random.{BernoulliSampler, PoissonSampler}
-import com.spotify.scio.values.SCollection.logger
 import com.twitter.algebird.{Aggregator, Monoid, MonoidAggregator, Semigroup}
 import org.apache.avro.file.CodecFactory
 import org.apache.beam.sdk.coders.{Coder => BCoder}
@@ -647,8 +645,8 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @group transform
    */
   def groupBy[K: Coder](f: T => K): SCollection[(K, Iterable[T])] = {
-    if (!context.isTest && thisWasCalledExternally) {
-      logger.warn(
+    if (!context.isTest && CallSites.thisWasCalledExternally) {
+      SCollection.logger.warn(
         "groupBy will materialize all values for a key to a single worker," +
           " which is a very common cause of memory issues." +
           " Consider using aggregateByKey/reduceByKey on a keyed SCollection instead."

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -31,6 +31,7 @@ import com.spotify.scio.estimators.{
 import com.spotify.scio.io._
 import com.spotify.scio.schemas.{Schema, SchemaMaterializer, To}
 import com.spotify.scio.testing.TestDataManager
+import com.spotify.scio.util.CallSites.thisWasCalledExternally
 import com.spotify.scio.util._
 import com.spotify.scio.util.random.{BernoulliSampler, PoissonSampler}
 import com.spotify.scio.values.SCollection.logger
@@ -646,7 +647,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @group transform
    */
   def groupBy[K: Coder](f: T => K): SCollection[(K, Iterable[T])] = {
-    if (context.isTest) {
+    if (!context.isTest && thisWasCalledExternally) {
       logger.warn(
         "groupBy will materialize all values for a key to a single worker," +
           " which is a very common cause of memory issues." +

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -651,7 +651,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
       logger.warn(
         "groupBy will materialize all values for a key to a single worker," +
           " which is a very common cause of memory issues." +
-          " Consider using `PairSCollectionFunctions.aggregateByKey` or `PairSCollectionFunctions.reduceByKey` instead."
+          " Consider using aggregateByKey/reduceByKey on a keyed SCollection instead."
       )
     }
     groupMap(f)(identity)


### PR DESCRIPTION
 it is a very common memory issue that keeps popping up with users that dont know how beam moves data around.