### PR TITLE
Mock BQ wildcard table

### DIFF
--- a/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/BigQueryIT.scala
+++ b/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/BigQueryIT.scala
@@ -81,7 +81,6 @@ class BigQueryIT extends AnyFlatSpec with Matchers {
         |  AND _TABLE_SUFFIX BETWEEN '20' AND '29'
         |ORDER BY
         |  max DESC
-        |LIMIT 1
         |""".stripMargin
 
     def gsod(max: Double, year: Int, mo: Int, da: Int): TableRow =
@@ -118,7 +117,14 @@ class BigQueryIT extends AnyFlatSpec with Matchers {
     suffixData.foreach { case (suffix, inData) =>
       mbq.mockWildcardTable(prefix, suffix).withData(inData)
     }
-    mbq.queryResult(wildcardSqlQuery) should contain only suffixData("21").head
+    mbq.queryResult(wildcardSqlQuery) should contain theSameElementsInOrderAs Seq(
+      gsod(54.2, 2021, 6, 30),
+      gsod(54.0, 2020, 6, 8),
+      gsod(53.2, 2021, 6, 22),
+      gsod(53.1, 2021, 7, 1),
+      gsod(52.2, 2020, 7, 31),
+      gsod(52.1, 2020, 7, 30)
+    )
   }
 
   // =======================================================================

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/MockBigQuery.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/MockBigQuery.scala
@@ -90,8 +90,8 @@ class MockBigQuery private (private val bq: BigQuery) {
       }
     )
 
-    val ref = tempWildcard.clone().setTableId(tempWildcard.getTableId.dropRight(1) + suffix)
-    val temp = bq.tables.createTemporary(ref).getTableReference
+    val temp = tempWildcard.clone().setTableId(tempWildcard.getTableId.dropRight(1) + suffix)
+    bq.tables.createTemporary(temp)
     mapping += (original -> temp)
     new MockTable(bq, t.getSchema, original, temp)
   }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
@@ -311,9 +311,10 @@ final private[client] class TableOps(client: Client) {
   }
 
   /* Creates a reference to a temporary table in the staging dataset */
-  private[bigquery] def createTemporary(location: String): Table = {
+  private[bigquery] def createTemporary(location: String, suffix: Option[String] = None): Table = {
     val now = Instant.now().toString(TimeFormatter)
-    val tableId = TablePrefix + "_" + now + "_" + Random.nextInt(Int.MaxValue)
+    val rand = Random.nextInt(Int.MaxValue)
+    val tableId = TablePrefix + "_" + now + "_" + rand + suffix.map("_" + _).getOrElse("")
     val tableReference = new TableReference()
       .setProjectId(client.project)
       .setDatasetId(stagingDatasetId(location))

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
@@ -311,18 +311,24 @@ final private[client] class TableOps(client: Client) {
   }
 
   /* Creates a reference to a temporary table in the staging dataset */
-  private[bigquery] def createTemporary(location: String, suffix: Option[String] = None): Table = {
-    val now = Instant.now().toString(TimeFormatter)
-    val rand = Random.nextInt(Int.MaxValue)
-    val tableId = TablePrefix + "_" + now + "_" + rand + suffix.map("_" + _).getOrElse("")
-    val tableReference = new TableReference()
-      .setProjectId(client.project)
-      .setDatasetId(stagingDatasetId(location))
-      .setTableId(tableId)
+  private[bigquery] def createTemporary(location: String): Table =
+    createTemporary(temporaryTableReference(location))
 
+  /* Creates a reference to a temporary table in the staging dataset */
+  private[bigquery] def createTemporary(tableReference: TableReference): Table =
     new Table()
       .setTableReference(tableReference)
       .setExpirationTime(System.currentTimeMillis() + StagingDatasetTableExpirationMs)
+
+  private[bigquery] def temporaryTableReference(location: String): TableReference = {
+    val now = Instant.now().toString(TimeFormatter)
+    val rand = Random.nextInt(Int.MaxValue)
+    val tableId = TablePrefix + "_" + now + "_" + rand
+
+    new TableReference()
+      .setProjectId(client.project)
+      .setDatasetId(stagingDatasetId(location))
+      .setTableId(tableId)
   }
 
   private def stagingDatasetId(location: String): String =


### PR DESCRIPTION
Fix #3248 

Adding `mockWildcardTable` API on `MockBigQuery` 

Eg: To get the highest recorded temperature from the 2020s decade 

```sql
SELECT
  max,
  year,
  mo,
  da,
FROM
  `bigquery-public-data.noaa_gsod.gsod202*`
WHERE
  max != 9999.9 # code for missing data
  AND _TABLE_SUFFIX BETWEEN '0' AND '9'
ORDER BY
  max DESC
LIMIT 1
```

We can mock `bigquery-public-data.noaa_gsod.gsod2022` and use it as only matched table by the query with 

```
mockWildcardTable("bigquery-public-data.noaa_gsod.gsod202", "2").withData(...)
```

