### PR TITLE
Pin caffeine dependency

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -9,6 +9,9 @@ updates.pin = [
   { groupId = "com.datastax.cassandra", version = "3." },
   { groupId = "org.apache.cassandra", version = "3." },
 
+  # caffeine v3 requires Java >= 11
+  { groupId = "com.github.ben-manes.caffeine", version = "2." },
+
   # org.scala-lang:scala-compiler_2.12 depends on scala-xml v1
   # see https://github.com/scalatest/scalatest/issues/2092
   { groupId = "org.scala-lang.modules", artifactId = "scala-xml", version = "1." }


### PR DESCRIPTION
Long overdue but v3 of caffeine is Java 11 only and we are not there yet.