### PR TITLE
Fix GHA publish due to non-deterministic implicit

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -197,11 +197,11 @@ final private[scio] case class LazyCoder[T](
       c match {
         // Stop the recursion. We already traversed that Coder
         case ref: Ref[_] if types.contains(ref.typeName) =>
-          Coder[Nothing].asInstanceOf[Coder[B]]
+          Coder.nothingCoder.asInstanceOf[Coder[B]]
         case Disjunction(typeName, _, _, _) if types.contains(typeName) =>
-          Coder[Nothing].asInstanceOf[Coder[B]]
+          Coder.nothingCoder.asInstanceOf[Coder[B]]
         case Record(typeName, _, _, _) if types.contains(typeName) =>
-          Coder[Nothing].asInstanceOf[Coder[B]]
+          Coder.nothingCoder.asInstanceOf[Coder[B]]
         //
         case ref: Ref[_]     => go(ref.value, types + ref.typeName)
         case c @ RawBeam(_)  => c


### PR DESCRIPTION
GHA [publish](https://github.com/spotify/scio/runs/6152964128?check_suite_focus=true) action is failing with 

```
[error] /home/runner/work/scio/scio/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala:200:16: diverging implicit expansion for type com.spotify.scio.coders.Coder[Nothing]
[error] starting with method javaBeanCoder in trait LowPriorityCoders
[error]           Coder[Nothing].asInstanceOf[Coder[B]]
[error]                ^
[error] one error found
```

By turning on the `Show Implicit Hints` in IntelliJ, I see the `Coder.nothing` is used there. However, I can't find any import for it.
I suspect the implicit search to be non-deterministic, and failing on the `publish` step only for unknown reason.

This PR directly uses the `Coder.nothingCoder`  instead to remove ambiguity