### PR TITLE
(fix #4285) Set expiration time explicitly for temp BQ view tables

### DIFF
--- a/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/BigQueryClientIT.scala
+++ b/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/BigQueryClientIT.scala
@@ -53,7 +53,7 @@ class BigQueryClientIT extends AnyFlatSpec with Matchers {
       |}
     """.stripMargin)
     val sources = List("gs://data-integration-test-eu/shakespeare-sample-10.json")
-    val table = bq.tables.createTemporary(location = "EU")
+    val table = bq.tables.createTemporary(location = "EU").getTableReference
     val tableRef = bq.load.json(sources, table.asTableSpec, schema = Some(schema))
     tableRef.map { ref =>
       val insertQuery = s"insert into `${ref.asTableSpec}` values (1603, 'alien', 9000, 'alien')"
@@ -171,7 +171,7 @@ class BigQueryClientIT extends AnyFlatSpec with Matchers {
         |}
       """.stripMargin)
     val sources = List("gs://data-integration-test-eu/shakespeare-sample-10.csv")
-    val table = bq.tables.createTemporary(location = "EU")
+    val table = bq.tables.createTemporary(location = "EU").getTableReference
     val tableRef =
       bq.load.csv(sources, table.asTableSpec, skipLeadingRows = 1, schema = Some(schema))
     val createdTable = tableRef.map(bq.tables.table)
@@ -192,7 +192,7 @@ class BigQueryClientIT extends AnyFlatSpec with Matchers {
         |}
       """.stripMargin)
     val sources = List("gs://data-integration-test-eu/shakespeare-sample-10.json")
-    val table = bq.tables.createTemporary(location = "EU")
+    val table = bq.tables.createTemporary(location = "EU").getTableReference
     val tableRef = bq.load.json(sources, table.asTableSpec, schema = Some(schema))
     val createdTable = tableRef.map(bq.tables.table)
     createdTable.map(_.getNumRows.intValue()) shouldBe Success(10)
@@ -201,7 +201,7 @@ class BigQueryClientIT extends AnyFlatSpec with Matchers {
 
   "Load.avro" should "work" in {
     val sources = List("gs://data-integration-test-eu/shakespeare-sample-10.avro")
-    val table = bq.tables.createTemporary(location = "EU")
+    val table = bq.tables.createTemporary(location = "EU").getTableReference
     val tableRef = bq.load.avro(sources, table.asTableSpec)
     val createdTable = tableRef.map(bq.tables.table)
     createdTable.map(_.getNumRows.intValue()) shouldBe Success(10)

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/MockBigQuery.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/MockBigQuery.scala
@@ -59,7 +59,7 @@ class MockBigQuery private (private val bq: BigQuery) {
     )
 
     val t = bq.tables.table(original)
-    val temp = bq.tables.createTemporary(t.getLocation)
+    val temp = bq.tables.createTemporary(t.getLocation).getTableReference
     mapping += (original -> temp)
     new MockTable(bq, t.getSchema, original, temp)
   }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/QueryOps.scala
@@ -175,10 +175,12 @@ final private[client] class QueryOps(client: Client, tableService: TableOps, job
       .recoverWith {
         case NonFatal(e: GoogleJsonResponseException) if isInvalidQuery(e) => Failure(e)
         case NonFatal(_) =>
-          val temp = tableService.createTemporary(
-            extractLocation(query.sql)
-              .getOrElse(BigQueryConfig.location)
-          ).getTableReference
+          val temp = tableService
+            .createTemporary(
+              extractLocation(query.sql)
+                .getOrElse(BigQueryConfig.location)
+            )
+            .getTableReference
 
           Logger.info(s"Cache miss for query: `${query.sql}`")
           Logger.info(s"New destination table: ${bq.BigQueryHelpers.toTableSpec(temp)}")

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
@@ -303,14 +303,18 @@ final private[client] class TableOps(client: Client) {
     }
   }
 
-  /* Creates a temporary table in the staging dataset */
-  private[bigquery] def createTemporary(location: String): TableReference = {
+  /* Creates a reference to a temporary table in the staging dataset */
+  private[bigquery] def createTemporary(location: String): Table = {
     val now = Instant.now().toString(TimeFormatter)
     val tableId = TablePrefix + "_" + now + "_" + Random.nextInt(Int.MaxValue)
-    new TableReference()
+    val tableReference = new TableReference()
       .setProjectId(client.project)
       .setDatasetId(stagingDatasetId(location))
       .setTableId(tableId)
+
+    new Table()
+      .setTableReference(tableReference)
+      .setExpirationTime(System.currentTimeMillis() + StagingDatasetTableExpirationMs)
   }
 
   private def stagingDatasetId(location: String): String =


### PR DESCRIPTION
fixes #4285

before:
<img width="575" alt="Screen Shot 2022-03-22 at 11 18 33 AM" src="https://user-images.githubusercontent.com/1360529/159516304-103259c1-9d14-4dda-9218-5a478e0cee90.png">

after:
<img width="505" alt="Screen Shot 2022-03-22 at 11 16 34 AM" src="https://user-images.githubusercontent.com/1360529/159515901-ec6c19f9-c862-47d3-8884-7e0522714811.png">

 