### PR TITLE
Support build metadata to identify proper previous version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: cache SBT
         uses: coursier/cache-action@v6
       - name: Java ${{matrix.java}} setup

--- a/build.sbt
+++ b/build.sbt
@@ -113,10 +113,20 @@ Global / excludeLint += sonatypeProfileName
 Global / excludeLint += site / Paradox / sourceManaged
 
 def previousVersion(currentVersion: String): Option[String] = {
-  val Version = """(\d+)\.(\d+)\.(\d+).*""".r
+  val Version =
+    """(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<preRelease>-.*)?(?<build>\+.*)?""".r
   currentVersion match {
-    case Version(x, y, z) if z != "0" => Some(s"$x.$y.${z.toInt - 1}")
-    case _                            => None
+    case Version(x, y, z, null, null) if z != "0" =>
+      // release
+      Some(s"$x.$y.${z.toInt - 1}")
+    case Version(x, y, z, null, _) =>
+      // build
+      Some(s"$x.$y.$z")
+    case Version(x, y, z, _, _) if z != "0" =>
+      // pre-release
+      Some(s"$x.$y.${z.toInt - 1}")
+    case _ =>
+      None
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -797,6 +797,8 @@ lazy val `scio-parquet`: Project = project
   .settings(commonSettings)
   .settings(publishSettings)
   .settings(
+    // TODO enable MiMa after next release
+    mimaPreviousArtifacts := Set.empty,
     // change annotation processor output directory so IntelliJ can pick them up
     ensureSourceManaged := IO.createDirectory(sourceManaged.value / "main"),
     Compile / compile := Def.task {

--- a/build.sbt
+++ b/build.sbt
@@ -377,7 +377,11 @@ def splitTests(tests: Seq[TestDefinition], filter: Seq[String], forkOptions: For
 
 lazy val root: Project = Project("scio", file("."))
   .settings(commonSettings)
-  .settings(publish / skip := true, assembly / aggregate := false)
+  .settings(
+    publish / skip := true,
+    mimaPreviousArtifacts := Set.empty,
+    assembly / aggregate := false
+  )
   .aggregate(
     `scio-core`,
     `scio-test`,
@@ -879,6 +883,7 @@ lazy val `scio-schemas`: Project = project
   .settings(
     description := "Avro/Proto schemas for testing",
     publish / skip := true,
+    mimaPreviousArtifacts := Set.empty,
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.avro" % "avro" % avroVersion
@@ -901,6 +906,7 @@ lazy val `scio-examples`: Project = project
   .settings(macroSettings)
   .settings(
     publish / skip := true,
+    mimaPreviousArtifacts := Set.empty,
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
@@ -1029,7 +1035,8 @@ lazy val `scio-jmh`: Project = project
       "org.hamcrest" % "hamcrest-library" % hamcrestVersion % "test",
       "org.slf4j" % "slf4j-nop" % slf4jVersion
     ),
-    publish / skip := true
+    publish / skip := true,
+    mimaPreviousArtifacts := Set.empty
   )
   .dependsOn(
     `scio-core`,

--- a/build.sbt
+++ b/build.sbt
@@ -117,13 +117,13 @@ def previousVersion(currentVersion: String): Option[String] = {
     """(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<preRelease>-.*)?(?<build>\+.*)?""".r
   currentVersion match {
     case Version(x, y, z, null, null) if z != "0" =>
-      // release
+      // patch release
       Some(s"$x.$y.${z.toInt - 1}")
     case Version(x, y, z, null, _) =>
-      // build
+      // post release build
       Some(s"$x.$y.$z")
     case Version(x, y, z, _, _) if z != "0" =>
-      // pre-release
+      // patch pre-release
       Some(s"$x.$y.${z.toInt - 1}")
     case _ =>
       None


### PR DESCRIPTION
Running `sbt mimaReportBinaryIssues` causes issue on a local setup:

```
> show version
 0.11.5+31-2f6d0ac8-SNAPSHOT
> show mimaPreviousArtifacts
 Set(com.spotify:scio-core_2.13:0.11.4)
 ```
 
 It should return `0.11.5` instead since the version indicates it is a post `0.11.5` release