### PR TITLE
Fix java waitForFutures impl

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
@@ -93,7 +93,8 @@ public class FutureHandlers {
         throws InterruptedException, ExecutionException {
       CompletableFuture[] array =
           StreamSupport.stream(futures.spliterator(), false).toArray(CompletableFuture[]::new);
-      CompletableFuture.allOf(array).get();
+      // combine & wait upon all futures, ignoring the result & any errors thrown
+      CompletableFuture.allOf(array).whenComplete((r, t) -> {}).get();
     }
 
     @Override

--- a/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
@@ -94,7 +94,7 @@ public class FutureHandlers {
       CompletableFuture[] array =
           StreamSupport.stream(futures.spliterator(), false).toArray(CompletableFuture[]::new);
       // combine & wait upon all futures, ignoring the result & any errors thrown
-      CompletableFuture.allOf(array).whenComplete((r, t) -> {}).get();
+      CompletableFuture.allOf(array).handle((r, t) -> "done").get();
     }
 
     @Override


### PR DESCRIPTION
`waitForFutures` shouldn't fail because one of the underlying futures failed. [See also](https://github.com/spotify/scio/blob/main/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java#L48)