### PR TITLE
Remove org.apache documentation exclusion

### DIFF
--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -100,7 +100,7 @@ object Scalac {
 
   val docOptions = Def.setting {
     val base =
-      baseOptions.value ++ scalaVersionOptions.value ++ List("-skip-packages", "org.apache")
+      baseOptions.value ++ scalaVersionOptions.value
 
     VersionNumber(scalaVersion.value) match {
       case v if v.matchesSemVer(SemanticSelector("2.12.x")) => base ++ List("-no-java-comments")


### PR DESCRIPTION
[Originally introduced here](https://github.com/spotify/scio/commit/644b7718f6feed58b82522d879d109da08fff0f4) and updated for beam [here](https://github.com/spotify/scio/commit/d1ff3e814e53ed3ee163e53c81604a0287b1ce64).

Removal allows proper documentation of SMB classes in org.apache tree.

Fixes #2770