### PR TITLE
add BigQuery jobs to pre-release check in GHA

### DIFF
--- a/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
+++ b/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
@@ -143,12 +143,23 @@ object RunPreReleaseIT {
 
   private def bigquery(runId: String): List[Future[Unit]] = {
     import com.spotify.scio.examples.extra.TypedStorageBigQueryTornadoes
+    import com.spotify.scio.examples.extra.TypedBigQueryTornadoes
 
-    List(Future
+    val start = Future
       .successful(log.info("Starting BigQuery tests... "))
-      .flatMap(_ =>
-        invokeJob[TypedStorageBigQueryTornadoes.type](s"--output=data-integration-test:gha_it.storage_$runId")
-      ))
+
+    List(
+      start.flatMap(_ =>
+        invokeJob[TypedStorageBigQueryTornadoes.type](
+          s"--output=data-integration-test:gha_it.typed_storage_$runId"
+        )
+      ),
+      start.flatMap(_ =>
+        invokeJob[TypedBigQueryTornadoes.type](
+          s"--output=data-integration-test:gha_it.typed_row_$runId"
+        )
+      )
+    )
   }
 
   private def invokeJob[T: ClassTag](args: String*): Future[Unit] =

--- a/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
+++ b/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
@@ -48,7 +48,7 @@ object RunPreReleaseIT {
       Await.result(
         Future
           .sequence(
-            parquet(runId) ++ avro(runId) ++ smb(runId)
+            parquet(runId) ++ avro(runId) ++ smb(runId) ++ bigquery(runId)
           )
           .map(_ => log.info("All Dataflow jobs ran successfully.")),
         Duration(1, TimeUnit.HOURS)
@@ -139,6 +139,16 @@ object RunPreReleaseIT {
         )
       )
     )
+  }
+
+  private def bigquery(runId: String): List[Future[Unit]] = {
+    import com.spotify.scio.examples.extra.TypedStorageBigQueryTornadoes
+
+    List(Future
+      .successful(log.info("Starting BigQuery tests... "))
+      .flatMap(_ =>
+        invokeJob[TypedStorageBigQueryTornadoes.type](s"--output=data-integration-test:gha_it.storage_$runId")
+      ))
   }
 
   private def invokeJob[T: ClassTag](args: String*): Future[Unit] =

--- a/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
+++ b/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
@@ -142,8 +142,7 @@ object RunPreReleaseIT {
   }
 
   private def bigquery(runId: String): List[Future[Unit]] = {
-    import com.spotify.scio.examples.extra.TypedStorageBigQueryTornadoes
-    import com.spotify.scio.examples.extra.TypedBigQueryTornadoes
+    import com.spotify.scio.examples.extra.{TypedBigQueryTornadoes, TypedStorageBigQueryTornadoes}
 
     val start = Future
       .successful(log.info("Starting BigQuery tests... "))

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedBigQueryTornadoes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedBigQueryTornadoes.scala
@@ -56,7 +56,7 @@ object TypedBigQueryTornadoes {
         createDisposition = CREATE_IF_NEEDED
       )
 
-    sc.run()
+    sc.run().waitUntilDone()
     ()
   }
 }

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedStorageBigQueryTornadoes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedStorageBigQueryTornadoes.scala
@@ -60,7 +60,7 @@ object TypedStorageBigQueryTornadoes {
         createDisposition = CREATE_IF_NEEDED
       )
 
-    sc.run()
+    sc.run().waitUntilDone()
     ()
   }
 }


### PR DESCRIPTION
adds two BQ jobs, storage and regular typed, to the GHA pre-release check. They both just read data from a bigquery-public-samples dataset, which is in the US, so I just switched the job locations over to us-central1.

successful full run here: https://github.com/spotify/scio/runs/5293980117?check_suite_focus=true 💅 