### PR TITLE
(fix #4216) extend BQ CoderInstances in main package

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/package.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/package.scala
@@ -18,6 +18,7 @@
 package com.spotify.scio
 
 import com.google.api.services.bigquery.model.{TableRow => GTableRow}
+import com.spotify.scio.bigquery.instances.CoderInstances
 import com.spotify.scio.bigquery.syntax.{
   SCollectionSyntax,
   ScioContextSyntax,
@@ -47,7 +48,8 @@ package object bigquery
     extends ScioContextSyntax
     with SCollectionSyntax
     with TableRowSyntax
-    with TableReferenceSyntax {
+    with TableReferenceSyntax
+    with CoderInstances {
 
   /** Alias for BigQuery `CreateDisposition`. */
   val CREATE_IF_NEEDED = Write.CreateDisposition.CREATE_IF_NEEDED


### PR DESCRIPTION
Previously we thought we didn't need to add this, as we were really careful to [manually set TableRowCoder](https://github.com/spotify/scio/pull/3640/files#diff-b9cd7faf03f813103b239cd67140fc3c08bc6f737e7e117860d7ab3139788fe0R69) in all BigQuery IOs specifically.

However, the reported bug #4216 shows that we need to have this implicit `TableRowJsonCoder` available in the main `com.spotify.scio.bigquery` package so that it's in scope for operations like `parallelize` and `map`. The example below shows that the default TableRow coder does not encode byte fields correctly--it encodes them as `ArrayList`s.  So when you have an operation like `data.map(i => toTableRow(i)).saveAsBigQueryTable` the damage is done during the `map` step, and it's not fixable by just setting the coder manually in the BQ sink operation (see `res6` in example below).

```scala
scala> :paste
// Entering paste mode (ctrl-D to finish)

def roundtrip[T](coder: Coder[T], t: T): T = {
  val bCoder = com.spotify.scio.coders.CoderMaterializer.beamWithDefault[T](coder)
  val bytes = org.apache.beam.sdk.util.CoderUtils.encodeToByteArray(bCoder, t)
  org.apache.beam.sdk.util.CoderUtils.decodeFromByteArray[T](bCoder, bytes)
}

scala> val tr = TableRow("bytesField" -> "test".getBytes)
val tr: com.spotify.scio.bigquery.TableRow = GenericData{classInfo=[f], {bytesField=[B@8659090}}

// Type of bytes field at construction time
scala> tr.get("bytesField").getClass
val res3: Class[_] = class [B // raw byte array

// Type of bytes field after roundtripping with default coder
scala> val defaultTrCoder = Coder[TableRow]
scala> roundtrip(defaultTrCoder, tr).get("bytesField").getClass
val res4: Class[_] = class java.util.ArrayList

// Type of bytes field after roundtripping with proper TableRowCoder
scala> val beamTrCoder = Coder.beam(org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder.of())
scala> roundtrip(beamTrCoder, tr).get("bytesField").getClass
val res5: Class[_] = class java.lang.String

// Type of bytes field after roundtripping with default coder and then TableRowCoder
// this is what happens with sc.parallelize(tableRows).saveAsBigQueryTable(...)
scala> roundtrip(beamTrCoder, roundtrip(defaultTrCoder, tr)).get("bytesField").getClass
(To diagnose errors in synthetic code, try adding `// show` to the end of your input.)
val res6: Class[_] = class java.util.ArrayList // still is type ArrayList when it should be a String
```

As a result of this PR, you can just import `com.spotify.scio.bigquery._` like so:

```scala
scala> import com.spotify.scio.bigquery._
scala> val newDefaultTrCoder = Coder[TableRow]
val newDefaultTrCoder: com.spotify.scio.coders.Coder[com.spotify.scio.bigquery.TableRow] = Beam(TableRowJsonCoder)

scala> roundtrip(newDefaultTrCoder, tr).get("bytesField").getClass
val res7: Class[_] = class java.lang.String // Now it behaves correctly
```