### PR TITLE
Fix projection for parquet.tensorflow JobTest + add example job

### DIFF
--- a/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
+++ b/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
@@ -48,7 +48,7 @@ object RunPreReleaseIT {
       Await.result(
         Future
           .sequence(
-            parquet(runId)
+            parquet(runId) ++ avro(runId) ++ smb(runId) ++ bigquery(runId)
           )
           .map(_ => log.info("All Dataflow jobs ran successfully.")),
         Duration(1, TimeUnit.HOURS)
@@ -88,30 +88,30 @@ object RunPreReleaseIT {
     val start = Future
       .successful(log.info("Starting Parquet IO tests... "))
 
-    val write = List(
-      start.flatMap(_ => invokeJob[ParquetExample.type]("--method=avroOut", s"--output=$out1")),
+    val avroWrite =
+      start.flatMap(_ => invokeJob[ParquetExample.type]("--method=avroOut", s"--output=$out1"))
+    val exampleWrite =
       start.flatMap(_ => invokeJob[ParquetExample.type]("--method=exampleOut", s"--output=$out5"))
-    )
 
     List(
-      write.flatMap(_ =>
+      avroWrite.flatMap(_ =>
         invokeJob[ParquetExample.type]("--method=typedIn", s"--input=$out1/*", s"--output=$out2")
       ),
-      write.flatMap(_ =>
+      avroWrite.flatMap(_ =>
         invokeJob[ParquetExample.type](
           "--method=avroSpecificIn",
           s"--input=$out1/*",
           s"--output=$out3"
         )
       ),
-      write.flatMap(_ =>
+      avroWrite.flatMap(_ =>
         invokeJob[ParquetExample.type](
           "--method=avroGenericIn",
           s"--input=$out1/*",
           s"--output=$out4"
         )
       ),
-      write.flatMap(_ =>
+      exampleWrite.flatMap(_ =>
         invokeJob[ParquetExample.type](
           "--method=exampleIn",
           s"--input=$out5/*",

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
@@ -17,12 +17,15 @@ package com.spotify.scio.examples.extra
  * under the License.
  */
 
+import com.google.protobuf.ByteString
 import com.spotify.scio.avro.Account
 import com.spotify.scio.examples.extra.ParquetExample.{AccountFull, AccountProjection}
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.parquet.avro._
 import com.spotify.scio.parquet.types._
+import com.spotify.scio.parquet.tensorflow._
 import com.spotify.scio.io.TextIO
+import org.tensorflow.proto.example.{BytesList, Example, Feature, Features, FloatList}
 
 class ParquetExampleTest extends PipelineSpec {
 
@@ -69,6 +72,40 @@ class ParquetExampleTest extends PipelineSpec {
       .output(ParquetTypeIO[AccountFull]("out.parquet"))(coll =>
         coll should containInAnyOrder(expected)
       )
+      .run()
+  }
+
+  it should "work for Example output" in {
+    val expected = ParquetExample.fakeData.map(ParquetExample.toExample)
+
+    JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
+      .args("--output=example-out", "--method=exampleOut")
+      .output(ParquetExampleIO("example-out"))(coll => coll should containInAnyOrder(expected))
+      .run()
+  }
+
+  it should "work for Example input" in {
+    val input = ParquetExample.fakeData.map(ParquetExample.toExample)
+    val projectedOutput = ParquetExample.fakeData
+      .map { account =>
+        val features = Features
+          .newBuilder()
+          .putFeature(
+            "amount",
+            Feature
+              .newBuilder()
+              .setFloatList(FloatList.newBuilder().addValue(account.getAmount.toFloat))
+              .build()
+          )
+
+        Example.newBuilder().setFeatures(features).build()
+      }
+      .map(_.toString)
+
+    JobTest[com.spotify.scio.examples.extra.ParquetExample.type]
+      .args("--input=example-in", "--method=exampleIn", "--output=example-out")
+      .input(ParquetExampleIO("example-in"), input)
+      .output(TextIO("example-out"))(coll => coll should containInAnyOrder(projectedOutput))
       .run()
   }
 }

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/ParquetExampleTest.scala
@@ -17,7 +17,6 @@ package com.spotify.scio.examples.extra
  * under the License.
  */
 
-import com.google.protobuf.ByteString
 import com.spotify.scio.avro.Account
 import com.spotify.scio.examples.extra.ParquetExample.{AccountFull, AccountProjection}
 import com.spotify.scio.testing.PipelineSpec
@@ -25,7 +24,7 @@ import com.spotify.scio.parquet.avro._
 import com.spotify.scio.parquet.types._
 import com.spotify.scio.parquet.tensorflow._
 import com.spotify.scio.io.TextIO
-import org.tensorflow.proto.example.{BytesList, Example, Feature, Features, FloatList}
+import org.tensorflow.proto.example.{Example, Feature, Features, FloatList}
 
 class ParquetExampleTest extends PipelineSpec {
 

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -23,19 +23,8 @@ import com.spotify.scio.io.{ScioIO, Tap, TapOf}
 import com.spotify.scio.parquet.{BeamInputFile, GcsConnectorUtil}
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
-import me.lyh.parquet.tensorflow.{
-  ExampleParquetInputFormat,
-  ExampleParquetReader,
-  ExampleReadSupport,
-  Schema
-}
-import org.apache.beam.sdk.io.{
-  DefaultFilenamePolicy,
-  DynamicFileDestinations,
-  FileBasedSink,
-  FileSystems,
-  WriteFiles
-}
+import me.lyh.parquet.tensorflow.{ExampleParquetInputFormat, ExampleParquetReader, ExampleReadSupport, Schema}
+import org.apache.beam.sdk.io.{DefaultFilenamePolicy, DynamicFileDestinations, FileBasedSink, FileSystems, WriteFiles}
 import org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider
 import org.apache.beam.sdk.transforms.SimpleFunction
@@ -43,10 +32,11 @@ import org.apache.hadoop.mapreduce.Job
 import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.hadoop.ParquetInputFormat
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
-import org.tensorflow.proto.example.Example
+import org.tensorflow.proto.example.{Example, Features}
 
 import scala.jdk.CollectionConverters._
 import com.spotify.scio.io.TapT
+import com.spotify.scio.testing.TestDataManager
 import org.apache.hadoop.conf.Configuration
 
 final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
@@ -77,6 +67,28 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
       })
       .withConfiguration(job.getConfiguration)
     sc.applyTransform(source).map(_.getValue)
+  }
+
+  override protected def readTest(sc: ScioContext, params: ReadP): SCollection[Example] = {
+    // The projection function is not part of the test input, so it must be applied directly
+    val projectionOpt = Option(params.projection)
+    TestDataManager
+      .getInput(sc.testId.get)(ParquetExampleIO(path))
+      .toSCollection(sc)
+      .map { case (example: Example) =>
+        projectionOpt match {
+          case None => example
+          case Some(projection) =>
+            val projectedFeatures = example.getFeatures.getFeatureMap.asScala
+              .filter { case (k, _) => projection.contains(k) }
+              .asJava
+
+            example
+              .toBuilder
+              .setFeatures(Features.newBuilder().putAllFeature(projectedFeatures))
+              .build()
+        }
+      }
   }
 
   override protected def write(data: SCollection[Example], params: WriteP): Tap[Example] = {

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -90,12 +90,11 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
         projectionOpt match {
           case None => example
           case Some(projection) =>
-            val projectedFeatures = example.getFeatures.getFeatureMap.asScala
-              .filter { case (k, _) => projection.contains(k) }
-              .asJava
+            val projectedFeatures = example.getFeatures.getFeatureMap.asScala.filter {
+              case (k, _) => projection.contains(k)
+            }.asJava
 
-            example
-              .toBuilder
+            example.toBuilder
               .setFeatures(Features.newBuilder().putAllFeature(projectedFeatures))
               .build()
         }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -23,8 +23,19 @@ import com.spotify.scio.io.{ScioIO, Tap, TapOf}
 import com.spotify.scio.parquet.{BeamInputFile, GcsConnectorUtil}
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
-import me.lyh.parquet.tensorflow.{ExampleParquetInputFormat, ExampleParquetReader, ExampleReadSupport, Schema}
-import org.apache.beam.sdk.io.{DefaultFilenamePolicy, DynamicFileDestinations, FileBasedSink, FileSystems, WriteFiles}
+import me.lyh.parquet.tensorflow.{
+  ExampleParquetInputFormat,
+  ExampleParquetReader,
+  ExampleReadSupport,
+  Schema
+}
+import org.apache.beam.sdk.io.{
+  DefaultFilenamePolicy,
+  DynamicFileDestinations,
+  FileBasedSink,
+  FileSystems,
+  WriteFiles
+}
 import org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider
 import org.apache.beam.sdk.transforms.SimpleFunction

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIOTest.scala
@@ -162,7 +162,7 @@ class ParquetExampleIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAl
     ()
   }
 
-  it should "read Examples with projection and predicate" in {
+  it should "read Examples with projection and predicate in non-test context" in {
     val sc = ScioContext()
     val data = sc.parquetExampleFile(s"$dir/*.parquet", projection, predicate)
     val expected = examples
@@ -174,5 +174,13 @@ class ParquetExampleIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAl
     data should containInAnyOrder(expected)
     sc.run()
     ()
+  }
+
+  it should "read Examples with projection in a JobTest context" in {
+    val projected = examples.map(projectFields(projection))
+
+    testJobTest(projected)(ParquetExampleIO(_))(_.parquetExampleFile(_, projection = projection))(
+      _.saveAsParquetExampleFile(_, schema)
+    )
   }
 }


### PR DESCRIPTION
- fixes `ParquetExampleIO` so that if user supplies a projection it will be applied to test input (same as how[ ParquetAvroIO works](https://github.com/spotify/scio/blob/main/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala#L73))
- Adds a Parquet-Tensorflow example to `ParquetExample` job and adds those read/write jobs to our GHA pre-release Dataflow test suite.