### PR TITLE
Parquet read: replace HadoopFormatIO with Splittable DoFn IO to improve read performance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -817,8 +817,7 @@ lazy val `scio-parquet`: Project = project
       "org.apache.parquet" % "parquet-column" % parquetVersion,
       "org.apache.parquet" % "parquet-common" % parquetVersion,
       "org.apache.parquet" % "parquet-hadoop" % parquetVersion,
-      "org.slf4j" % "slf4j-api" % slf4jVersion,
-      "com.google.auto.value" % "auto-value" % autoValueVersion
+      "org.slf4j" % "slf4j-api" % slf4jVersion
     )
   )
   .dependsOn(

--- a/build.sbt
+++ b/build.sbt
@@ -817,7 +817,8 @@ lazy val `scio-parquet`: Project = project
       "org.apache.parquet" % "parquet-column" % parquetVersion,
       "org.apache.parquet" % "parquet-common" % parquetVersion,
       "org.apache.parquet" % "parquet-hadoop" % parquetVersion,
-      "org.slf4j" % "slf4j-api" % slf4jVersion
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
+      "com.google.auto.value" % "auto-value" % autoValueVersion
     )
   )
   .dependsOn(

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -27,7 +27,6 @@ import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
 import com.twitter.chill.ClosureCleaner
 import org.apache.avro.Schema
-import org.apache.avro.generic.GenericRecord
 import org.apache.avro.reflect.ReflectData
 import org.apache.avro.specific.SpecificRecordBase
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy
@@ -194,7 +193,7 @@ object ParquetAvroIO {
       val hadoopConf = new Configuration(conf)
       // Needed to make GenericRecord read by parquet-avro work with Beam's
       // org.apache.beam.sdk.coders.AvroCoder.
-      if (ScioUtil.classOf[A] == classOf[GenericRecord]) {
+      if (!isSpecific) {
         hadoopConf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, false)
         hadoopConf.set(
           AvroReadSupport.AVRO_DATA_SUPPLIER,

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -212,8 +212,7 @@ object ParquetAvroIO {
       val tCoder = sc.pipeline.getCoderRegistry.getCoder(ScioUtil.classOf[T])
       val cleanedProjectionFn = ClosureCleaner.clean(projectionFn)
 
-      sc.customInput(
-        "AvroParquetIO",
+      sc.applyTransform(
         ParquetRead.read[A, T](
           ReadSupportFactory.avro,
           new SerializableConfiguration(hadoopConf),

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -40,7 +40,7 @@ import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, PaneInfo}
 import org.apache.beam.sdk.values.WindowingStrategy
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.Job
-import org.apache.parquet.avro.{AvroParquetReader, AvroReadSupport}
+import org.apache.parquet.avro.{AvroParquetReader, AvroReadSupport, GenericDataSupplier}
 import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.hadoop.ParquetInputFormat
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
@@ -197,7 +197,7 @@ object ParquetAvroIO {
         hadoopConf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, false)
         hadoopConf.set(
           AvroReadSupport.AVRO_DATA_SUPPLIER,
-          "org.apache.parquet.avro.GenericDataSupplier"
+          classOf[GenericDataSupplier].getCanonicalName
         )
       }
 

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetRead.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetRead.scala
@@ -1,0 +1,41 @@
+package com.spotify.scio.parquet.read
+
+import org.apache.beam.sdk.coders.StringUtf8Coder
+import org.apache.beam.sdk.io.FileIO
+import org.apache.beam.sdk.io.FileIO.ReadableFile
+import org.apache.beam.sdk.io.hadoop.SerializableConfiguration
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider
+import org.apache.beam.sdk.transforms.{Create, PTransform, ParDo, SerializableFunction}
+import org.apache.beam.sdk.values.{PBegin, PCollection}
+
+object ParquetRead {
+
+  def read[T, R](
+    readSupportFactory: ReadSupportFactory[T],
+    conf: SerializableConfiguration,
+    filePattern: String,
+    projectionFn: SerializableFunction[T, R]
+  ): PTransform[PBegin, PCollection[R]] =
+    new PTransform[PBegin, PCollection[R]] {
+      override def expand(input: PBegin): PCollection[R] = {
+        input
+          .apply(Create.ofProvider(StaticValueProvider.of(filePattern), StringUtf8Coder.of))
+          .apply(FileIO.matchAll)
+          .apply(FileIO.readMatches)
+          .apply(readFiles(readSupportFactory, conf, projectionFn))
+      }
+    }
+
+  def readFiles[T, R](
+    readSupportFactory: ReadSupportFactory[T],
+    conf: SerializableConfiguration,
+    projectionFn: SerializableFunction[T, R]
+  ): PTransform[PCollection[ReadableFile], PCollection[R]] =
+    new PTransform[PCollection[ReadableFile], PCollection[R]] {
+      override def expand(input: PCollection[ReadableFile]): PCollection[R] = {
+        val sdf = new ParquetReadFn[T, R](readSupportFactory, conf, projectionFn)
+        input.apply(ParDo.of(sdf))
+      }
+    }
+
+}

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetRead.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetRead.scala
@@ -19,8 +19,7 @@ object ParquetRead {
     new PTransform[PBegin, PCollection[R]] {
       override def expand(input: PBegin): PCollection[R] = {
         input
-          .apply(Create.ofProvider(StaticValueProvider.of(filePattern), StringUtf8Coder.of))
-          .apply(FileIO.matchAll)
+          .apply(FileIO.`match`().filepattern(filePattern))
           .apply(FileIO.readMatches)
           .apply(readFiles(readSupportFactory, conf, projectionFn))
       }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetRead.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetRead.scala
@@ -1,11 +1,9 @@
 package com.spotify.scio.parquet.read
 
-import org.apache.beam.sdk.coders.StringUtf8Coder
 import org.apache.beam.sdk.io.FileIO
 import org.apache.beam.sdk.io.FileIO.ReadableFile
 import org.apache.beam.sdk.io.hadoop.SerializableConfiguration
-import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider
-import org.apache.beam.sdk.transforms.{Create, PTransform, ParDo, SerializableFunction}
+import org.apache.beam.sdk.transforms.{PTransform, ParDo, SerializableFunction}
 import org.apache.beam.sdk.values.{PBegin, PCollection}
 
 object ParquetRead {

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadFn.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadFn.scala
@@ -81,7 +81,7 @@ class ParquetReadFn[T, R](
     outputReceiver: DoFn.OutputReceiver[R]
   ): Unit = {
     logger.debug(
-      "start {} to {}",
+      "reading file from offset {} to {}",
       tracker.currentRestriction.getFrom,
       tracker.currentRestriction.getTo
     )
@@ -189,7 +189,7 @@ class ParquetReadFn[T, R](
         case e: RuntimeException =>
           throw new ParquetDecodingException(
             s"Can not read value at $currentRow in row group" +
-              s" $rowGroupIndex in file ${file.toString}",
+              s" $rowGroupIndex in file $file",
             e
           )
       }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadFn.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadFn.scala
@@ -1,0 +1,242 @@
+package com.spotify.scio.parquet.read
+
+import com.spotify.scio.parquet.BeamInputFile
+import org.apache.beam.sdk.io.FileIO.ReadableFile
+import org.apache.beam.sdk.io.hadoop.SerializableConfiguration
+import org.apache.beam.sdk.io.range.OffsetRange
+import org.apache.beam.sdk.transforms.DoFn._
+import org.apache.beam.sdk.transforms._
+import org.apache.beam.sdk.transforms.splittabledofn.{OffsetRangeTracker, RestrictionTracker}
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.{ImmutableSet, Maps}
+import org.apache.parquet.filter2.compat.FilterCompat
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.api.InitContext
+import org.apache.parquet.hadoop.metadata.BlockMetaData
+import org.apache.parquet.io.{ColumnIOFactory, ParquetDecodingException, RecordReader}
+import org.apache.parquet.{HadoopReadOptions, ParquetReadOptions}
+import org.slf4j.LoggerFactory
+
+import java.lang.String.format
+import java.util.{Set => JSet}
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+class ParquetReadFn[T, R](
+  readSupportFactory: ReadSupportFactory[T],
+  conf: SerializableConfiguration,
+  projectionFn: SerializableFunction[T, R]
+) extends DoFn[ReadableFile, R] {
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+  private val SPLIT_LIMIT = 64000000L
+
+  private def parquetFileReader(file: ReadableFile): ParquetFileReader = {
+    val options = HadoopReadOptions.builder(conf.get()).build
+    ParquetFileReader.open(BeamInputFile.of(file.openSeekable), options)
+  }
+
+  @GetRestrictionCoder def getRestrictionCoder = new OffsetRange.Coder
+
+  @GetInitialRestriction
+  def getInitialRestriction(@Element file: ReadableFile): OffsetRange = {
+    val reader = parquetFileReader(file)
+
+    val offsetRangeResult = Try(new OffsetRange(0, reader.getRowGroups.size)).toEither
+    reader.close()
+
+    offsetRangeResult.fold(throw _, identity)
+  }
+
+  @NewTracker def newTracker(@Restriction restriction: OffsetRange) =
+    new OffsetRangeTracker(restriction)
+
+  @GetSize
+  def getSize(@Element file: ReadableFile, @Restriction restriction: OffsetRange): Double = {
+    val (_, size) = getRecordCountAndSize(file, restriction)
+    size
+  }
+
+  @SplitRestriction
+  def split(
+    @Restriction restriction: OffsetRange,
+    output: DoFn.OutputReceiver[OffsetRange],
+    @Element file: ReadableFile
+  ): Unit = {
+    val reader = parquetFileReader(file)
+
+    val splitResult = Try {
+      splitRowGroupsWithLimit(
+        restriction.getFrom,
+        restriction.getTo,
+        reader.getRowGroups.asScala.toSeq
+      ).foreach(output.output)
+    }.toEither
+
+    reader.close()
+
+    splitResult.fold(throw _, identity)
+  }
+
+  @ProcessElement
+  def processElement(
+    @Element file: ReadableFile,
+    tracker: RestrictionTracker[OffsetRange, Long],
+    outputReceiver: DoFn.OutputReceiver[R]
+  ): Unit = {
+    logger.info(
+      "start {} to {}",
+      tracker.currentRestriction.getFrom,
+      tracker.currentRestriction.getTo
+    )
+    val options: ParquetReadOptions = HadoopReadOptions.builder(conf.get()).build
+
+    val reader = ParquetFileReader.open(BeamInputFile.of(file.openSeekable), options)
+    try {
+      val filter = options.getRecordFilter
+      val hadoopConf = options.asInstanceOf[HadoopReadOptions].getConf
+      val parquetFileMetadata = reader.getFooter.getFileMetaData
+      val fileSchema = parquetFileMetadata.getSchema
+      val fileMetadata = parquetFileMetadata.getKeyValueMetaData
+      val readSupport = readSupportFactory.readSupport
+      val readContext = readSupport.init(
+        new InitContext(
+          hadoopConf,
+          Maps.transformValues[String, String, JSet[String]](
+            fileMetadata,
+            v => ImmutableSet.of(v).asInstanceOf[JSet[String]]
+          ),
+          fileSchema
+        )
+      )
+      reader.setRequestedSchema(readContext.getRequestedSchema)
+
+      val columnIOFactory = new ColumnIOFactory(parquetFileMetadata.getCreatedBy)
+      val recordConverter =
+        readSupport.prepareForRead(hadoopConf, fileMetadata, fileSchema, readContext)
+      val columnIO = columnIOFactory.getColumnIO(readContext.getRequestedSchema, fileSchema, true)
+
+      var currentRowGroupIndex = tracker.currentRestriction.getFrom
+      (0L until currentRowGroupIndex).foreach(_ => reader.skipNextRowGroup())
+
+      while (tracker.tryClaim(currentRowGroupIndex)) {
+        val pages = reader.readNextRowGroup
+
+        logger.info(
+          "block {} read in memory. row count = {}",
+          currentRowGroupIndex,
+          pages.getRowCount
+        )
+
+        val recordReader = columnIO.getRecordReader(
+          pages,
+          recordConverter,
+          if (options.useRecordFilter) filter else FilterCompat.NOOP
+        )
+        readRowGroup(
+          currentRowGroupIndex,
+          pages.getRowCount,
+          file,
+          recordReader,
+          outputReceiver,
+          projectionFn
+        )
+
+        logger.info(
+          "Finish processing {} rows from block {} in file {}",
+          pages.getRowCount,
+          currentRowGroupIndex,
+          file.toString
+        )
+
+        currentRowGroupIndex += 1
+      }
+    } finally {
+      reader.close()
+    }
+  }
+
+  private def readRowGroup(
+    rowGroupIndex: Long,
+    rowCount: Long,
+    file: ReadableFile,
+    recordReader: RecordReader[T],
+    outputReceiver: DoFn.OutputReceiver[R],
+    projectionFn: SerializableFunction[T, R]
+  ): Unit = {
+    var currentRow = 0L
+    while (currentRow < rowCount) {
+      try {
+        val record = recordReader.read
+        if (record == null) {
+          // it happens when a record is filtered out in this block
+          logger.debug(
+            "record is filtered out by reader in block {} in file {}",
+            rowGroupIndex,
+            file.toString
+          )
+        } else if (recordReader.shouldSkipCurrentRecord) {
+          // this record is being filtered via the filter2 package
+          logger.debug(
+            "skipping record at {} in block {} in file {}",
+            currentRow,
+            rowGroupIndex,
+            file.toString
+          )
+
+        } else {
+          outputReceiver.output(projectionFn(record))
+        }
+
+        currentRow += 1
+      } catch {
+        case e: RuntimeException =>
+          throw new ParquetDecodingException(
+            format(
+              "Can not read value at %d in block %d in file %s",
+              currentRow,
+              rowGroupIndex,
+              file.toString
+            ),
+            e
+          )
+      }
+    }
+  }
+
+  private def getRecordCountAndSize(file: ReadableFile, restriction: OffsetRange) = {
+    val reader = parquetFileReader(file)
+
+    val countSize = Try {
+      reader.getRowGroups.asScala
+        .slice(restriction.getFrom.toInt, restriction.getTo.toInt)
+        .foldLeft((0.0, 0.0)) { case ((count, size), rowGroup) =>
+          (count + rowGroup.getRowCount, size + rowGroup.getTotalByteSize)
+        }
+    }.toEither
+    reader.close()
+
+    countSize.fold(throw _, identity)
+  }
+
+  def splitRowGroupsWithLimit(
+    startGroup: Long,
+    endGroup: Long,
+    rowGroups: Seq[BlockMetaData]
+  ): Seq[OffsetRange] = {
+    val (offsets, _, _) = rowGroups.zipWithIndex
+      .slice(startGroup.toInt, endGroup.toInt)
+      .foldLeft((Seq.empty[OffsetRange], startGroup.toInt, 0.0)) {
+        case ((offsets, start, size), (rowGroup, end)) =>
+          val currentSize = size + rowGroup.getTotalByteSize
+
+          if (currentSize > SPLIT_LIMIT || endGroup - 1 == end) {
+            (new OffsetRange(start, end + 1) +: offsets, end + 1, 0.0)
+          } else {
+            (offsets, start, currentSize)
+          }
+      }
+
+    offsets.reverse
+  }
+
+}

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadFn.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadFn.scala
@@ -13,7 +13,7 @@ import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.hadoop.api.InitContext
 import org.apache.parquet.hadoop.metadata.BlockMetaData
 import org.apache.parquet.io.{ColumnIOFactory, ParquetDecodingException, RecordReader}
-import org.apache.parquet.{HadoopReadOptions, ParquetReadOptions}
+import org.apache.parquet.HadoopReadOptions
 import org.slf4j.LoggerFactory
 
 import java.util.{Set => JSet}
@@ -100,7 +100,7 @@ class ParquetReadFn[T, R](
         new InitContext(
           hadoopConf,
           fileMetadata.asScala.map { case (k, v) =>
-            k -> ImmutableSet.of(v).asInstanceOf[JSet[String]]
+            k -> (ImmutableSet.of(v): JSet[String])
           }.asJava,
           fileSchema
         )

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadFn.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadFn.scala
@@ -16,7 +16,6 @@ import org.apache.parquet.io.{ColumnIOFactory, ParquetDecodingException, RecordR
 import org.apache.parquet.{HadoopReadOptions, ParquetReadOptions}
 import org.slf4j.LoggerFactory
 
-import java.lang.String.format
 import java.util.{Set => JSet}
 import scala.jdk.CollectionConverters._
 import scala.util.Try
@@ -98,14 +97,13 @@ class ParquetReadFn[T, R](
       val fileSchema = parquetFileMetadata.getSchema
       val fileMetadata = parquetFileMetadata.getKeyValueMetaData
       val readSupport = readSupportFactory.readSupport
-      fileMetadata.asScala.mapValues(v => ImmutableSet.of(v)).asJava
 
       val readContext = readSupport.init(
         new InitContext(
           hadoopConf,
-          fileMetadata.asScala
-            .mapValues(v => ImmutableSet.of(v).asInstanceOf[JSet[String]])
-            .asJava,
+          fileMetadata.asScala.map { case (k, v) =>
+            k -> ImmutableSet.of(v).asInstanceOf[JSet[String]]
+          }.asJava,
           fileSchema
         )
       )

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ReadSupportFactory.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ReadSupportFactory.scala
@@ -9,8 +9,8 @@ sealed trait ReadSupportFactory[T] extends Serializable {
 }
 
 object ReadSupportFactory {
-  def typed[T: ParquetType]: ReadSupportFactory[T] = new ReadSupportFactory[T] {
-    def readSupport: ReadSupport[T] = implicitly[ParquetType[T]].readSupport
+  def typed[T](implicit pt: ParquetType[T]): ReadSupportFactory[T] = new ReadSupportFactory[T] {
+    def readSupport: ReadSupport[T] = pt.readSupport
   }
 
   def avro[T]: ReadSupportFactory[T] = new ReadSupportFactory[T] {

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ReadSupportFactory.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ReadSupportFactory.scala
@@ -1,0 +1,20 @@
+package com.spotify.scio.parquet.read
+
+import magnolify.parquet.ParquetType
+import org.apache.parquet.avro.AvroReadSupport
+import org.apache.parquet.hadoop.api.ReadSupport
+
+sealed trait ReadSupportFactory[T] extends Serializable {
+  def readSupport: ReadSupport[T]
+}
+
+object ReadSupportFactory {
+
+  def typed[T: ParquetType]: ReadSupportFactory[T] = new ReadSupportFactory[T] {
+    def readSupport: ReadSupport[T] = implicitly[ParquetType[T]].readSupport
+  }
+
+  def avro[T]: ReadSupportFactory[T] = new ReadSupportFactory[T] {
+    def readSupport: ReadSupport[T] = new AvroReadSupport
+  }
+}

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ReadSupportFactory.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ReadSupportFactory.scala
@@ -9,7 +9,6 @@ sealed trait ReadSupportFactory[T] extends Serializable {
 }
 
 object ReadSupportFactory {
-
   def typed[T: ParquetType]: ReadSupportFactory[T] = new ReadSupportFactory[T] {
     def readSupport: ReadSupport[T] = implicitly[ParquetType[T]].readSupport
   }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ReadSupportFactory.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ReadSupportFactory.scala
@@ -1,8 +1,10 @@
 package com.spotify.scio.parquet.read
 
 import magnolify.parquet.ParquetType
+import me.lyh.parquet.tensorflow.ExampleReadSupport
 import org.apache.parquet.avro.AvroReadSupport
 import org.apache.parquet.hadoop.api.ReadSupport
+import org.tensorflow.proto.example.Example
 
 sealed trait ReadSupportFactory[T] extends Serializable {
   def readSupport: ReadSupport[T]
@@ -15,5 +17,9 @@ object ReadSupportFactory {
 
   def avro[T]: ReadSupportFactory[T] = new ReadSupportFactory[T] {
     def readSupport: ReadSupport[T] = new AvroReadSupport
+  }
+
+  def example: ReadSupportFactory[Example] = new ReadSupportFactory[Example] {
+    def readSupport: ReadSupport[Example] = new ExampleReadSupport()
   }
 }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -17,28 +17,18 @@
 
 package com.spotify.scio.parquet.tensorflow
 
-import java.lang.{Boolean => JBoolean}
 import com.spotify.scio.ScioContext
-import com.spotify.scio.io.{ScioIO, Tap, TapOf}
+import com.spotify.scio.coders.{Coder, CoderMaterializer}
+import com.spotify.scio.io.{ScioIO, Tap, TapOf, TapT}
+import com.spotify.scio.parquet.read.{ParquetRead, ReadSupportFactory}
 import com.spotify.scio.parquet.{BeamInputFile, GcsConnectorUtil}
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
-import me.lyh.parquet.tensorflow.{
-  ExampleParquetInputFormat,
-  ExampleParquetReader,
-  ExampleReadSupport,
-  Schema
-}
-import org.apache.beam.sdk.io.{
-  DefaultFilenamePolicy,
-  DynamicFileDestinations,
-  FileBasedSink,
-  FileSystems,
-  WriteFiles
-}
-import org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO
+import me.lyh.parquet.tensorflow.{ExampleParquetInputFormat, ExampleParquetReader, Schema}
+import org.apache.beam.sdk.io.hadoop.SerializableConfiguration
+import org.apache.beam.sdk.io._
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider
-import org.apache.beam.sdk.transforms.SimpleFunction
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.Job
 import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.hadoop.ParquetInputFormat
@@ -46,8 +36,6 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.tensorflow.proto.example.Example
 
 import scala.jdk.CollectionConverters._
-import com.spotify.scio.io.TapT
-import org.apache.hadoop.conf.Configuration
 
 final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
   override type ReadP = ParquetExampleIO.ReadParam
@@ -56,27 +44,24 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
 
   override protected def read(sc: ScioContext, params: ReadP): SCollection[Example] = {
     val job = Job.getInstance(params.conf)
-    GcsConnectorUtil.setInputPaths(sc, job, path)
-    job.setInputFormatClass(classOf[ExampleParquetInputFormat])
-    job.getConfiguration.setClass("key.class", classOf[Void], classOf[Void])
-    job.getConfiguration.setClass("value.class", classOf[Example], classOf[Example])
 
-    ParquetInputFormat.setReadSupportClass(job, classOf[ExampleReadSupport])
     if (params.projection != null) {
       ExampleParquetInputFormat.setFields(job, params.projection.asJava)
     }
     if (params.predicate != null) {
-      ParquetInputFormat.setFilterPredicate(job.getConfiguration, params.predicate)
+      ParquetInputFormat.setFilterPredicate(params.conf, params.predicate)
     }
 
-    val source = HadoopFormatIO
-      .read[JBoolean, Example]()
-      // Hadoop input always emit key-value, and `Void` causes NPE in Beam coder
-      .withKeyTranslation(new SimpleFunction[Void, JBoolean]() {
-        override def apply(input: Void): JBoolean = true
-      })
-      .withConfiguration(job.getConfiguration)
-    sc.applyTransform(source).map(_.getValue)
+    val coder = CoderMaterializer.beam(sc, Coder[Example])
+
+    sc.applyTransform(
+      ParquetRead.read(
+        ReadSupportFactory.example,
+        new SerializableConfiguration(params.conf),
+        path,
+        identity[Example]
+      )
+    ).setCoder(coder)
   }
 
   override protected def write(data: SCollection[Example], params: WriteP): Tap[Example] = {

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -45,11 +45,13 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
   override protected def read(sc: ScioContext, params: ReadP): SCollection[Example] = {
     val job = Job.getInstance(params.conf)
 
-    if (params.projection != null) {
-      ExampleParquetInputFormat.setFields(job, params.projection.asJava)
+    Option(params.projection).foreach { projection =>
+      ExampleParquetInputFormat.setFields(job, projection.asJava)
+      params.conf.set(ExampleParquetInputFormat.FIELDS_KEY, String.join(",", projection: _*))
     }
-    if (params.predicate != null) {
-      ParquetInputFormat.setFilterPredicate(params.conf, params.predicate)
+
+    Option(params.predicate).foreach { predicate =>
+      ParquetInputFormat.setFilterPredicate(params.conf, predicate)
     }
 
     val coder = CoderMaterializer.beam(sc, Coder[Example])

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -59,8 +59,7 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
 
     val coder = CoderMaterializer.beam(sc, implicitly[Coder[T]])
 
-    sc.customInput(
-      "TypedParquetIO",
+    sc.applyTransform(
       ParquetRead.read(
         ReadSupportFactory.typed,
         new SerializableConfiguration(params.conf),

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/syntax/ScioContextSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/syntax/ScioContextSyntax.scala
@@ -35,10 +35,9 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   def typedParquetFile[T: ClassTag: Coder: ParquetType](
     path: String,
     predicate: FilterPredicate = ReadParam.DefaultPredicate,
-    conf: Configuration = ReadParam.DefaultConfiguration,
-    skipClone: Boolean = ReadParam.DefaultSkipClone
+    conf: Configuration = ReadParam.DefaultConfiguration
   ): SCollection[T] =
-    self.read(ParquetTypeIO[T](path))(ParquetTypeIO.ReadParam(predicate, conf, skipClone))
+    self.read(ParquetTypeIO[T](path))(ParquetTypeIO.ReadParam(predicate, conf))
 }
 trait ScioContextSyntax {
   implicit def parquetTypeScioContext(c: ScioContext): ScioContextOps = new ScioContextOps(c)

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/types/ParquetTypeIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/types/ParquetTypeIOTest.scala
@@ -63,14 +63,6 @@ class ParquetTypeIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
     ()
   }
 
-  it should "read case classes with skip clone disabled" in {
-    val sc = ScioContext()
-    val data = sc.typedParquetFile[Wide](s"$dir/*.parquet", skipClone = false)
-    data should containInAnyOrder(records)
-    sc.run()
-    ()
-  }
-
   it should "read case classes with projection" in {
     val sc = ScioContext()
     val data = sc.typedParquetFile[Narrow](s"$dir/*.parquet")


### PR DESCRIPTION
### Context

We have been getting complaints about sub-optimal Scio Parquet read performance. Even after some attempts to improve the performance by tweaking [HadoopFormatIO](https://beam.apache.org/documentation/io/built-in/hadoop/) (e.g. this [PR](https://github.com/spotify/scio/pull/4108)) it's still below what we would expect.

### Benchmarking

Parquet read performance benchmarks executed by Spotify confirmed performance issues with using [HadoopFormatIO](https://beam.apache.org/documentation/io/built-in/hadoop/) for reading Parquet. At the same time, built-in Beam's [ParquetIO](https://github.com/apache/beam/blob/master/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/ParquetIO.java) can't be integrated with scio as-is because of coder issues and lack of support for typed reads we do using `magnolify-parquet`.

<img width="528" alt="image" src="https://user-images.githubusercontent.com/5732047/154758833-4446718e-3791-4f9c-a7c8-c59939874f0a.png">

As it can be seen on the graph, scio 0.11.4 Parquet reads are 4-5x times slower than reads with the tweaked Beam's [ParquetIO](https://github.com/apache/beam/blob/master/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/ParquetIO.java). Beam's Parquet IO was tweaked to work with scio.

### Solution

The PR introduces a generalized implementation of a brand new scio "Parquet read IO" which supports both Avro and typed reads. The change is backwards compatible and doesn't require any changes in a user code. The new Parquet Read IO is implemented as a splittable Do Fn which can split to read multiple row groups from a Parquet file in parallel.