### PR TITLE
Add Avro primitive type bytes to tests

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroExample.scala
@@ -32,6 +32,7 @@ import com.spotify.scio.io.ClosedTap
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericData, GenericRecord}
 
+import java.nio.ByteBuffer
 import scala.jdk.CollectionConverters._
 
 object AvroExample {
@@ -88,6 +89,7 @@ object AvroExample {
           .newBuilder()
           .setId(i)
           .setAmount(i.toDouble)
+          .setBytes(ByteBuffer.wrap(Array(i.toByte)))
           .setName("account" + i)
           .setType("checking")
           .build()

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroInOut.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroInOut.scala
@@ -43,6 +43,7 @@ object AvroInOut {
           .setType("checking")
           .setName(r.getStringField)
           .setAmount(r.getDoubleField)
+          .setBytes(r.getBytesField)
           .setAccountStatus(AccountStatus.Active)
           .build()
       }

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroExampleTest.scala
@@ -22,12 +22,16 @@ import com.spotify.scio.examples.extra.AvroExample.{AccountFromSchema, AccountTo
 import com.spotify.scio.io._
 import com.spotify.scio.testing._
 
+import java.nio.ByteBuffer
+
 class AvroExampleTest extends PipelineSpec {
+  private def byteBuffer(i: Int): ByteBuffer = ByteBuffer.wrap(Array(i.toByte))
+
   "AvroExample" should "work for specific input" in {
     val input =
       Seq(
-        new Account(1, "checking", "Alice", 1000.0, AccountStatus.Active),
-        new Account(2, "checking", "Bob", 1500.0, AccountStatus.Active)
+        new Account(1, "checking", "Alice", 1000.0, byteBuffer(123), AccountStatus.Active),
+        new Account(2, "checking", "Bob", 1500.0, byteBuffer(234), AccountStatus.Active)
       )
 
     val expected = input.map(_.toString)
@@ -46,6 +50,7 @@ class AvroExampleTest extends PipelineSpec {
           .newBuilder()
           .setId(i)
           .setAmount(i.toDouble)
+          .setBytes(byteBuffer(i))
           .setName("account" + i)
           .setType("checking")
           .build()

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroInOutTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/AvroInOutTest.scala
@@ -20,18 +20,30 @@ package com.spotify.scio.examples.extra
 import com.spotify.scio.avro._
 import com.spotify.scio.testing._
 
+import java.nio.ByteBuffer
 import scala.jdk.CollectionConverters._
 
 class AvroInOutTest extends PipelineSpec {
+  private def byteBuffer(i: Int): ByteBuffer = ByteBuffer.wrap(Array(i.toByte))
+
   val input: Seq[TestRecord] = Seq(
-    new TestRecord(1, 0L, 0f, 1000.0, false, "Alice", List[CharSequence]("a").asJava),
-    new TestRecord(2, 0L, 0f, 1500.0, false, "Bob", List[CharSequence]("b").asJava)
+    new TestRecord(
+      1,
+      0L,
+      0f,
+      1000.0,
+      false,
+      byteBuffer(123),
+      "Alice",
+      List[CharSequence]("a").asJava
+    ),
+    new TestRecord(2, 0L, 0f, 1500.0, false, byteBuffer(234), "Bob", List[CharSequence]("b").asJava)
   )
 
   val expected: Seq[Account] =
     Seq(
-      new Account(1, "checking", "Alice", 1000.0, AccountStatus.Active),
-      new Account(2, "checking", "Bob", 1500.0, AccountStatus.Active)
+      new Account(1, "checking", "Alice", 1000.0, byteBuffer(123), AccountStatus.Active),
+      new Account(2, "checking", "Bob", 1500.0, byteBuffer(234), AccountStatus.Active)
     )
 
   "AvroInOut" should "work" in {

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
@@ -29,6 +29,8 @@ import com.spotify.scio.pubsub.coders._
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException
 import org.joda.time.Instant
 
+import java.nio.ByteBuffer
+
 class PubsubIOTest extends PipelineSpec with ScioIOSpec {
   "PubsubIO" should "work with subscription" in {
     val xs = (1 to 100).map(_.toString)
@@ -62,7 +64,9 @@ class PubsubIOTest extends PipelineSpec with ScioIOSpec {
   }
 
   it should "support deprecated readAvro" in {
-    val xs = (1 to 100).map(x => new Account(x, "", "", x.toDouble, AccountStatus.Active))
+    val xs = (1 to 100).map(x =>
+      new Account(x, "", "", x.toDouble, ByteBuffer.wrap(Array(x.toByte)), AccountStatus.Active)
+    )
     testJobTest(xs)(PubsubIO.readAvro[Account](_))(_.pubsubSubscription(_))(_.saveAsPubsub(_))
   }
 

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
@@ -18,6 +18,7 @@
 package com.spotify.scio.parquet.avro
 
 import java.io.File
+import java.nio.ByteBuffer
 import com.spotify.scio._
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.avro._
@@ -99,7 +100,16 @@ class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
 
     val sc1 = ScioContext()
     val nestedRecords =
-      (1 to 10).map(x => new Account(x, x.toString, x.toString, x.toDouble, AccountStatus.Active))
+      (1 to 10).map(x =>
+        new Account(
+          x,
+          x.toString,
+          x.toString,
+          x.toDouble,
+          ByteBuffer.wrap(Array(x.toByte)),
+          AccountStatus.Active
+        )
+      )
     sc1
       .parallelize(nestedRecords)
       .saveAsParquetAvroFile(dir.toString)
@@ -281,7 +291,16 @@ class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
       .args("--input=input", "--output=output")
       .input(
         ParquetAvroIO[Account]("input"),
-        List(Account.newBuilder().setId(1).setName("foo").setType("bar").setAmount(2.0).build())
+        List(
+          Account
+            .newBuilder()
+            .setId(1)
+            .setName("foo")
+            .setType("bar")
+            .setAmount(2.0)
+            .setBytes(ByteBuffer.wrap(Array(123.toByte)))
+            .build()
+        )
       )
       .output(TextIO("output"))(_ should containSingleValue(("foo", 2.0).toString))
       .run()

--- a/scio-schemas/src/main/avro/schema.avsc
+++ b/scio-schemas/src/main/avro/schema.avsc
@@ -8,6 +8,7 @@
         {"name": "type", "type": "string"},
         {"name": "name", "type": ["null", "string"]},
         {"name": "amount", "type": "double"},
+        {"name": "bytes", "type": "bytes"},
         {
          "name": "account_status",
          "type": [
@@ -63,6 +64,7 @@
         {"name": "float_field", "type": ["null", "float"], "default": null},
         {"name": "double_field", "type": ["null", "double"], "default": null},
         {"name": "boolean_field", "type": ["null", "boolean"], "default": null},
+        {"name": "bytes_field", "type": ["null", "bytes"], "default": null},
         {"name": "string_field", "type": ["null", "string"], "default": null},
         {"name": "array_field", "type": {"type": "array", "items": "string"}, "default": null}
     ]

--- a/scio-schemas/src/main/scala/com/spotify/scio/avro/AvroUtils.scala
+++ b/scio-schemas/src/main/scala/com/spotify/scio/avro/AvroUtils.scala
@@ -22,6 +22,8 @@ import org.apache.avro.generic.{GenericData, GenericRecord}
 
 import scala.jdk.CollectionConverters._
 
+import java.nio.ByteBuffer
+
 object AvroUtils {
   private def f(name: String, tpe: Schema.Type) =
     new Schema.Field(
@@ -42,10 +44,13 @@ object AvroUtils {
       f("float_field", Schema.Type.FLOAT),
       f("double_field", Schema.Type.DOUBLE),
       f("boolean_field", Schema.Type.BOOLEAN),
+      f("bytes_field", Schema.Type.BYTES),
       f("string_field", Schema.Type.STRING),
       fArr("array_field", Schema.Type.STRING)
     ).asJava
   )
+
+  private def byteBuffer(i: Int): ByteBuffer = ByteBuffer.wrap(Array(i.toByte))
 
   def newGenericRecord(i: Int): GenericRecord = {
     val r = new GenericData.Record(schema)
@@ -54,6 +59,7 @@ object AvroUtils {
     r.put("float_field", 1f * i)
     r.put("double_field", 1.0 * i)
     r.put("boolean_field", true)
+    r.put("bytes_field", byteBuffer(i))
     r.put("string_field", "hello")
     r.put("array_field", List[CharSequence]("a", "b", "c").asJava)
     r
@@ -66,6 +72,7 @@ object AvroUtils {
       i.toFloat,
       i.toDouble,
       true,
+      byteBuffer(i),
       "hello",
       List[CharSequence]("a", "b", "c").asJava
     )

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -35,6 +35,8 @@ import org.apache.beam.sdk.testing.CoderProperties
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
 import com.twitter.algebird.Moments
 
+import java.nio.ByteBuffer
+
 final case class UserId(bytes: Seq[Byte])
 final case class User(id: UserId, username: String, email: String)
 
@@ -218,7 +220,9 @@ final class CoderTest extends AnyFlatSpec with Matchers {
   object Avro {
     import com.spotify.scio.avro.{Account, Address, User => AvUser}
 
-    val accounts: List[Account] = List(new Account(1, "type", "name", 12.5, null))
+    val accounts: List[Account] = List(
+      new Account(1, "type", "name", 12.5, ByteBuffer.wrap(Array(123.toByte)), null)
+    )
     val address =
       new Address("street1", "street2", "city", "state", "01234", "Sweden")
     val user = new AvUser(1, "lastname", "firstname", "email@foobar.com", accounts.asJava, address)
@@ -231,6 +235,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
 
   it should "Derive serializable coders" in {
     coderIsSerializable[Int]
+    coderIsSerializable[ByteBuffer]
     coderIsSerializable[String]
     coderIsSerializable[List[Int]]
     coderIsSerializable(Coder.kryo[Int])


### PR DESCRIPTION
`bytes` is one of Avro's primitive types (https://avro.apache.org/docs/1.8.2/spec.html#schema_primitive), however it is currently not covered by tests