### PR TITLE
fix scio-google-cloud-platform it tests

### DIFF
--- a/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/TypedBigQueryIT.scala
+++ b/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/TypedBigQueryIT.scala
@@ -52,6 +52,7 @@ object TypedBigQueryIT {
 
   // Workaround for millis rounding error
   val epochGen: Gen[Long] = Gen.chooseNum[Long](0L, 1000000000000L).map(x => x / 1000 * 1000)
+  implicit val arbString: Arbitrary[String] = Arbitrary(Gen.alphaStr)
   implicit val arbByteString: Arbitrary[ByteString] = Arbitrary(
     Gen.alphaStr.map(ByteString.copyFromUtf8)
   )


### PR DESCRIPTION
it looks like the IT tests for `scio-google-cloud-platform` have been failing transiently for over a month now with this pprint error:

```
org.apache.beam.sdk.Pipeline$PipelineExecutionException: java.lang.AssertionError: apply@***Matchers.scala:6773***:10/ParMultiDo(Anonymous).output: Unknown ansi-escape at index 51 inside string cannot be parsed into an fansi.Str
[info]   at org.apache.beam.runners.direct.DirectRunner$DirectPipelineResult.waitUntilFinish(DirectRunner.java:373)
[info]   at org.apache.beam.runners.direct.DirectRunner$DirectPipelineResult.waitUntilFinish(DirectRunner.java:341)
[info]   at org.apache.beam.runners.direct.DirectRunner.run(DirectRunner.java:218)
[info]   at org.apache.beam.runners.direct.DirectRunner.run(DirectRunner.java:67)
[info]   at org.apache.beam.sdk.Pipeline.run(Pipeline.java:323)
[info]   at org.apache.beam.sdk.Pipeline.run(Pipeline.java:309)
[info]   at com.spotify.scio.ScioContext.execute(ScioContext.scala:587)
[info]   at com.spotify.scio.ScioContext$$anonfun$run$1.apply(ScioContext.scala:574)
[info]   at com.spotify.scio.ScioContext$$anonfun$run$1.apply(ScioContext.scala:562)
[info]   at com.spotify.scio.ScioContext.requireNotClosed(ScioContext.scala:653)
[info]   ...
[info]   Cause: java.lang.AssertionError: apply@***Matchers.scala:6773***:10/ParMultiDo(Anonymous).output: Unknown ansi-escape at index 51 inside string cannot be parsed into an fansi.Str
[info]   at org.apache.beam.sdk.testing.PAssert$PAssertionSite.capture(PAssert.java:175)
[info]   at org.apache.beam.sdk.testing.PAssert.that(PAssert.java:433)
[info]   at org.apache.beam.sdk.testing.PAssert.that(PAssert.java:425)
[info]   at com.spotify.scio.testing.SCollectionMatchers$$anon$5$$anon$6.apply(SCollectionMatchers.scala:346)
[info]   at com.spotify.scio.testing.SCollectionMatchers$$anon$5$$anon$6.apply(SCollectionMatchers.scala:340)
[info]   at com.spotify.scio.testing.SCollectionMatchers$IterableMatcher.apply(SCollectionMatchers.scala:207)
[info]   at com.spotify.scio.testing.SCollectionMatchers$IterableMatcher.apply$(SCollectionMatchers.scala:207)
[info]   at com.spotify.scio.testing.SCollectionMatchers$$anon$5.apply(SCollectionMatchers.scala:338)
[info]   at org.scalatest.matchers.should.Matchers$ShouldMethodHelperClass.shouldMatcher(Matchers.scala:6773)
[info]   at org.scalatest.matchers.should.Matchers$AnyShouldWrapper.should(Matchers.scala:6829)
```

I debugged the failing test and saw that the Scalacheck-genned records contain many non-UTF8 characters (including emojis) that scio-test's [pretty printer](https://github.com/spotify/scio/blob/main/scio-test/src/main/scala/com/spotify/scio/testing/Pretty.scala) is failing to print them. This PR restricts the generated characters by using the `alphaStr` `Gen` instance. seems to fix the problem!