### PR TITLE
Reduce warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -148,6 +148,7 @@ ThisBuild / tpolecatDevModeOptions ~= { opts =>
     Scalac.parallelismOption,
     Scalac.targetOption,
     Scalac.warnMacrosOption,
+    Scalac.privateWarnMacrosOption,
     Scalac.warnConfOption
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -143,14 +143,20 @@ ThisBuild / tpolecatDevModeOptions ~= { opts =>
   val extras = Set(
     Scalac.delambdafyInlineOption,
     Scalac.macroAnnotationsOption,
+    Scalac.macroSettingsOption,
+    Scalac.maxClassfileName,
     Scalac.parallelismOption,
     Scalac.targetOption,
-    Scalac.warnMacrosOption,
-    Scalac.extraMacroSettingsOption
+    Scalac.warnMacrosOption
   )
 
   opts.filterNot(excludes).union(extras)
 }
+
+ThisBuild / doc / tpolecatDevModeOptions ++= Set(
+  Scalac.docSkipPackageOption,
+  Scalac.docNoJavaCommentOption
+)
 
 ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)
 val excludeLint = SettingKey[Set[Def.KeyedInitialize[_]]]("excludeLintKeys")
@@ -203,6 +209,9 @@ val commonSettings = Def
     headerMappings := headerMappings.value + (HeaderFileType.scala -> keepExistingHeader, HeaderFileType.java -> keepExistingHeader),
     scalaVersion := "2.13.8",
     crossScalaVersions := Seq("2.12.16", scalaVersion.value),
+    // this setting is not derived in sbt-tpolecat
+    // https://github.com/typelevel/sbt-tpolecat/issues/36
+    inTask(doc)(TpolecatPlugin.projectSettings),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
     Compile / doc / javacOptions := Seq("-source", "1.8"),
     // protobuf-lite is an older subset of protobuf-java and causes issues
@@ -1050,6 +1059,7 @@ lazy val `scio-examples`: Project = project
     `scio-redis`,
     `scio-parquet`
   )
+  .disablePlugins(ScalafixPlugin)
 
 lazy val `scio-repl`: Project = project
   .in(file("scio-repl"))
@@ -1058,7 +1068,6 @@ lazy val `scio-repl`: Project = project
   .settings(assemblySettings)
   .settings(macroSettings)
   .settings(
-    tpolecatExcludeOptions ++= ScalacOptions.defaultConsoleExclude,
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-runners-direct-java" % beamVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -141,10 +141,12 @@ ThisBuild / tpolecatDevModeOptions ~= { opts =>
   )
 
   val extras = Set(
+    Scalac.delambdafyInlineOption,
     Scalac.macroAnnotationsOption,
     Scalac.parallelismOption,
     Scalac.targetOption,
-    Scalac.warnMacrosOption
+    Scalac.warnMacrosOption,
+    Scalac.extraMacroSettingsOption
   )
 
   opts.filterNot(excludes).union(extras)

--- a/build.sbt
+++ b/build.sbt
@@ -141,16 +141,18 @@ ThisBuild / tpolecatDevModeOptions ~= { opts =>
     ScalacOptions.warnValueDiscard
   )
 
+  val parallelism = math.min(java.lang.Runtime.getRuntime.availableProcessors(), 16)
   val extras = Set(
     Scalac.delambdafyInlineOption,
     Scalac.macroAnnotationsOption,
     Scalac.macroSettingsOption,
     Scalac.maxClassfileName,
-    Scalac.parallelismOption,
     Scalac.privateWarnMacrosOption,
     Scalac.targetOption,
     Scalac.warnConfOption,
-    Scalac.warnMacrosOption
+    Scalac.warnMacrosOption,
+    ScalacOptions.privateBackendParallelism(parallelism),
+    ScalacOptions.release("8")
   )
 
   opts.filterNot(excludes).union(extras)

--- a/build.sbt
+++ b/build.sbt
@@ -134,10 +134,11 @@ val scalatestplusVersion = s"$scalatestVersion.0"
 ThisBuild / tpolecatDefaultOptionsMode := DevMode
 ThisBuild / tpolecatDevModeOptions ~= { opts =>
   val excludes = Set(
-    ScalacOptions.warnDeadCode,
+    ScalacOptions.lintPackageObjectClasses,
     ScalacOptions.privateWarnDeadCode,
-    ScalacOptions.warnValueDiscard,
-    ScalacOptions.privateWarnValueDiscard
+    ScalacOptions.privateWarnValueDiscard,
+    ScalacOptions.warnDeadCode,
+    ScalacOptions.warnValueDiscard
   )
 
   val extras = Set(
@@ -146,10 +147,10 @@ ThisBuild / tpolecatDevModeOptions ~= { opts =>
     Scalac.macroSettingsOption,
     Scalac.maxClassfileName,
     Scalac.parallelismOption,
-    Scalac.targetOption,
-    Scalac.warnMacrosOption,
     Scalac.privateWarnMacrosOption,
-    Scalac.warnConfOption
+    Scalac.targetOption,
+    Scalac.warnConfOption,
+    Scalac.warnMacrosOption
   )
 
   opts.filterNot(excludes).union(extras)

--- a/build.sbt
+++ b/build.sbt
@@ -147,7 +147,8 @@ ThisBuild / tpolecatDevModeOptions ~= { opts =>
     Scalac.maxClassfileName,
     Scalac.parallelismOption,
     Scalac.targetOption,
-    Scalac.warnMacrosOption
+    Scalac.warnMacrosOption,
+    Scalac.warnConfOption
   )
 
   opts.filterNot(excludes).union(extras)

--- a/build.sbt
+++ b/build.sbt
@@ -141,18 +141,17 @@ ThisBuild / tpolecatDevModeOptions ~= { opts =>
     ScalacOptions.warnValueDiscard
   )
 
-  val parallelism = math.min(java.lang.Runtime.getRuntime.availableProcessors(), 16)
   val extras = Set(
     Scalac.delambdafyInlineOption,
     Scalac.macroAnnotationsOption,
     Scalac.macroSettingsOption,
     Scalac.maxClassfileName,
+    Scalac.privateBackendParallelism,
     Scalac.privateWarnMacrosOption,
+    Scalac.release8,
     Scalac.targetOption,
     Scalac.warnConfOption,
-    Scalac.warnMacrosOption,
-    ScalacOptions.privateBackendParallelism(parallelism),
-    ScalacOptions.release("8")
+    Scalac.warnMacrosOption
   )
 
   opts.filterNot(excludes).union(extras)
@@ -1072,6 +1071,8 @@ lazy val `scio-repl`: Project = project
   .settings(assemblySettings)
   .settings(macroSettings)
   .settings(
+    // drop repl compatibility with java 8
+    tpolecatDevModeOptions ~= { _.filterNot(_ == Scalac.release8) },
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-runners-direct-java" % beamVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,6 @@ ThisBuild / tpolecatDevModeOptions ~= { opts =>
 }
 
 ThisBuild / doc / tpolecatDevModeOptions ++= Set(
-  Scalac.docSkipPackageOption,
   Scalac.docNoJavaCommentOption
 )
 

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -64,6 +64,16 @@ object Scalac {
 
   val targetOption = new ScalacOption("-target:jvm-1.8" :: Nil)
 
+  // silence all scala library deprecation warnings from 2.13
+  // since we still support 2.12
+  // unused-imports origin will be supported in next 2.13.9
+  // https://github.com/scala/scala/pull/9939
+  val warnConfOption = new ScalacOption(
+    "-Wconf:cat=deprecation&origin=scala\\..*&since>2.12.99:s" +
+      ",cat=unused-imports&origin=scala\\.collection\\.compat\\..*:s"
+      :: Nil
+  )
+
   val warnMacrosOption = new ScalacOption(
     "-Ywarn-macros:after" :: Nil,
     version => version.isBetween(V2_12_0, V3_0_0)

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -22,12 +22,6 @@ import _root_.io.github.davidgregory084.ScalaVersion._
 
 object Scalac {
 
-  private val parallelism = math.min(Runtime.getRuntime.availableProcessors(), 16)
-  val parallelismOption = new ScalacOption(
-    "-Ybackend-parallelism" :: parallelism.toString :: Nil,
-    version => version.isBetween(V2_12_0, V3_0_0)
-  )
-
   // Set the strategy used for translating lambdas into JVM code to "inline"
   val delambdafyInlineOption = new ScalacOption(
     "-Ydelambdafy:inline" :: Nil
@@ -49,12 +43,6 @@ object Scalac {
 
   // JVM
   val targetOption = new ScalacOption("-target:jvm-1.8" :: Nil)
-
-  private val javaVersion = VersionNumber(sys.props("java.version"))
-  val releaseOption = new ScalacOption(
-    "-release" :: "8" :: Nil,
-    _ => javaVersion.matchesSemVer(SemanticSelector(">1.8"))
-  )
 
   // Warn
   val privateWarnMacrosOption = new ScalacOption(

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -22,24 +22,15 @@ import _root_.io.github.davidgregory084.ScalaVersion._
 
 object Scalac {
 
-  val docNoJavaCommentOption = new ScalacOption(
-    "-no-java-comments" :: Nil,
-    version => version.isBetween(V2_12_0, V2_13_0)
-  )
-
-  val docSkipPackageOption = new ScalacOption(
-    "-skip-packages" :: "org.apache" :: Nil
+  private val parallelism = math.min(Runtime.getRuntime.availableProcessors(), 16)
+  val parallelismOption = new ScalacOption(
+    "-Ybackend-parallelism" :: parallelism.toString :: Nil,
+    version => version.isBetween(V2_12_0, V3_0_0)
   )
 
   // Set the strategy used for translating lambdas into JVM code to "inline"
   val delambdafyInlineOption = new ScalacOption(
     "-Ydelambdafy:inline" :: Nil
-  )
-
-  private val javaVersion = VersionNumber(sys.props("java.version"))
-  val releaseOption = new ScalacOption(
-    "-release" :: "8" :: Nil,
-    _ => javaVersion.matchesSemVer(SemanticSelector(">1.8"))
   )
 
   val macroAnnotationsOption = new ScalacOption(
@@ -56,27 +47,43 @@ object Scalac {
     version => version.isBetween(V2_12_0, V2_13_0)
   )
 
-  private val parallelism = math.min(Runtime.getRuntime.availableProcessors(), 16)
-  val parallelismOption = new ScalacOption(
-    "-Ybackend-parallelism" :: parallelism.toString :: Nil,
-    version => version.isBetween(V2_12_0, V3_0_0)
-  )
-
+  // JVM
   val targetOption = new ScalacOption("-target:jvm-1.8" :: Nil)
 
-  // silence all scala library deprecation warnings from 2.13
+  private val javaVersion = VersionNumber(sys.props("java.version"))
+  val releaseOption = new ScalacOption(
+    "-release" :: "8" :: Nil,
+    _ => javaVersion.matchesSemVer(SemanticSelector(">1.8"))
+  )
+
+  // Warn
+  val privateWarnMacrosOption = new ScalacOption(
+    "-Ywarn-macros:after" :: Nil,
+    version => version.isBetween(V2_12_0, V2_13_0)
+  )
+  val warnMacrosOption = new ScalacOption(
+    "-Wmacros:after" :: Nil,
+    version => version.isBetween(V2_13_0, V3_0_0)
+  )
+  // silence all scala library deprecation warnings in 2.13
   // since we still support 2.12
   // unused-imports origin will be supported in next 2.13.9
   // https://github.com/scala/scala/pull/9939
   val warnConfOption = new ScalacOption(
     "-Wconf:cat=deprecation&origin=scala\\..*&since>2.12.99:s" +
       ",cat=unused-imports&origin=scala\\.collection\\.compat\\..*:s"
-      :: Nil
+      :: Nil,
+    version => version.isBetween(V2_13_2, V3_0_0)
   )
 
-  val warnMacrosOption = new ScalacOption(
-    "-Ywarn-macros:after" :: Nil,
-    version => version.isBetween(V2_12_0, V3_0_0)
+  // Doc
+  val docNoJavaCommentOption = new ScalacOption(
+    "-no-java-comments" :: Nil,
+    version => version.isBetween(V2_12_0, V2_13_0)
+  )
+
+  val docSkipPackageOption = new ScalacOption(
+    "-skip-packages" :: "org.apache" :: Nil
   )
 
 }

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -22,14 +22,38 @@ import _root_.io.github.davidgregory084.ScalaVersion._
 
 object Scalac {
 
+  val docNoJavaCommentOption = new ScalacOption(
+    "-no-java-comments" :: Nil,
+    version => version.isBetween(V2_12_0, V2_13_0)
+  )
+
+  val docSkipPackageOption = new ScalacOption(
+    "-skip-packages" :: "org.apache" :: Nil
+  )
+
   // Set the strategy used for translating lambdas into JVM code to "inline"
   val delambdafyInlineOption = new ScalacOption(
     "-Ydelambdafy:inline" :: Nil
   )
 
+  private val javaVersion = VersionNumber(sys.props("java.version"))
+  val releaseOption = new ScalacOption(
+    "-release" :: "8" :: Nil,
+    _ => javaVersion.matchesSemVer(SemanticSelector(">1.8"))
+  )
+
   val macroAnnotationsOption = new ScalacOption(
     "-Ymacro-annotations" :: Nil,
     version => version.isBetween(V2_13_0, V3_0_0)
+  )
+
+  val macroSettingsOption = new ScalacOption(
+    "-Xmacro-settings:show-coder-fallback=true" :: Nil
+  )
+
+  val maxClassfileName = new ScalacOption(
+    "-Xmax-classfile-name" :: "100" :: Nil,
+    version => version.isBetween(V2_12_0, V2_13_0)
   )
 
   private val parallelism = math.min(Runtime.getRuntime.availableProcessors(), 16)
@@ -40,19 +64,9 @@ object Scalac {
 
   val targetOption = new ScalacOption("-target:jvm-1.8" :: Nil)
 
-  private val javaVersion = VersionNumber(sys.props("java.version"))
-  val releaseOption = new ScalacOption(
-    "-release" :: "8" :: Nil,
-    _ => javaVersion.matchesSemVer(SemanticSelector(">1.8"))
-  )
-
   val warnMacrosOption = new ScalacOption(
     "-Ywarn-macros:after" :: Nil,
     version => version.isBetween(V2_12_0, V3_0_0)
-  )
-
-  val extraMacroSettingsOption = new ScalacOption(
-    "-Xmacro-settings:show-coder-fallback=true" :: Nil
   )
 
 }

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -15,13 +15,17 @@
  * under the License.
  */
 
-import sbt._, Keys._
 import sbt.librarymanagement.{SemanticSelector, VersionNumber}
 import java.lang.Runtime
 import _root_.io.github.davidgregory084.ScalacOption
 import _root_.io.github.davidgregory084.ScalaVersion._
 
 object Scalac {
+
+  // Set the strategy used for translating lambdas into JVM code to "inline"
+  val delambdafyInlineOption = new ScalacOption(
+    "-Ydelambdafy:inline" :: Nil
+  )
 
   val macroAnnotationsOption = new ScalacOption(
     "-Ymacro-annotations" :: Nil,
@@ -46,4 +50,9 @@ object Scalac {
     "-Ywarn-macros:after" :: Nil,
     version => version.isBetween(V2_12_0, V3_0_0)
   )
+
+  val extraMacroSettingsOption = new ScalacOption(
+    "-Xmacro-settings:show-coder-fallback=true" :: Nil
+  )
+
 }

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -69,9 +69,4 @@ object Scalac {
     "-no-java-comments" :: Nil,
     version => version.isBetween(V2_12_0, V2_13_0)
   )
-
-  val docSkipPackageOption = new ScalacOption(
-    "-skip-packages" :: "org.apache" :: Nil
-  )
-
 }

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -19,6 +19,7 @@ import sbt.librarymanagement.{SemanticSelector, VersionNumber}
 import java.lang.Runtime
 import _root_.io.github.davidgregory084.ScalacOption
 import _root_.io.github.davidgregory084.ScalaVersion._
+import _root_.io.github.davidgregory084.TpolecatPlugin.autoImport.ScalacOptions
 
 object Scalac {
 
@@ -40,6 +41,11 @@ object Scalac {
     "-Xmax-classfile-name" :: "100" :: Nil,
     version => version.isBetween(V2_12_0, V2_13_0)
   )
+
+  private val parallelism = math.min(java.lang.Runtime.getRuntime.availableProcessors(), 16)
+  val privateBackendParallelism = ScalacOptions.privateBackendParallelism(parallelism)
+
+  val release8 = ScalacOptions.release("8")
 
   // JVM
   val targetOption = new ScalacOption("-target:jvm-1.8" :: Nil)

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -17,97 +17,33 @@
 
 import sbt._, Keys._
 import sbt.librarymanagement.{SemanticSelector, VersionNumber}
+import java.lang.Runtime
+import _root_.io.github.davidgregory084.ScalacOption
+import _root_.io.github.davidgregory084.ScalaVersion._
 
 object Scalac {
-  // see: https://tpolecat.github.io/2017/04/25/scalac-flags.html
-  val parallelism = math.min(math.max(4, java.lang.Runtime.getRuntime().availableProcessors()), 16)
-  val baseOptions = Def.setting {
-    List(
-      "-target:jvm-1.8",
-      "-deprecation", // Emit warning and location for usages of deprecated APIs.
-      "-feature", // Emit warning and location for usages of features that should be imported explicitly.
-      "-unchecked", // Enable additional warnings where generated code depends on assumptions.
-      "-encoding",
-      "utf-8", // Specify character encoding used by source files.
-      "-explaintypes", // Explain type errors in more detail.
-      // "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
-      "-language:experimental.macros", // Allow macro definition (besides implementation and application)
-      "-language:higherKinds", // Allow higher-kinded types
-      "-language:implicitConversions", // Allow definition of implicit functions called views
-      "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
-      // "-Xfatal-warnings", // Fail the compilation if there are any warnings.
-      // "-Xfuture", // Turn on future language features.
-      "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
-      // "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
-      "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
-      "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
-      "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
-      "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
-      "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
-      "-Xlint:option-implicit", // Option.apply used implicit view.
-      // "-Xlint:package-object-classes", // Class or object defined in package object.
-      "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
-      "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
-      "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
-      "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
-      // "-Ywarn-dead-code", // Warn when dead code is identified.
-      // "-Ywarn-numeric-widen", // Warn when numerics are widened.
-      // "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
-      // "-Ywarn-unused:locals", // Warn if a local definition is unused.
-      // "-Ywarn-unused:params", // Warn if a value parameter is unused.
-      // "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
-      // "-Ywarn-unused:privates", // Warn if a private member is unused.
-      "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
-      "-Xmacro-settings:show-coder-fallback=true",
-      "-Ydelambdafy:inline", // Set the strategy used for translating lambdas into JVM code to "inline"
-      "-Ybackend-parallelism",
-      parallelism.toString
-    )
-  }
 
-  val scalaVersionOptions = Def.setting {
-    VersionNumber(scalaVersion.value) match {
-      case v if v.matchesSemVer(SemanticSelector("2.12.x")) =>
-        List(
-          "-Xmax-classfile-name",
-          "100",
-          "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
-          "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
-          "-Xlint:unsound-match", // Pattern match may not be typesafe.
-          "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-          "-Ypartial-unification", // Enable partial unification in type constructor inference
-          "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
-          "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.,
-          "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
-          "-Ywarn-infer-any" // Warn when a type argument is inferred to be `Any`.
-        )
-      case v if v.matchesSemVer(SemanticSelector(">=2.13")) =>
-        List("-Ymacro-annotations", "-Ywarn-unused")
-      case _ =>
-        Nil
-    }
-  }
+  val macroAnnotationsOption = new ScalacOption(
+    "-Ymacro-annotations" :: Nil,
+    version => version.isBetween(V2_13_0, V3_0_0)
+  )
 
-  val jvmVersionOptions = Def.setting {
-    VersionNumber(sys.props("java.version")) match {
-      case v if v.matchesSemVer(SemanticSelector(">1.8")) => List("-release", "8")
-      case _                                              => Nil
-    }
-  }
+  private val parallelism = math.min(Runtime.getRuntime.availableProcessors(), 16)
+  val parallelismOption = new ScalacOption(
+    "-Ybackend-parallelism" :: parallelism.toString :: Nil,
+    version => version.isBetween(V2_12_0, V3_0_0)
+  )
 
-  val commonsOptions =
-    Def.setting(baseOptions.value ++ scalaVersionOptions.value ++ jvmVersionOptions.value)
+  val targetOption = new ScalacOption("-target:jvm-1.8" :: Nil)
 
-  val docOptions = Def.setting {
-    val base =
-      baseOptions.value ++ scalaVersionOptions.value
+  private val javaVersion = VersionNumber(sys.props("java.version"))
+  val releaseOption = new ScalacOption(
+    "-release" :: "8" :: Nil,
+    _ => javaVersion.matchesSemVer(SemanticSelector(">1.8"))
+  )
 
-    VersionNumber(scalaVersion.value) match {
-      case v if v.matchesSemVer(SemanticSelector("2.12.x")) => base ++ List("-no-java-comments")
-      case _                                                => base
-    }
-  }
-
-  val replOptions = Def.setting(baseOptions.value ++ scalaVersionOptions.value)
-
+  val warnMacrosOption = new ScalacOption(
+    "-Ywarn-macros:after" :: Nil,
+    version => version.isBetween(V2_12_0, V3_0_0)
+  )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.3.1")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.3.3")
 
 libraryDependencies ++= Seq(
   "com.github.os72" % "protoc-jar" % "3.11.4",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,6 +20,7 @@ addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.3.1")
 
 libraryDependencies ++= Seq(
   "com.github.os72" % "protoc-jar" % "3.11.4",

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/AvroType.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/AvroType.scala
@@ -20,7 +20,7 @@ package com.spotify.scio.avro.types
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 
-import scala.annotation.{StaticAnnotation, compileTimeOnly, nowarn}
+import scala.annotation.{compileTimeOnly, nowarn, StaticAnnotation}
 import scala.reflect.runtime.universe._
 
 /**

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/AvroType.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/AvroType.scala
@@ -20,7 +20,7 @@ package com.spotify.scio.avro.types
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 
-import scala.annotation.{compileTimeOnly, StaticAnnotation}
+import scala.annotation.{StaticAnnotation, compileTimeOnly, nowarn}
 import scala.reflect.runtime.universe._
 
 /**
@@ -83,6 +83,7 @@ object AvroType {
    * Also generate a companion object with convenience methods.
    * @group annotation
    */
+  @nowarn
   @compileTimeOnly(
     "enable macro paradise (2.12) or -Ymacro-annotations (2.13) to expand macro annotations"
   )
@@ -126,6 +127,7 @@ object AvroType {
    * Also generate a companion object with convenience methods.
    * @group annotation
    */
+  @nowarn
   @compileTimeOnly(
     "enable macro paradise (2.12) or -Ymacro-annotations (2.13) to expand macro annotations"
   )
@@ -155,6 +157,7 @@ object AvroType {
    * Also generate a companion object with convenience methods.
    * @group annotation
    */
+  @nowarn
   @compileTimeOnly(
     "enable macro paradise (2.12) or -Ymacro-annotations (2.13) to expand macro annotations"
   )

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/SchemaProvider.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/SchemaProvider.scala
@@ -20,7 +20,6 @@ package com.spotify.scio.avro.types
 import java.util.Collections.{emptyList, emptyMap}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function
-
 import com.google.protobuf.ByteString
 import com.spotify.scio.avro.types.MacroUtil._
 import org.apache.avro.{JsonProperties, Schema}
@@ -103,7 +102,7 @@ private[types] object SchemaProvider {
     t.typeSymbol.annotations
       .find(_.tree.tpe.toString == tpe)
       .map { a =>
-        val q"new $t($v)" = a.tree
+        val q"new $_($v)" = a.tree
         val Literal(Constant(s)) = v
         s.toString
       }
@@ -115,7 +114,7 @@ private[types] object SchemaProvider {
       _.annotations
         .find(_.tree.tpe.toString == tpe)
         .map { a =>
-          val q"new $t($v)" = a.tree
+          val q"new $_($v)" = a.tree
           val Literal(Constant(s)) = v
           s.toString
         }

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/TypeProvider.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/TypeProvider.scala
@@ -21,7 +21,6 @@ import java.io.InputStream
 import java.net.URL
 import java.nio.channels.Channels
 import java.nio.file.{Path, Paths}
-
 import com.spotify.scio.CoreSysProps
 import com.spotify.scio.avro.AvroSysProps
 import com.spotify.scio.avro.types.MacroUtil._
@@ -38,6 +37,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.hash.Hashing
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.Files
 import org.slf4j.LoggerFactory
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 import scala.reflect.macros._
 import scala.util.Try
@@ -139,6 +139,7 @@ private[types] object TypeProvider {
     }
   }
 
+  @nowarn
   def toSchemaImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
     checkMacroEnclosed(c)

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/TypeProvider.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/TypeProvider.scala
@@ -139,7 +139,6 @@ private[types] object TypeProvider {
     }
   }
 
-  @nowarn
   def toSchemaImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
     checkMacroEnclosed(c)
@@ -429,6 +428,7 @@ private[types] object TypeProvider {
         .resolve("generated-classes")
     }
 
+  @nowarn("msg=match may not be exhaustive")
   private def pShowCode(
     c: blackbox.Context
   )(records: Seq[c.Tree], caseClass: c.Tree): Seq[String] = {

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/types.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/types.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.avro
 
-import scala.annotation.{StaticAnnotation, nowarn}
+import scala.annotation.{nowarn, StaticAnnotation}
 
 package object types {
 

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/types.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/types.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.avro
 
-import scala.annotation.StaticAnnotation
+import scala.annotation.{StaticAnnotation, nowarn}
 
 package object types {
 
@@ -35,5 +35,6 @@ package object types {
    *                 @doc("user age") age: Int)
    * }}}
    */
+  @nowarn("msg=parameter value value in class doc is never used")
   class doc(value: String) extends StaticAnnotation
 }

--- a/scio-avro/src/test/scala/com/spotify/scio/avro/types/Schemas.scala
+++ b/scio-avro/src/test/scala/com/spotify/scio/avro/types/Schemas.scala
@@ -168,6 +168,7 @@ object Schemas {
       case OPTIONAL => s"""["null", $basicType]"""
       case ARRAY    => s"""{ "type" : "array", "items" : $basicType }"""
       case MAP      => s"""{ "type" : "map", "values" : $basicType }"""
+      case _        => throw new IllegalArgumentException(s"Unsupported mode $mode")
     }
 
   private def setDefaultValue(mode: FieldMode): String =
@@ -176,6 +177,7 @@ object Schemas {
       case OPTIONAL => s""", "default": null"""
       case ARRAY    => s""", "default": []"""
       case MAP      => s""", "default": {}"""
+      case _        => throw new IllegalArgumentException(s"Unsupported mode $mode")
     }
 
   private def basicRecordName(mode: FieldMode): String =
@@ -184,6 +186,7 @@ object Schemas {
       case OPTIONAL => "OptionalFields"
       case ARRAY    => "ArrayFields"
       case MAP      => "MapFields"
+      case _        => throw new IllegalArgumentException(s"Unsupported mode $mode")
     }
 
   private def nestedRecordName(mode: FieldMode): String =
@@ -192,5 +195,6 @@ object Schemas {
       case OPTIONAL => "OptionalNestedFields"
       case ARRAY    => "ArrayNestedFields"
       case MAP      => "MapNestedFields"
+      case _        => throw new IllegalArgumentException(s"Unsupported mode $mode")
     }
 }

--- a/scio-cassandra/cassandra3/src/it/scala/com/spotify/scio/cassandra/CassandraIT.scala
+++ b/scio-cassandra/cassandra3/src/it/scala/com/spotify/scio/cassandra/CassandraIT.scala
@@ -165,7 +165,7 @@ object CassandraIT {
       i.toShort,
       i,
       i.toLong,
-      JBigDecimal.valueOf(i),
+      JBigDecimal.valueOf(i.toLong),
       i.toFloat,
       i.toDouble,
       i % 2 == 0,
@@ -176,7 +176,7 @@ object CassandraIT {
       u1,
       u2,
       s"varchar$i",
-      BigInteger.valueOf(i),
+      BigInteger.valueOf(i.toLong),
       List(s"list$i").asJava,
       Set(s"set$i").asJava,
       Map(s"key$i" -> i).asJava

--- a/scio-cassandra/cassandra3/src/main/scala/com/spotify/scio/cassandra/BulkOperations.scala
+++ b/scio-cassandra/cassandra3/src/main/scala/com/spotify/scio/cassandra/BulkOperations.scala
@@ -70,7 +70,7 @@ private[cassandra] class BulkOperations(val opts: CassandraOptions, val parallel
       .zipWithIndex
       .filter(t => partitionKeys.contains(t._1))
       .map(_._2)
-      .toIndexedSeq
+      .toSeq
     val dataTypes = variables.iterator.map(v => DataTypeExternalizer(v.getType)).toSeq
     cluster.close()
 

--- a/scio-cassandra/cassandra3/src/main/scala/com/spotify/scio/cassandra/BulkOperations.scala
+++ b/scio-cassandra/cassandra3/src/main/scala/com/spotify/scio/cassandra/BulkOperations.scala
@@ -70,7 +70,7 @@ private[cassandra] class BulkOperations(val opts: CassandraOptions, val parallel
       .zipWithIndex
       .filter(t => partitionKeys.contains(t._1))
       .map(_._2)
-      .toArray
+      .toIndexedSeq
     val dataTypes = variables.iterator.map(v => DataTypeExternalizer(v.getType)).toSeq
     cluster.close()
 

--- a/scio-core/src/main/scala-2.13/com/spotify/scio/coders/instances/kryo/JTraversableSerializer.scala
+++ b/scio-core/src/main/scala-2.13/com/spotify/scio/coders/instances/kryo/JTraversableSerializer.scala
@@ -73,7 +73,7 @@ abstract private[coders] class JWrapperCBF[T] extends Factory[T, Iterable[T]] {
 
   override def fromSpecific(it: IterableOnce[T]): Iterable[T] = {
     val b = new JIterableWrapperBuilder
-    it.foreach(b += _)
+    it.iterator.foreach(b += _)
     b.result()
   }
 

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -340,7 +340,7 @@ object ScioContext {
         }
     } yield s"--$str($$|=)".r
 
-    val patterns = registeredPatterns + "--help($$|=)".r
+    val patterns = registeredPatterns.toSet + "--help($$|=)".r
 
     // Split cmdlineArgs into 2 parts, optArgs for PipelineOptions and appArgs for Args
     val (optArgs, appArgs) =

--- a/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
@@ -18,9 +18,9 @@
 package com.spotify.scio
 
 import com.google.api.client.http.javanet.NetHttpTransport
-import com.google.api.client.http.{GenericUrl, HttpRequest, HttpRequestInitializer}
+import com.google.api.client.http.{GenericUrl, HttpRequest}
 import com.google.api.client.json.JsonObjectParser
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import org.apache.beam.sdk.util.ReleaseInfo
 import org.apache.beam.sdk.{PipelineResult, PipelineRunner}
 import org.slf4j.LoggerFactory
@@ -59,14 +59,11 @@ private[scio] object VersionUtil {
   private lazy val latest: Option[String] = Try {
     val transport = new NetHttpTransport()
     val response = transport
-      .createRequestFactory(new HttpRequestInitializer {
-        override def initialize(request: HttpRequest): Unit = {
-          request.setConnectTimeout(Timeout)
-          request.setReadTimeout(Timeout)
-          request.setParser(new JsonObjectParser(new JacksonFactory))
-
-          ()
-        }
+      .createRequestFactory((request: HttpRequest) => {
+        request.setConnectTimeout(Timeout)
+        request.setReadTimeout(Timeout)
+        request.setParser(new JsonObjectParser(GsonFactory.getDefaultInstance))
+        ()
       })
       .buildGetRequest(new GenericUrl(Url))
       .execute()

--- a/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
@@ -59,12 +59,12 @@ private[scio] object VersionUtil {
   private lazy val latest: Option[String] = Try {
     val transport = new NetHttpTransport()
     val response = transport
-      .createRequestFactory((request: HttpRequest) => {
+      .createRequestFactory { (request: HttpRequest) =>
         request.setConnectTimeout(Timeout)
         request.setReadTimeout(Timeout)
         request.setParser(new JsonObjectParser(GsonFactory.getDefaultInstance))
         ()
-      })
+      }
       .buildGetRequest(new GenericUrl(Url))
       .execute()
       .parseAs(classOf[java.util.List[java.util.Map[String, AnyRef]]])

--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -73,7 +73,7 @@ final private[scio] class Ref[T](val typeName: String, c: => Coder[T]) extends C
 
 private[scio] object Ref {
   def apply[T](t: String, c: => Coder[T]): Ref[T] = new Ref[T](t, c)
-  def unapply[T](c: Ref[T]): Option[(String, Coder[T])] = Option((c.typeName, c.value))
+  def unapply[T](c: Ref[T]): Some[(String, Coder[T])] = Some((c.typeName, c.value))
 }
 
 final case class RawBeam[T] private (beam: BCoder[T]) extends Coder[T] {

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/BeamTypeCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/BeamTypeCoders.scala
@@ -18,10 +18,11 @@
 package com.spotify.scio.coders.instances
 
 import com.google.api.client.json.GenericJson
-import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.json.JsonObjectParser
+import com.google.api.client.json.gson.GsonFactory
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.util.ScioUtil
+
 import java.io.StringReader
 import org.apache.beam.sdk.coders.RowCoder
 import org.apache.beam.sdk.io.FileIO.ReadableFile
@@ -30,6 +31,7 @@ import org.apache.beam.sdk.io.ReadableFileCoder
 import org.apache.beam.sdk.schemas.{Schema => BSchema}
 import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, IntervalWindow, PaneInfo}
 import org.apache.beam.sdk.values.{KV, Row}
+
 import scala.reflect.ClassTag
 
 trait BeamTypeCoders {
@@ -58,5 +60,5 @@ trait BeamTypeCoders {
 }
 
 private[coders] object BeamTypeCoders extends BeamTypeCoders {
-  private lazy val DefaultJsonObjectParser = new JsonObjectParser(new JacksonFactory)
+  private lazy val DefaultJsonObjectParser = new JsonObjectParser(GsonFactory.getDefaultInstance)
 }

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/JodaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/JodaCoders.scala
@@ -86,13 +86,13 @@ final private class JodaLocalDateTimeCoder extends AtomicCoder[LocalDateTime] {
   override def decode(is: InputStream): LocalDateTime = {
     val dis = new DataInputStream(is)
 
-    val year = dis.readShort()
-    val month = dis.readShort()
-    val day = dis.readShort()
-    val hour = dis.readShort()
-    val minute = dis.readShort()
-    val second = dis.readShort()
-    val ms = dis.readShort()
+    val year = dis.readShort().toInt
+    val month = dis.readShort().toInt
+    val day = dis.readShort().toInt
+    val hour = dis.readShort().toInt
+    val minute = dis.readShort().toInt
+    val second = dis.readShort().toInt
+    val ms = dis.readShort().toInt
 
     new LocalDateTime(year, month, day, hour, minute, second, ms)
   }
@@ -113,9 +113,9 @@ final private class JodaLocalDateCoder extends AtomicCoder[LocalDate] {
   override def decode(is: InputStream): LocalDate = {
     val dis = new DataInputStream(is)
 
-    val year = dis.readShort()
-    val month = dis.readShort()
-    val day = dis.readShort()
+    val year = dis.readShort().toInt
+    val month = dis.readShort().toInt
+    val day = dis.readShort().toInt
 
     new LocalDate(year, month, day)
   }
@@ -137,10 +137,10 @@ final private class JodaLocalTimeCoder extends AtomicCoder[LocalTime] {
   override def decode(is: InputStream): LocalTime = {
     val dis = new DataInputStream(is)
 
-    val hour = dis.readShort()
-    val minute = dis.readShort()
-    val second = dis.readShort()
-    val ms = dis.readShort()
+    val hour = dis.readShort().toInt
+    val minute = dis.readShort().toInt
+    val second = dis.readShort().toInt
+    val ms = dis.readShort().toInt
 
     new LocalTime(hour, minute, second, ms)
   }

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/kryo/ByteStringSerializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/kryo/ByteStringSerializer.scala
@@ -33,7 +33,7 @@ private[coders] class ByteStringSerializer extends KSerializer[ByteString] {
     output.writeInt(len)
     val bytes = byteStr.iterator
     while (bytes.hasNext) {
-      output.write(bytes.nextByte())
+      output.writeByte(bytes.nextByte())
     }
   }
 }

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/kryo/JodaSerializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/kryo/JodaSerializer.scala
@@ -27,9 +27,9 @@ private[coders] class JodaLocalDateTimeSerializer extends Serializer[LocalDateTi
 
   def write(kryo: Kryo, output: Output, ldt: LocalDateTime): Unit = {
     output.writeInt(ldt.getYear, /*optimizePositive=*/ false)
-    output.writeByte(ldt.getMonthOfYear)
-    output.writeByte(ldt.getDayOfMonth)
-    output.writeLong(ldt.getMillisOfDay)
+    output.writeByte(ldt.getMonthOfYear.toByte)
+    output.writeByte(ldt.getDayOfMonth.toByte)
+    output.writeLong(ldt.getMillisOfDay.toLong)
 
     val chronology = ldt.getChronology
     if (chronology != null && chronology != ISOChronology.getInstanceUTC) {
@@ -65,7 +65,7 @@ private[coders] class JodaLocalTimeSerializer extends Serializer[LocalTime] {
   }
 
   def read(kryo: Kryo, input: Input, tpe: Class[LocalTime]): LocalTime =
-    LocalTime.fromMillisOfDay(input.readInt( /*optimizePositive=*/ false))
+    LocalTime.fromMillisOfDay(input.readInt( /*optimizePositive=*/ false).toLong)
 }
 
 private[coders] class JodaLocalDateSerializer extends Serializer[LocalDate] {

--- a/scio-core/src/main/scala/com/spotify/scio/hash/ApproxFilter.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/hash/ApproxFilter.scala
@@ -101,7 +101,7 @@ sealed trait ApproxFilterCompanion {
   // Empirically (see [[com.twitter.algebird.BF.contains]])
   // `expectedInsertions` to number of unique elements ratio should be 1.1
   final def create[T: Hash](elems: Iterable[T]): Filter[T] =
-    create(elems, elems.size)
+    create(elems, elems.size.toLong)
 
   /**
    * Creates an [[ApproxFilter]] from an [[Iterable]] with the expected number of insertions and
@@ -196,7 +196,7 @@ sealed trait ApproxFilterCompanion {
     elems.transform {
       _.groupBy(_ => ()).values
         .map { xs =>
-          val n = if (expectedInsertions > 0) expectedInsertions else xs.size
+          val n = if (expectedInsertions > 0) expectedInsertions else xs.size.toLong
           create(xs, n, fpp)
         }
     }

--- a/scio-core/src/main/scala/com/spotify/scio/hash/MutableScalableBloomFilter.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/hash/MutableScalableBloomFilter.scala
@@ -22,6 +22,8 @@ import com.google.common.io.ByteStreams
 import com.google.common.{hash => g}
 import com.spotify.scio.coders.Coder
 
+import scala.collection.compat._ // scalafix:ok
+
 /**
  * A mutable, scalable wrapper around a Guava [[com.google.common.hash.BloomFilter BloomFilter]]
  *
@@ -253,7 +255,7 @@ case class MutableScalableBloomFilter[T](
   }
 
   def ++=(items: TraversableOnce[T]): MutableScalableBloomFilter[T] = {
-    items.foreach(i => this += i) // no bulk insert for guava BFs
+    items.iterator.foreach(i => this += i) // no bulk insert for guava BFs
     this
   }
 }

--- a/scio-core/src/main/scala/com/spotify/scio/io/BinaryIO.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/BinaryIO.scala
@@ -40,7 +40,7 @@ import scala.util.Try
 final case class BinaryIO(path: String) extends ScioIO[Array[Byte]] {
   override type ReadP = Nothing
   override type WriteP = BinaryIO.WriteParam
-  final override val tapT: TapT.Aux[Array[Byte], Nothing] = EmptyTapOf[Array[Byte]]
+  override val tapT: TapT.Aux[Array[Byte], Nothing] = EmptyTapOf[Array[Byte]]
 
   override def testId: String = s"BinaryIO($path)"
 

--- a/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/FileStorage.scala
@@ -21,8 +21,6 @@ import java.io._
 import java.nio.ByteBuffer
 import java.nio.channels.{Channels, SeekableByteChannel}
 import java.util.Collections
-
-import com.google.api.client.util.Charsets
 import com.google.api.services.bigquery.model.TableRow
 import com.spotify.scio.util.ScioUtil
 import org.apache.avro.Schema
@@ -35,6 +33,8 @@ import org.apache.beam.sdk.io.fs.MatchResult.Metadata
 import org.apache.commons.compress.compressors.CompressorStreamFactory
 import org.apache.commons.io.IOUtils
 
+import java.nio.charset.StandardCharsets
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
@@ -93,7 +93,7 @@ final private[scio] class FileStorage(protected[scio] val path: String) {
       }
     }
     val input = getDirectoryInputStream(path, wrapInputStream)
-    IOUtils.lineIterator(input, Charsets.UTF_8).asScala
+    IOUtils.lineIterator(input, StandardCharsets.UTF_8).asScala
   }
 
   def tableRowJsonFile: Iterator[TableRow] =
@@ -131,6 +131,7 @@ final private[scio] class FileStorage(protected[scio] val path: String) {
     }
   }
 
+  @nowarn("msg=parameter value path in method getDirectoryInputStream is never used")
   private[scio] def getDirectoryInputStream(
     path: String,
     wrapperFn: InputStream => InputStream = identity

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/Schema.scala
@@ -139,7 +139,7 @@ object LogicalType {
     }
   }
 
-  def unapply[T](logicalType: LogicalType[T]): Option[BSchema.FieldType] =
+  def unapply[T](logicalType: LogicalType[T]): Some[BSchema.FieldType] =
     Some(logicalType.underlying)
 }
 

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/SchemaMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/SchemaMaterializer.scala
@@ -19,13 +19,14 @@ package com.spotify.scio.schemas
 
 import java.util
 import java.util.function.BiConsumer
-
 import scala.reflect.ClassTag
 import scala.jdk.CollectionConverters._
 import org.apache.beam.sdk.schemas.{Schema => BSchema}
 import org.apache.beam.sdk.transforms.SerializableFunction
 import org.apache.beam.sdk.values.Row
 import BSchema.{Field => BField, FieldType => BFieldType}
+
+import scala.collection.compat.immutable.ArraySeq
 
 object SchemaMaterializer {
   @inline private[scio] def fieldType[A](schema: Schema[A]): BFieldType =
@@ -72,7 +73,7 @@ object SchemaMaterializer {
       values.update(i, dispatchDecode(schema)(v.asInstanceOf[schema.Repr]))
       i = i + 1
     }
-    record.construct(values)
+    record.construct(ArraySeq.unsafeWrapArray(values))
   }
 
   private[scio] def decode[A](schema: Type[A])(v: schema.Repr): A = v

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/instances/ScalaInstances.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/instances/ScalaInstances.scala
@@ -24,6 +24,7 @@ import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.collection.mutable
 import scala.collection.SortedSet
+import scala.collection.compat._ // scalafix:ok
 
 trait ScalaInstances {
   implicit val stringSchema: Type[String] =
@@ -69,7 +70,7 @@ trait ScalaInstances {
     ArrayType(s, _.asJava, _.asScala.toList)
 
   implicit def traversableOnceSchema[T](implicit s: Schema[T]): Schema[TraversableOnce[T]] =
-    ArrayType(s, _.toList.asJava, _.asScala.toList)
+    ArrayType(s, _.iterator.to(List).asJava, _.asScala.toList)
 
   implicit def iterableSchema[T](implicit s: Schema[T]): Schema[Iterable[T]] =
     ArrayType(s, _.toList.asJava, _.asScala.toList)

--- a/scio-core/src/main/scala/com/spotify/scio/transforms/ParallelismDoFns.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/transforms/ParallelismDoFns.scala
@@ -20,6 +20,8 @@ import com.spotify.scio.util.ParallelLimitedFn
 import com.twitter.chill.ClosureCleaner
 import org.apache.beam.sdk.transforms.DoFn
 
+import scala.collection.compat._ // scalafix:ok
+
 class ParallelCollectFn[T, U](parallelism: Int)(pfn: PartialFunction[T, U])
     extends ParallelLimitedFn[T, U](parallelism) {
   val isDefined: T => Boolean = ClosureCleaner.clean(pfn.isDefinedAt(_)) // defeat closure
@@ -50,7 +52,7 @@ class ParallelFlatMapFn[T, U](parallelism: Int)(f: T => TraversableOnce[U])
     extends ParallelLimitedFn[T, U](parallelism: Int) {
   val g: T => TraversableOnce[U] = ClosureCleaner.clean(f) // defeat closure
   def parallelProcessElement(c: DoFn[T, U]#ProcessContext): Unit = {
-    val i = g(c.element()).toIterator
+    val i = g(c.element()).iterator
     while (i.hasNext) c.output(i.next())
   }
 }

--- a/scio-core/src/main/scala/com/spotify/scio/transforms/WithResourceDoFns.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/transforms/WithResourceDoFns.scala
@@ -22,6 +22,8 @@ import com.twitter.chill.ClosureCleaner
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.transforms.DoFn
 
+import scala.collection.compat._ // scalafix:ok
+
 class CollectFnWithResource[T, U, R] private[transforms] (
   resource: => R,
   resourceType: ResourceType,
@@ -68,7 +70,7 @@ class FlatMapFnWithResource[T, U, R] private[transforms] (
   val g: (R, T) => TraversableOnce[U] = ClosureCleaner.clean(f)
   @ProcessElement
   def processElement(c: DoFn[T, U]#ProcessContext): Unit = {
-    val i = g(getResource, c.element()).toIterator
+    val i = g(getResource, c.element()).iterator
     while (i.hasNext) c.output(i.next())
   }
 }

--- a/scio-core/src/main/scala/com/spotify/scio/transforms/syntax/SCollectionSafeSyntax.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/transforms/syntax/SCollectionSafeSyntax.scala
@@ -24,6 +24,8 @@ import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.transforms.{DoFn, ParDo}
 import org.apache.beam.sdk.values.{TupleTag, TupleTagList}
 
+import scala.collection.compat._ // scalafix:ok
+
 trait SCollectionSafeSyntax {
 
   /**
@@ -51,7 +53,7 @@ trait SCollectionSafeSyntax {
         private[scio] def processElement(c: DoFn[T, U]#ProcessContext): Unit = {
           val i =
             try {
-              g(c.element()).toIterator
+              g(c.element()).iterator
             } catch {
               case e: Throwable =>
                 c.output(errorTag, (c.element(), e))

--- a/scio-core/src/main/scala/com/spotify/scio/util/ArtisanJoin.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/ArtisanJoin.scala
@@ -72,7 +72,7 @@ private[scio] object ArtisanJoin {
       .and(tagB, b.toKV.internal)
       .apply(s"CoGroupByKey@$name", CoGroupByKey.create())
 
-    implicit val (kCoder, aCoder, bCoder) = (a.keyCoder, a.valueCoder, b.valueCoder)
+    implicit val kCoder: Coder[KEY] = a.keyCoder
 
     type DF = DoFn[KV[KEY, CoGbkResult], (KEY, (A1, B1))]
     a.context

--- a/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.transforms.Partition.PartitionFn
 import org.apache.beam.sdk.transforms.{DoFn, ProcessFunction, SerializableFunction, SimpleFunction}
 
 import scala.jdk.CollectionConverters._
+import scala.collection.compat._ // scalafix:ok
 
 private[scio] object Functions {
   private[this] val BufferSize = 20
@@ -232,7 +233,7 @@ private[scio] object Functions {
       private[this] val g = ClosureCleaner.clean(f) // defeat closure
       @ProcessElement
       private[scio] def processElement(c: DoFn[T, U]#ProcessContext): Unit = {
-        val i = g(c.element()).toIterator
+        val i = g(c.element()).iterator
         while (i.hasNext) c.output(i.next())
       }
     }

--- a/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithSideInput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithSideInput.scala
@@ -23,6 +23,8 @@ import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow
 import com.twitter.chill.ClosureCleaner
 
+import scala.collection.compat._ // scalafix:ok
+
 private[scio] object FunctionsWithSideInput {
   trait SideInputDoFn[T, U] extends NamedDoFn[T, U] {
     def sideInputContext(c: DoFn[T, U]#ProcessContext, w: BoundedWindow): SideInputContext[T] =
@@ -45,7 +47,7 @@ private[scio] object FunctionsWithSideInput {
       val g = ClosureCleaner.clean(f) // defeat closure
       @ProcessElement
       private[scio] def processElement(c: DoFn[T, U]#ProcessContext, w: BoundedWindow): Unit = {
-        val i = g(c.element(), sideInputContext(c, w)).toIterator
+        val i = g(c.element(), sideInputContext(c, w)).iterator
         while (i.hasNext) c.output(i.next())
       }
     }

--- a/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithSideOutput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithSideOutput.scala
@@ -22,6 +22,8 @@ import com.spotify.scio.values.SideOutputContext
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import com.twitter.chill.ClosureCleaner
 
+import scala.collection.compat._ // scalafix:ok
+
 private[scio] object FunctionsWithSideOutput {
   trait SideOutputFn[T, U] extends NamedDoFn[T, U] {
     private var ctx: SideOutputContext[T] = _
@@ -47,7 +49,7 @@ private[scio] object FunctionsWithSideOutput {
       val g = ClosureCleaner.clean(f) // defeat closure
       @ProcessElement
       private[scio] def processElement(c: DoFn[T, U]#ProcessContext): Unit = {
-        val i = g(c.element(), sideOutputContext(c)).toIterator
+        val i = g(c.element(), sideOutputContext(c)).iterator
         while (i.hasNext) c.output(i.next())
       }
     }

--- a/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithWindowedValue.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithWindowedValue.scala
@@ -23,6 +23,8 @@ import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow
 import com.twitter.chill.ClosureCleaner
 
+import scala.collection.compat._ // scalafix:ok
+
 private[scio] object FunctionsWithWindowedValue {
   def filterFn[T, U](f: WindowedValue[T] => Boolean): DoFn[T, T] =
     new NamedDoFn[T, T] {
@@ -46,7 +48,7 @@ private[scio] object FunctionsWithWindowedValue {
         window: BoundedWindow
       ): Unit = {
         val wv = WindowedValue(c.element(), c.timestamp(), window, c.pane())
-        val i = g(wv).toIterator
+        val i = g(wv).iterator
         while (i.hasNext) {
           val v = i.next()
           c.outputWithTimestamp(v.value, v.timestamp)

--- a/scio-core/src/main/scala/com/spotify/scio/util/StatCounter.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/StatCounter.scala
@@ -21,6 +21,8 @@ package com.spotify.scio.util
 
 import com.spotify.scio.coders.Coder
 
+import scala.collection.compat._ // scalafix:ok
+
 /**
  * A class for tracking the statistics of a set of numbers (count, mean and variance) in a
  * numerically robust way. Includes support for merging two StatCounters. Based on Welford and
@@ -55,7 +57,7 @@ class StatCounter(values: TraversableOnce[Double]) extends Serializable {
 
   /** Add multiple values into this StatCounter, updating the internal statistics. */
   def merge(values: TraversableOnce[Double]): StatCounter = {
-    values.foreach(v => merge(v))
+    values.iterator.foreach(v => merge(v))
     this
   }
 

--- a/scio-core/src/main/scala/com/spotify/scio/util/random/RandomSampler.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/random/RandomSampler.scala
@@ -20,10 +20,11 @@
 package com.spotify.scio.util.random
 
 import java.util.{Random => JRandom}
-
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.transforms.DoFn.{ProcessElement, StartBundle}
 import org.apache.commons.math3.distribution.{IntegerDistribution, PoissonDistribution}
+
+import scala.annotation.nowarn
 
 private[scio] object RandomSampler {
 
@@ -43,6 +44,7 @@ abstract private[scio] class RandomSampler[T, R] extends DoFn[T, T] {
   protected var seed: Long = -1
 
   // TODO: is it necessary to setSeed for each instance like Spark does?
+  @nowarn("msg=parameter value c in method startBundle is never used")
   @StartBundle
   def startBundle(c: DoFn[T, T]#StartBundleContext): Unit = rng = init
 
@@ -133,6 +135,7 @@ abstract private[scio] class RandomValueSampler[K, V, R](val fractions: Map[K, D
   protected var seed: Long = -1
 
   // TODO: is it necessary to setSeed for each instance like Spark does?
+  @nowarn("msg=parameter value c in method startBundle is never used")
   @StartBundle
   def startBundle(c: DoFn[(K, V), (K, V)]#StartBundleContext): Unit =
     rngs = fractions.iterator.map { case (k, v) =>

--- a/scio-core/src/main/scala/com/spotify/scio/util/random/RandomSampler.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/random/RandomSampler.scala
@@ -20,6 +20,7 @@
 package com.spotify.scio.util.random
 
 import java.util.{Random => JRandom}
+
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.transforms.DoFn.{ProcessElement, StartBundle}
 import org.apache.commons.math3.distribution.{IntegerDistribution, PoissonDistribution}

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithSideInput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithSideInput.scala
@@ -28,6 +28,7 @@ import org.apache.beam.sdk.transforms.{DoFn, ParDo}
 import org.apache.beam.sdk.values.{PCollection, TupleTag, TupleTagList}
 
 import scala.jdk.CollectionConverters._
+import scala.collection.compat._ // scalafix:ok
 import scala.util.Try
 import com.twitter.chill.ClosureCleaner
 
@@ -123,6 +124,7 @@ class SCollectionWithSideInput[T] private[values] (
 
     val pCollectionWrapper = this.internal.apply(name, transform)
     pCollectionWrapper.getAll.asScala
+      .view
       .mapValues(
         context
           .wrap(_)

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithSideInput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithSideInput.scala
@@ -123,8 +123,7 @@ class SCollectionWithSideInput[T] private[values] (
       .withOutputTags(_mainTag.tupleTag, sideTags)
 
     val pCollectionWrapper = this.internal.apply(name, transform)
-    pCollectionWrapper.getAll.asScala
-      .view
+    pCollectionWrapper.getAll.asScala.view
       .mapValues(
         context
           .wrap(_)

--- a/scio-core/src/main/scala/com/spotify/scio/values/TransformNameable.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/TransformNameable.scala
@@ -27,8 +27,8 @@ trait TransformNameable {
 
   private[scio] def tfName(default: Option[String]): String = {
     val n = nameProvider match {
-      case p: CallSiteNameProvider.type => default.getOrElse(p.name)
-      case ConstNameProvider(name)      => name
+      case CallSiteNameProvider    => default.getOrElse(CallSiteNameProvider.name)
+      case ConstNameProvider(name) => name
     }
     nameProvider = CallSiteNameProvider
     n
@@ -45,7 +45,7 @@ trait TransformNameable {
   }
 }
 
-private trait TransformNameProvider {
+sealed private trait TransformNameProvider {
   def name: String
 }
 

--- a/scio-elasticsearch/es6/src/main/scala/com/spotify/scio/elasticsearch/ElasticsearchIO.scala
+++ b/scio-elasticsearch/es6/src/main/scala/com/spotify/scio/elasticsearch/ElasticsearchIO.scala
@@ -44,7 +44,7 @@ final case class ElasticsearchIO[T](esOptions: ElasticsearchOptions) extends Sci
     val shards = if (params.numOfShards >= 0) {
       params.numOfShards
     } else {
-      esOptions.servers.size
+      esOptions.servers.size.toLong
     }
 
     data.applyInternal(
@@ -77,7 +77,7 @@ object ElasticsearchIO {
   object WriteParam {
     private[elasticsearch] val DefaultErrorFn: BulkExecutionException => Unit = m => throw m
     private[elasticsearch] val DefaultFlushInterval = Duration.standardSeconds(1)
-    private[elasticsearch] val DefaultNumShards = -1
+    private[elasticsearch] val DefaultNumShards = -1L
     private[elasticsearch] val DefaultMaxBulkRequestSize = 3000
     private[elasticsearch] val DefaultMaxBulkRequestBytes = 5L * 1024L * 1024L
     private[elasticsearch] val DefaultMaxRetries = 3

--- a/scio-elasticsearch/es7/src/main/scala/com/spotify/scio/elasticsearch/ElasticsearchIO.scala
+++ b/scio-elasticsearch/es7/src/main/scala/com/spotify/scio/elasticsearch/ElasticsearchIO.scala
@@ -45,7 +45,7 @@ final case class ElasticsearchIO[T](esOptions: ElasticsearchOptions) extends Sci
     val shards = if (params.numOfShards >= 0) {
       params.numOfShards
     } else {
-      esOptions.nodes.size
+      esOptions.nodes.size.toLong
     }
 
     val write = beam.ElasticsearchIO.Write
@@ -81,7 +81,7 @@ object ElasticsearchIO {
   object WriteParam {
     private[elasticsearch] val DefaultErrorFn: BulkExecutionException => Unit = m => throw m
     private[elasticsearch] val DefaultFlushInterval = Duration.standardSeconds(1)
-    private[elasticsearch] val DefaultNumShards = -1
+    private[elasticsearch] val DefaultNumShards = -1L
     private[elasticsearch] val DefaultMaxBulkRequestSize = 3000
     private[elasticsearch] val DefaultMaxBulkRequestBytes = 5L * 1024L * 1024L
     private[elasticsearch] val DefaultMaxRetries = 3

--- a/scio-elasticsearch/es7/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
+++ b/scio-elasticsearch/es7/src/test/scala/com/spotify/scio/elasticsearch/CoderInstancesTest.scala
@@ -108,7 +108,7 @@ case class FooDocWriteRequest(_index: String, id: String) extends DocWriteReques
 
   override def indices(): Array[String] = Array("foo")
 
-  override def ramBytesUsed(): Long = _index.size + id.size
+  override def ramBytesUsed(): Long = _index.size.toLong + id.size.toLong
 
   override def isRequireAlias(): Boolean = false
 }

--- a/scio-elasticsearch/es8/src/main/scala/com/spotify/scio/elasticsearch/ElasticsearchIO.scala
+++ b/scio-elasticsearch/es8/src/main/scala/com/spotify/scio/elasticsearch/ElasticsearchIO.scala
@@ -45,7 +45,7 @@ final case class ElasticsearchIO[T](esOptions: ElasticsearchOptions) extends Sci
 
   /** Save this SCollection into Elasticsearch. */
   override protected def write(data: SCollection[T], params: WriteP): Tap[Nothing] = {
-    val shards = if (params.numOfShards >= 0) params.numOfShards else esOptions.nodes.size
+    val shards = if (params.numOfShards >= 0) params.numOfShards else esOptions.nodes.size.toLong
     val credentials = esOptions.usernameAndPassword.map { case (username, password) =>
       new UsernamePasswordCredentials(username, password)
     }
@@ -77,7 +77,7 @@ object ElasticsearchIO {
   object WriteParam {
     private[elasticsearch] val DefaultErrorFn: BulkExecutionException => Unit = m => throw m
     private[elasticsearch] val DefaultFlushInterval = Duration.standardSeconds(1)
-    private[elasticsearch] val DefaultNumShards = -1
+    private[elasticsearch] val DefaultNumShards = -1L
     private[elasticsearch] val DefaultMaxBulkRequestOperations = 3000
     private[elasticsearch] val DefaultMaxBulkRequestBytes = 5L * 1024L * 1024L
     private[elasticsearch] val DefaultMaxRetries = 3

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/WordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/WordCount.scala
@@ -53,7 +53,7 @@ object WordCount {
         _.map { w =>
           // Trim input lines, update distribution metric
           val trimmed = w.trim
-          lineDist.update(trimmed.length)
+          lineDist.update(trimmed.length.toLong)
           trimmed
         }.filter { w =>
           // Filter out empty lines, update counter metrics

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficMaxLaneFlow.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficMaxLaneFlow.scala
@@ -68,8 +68,8 @@ object TrafficMaxLaneFlow {
 
     // arguments
     val input = args.getOrElse("input", ExampleData.TRAFFIC)
-    val windowDuration = args.getOrElse("windowDuration", "60").toInt
-    val windowSlideEvery = args.getOrElse("windowSlideEvery", "5").toInt
+    val windowDuration = args.long("windowDuration", 60)
+    val windowSlideEvery = args.long("windowSlideEvery", 5)
 
     val sc = ScioContext(opts)
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficRoutes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficRoutes.scala
@@ -55,8 +55,8 @@ object TrafficRoutes {
 
     // arguments
     val input = args.getOrElse("input", ExampleData.TRAFFIC)
-    val windowDuration = args.getOrElse("windowDuration", "3").toInt
-    val windowSlideEvery = args.getOrElse("windowSlideEvery", "1").toInt
+    val windowDuration = args.long("windowDuration", 3)
+    val windowSlideEvery = args.long("windowSlideEvery", 1)
 
     val sc = ScioContext(opts)
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/GameStats.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/GameStats.scala
@@ -66,11 +66,11 @@ object GameStats {
         .forPattern("yyyy-MM-dd HH:mm:ss.SSS")
         .withZone(DateTimeZone.forTimeZone(TimeZone.getTimeZone("PST")))
     // Duration in minutes for windowing of user and team score sums, defaults to 1 hour
-    val fixedWindowDuration = args.int("fixedWindowDuration", 60)
+    val fixedWindowDuration = args.long("fixedWindowDuration", 60)
     // Duration in minutes for length of inactivity after which to start a session, defaults to 5m
-    val sessionGap = args.int("sessionGap", 5)
+    val sessionGap = args.long("sessionGap", 5)
     // Duration in minutes for windowing of user activities, defaults to 30 min
-    val userActivityWindowDuration = args.int("userActivityWindowDuration", 30)
+    val userActivityWindowDuration = args.long("userActivityWindowDuration", 30)
 
     // Read streaming events from PubSub topic, using ms of events as their ID
     val rawEvents = sc

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/LeaderBoard.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/LeaderBoard.scala
@@ -70,11 +70,11 @@ object LeaderBoard {
         .withZone(DateTimeZone.forTimeZone(TimeZone.getTimeZone("PST")))
     // Duration in minutes over which to calculate team scores, defaults to 1 hour
     val teamWindowDuration =
-      Duration.standardMinutes(args.int("teamWindowDuration", 60))
+      Duration.standardMinutes(args.long("teamWindowDuration", 60))
     // Data that comes in from our streaming pipeline after this duration isn't considered in our
     // processing. Measured in minutes, defaults to 2 hours
     val allowedLateness =
-      Duration.standardMinutes(args.int("allowedLateness", 120))
+      Duration.standardMinutes(args.long("allowedLateness", 120))
 
     // Read in streaming data from PubSub and parse each row as `GameActionInfo` events
     val gameEvents = sc

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/TriggerExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/TriggerExample.scala
@@ -60,7 +60,7 @@ object TriggerExample {
     // arguments
     val input = args.getOrElse("input", ExampleData.TRAFFIC)
     val windowDuration =
-      Duration.standardMinutes(args.int("windowDuration", 30))
+      Duration.standardMinutes(args.long("windowDuration", 30))
 
     val sc = ScioContext(opts)
 
@@ -183,7 +183,7 @@ object TriggerExample {
   def totalFlow(flowInfo: SCollection[(String, Int)], triggerType: String): SCollection[Record] =
     flowInfo.groupByKey.toWindowed.map { wv =>
       val (key, values) = wv.value
-      var sum = 0
+      var sum = 0L
       var numberOfRecords = 0L
       values.foreach { v =>
         sum += v

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AnnoyExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AnnoyExamples.scala
@@ -39,7 +39,7 @@ object AnnoyExamples {
       ss2 += v2(i) * v2(i)
       i += 1
     }
-    (dp / math.sqrt(ss1 * ss2)).toFloat
+    (dp / math.sqrt((ss1 * ss2).toDouble)).toFloat
   }
 }
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BeamExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BeamExample.scala
@@ -90,7 +90,7 @@ object BeamExample {
       sc.customInput("Input", pubsubIn(args("inputTopic")))
 
     // Underlying Beam `PCollection[Account]`
-    val p: PCollection[Account] = accounts.internal // scalafix:ok
+    val p: PCollection[Account] = accounts.internal
 
     accounts
       // Beam `PTransform`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyBigtableExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyBigtableExample.scala
@@ -31,6 +31,8 @@ import com.spotify.scio.bigtable._
 import com.spotify.scio.examples.common.ExampleData
 import magnolify.bigtable._
 
+import scala.collection.compat._ // scalafix:ok
+
 object MagnolifyBigtableExample {
   // Define case class representation of TensorFlow `Example`
   case class WordCount(cnt: Long)
@@ -67,7 +69,7 @@ object MagnolifyBigtableWriteExample {
       // for saving to Bigtable table.
       .map { case (word, count) =>
         val mutations =
-          WordCountType(WordCount(count), columnFamily = "counts").iterator.toIterable
+          WordCountType(WordCount(count), columnFamily = "counts").iterator.to(Iterable)
         ByteString.copyFromUtf8(word) -> mutations
       }
       .saveAsBigtable(btProjectId, btInstanceId, btTableId)

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyBigtableExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyBigtableExample.scala
@@ -31,7 +31,7 @@ import com.spotify.scio.bigtable._
 import com.spotify.scio.examples.common.ExampleData
 import magnolify.bigtable._
 
-import scala.collection.compat._ // scalafix:ok
+import scala.collection.compat._
 
 object MagnolifyBigtableExample {
   // Define case class representation of TensorFlow `Example`

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MetricsExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MetricsExample.scala
@@ -25,7 +25,7 @@ package com.spotify.scio.examples.extra
 import com.spotify.scio._
 import org.apache.beam.sdk.metrics.{Counter, Distribution, Gauge}
 
-import scala.collection.compat._ // scalafix:ok
+import scala.collection.compat._
 
 object MetricsExample {
   // ## Creating metrics

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MetricsExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MetricsExample.scala
@@ -25,6 +25,8 @@ package com.spotify.scio.examples.extra
 import com.spotify.scio._
 import org.apache.beam.sdk.metrics.{Counter, Distribution, Gauge}
 
+import scala.collection.compat._ // scalafix:ok
+
 object MetricsExample {
   // ## Creating metrics
 
@@ -49,7 +51,7 @@ object MetricsExample {
     sc.initCounter(count)
 
     // ## Accessing metrics
-    sc.parallelize(1 to 100)
+    sc.parallelize(1L to 100L)
       .filter { i =>
         // Access metrics inside a lambda function
         sum.inc(i)
@@ -84,7 +86,7 @@ object MetricsExample {
     println("sum2: " + s2)
 
     // Values at steps
-    val s2steps = result.counterAtSteps(sum2).mapValues(_.committed.get)
+    val s2steps = result.counterAtSteps(sum2).view.mapValues(_.committed.get).toMap
     s2steps.foreach { case (step, value) =>
       println(s"sum2 at $step: " + value)
     }
@@ -113,7 +115,7 @@ object MetricsExample {
     require(d.getMean == (1 to 100).sum / 100.0)
 
     // Dynamic metricsk
-    result.allCounters
+    result.allCounters.view
       .filterKeys(_.getName.startsWith("even_"))
       .foreach { case (name, value) =>
         println(name.getName + ": " + value.committed.get)

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RefreshingSideInputExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RefreshingSideInputExample.scala
@@ -109,7 +109,7 @@ object RefreshingSideInputExample {
   }
 
   private def toLotteryTicket(message: String): Option[LotteryTicket] =
-    Try(LotteryTicket(message.split(",").map(_.toInt))) match {
+    Try(LotteryTicket(message.split(",").map(_.toInt).toSeq)) match {
       case Success(s) if s.numbers.size == ticketSize => Some(s)
       case _ =>
         logger.error(s"Malformed message: $message")

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SideInOutExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SideInOutExample.scala
@@ -43,7 +43,7 @@ object SideInOutExample {
     }
 
     // Convert stop words to a `SideInput[Map[String, Unit]]`
-    val sideIn = stopWords.map(_ -> ()).asMapSideInput
+    val sideIn = stopWords.map(w => (w, ())).asMapSideInput
 
     // Open text files a `SCollection[String]`
     val wordCount = sc

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/StatefulExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/StatefulExample.scala
@@ -36,7 +36,7 @@ object StatefulExample {
 
   class StatefulDoFn extends DoFnT {
     // Declare mutable state
-    @StateId("count") private val count = StateSpecs.value[JInt]() // scalafix:ok
+    @StateId("count") private val count = StateSpecs.value[JInt]()
 
     @ProcessElement
     def processElement(

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WordCountScioIO.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WordCountScioIO.scala
@@ -57,7 +57,7 @@ object WordCountScioIO {
       .map { w =>
         // Trim input lines, update distribution metric
         val trimmed = w.trim
-        lineDist.update(trimmed.length)
+        lineDist.update(trimmed.length.toLong)
         trimmed
       }
       .filter { w =>

--- a/scio-extra/src/it/scala/com/spotify/scio/extra/bigquery/BigQueryIT.scala
+++ b/scio-extra/src/it/scala/com/spotify/scio/extra/bigquery/BigQueryIT.scala
@@ -49,7 +49,7 @@ final class BigQueryIT extends AnyFlatSpec with Matchers {
 
     val data: Seq[GenericRecord] = (1 to 100).map { i =>
       Account.toGenericRecord(
-        Account(i, "checking", s"account$i", i.toDouble, ByteString.copyFromUtf8("%20cフーバー"))
+        Account(i.toLong, "checking", s"account$i", i.toDouble, ByteString.copyFromUtf8("%20cフーバー"))
       )
     }
 

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/Breeze.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/Breeze.scala
@@ -21,6 +21,8 @@ import breeze.linalg.operators.OpAdd
 import breeze.linalg.support.CanCopy
 import com.twitter.algebird.Semigroup
 
+import scala.collection.compat._ // scalafix:ok
+
 /**
  * Utilities for Breeze.
  *
@@ -44,7 +46,7 @@ object Breeze {
       override def plus(l: M[T], r: M[T]): M[T] = add(l, r)
       override def sumOption(xs: TraversableOnce[M[T]]): Option[M[T]] = {
         var s: M[T] = null.asInstanceOf[M[T]]
-        val i = xs.toIterator
+        val i = xs.iterator
         while (i.hasNext) {
           val a = i.next()
           if (s == null) {

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableRow.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/bigquery/ToTableRow.scala
@@ -90,7 +90,7 @@ private[bigquery] trait ToTableRow {
       .toList
       .asJava
 
-  private def toTableRowFromMap(map: Iterable[Any], field: Schema.Field): util.List[_] =
+  private def toTableRowFromMap(map: Iterable[(Any, Any)], field: Schema.Field): util.List[_] =
     map
       .map { case (k, v) =>
         new TableRow()

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyUri.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyUri.scala
@@ -86,9 +86,9 @@ private[sparkey] class SparkeyWriter(
   maxMemoryUsage: Long = -1
 ) {
   private val localFile = uri match {
-    case u: LocalSparkeyUri   => u.basePath
-    case _: RemoteSparkeyUri  => Files.createTempDirectory("sparkey-").resolve("data").toString
-    case _: ShardedSparkeyUri => throw new NotImplementedError("Unsupported ShardedSparkeyUri")
+    case u: LocalSparkeyUri  => u.basePath
+    case _: RemoteSparkeyUri => Files.createTempDirectory("sparkey-").resolve("data").toString
+    case _                   => throw new NotImplementedError(s"Unsupported SparkeyUri $uri")
   }
 
   private lazy val delegate = {

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyUri.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyUri.scala
@@ -86,9 +86,9 @@ private[sparkey] class SparkeyWriter(
   maxMemoryUsage: Long = -1
 ) {
   private val localFile = uri match {
-    case u: LocalSparkeyUri => u.basePath
-    case _: RemoteSparkeyUri =>
-      Files.createTempDirectory("sparkey-").resolve("data").toString
+    case u: LocalSparkeyUri   => u.basePath
+    case _: RemoteSparkeyUri  => Files.createTempDirectory("sparkey-").resolve("data").toString
+    case _: ShardedSparkeyUri => throw new NotImplementedError("Unsupported ShardedSparkeyUri")
   }
 
   private lazy val delegate = {

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/instances/ShardedSparkeyReader.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/instances/ShardedSparkeyReader.scala
@@ -35,10 +35,10 @@ import scala.jdk.CollectionConverters._
 class ShardedSparkeyReader(val sparkeys: Map[Short, SparkeyReader], val numShards: Short)
     extends SparkeyReader {
   def hashKey(arr: Array[Byte]): Short =
-    Math.floorMod(MurmurHash3.bytesHash(arr, 1), numShards).toShort
+    Math.floorMod(MurmurHash3.bytesHash(arr, 1), numShards.toInt).toShort
 
   def hashKey(str: String): Short =
-    Math.floorMod(MurmurHash3.stringHash(str, 1), numShards).toShort
+    Math.floorMod(MurmurHash3.stringHash(str, 1), numShards.toInt).toShort
 
   override def getAsString(key: String): String = {
     val hashed = hashKey(key)

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -254,7 +254,7 @@ package object sparkey extends SparkeyReaderInstances {
 
       self.transform { collection =>
         val shards = collection
-          .groupBy { case (k, _) => floorMod(w.shardHash(k), numShards).toShort }
+          .groupBy { case (k, _) => floorMod(w.shardHash(k), numShards.toInt).toShort }
           .map { case (shard, xs) =>
             shard -> writeToSparkey(
               uri.sparkeyUriForShard(shard, numShards),
@@ -268,7 +268,7 @@ package object sparkey extends SparkeyReaderInstances {
         val shardsMap = shards.asMapSideInput
 
         val uris = shards.context
-          .parallelize((0 until numShards).map(_.toShort))
+          .parallelize((0 until numShards.toInt).map(_.toShort))
           .withSideInputs(shardsMap)
           .map { case (shard, sideContext) =>
             sideContext(shardsMap).getOrElse(

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/CollectionsSpec.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/CollectionsSpec.scala
@@ -21,6 +21,8 @@ import com.spotify.scio.extra.Collections._
 import org.scalacheck._
 import org.scalatest._
 
+import scala.collection.compat._ // scalafix:ok
+
 class CollectionsSpec extends PropertySpec {
   val posInts: Gen[Int] = Gen.posNum[Int]
   val intLists: Gen[List[Int]] = Arbitrary.arbitrary[List[Int]]
@@ -35,13 +37,8 @@ class CollectionsSpec extends PropertySpec {
 
       verify(xs.top(num), maxExpected)
       verify(xs.top(num)(Ordering[Int].reverse), minExpected)
-      verify(xs.toArray.top(num), maxExpected)
-      verify(xs.toBuffer.top(num), maxExpected)
-      verify(xs.toIndexedSeq.top(num), maxExpected)
-      verify(xs.top(num), maxExpected)
-      verify(xs.top(num), maxExpected)
-      verify(xs.toStream.top(num), maxExpected)
-      verify(xs.toVector.top(num), maxExpected)
+      verify(xs.to(Array).top(num), maxExpected)
+      verify(xs.to(Iterable).top(num), maxExpected)
     }
   }
 
@@ -61,12 +58,8 @@ class CollectionsSpec extends PropertySpec {
         actual.iterator.map { case (k, v) => k -> v.toList.sorted }.toMap shouldBe expected
       verify(xs.topByKey(num), maxExpected)
       verify(xs.topByKey(num)(Ordering[Int].reverse), minExpected)
-      verify(xs.toArray.topByKey(num), maxExpected)
-      verify(xs.toIndexedSeq.topByKey(num), maxExpected)
-      verify(xs.topByKey(num), maxExpected)
-      verify(xs.topByKey(num), maxExpected)
-      verify(xs.toStream.topByKey(num), maxExpected)
-      verify(xs.toVector.topByKey(num), maxExpected)
+      verify(xs.to(Array).topByKey(num), maxExpected)
+      verify(xs.to(Iterable).topByKey(num), maxExpected)
     }
   }
 }

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
@@ -564,7 +564,7 @@ class SparkeyTest extends PipelineSpec {
     val basePath = scioResult
       .tap(sparkeyMaterialized)
       .value
-      .next
+      .next()
       .asInstanceOf[SparkeyUri]
       .basePath
     FileUtils.deleteDirectory(new File(basePath))
@@ -596,7 +596,7 @@ class SparkeyTest extends PipelineSpec {
     val basePath = scioResult
       .tap(sparkeyMaterialized)
       .value
-      .next
+      .next()
       .asInstanceOf[SparkeyUri]
       .basePath
     FileUtils.deleteDirectory(new File(basePath))
@@ -627,7 +627,7 @@ class SparkeyTest extends PipelineSpec {
     val basePath = scioResult
       .tap(sparkeyMaterialized)
       .value
-      .next
+      .next()
       .asInstanceOf[SparkeyUri]
       .basePath
     FileUtils.deleteDirectory(new File(basePath))
@@ -658,7 +658,7 @@ class SparkeyTest extends PipelineSpec {
     val basePath = scioResult
       .tap(sparkeyMaterialized)
       .value
-      .next
+      .next()
       .asInstanceOf[SparkeyUri]
       .basePath
     FileUtils.deleteDirectory(new File(basePath))

--- a/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/PopulateTestData.scala
+++ b/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/PopulateTestData.scala
@@ -173,7 +173,7 @@ object PopulateTestData {
     val optional = (0 until 10).toList.map(newOptional)
     val repeated = (0 until 10).toList.map(newRepeated)
     val nested = (0 until 10).toList.map { i =>
-      val r = Record(i, s"s$i")
+      val r = Record(i.toLong, s"s$i")
       Nested(r, Some(r), List(r))
     }
 
@@ -192,12 +192,12 @@ object PopulateTestData {
     val dt = t.toDateTime(DateTimeZone.UTC)
     Required(
       true,
-      i,
-      i,
+      i.toLong,
+      i.toDouble,
       BigDecimal(i),
       s"s$i",
       ByteString.copyFromUtf8(s"s$i"),
-      t.plus(Duration.millis(i)),
+      t.plus(Duration.millis(i.toLong)),
       dt.toLocalDate.plusDays(i),
       dt.toLocalTime.plusMillis(i),
       dt.toLocalDateTime.plusMillis(i)
@@ -209,12 +209,12 @@ object PopulateTestData {
     val dt = t.toDateTime(DateTimeZone.UTC)
     Optional(
       Some(true),
-      Some(i),
-      Some(i),
+      Some(i.toLong),
+      Some(i.toDouble),
       Some(BigDecimal(i)),
       Some(s"s$i"),
       Some(ByteString.copyFromUtf8(s"s$i")),
-      Some(t.plus(Duration.millis(i))),
+      Some(t.plus(Duration.millis(i.toLong))),
       Some(dt.toLocalDate.plusDays(i)),
       Some(dt.toLocalTime.plusMillis(i)),
       Some(dt.toLocalDateTime.plusMillis(i))
@@ -226,12 +226,12 @@ object PopulateTestData {
     val dt = t.toDateTime(DateTimeZone.UTC)
     Repeated(
       List(true),
-      List(i),
-      List(i),
+      List(i.toLong),
+      List(i.toDouble),
       List(BigDecimal(i)),
       List(s"s$i"),
       List(ByteString.copyFromUtf8(s"s$i")),
-      List(t.plus(Duration.millis(i))),
+      List(t.plus(Duration.millis(i.toLong))),
       List(dt.toLocalDate.plusDays(i)),
       List(dt.toLocalTime.plusMillis(i)),
       List(dt.toLocalDateTime.plusMillis(i))

--- a/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/types/StorageIT.scala
+++ b/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/types/StorageIT.scala
@@ -41,12 +41,12 @@ class StorageIT extends AnyFlatSpec with Matchers {
     val expected = (0 until 10).map { i =>
       Required(
         true,
-        i,
-        i,
+        i.toLong,
+        i.toDouble,
         BigDecimal(i),
         s"s$i",
         ByteString.copyFromUtf8(s"s$i"),
-        t.plus(Duration.millis(i)),
+        t.plus(Duration.millis(i.toLong)),
         dt.toLocalDate.plusDays(i),
         dt.toLocalTime.plusMillis(i),
         dt.toLocalDateTime.plusMillis(i)
@@ -91,12 +91,12 @@ class StorageIT extends AnyFlatSpec with Matchers {
     val expected = (0 until 10).map { i =>
       Repeated(
         List(true),
-        List(i),
-        List(i),
+        List(i.toLong),
+        List(i.toDouble),
         List(BigDecimal(i)),
         List(s"s$i"),
         List(ByteString.copyFromUtf8(s"s$i")),
-        List(t.plus(Duration.millis(i))),
+        List(t.plus(Duration.millis(i.toLong))),
         List(dt.toLocalDate.plusDays(i)),
         List(dt.toLocalTime.plusMillis(i)),
         List(dt.toLocalDateTime.plusMillis(i))
@@ -176,12 +176,12 @@ class StorageIT extends AnyFlatSpec with Matchers {
     val expected = (0 until 10).map { i =>
       FromQuery(
         Some(true),
-        Some(i),
-        Some(i),
+        Some(i.toLong),
+        Some(i.toDouble),
         Some(BigDecimal(i)),
         Some(s"s$i"),
         Some(ByteString.copyFromUtf8(s"s$i")),
-        Some(t.plus(Duration.millis(i))),
+        Some(t.plus(Duration.millis(i.toLong))),
         Some(dt.toLocalDate.plusDays(i)),
         Some(dt.toLocalTime.plusMillis(i)),
         Some(dt.toLocalDateTime.plusMillis(i))
@@ -203,12 +203,12 @@ class StorageIT extends AnyFlatSpec with Matchers {
     val expected = (0 until 10).map { i =>
       FromTable(
         true,
-        i,
-        i,
+        i.toLong,
+        i.toDouble,
         BigDecimal(i),
         s"s$i",
         ByteString.copyFromUtf8(s"s$i"),
-        t.plus(Duration.millis(i)),
+        t.plus(Duration.millis(i.toLong)),
         dt.toLocalDate.plusDays(i),
         dt.toLocalTime.plusMillis(i),
         dt.toLocalDateTime.plusMillis(i)
@@ -240,12 +240,12 @@ class StorageIT extends AnyFlatSpec with Matchers {
     val expected = (0 until 10).map { i =>
       FromQuery(
         Some(true),
-        Some(i),
-        Some(i),
+        Some(i.toLong),
+        Some(i.toDouble),
         Some(BigDecimal(i)),
         Some(s"s$i"),
         Some(ByteString.copyFromUtf8(s"s$i")),
-        Some(t.plus(Duration.millis(i))),
+        Some(t.plus(Duration.millis(i.toLong))),
         Some(dt.toLocalDate.plusDays(i)),
         Some(dt.toLocalTime.plusMillis(i)),
         Some(dt.toLocalDateTime.plusMillis(i))

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -19,7 +19,6 @@ package com.spotify.scio.bigquery
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function
-
 import com.google.api.services.bigquery.model.TableSchema
 import com.spotify.scio.ScioContext
 import com.spotify.scio.bigquery.ExtendedErrorInfo._

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryUtil.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryUtil.scala
@@ -19,14 +19,13 @@ package com.spotify.scio.bigquery
 
 import java.io.StringReader
 import java.util.UUID
-
 import com.google.api.client.json.JsonObjectParser
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.bigquery.model.TableSchema
 
 /** Utility for BigQuery data types. */
 object BigQueryUtil {
-  private lazy val jsonObjectParser = new JsonObjectParser(new JacksonFactory)
+  private lazy val jsonObjectParser = new JsonObjectParser(GsonFactory.getDefaultInstance)
 
   /** Parse a schema string. */
   def parseSchema(schemaString: String): TableSchema =

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
@@ -28,7 +28,7 @@ import com.google.api.client.http.{
   HttpResponseException,
   HttpStatusCodes
 }
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.api.gax.rpc.FixedHeaderProvider
 import com.google.api.services.bigquery.Bigquery
@@ -272,7 +272,7 @@ object BigQuery {
           }
         }
       )
-      new Bigquery.Builder(new NetHttpTransport, new JacksonFactory, requestInitializer)
+      new Bigquery.Builder(new NetHttpTransport, GsonFactory.getDefaultInstance, requestInitializer)
         .setApplicationName("scio")
         .build()
     }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/LoadOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/LoadOps.scala
@@ -24,6 +24,7 @@ import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.{CreateDisposition, 
 import org.apache.beam.sdk.io.gcp.{bigquery => bq}
 import org.slf4j.LoggerFactory
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
@@ -112,6 +113,7 @@ final private[client] class LoadOps(client: Client, jobService: JobOps) {
       encoding = encoding
     )
 
+  @nowarn("msg=private default argument in class LoadOps is never used")
   private def execute(
     sources: List[String],
     sourceFormat: String,

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/taps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/taps.scala
@@ -142,7 +142,7 @@ final case class BigQueryTaps(self: Taps) {
       () => {
         val selectedFields = readOptions.getSelectedFieldsList.asScala.toList
         val rowRestriction = Option(readOptions.getRowRestriction)
-        BigQueryStorage(Table.Ref(table), selectedFields, rowRestriction).tap()
+        BigQueryStorage(Table.Ref(table), selectedFields, rowRestriction).tap(())
       }
     )
 
@@ -158,7 +158,7 @@ final case class BigQueryTaps(self: Taps) {
         val selectedFields = readOptions.getSelectedFieldsList.asScala.toList
         val rowRestriction = Option(readOptions.getRowRestriction)
         BigQueryStorage(Table.Ref(table), selectedFields, rowRestriction)
-          .tap()
+          .tap(())
           .map(fn)
       }
     )

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
@@ -21,7 +21,7 @@ import com.google.api.services.bigquery.model.{TableRow, TableSchema}
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 
-import scala.annotation.{compileTimeOnly, StaticAnnotation}
+import scala.annotation.{StaticAnnotation, compileTimeOnly, nowarn}
 import scala.reflect.runtime.universe._
 import scala.util.Try
 
@@ -198,6 +198,7 @@ object BigQueryType {
    * Also generate a companion object with convenience methods.
    * @group annotation
    */
+  @nowarn
   @compileTimeOnly(
     "enable macro paradise (2.12) or -Ymacro-annotations (2.13) to expand macro annotations"
   )
@@ -228,6 +229,7 @@ object BigQueryType {
    * Also generate a companion object with convenience methods.
    * @group annotation
    */
+  @nowarn
   @compileTimeOnly(
     "enable macro paradise (2.12) or -Ymacro-annotations (2.13) to expand macro annotations"
   )
@@ -277,6 +279,7 @@ object BigQueryType {
    * Also generate a companion object with convenience methods.
    * @group annotation
    */
+  @nowarn
   @compileTimeOnly(
     "enable macro paradise (2.12) or -Ymacro-annotations (2.13) to expand macro annotations"
   )
@@ -323,6 +326,7 @@ object BigQueryType {
    * behavior, start the query string with `#legacysql` or `#standardsql`.
    * @group annotation
    */
+  @nowarn
   @compileTimeOnly(
     "enable macro paradise (2.12) or -Ymacro-annotations (2.13) to expand macro annotations"
   )

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
@@ -21,7 +21,7 @@ import com.google.api.services.bigquery.model.{TableRow, TableSchema}
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 
-import scala.annotation.{StaticAnnotation, compileTimeOnly, nowarn}
+import scala.annotation.{compileTimeOnly, nowarn, StaticAnnotation}
 import scala.reflect.runtime.universe._
 import scala.util.Try
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -29,6 +29,8 @@ import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
 import com.spotify.scio.util.Cache
 
+import scala.annotation.nowarn
+
 private[types] object SchemaProvider {
   private[this] val AvroSchemaCache = Cache.concurrentHashMap[String, Schema]
   private[this] val TableSchemaCache = Cache.concurrentHashMap[Type, TableSchema]
@@ -117,6 +119,7 @@ private[types] object SchemaProvider {
   private def getFields(t: Type): Iterable[(Symbol, Option[String])] =
     t.decls.filter(isField) zip fieldDescs(t)
 
+  @nowarn
   private def fieldDescs(t: Type): Iterable[Option[String]] = {
     val tpe = "com.spotify.scio.bigquery.types.description"
     t.typeSymbol.asClass.primaryConstructor.typeSignature.paramLists.head.map {

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -29,8 +29,6 @@ import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
 import com.spotify.scio.util.Cache
 
-import scala.annotation.nowarn
-
 private[types] object SchemaProvider {
   private[this] val AvroSchemaCache = Cache.concurrentHashMap[String, Schema]
   private[this] val TableSchemaCache = Cache.concurrentHashMap[Type, TableSchema]
@@ -119,7 +117,6 @@ private[types] object SchemaProvider {
   private def getFields(t: Type): Iterable[(Symbol, Option[String])] =
     t.decls.filter(isField) zip fieldDescs(t)
 
-  @nowarn
   private def fieldDescs(t: Type): Iterable[Option[String]] = {
     val tpe = "com.spotify.scio.bigquery.types.description"
     t.typeSymbol.asClass.primaryConstructor.typeSignature.paramLists.head.map {

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -17,10 +17,10 @@
 
 package com.spotify.scio.bigquery.types
 
+import com.google.api.client.json.gson.GsonFactory
+
 import java.nio.file.{Path, Paths}
 import java.util.{List => JList}
-
-import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
 import com.spotify.scio.CoreSysProps
 import com.spotify.scio.bigquery.client.BigQuery
@@ -37,6 +37,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.hash.Hashing
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.Files
 import org.slf4j.LoggerFactory
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable.{Buffer => MBuffer, Map => MMap}
 import scala.reflect.macros._
@@ -45,6 +46,7 @@ private[types] object TypeProvider {
   private[this] val logger = LoggerFactory.getLogger(this.getClass)
   private lazy val bigquery: BigQuery = BigQuery.defaultInstance()
 
+  @nowarn
   def tableImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
 
@@ -338,7 +340,7 @@ private[types] object TypeProvider {
         val defTblTrait =
           defTblDesc.map(_ => tq"${p(c, SType)}.HasTableDescription").toSeq
         val defSchema = {
-          schema.setFactory(new JacksonFactory)
+          schema.setFactory(GsonFactory.getDefaultInstance)
           q"override def schema: ${p(c, GModel)}.TableSchema = ${p(c, SUtil)}.parseSchema(${schema.toString})"
         }
         val defAvroSchema =
@@ -529,6 +531,7 @@ private[types] object TypeProvider {
         .resolve("generated-classes")
     }
 
+  @nowarn
   private def pShowCode(
     c: blackbox.Context
   )(records: Seq[c.Tree], caseClass: c.Tree): Seq[String] = {

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -46,7 +46,6 @@ private[types] object TypeProvider {
   private[this] val logger = LoggerFactory.getLogger(this.getClass)
   private lazy val bigquery: BigQuery = BigQuery.defaultInstance()
 
-  @nowarn
   def tableImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
 
@@ -177,6 +176,7 @@ private[types] object TypeProvider {
       .filter(_.children.head.toString.matches("^new description$"))
       .map(_.children.tail.head)
 
+  @nowarn("msg=match may not be exhaustive")
   def toTableImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
     checkMacroEnclosed(c)
@@ -404,6 +404,7 @@ private[types] object TypeProvider {
   ): (String, List[String], List[String], Option[String]) = {
     import c.universe._
 
+    @nowarn("msg=match may not be exhaustive")
     def str(tree: c.Tree) = tree match {
       // "argument literal"
       case Literal(Constant(arg @ (_: String))) => arg

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -404,7 +404,6 @@ private[types] object TypeProvider {
   ): (String, List[String], List[String], Option[String]) = {
     import c.universe._
 
-    @nowarn("msg=match may not be exhaustive")
     def str(tree: c.Tree) = tree match {
       // "argument literal"
       case Literal(Constant(arg @ (_: String))) => arg
@@ -425,6 +424,7 @@ private[types] object TypeProvider {
           case q"rowRestriction = $s"          => namedArgs("rowRestriction") = List(str(s))
           case q"List(..$xs)"                  => posList += xs.map(str)
           case q"$s"                           => posList += List(str(s))
+          case _                               => throw new Exception("Invalid macro application")
         }
         val posArgs = List("args", "selectedFields", "rowRestriction").zip(posList).toMap
         val dups = posArgs.keySet intersect namedArgs.keySet

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.bigquery
 
-import scala.annotation.StaticAnnotation
+import scala.annotation.{StaticAnnotation, nowarn}
 
 package object types {
 
@@ -32,6 +32,7 @@ package object types {
    *                 @description("user age") age: Int)
    * }}}
    */
+  @nowarn("msg=parameter value value in class description is never used")
   final class description(value: String) extends StaticAnnotation with Serializable
 
   /**

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.bigquery
 
-import scala.annotation.{StaticAnnotation, nowarn}
+import scala.annotation.{nowarn, StaticAnnotation}
 
 package object types {
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/validation/OverrideTypeProviderFinder.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/validation/OverrideTypeProviderFinder.scala
@@ -38,6 +38,7 @@ object OverrideTypeProviderFinder {
     classInstance match {
       case Success(value)       => value
       case Failure(NonFatal(_)) => new DummyOverrideTypeProvider
+      case Failure(e)           => throw e
     }
   }
 

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/BigQueryUtilTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/BigQueryUtilTest.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.bigquery
 
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
@@ -61,7 +61,7 @@ class BigQueryUtilTest extends AnyFlatSpec with Matchers {
           )
       ).asJava
     )
-    schema.setFactory(new JacksonFactory)
+    schema.setFactory(GsonFactory.getDefaultInstance)
     BigQueryUtil.parseSchema(schema.toString) shouldBe schema
   }
 }

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/datastore/DatastoreIOTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/datastore/DatastoreIOTest.scala
@@ -19,7 +19,6 @@ package com.spotify.scio.datastore
 
 import com.spotify.scio.ContextAndArgs
 import com.spotify.scio.testing._
-import com.spotify.scio.datastore._
 import com.google.datastore.v1.Entity
 import com.google.datastore.v1.client.DatastoreHelper
 

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/datastore/DatastoreIOTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/datastore/DatastoreIOTest.scala
@@ -37,7 +37,7 @@ object DatastoreJob {
 class DatastoreIOTest extends PipelineSpec with ScioIOSpec {
 
   "DatastoreIO" should "work" in {
-    val xs = (1 to 100).map { x =>
+    val xs = (1L to 100L).map { x =>
       Entity
         .newBuilder()
         .putProperties("int", DatastoreHelper.makeValue(x).build())
@@ -46,7 +46,7 @@ class DatastoreIOTest extends PipelineSpec with ScioIOSpec {
     testJobTest(xs)(DatastoreIO(_))(_.datastore(_, null))(_.saveAsDatastore(_))
   }
 
-  def newEntity(i: Int): Entity =
+  def newEntity(i: Long): Entity =
     Entity
       .newBuilder()
       .setKey(DatastoreHelper.makeKey())
@@ -56,20 +56,20 @@ class DatastoreIOTest extends PipelineSpec with ScioIOSpec {
   def testDatastore(xs: Seq[Entity]): Unit =
     JobTest[DatastoreJob.type]
       .args("--input=store.in", "--output=store.out")
-      .input(DatastoreIO("store.in"), (1 to 3).map(newEntity))
+      .input(DatastoreIO("store.in"), (1L to 3L).map(newEntity))
       .output(DatastoreIO("store.out"))(coll => coll should containInAnyOrder(xs))
       .run()
 
   it should "pass correct DatastoreJob" in {
-    testDatastore((1 to 3).map(newEntity))
+    testDatastore((1L to 3L).map(newEntity))
   }
 
   it should "fail incorrect DatastoreJob" in {
     an[AssertionError] should be thrownBy {
-      testDatastore((1 to 2).map(newEntity))
+      testDatastore((1L to 2L).map(newEntity))
     }
     an[AssertionError] should be thrownBy {
-      testDatastore((1 to 4).map(newEntity))
+      testDatastore((1L to 4L).map(newEntity))
     }
   }
 

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
@@ -24,7 +24,6 @@ import com.spotify.scio._
 import com.spotify.scio.avro.{Account, AccountStatus}
 import com.spotify.scio.proto.Track.TrackPB
 import com.spotify.scio.testing._
-import com.spotify.scio.pubsub._
 import com.spotify.scio.pubsub.coders._
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException
 import org.joda.time.Instant

--- a/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/JdbcTest.scala
+++ b/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/JdbcTest.scala
@@ -63,13 +63,13 @@ object JdbcJob {
 
 class JdbcTest extends PipelineSpec {
   def testJdbc(xs: String*): Unit = {
-    val args = Array(
+    val args = Seq(
       "--cloudSqlUsername=john",
       "--cloudSqlPassword=secret",
       "--cloudSqlDb=mydb",
       "--cloudSqlInstanceConnectionName=project-id:zone:db-instance-name"
     )
-    val (opts, _) = ScioContext.parseArguments[CloudSqlOptions](args)
+    val (opts, _) = ScioContext.parseArguments[CloudSqlOptions](args.toArray)
     val readOpts = JdbcJob.getReadOptions(opts)
     val writeOpts = JdbcJob.getWriteOptions(opts)
 
@@ -90,13 +90,12 @@ class JdbcTest extends PipelineSpec {
   }
 
   it should "connnect via JDBC without a password" in {
-    val args =
-      Array(
+    val args = Seq(
         "--cloudSqlUsername=john",
         "--cloudSqlDb=mydb",
         "--cloudSqlInstanceConnectionName=project-id:zone:db-instance-name"
       )
-    val (opts, _) = ScioContext.parseArguments[CloudSqlOptions](args)
+    val (opts, _) = ScioContext.parseArguments[CloudSqlOptions](args.toArray)
     val readOpts = JdbcJob.getReadOptions(opts)
     val writeOpts = JdbcJob.getWriteOptions(opts)
 

--- a/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/JdbcTest.scala
+++ b/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/JdbcTest.scala
@@ -91,10 +91,10 @@ class JdbcTest extends PipelineSpec {
 
   it should "connnect via JDBC without a password" in {
     val args = Seq(
-        "--cloudSqlUsername=john",
-        "--cloudSqlDb=mydb",
-        "--cloudSqlInstanceConnectionName=project-id:zone:db-instance-name"
-      )
+      "--cloudSqlUsername=john",
+      "--cloudSqlDb=mydb",
+      "--cloudSqlInstanceConnectionName=project-id:zone:db-instance-name"
+    )
     val (opts, _) = ScioContext.parseArguments[CloudSqlOptions](args.toArray)
     val readOpts = JdbcJob.getReadOptions(opts)
     val writeOpts = JdbcJob.getWriteOptions(opts)

--- a/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/sharded/JdbcShardedSelectTest.scala
+++ b/scio-jdbc/src/test/scala/com/spotify/scio/jdbc/sharded/JdbcShardedSelectTest.scala
@@ -50,13 +50,13 @@ object JdbcShardedSelectJob {
 class JdbcShardedSelectTest extends PipelineSpec {
 
   it should "pass correct sharded JDBC read" in {
-    val args = Array(
+    val args = Seq(
       "--cloudSqlUsername=john",
       "--cloudSqlPassword=secret",
       "--cloudSqlDb=mydb",
       "--cloudSqlInstanceConnectionName=project-id:zone:db-instance-name"
     )
-    val (opts, _) = ScioContext.parseArguments[CloudSqlOptions](args)
+    val (opts, _) = ScioContext.parseArguments[CloudSqlOptions](args.toArray)
     val readOpts = JdbcShardedSelectJob.getShardedReadOptions(opts)
 
     JobTest[JdbcShardedSelectJob.type]

--- a/scio-jmh/src/test/scala/com/spotify/scio/jmh/JoinBenchmark.scala
+++ b/scio-jmh/src/test/scala/com/spotify/scio/jmh/JoinBenchmark.scala
@@ -27,7 +27,6 @@ import org.openjdk.jmh.infra.Blackhole
 import scala.jdk.CollectionConverters._
 import scala.collection.compat._ // scalafix:ok
 
-
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)

--- a/scio-jmh/src/test/scala/com/spotify/scio/jmh/JoinBenchmark.scala
+++ b/scio-jmh/src/test/scala/com/spotify/scio/jmh/JoinBenchmark.scala
@@ -25,6 +25,9 @@ import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
 import scala.jdk.CollectionConverters._
+import scala.collection.compat._ // scalafix:ok
+
+
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
@@ -70,7 +73,7 @@ class JoinBenchmark {
         a <- as.asScala.iterator
         b <- bs.asScala.iterator
       } yield (a, b)
-    val i = xs.toIterator
+    val i = xs.iterator
     while (i.hasNext) c.output(i.next())
   }
 

--- a/scio-macros/src/main/scala/com/spotify/scio/MacroSettings.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/MacroSettings.scala
@@ -30,8 +30,9 @@ private[scio] object MacroSettings {
     val ss: Map[String, String] =
       settings
         .map(_.split("="))
-        .map { case Array(k, v) =>
-          (k.trim, v.trim)
+        .flatMap {
+          case Array(k, v) => Some(k.trim -> v.trim)
+          case _           => None
         }
         .toMap
 

--- a/scio-macros/src/main/scala/com/spotify/scio/MagnoliaMacros.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/MagnoliaMacros.scala
@@ -17,14 +17,12 @@
 
 package com.spotify.scio
 
-import scala.annotation.nowarn
 import scala.reflect.macros._
 
 private[scio] object MagnoliaMacros {
 
   // Add a level of indirection to prevent the macro from capturing
   // $outer which would make the Coder serialization fail
-  @nowarn
   def genWithoutAnnotations[T: c.WeakTypeTag](c: whitebox.Context): c.Tree = {
     import c.universe._
     val wtt = weakTypeOf[T]

--- a/scio-macros/src/main/scala/com/spotify/scio/MagnoliaMacros.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/MagnoliaMacros.scala
@@ -17,11 +17,14 @@
 
 package com.spotify.scio
 
+import scala.annotation.nowarn
 import scala.reflect.macros._
 
 private[scio] object MagnoliaMacros {
+
   // Add a level of indirection to prevent the macro from capturing
   // $outer which would make the Coder serialization fail
+  @nowarn
   def genWithoutAnnotations[T: c.WeakTypeTag](c: whitebox.Context): c.Tree = {
     import c.universe._
     val wtt = weakTypeOf[T]

--- a/scio-macros/src/main/scala/com/spotify/scio/SysPropsMacros.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/SysPropsMacros.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio
 
-import scala.annotation.{compileTimeOnly, StaticAnnotation}
+import scala.annotation.{StaticAnnotation, compileTimeOnly, nowarn}
 import scala.reflect.macros.blackbox
 
 @compileTimeOnly(
@@ -28,6 +28,8 @@ final class registerSysProps extends StaticAnnotation {
 }
 
 private object registerSysPropsMacro {
+
+  @nowarn
   def impl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
 

--- a/scio-macros/src/main/scala/com/spotify/scio/SysPropsMacros.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/SysPropsMacros.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio
 
-import scala.annotation.{StaticAnnotation, compileTimeOnly, nowarn}
+import scala.annotation.{compileTimeOnly, StaticAnnotation}
 import scala.reflect.macros.blackbox
 
 @compileTimeOnly(
@@ -29,7 +29,6 @@ final class registerSysProps extends StaticAnnotation {
 
 private object registerSysPropsMacro {
 
-  @nowarn
   def impl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
 

--- a/scio-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
@@ -19,6 +19,7 @@ package com.spotify.scio.coders
 
 import com.spotify.scio.{FeatureFlag, MacroSettings, MagnoliaMacros}
 
+import scala.annotation.nowarn
 import scala.reflect.macros._
 
 private[coders] object CoderMacros {
@@ -39,6 +40,7 @@ private[coders] object CoderMacros {
         """.stripMargin
     )
 
+  @nowarn("msg=parameter value lp in method issueFallbackWarning is never used")
   def issueFallbackWarning[T: c.WeakTypeTag](
     c: whitebox.Context
   )(lp: c.Expr[shapeless.LowPriority]): c.Tree = {

--- a/scio-macros/src/main/scala/com/spotify/scio/coders/KryoRegistrar.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/coders/KryoRegistrar.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.coders
 
-import scala.annotation.{StaticAnnotation, compileTimeOnly, nowarn}
+import scala.annotation.{compileTimeOnly, StaticAnnotation}
 import scala.reflect.macros._
 
 /**
@@ -34,7 +34,6 @@ class KryoRegistrar extends StaticAnnotation {
 
 private object KryoRegistrarMacro {
 
-  @nowarn
   def impl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
 

--- a/scio-macros/src/main/scala/com/spotify/scio/coders/KryoRegistrar.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/coders/KryoRegistrar.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.coders
 
-import scala.annotation.{compileTimeOnly, StaticAnnotation}
+import scala.annotation.{StaticAnnotation, compileTimeOnly, nowarn}
 import scala.reflect.macros._
 
 /**
@@ -33,6 +33,8 @@ class KryoRegistrar extends StaticAnnotation {
 }
 
 private object KryoRegistrarMacro {
+
+  @nowarn
   def impl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
 

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
@@ -154,7 +154,7 @@ class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
       // Explicit optional arguments `Duration.Zero` and `WindowOptions()` as a workaround for the
       // mysterious "Could not find proxy for val sc1" compiler error
       // take each records int value and multiply it by half hour, so we should have 2 records in each hour window
-      .timestampBy(x => new Instant(x.get("int_field").asInstanceOf[Int] * 1800000), Duration.ZERO)
+      .timestampBy(x => new Instant(x.get("int_field").asInstanceOf[Int] * 1800000L), Duration.ZERO)
       .withFixedWindows(Duration.standardHours(1), Duration.ZERO, WindowOptions())
       .saveAsDynamicParquetAvroFile(
         dir.toString,
@@ -261,7 +261,7 @@ class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
       val sc = ScioContext()
       sc.parallelize(genericRecords)
         .timestampBy(
-          x => new Instant(x.get("int_field").asInstanceOf[Int] * 1800000),
+          x => new Instant(x.get("int_field").asInstanceOf[Int] * 1800000L),
           Duration.ZERO
         )
         .withFixedWindows(Duration.standardHours(1), Duration.ZERO, WindowOptions())

--- a/scio-repl/src/main/scala/com/spotify/scio/repl/ScioILoop.scala
+++ b/scio-repl/src/main/scala/com/spotify/scio/repl/ScioILoop.scala
@@ -103,7 +103,7 @@ class ScioILoop(command: CompilerCommand, args: List[String]) extends compat.ILo
       // update options
       val newOpts = args.split("\\s+")
       intp.beQuietDuring {
-        intp.interpret(optsFromArgs(newOpts))
+        intp.interpret(optsFromArgs(ArraySeq.unsafeWrapArray(newOpts)))
         scioOpts = newOpts
         echo("Scio options updated. Use :newScio to get a new Scio context.")
       }

--- a/scio-repl/src/main/scala/com/spotify/scio/repl/ScioReplClassLoader.scala
+++ b/scio-repl/src/main/scala/com/spotify/scio/repl/ScioReplClassLoader.scala
@@ -35,6 +35,7 @@ object ScioReplClassLoader {
             MethodType.methodType(classOf[ClassLoader])
           )
           .invoke()
+          .asInstanceOf[ClassLoader]
       } catch { case _: Throwable => null }
     }
   }

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
@@ -121,7 +121,7 @@ private case class ParquetTypeSink[T](
   override def open(channel: WritableByteChannel): Unit = {
     // https://github.com/apache/parquet-mr/tree/master/parquet-hadoop#class-parquetoutputformat
     val rowGroupSize =
-      conf.get().getInt(ParquetOutputFormat.BLOCK_SIZE, ParquetWriter.DEFAULT_BLOCK_SIZE)
+      conf.get().getLong(ParquetOutputFormat.BLOCK_SIZE, ParquetWriter.DEFAULT_BLOCK_SIZE)
     writer = pt
       .writeBuilder(new ParquetOutputFile(channel))
       .withCompressionCodec(compression)

--- a/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetEndToEndTest.scala
+++ b/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetEndToEndTest.scala
@@ -28,6 +28,7 @@ import org.apache.beam.sdk.io.AvroGeneratedUser
 import org.apache.beam.sdk.values.TupleTag
 
 import scala.jdk.CollectionConverters._
+import scala.collection.compat._ // scalafix:ok
 
 object ParquetEndToEndTest {
   val eventSchema: Schema = Schema.createRecord(
@@ -122,7 +123,7 @@ class ParquetEndToEndTest extends PipelineSpec {
           .read[User](new TupleTag[User]("rhs"))
           .from(usersDir.toString)
       )
-    val userMap = users.groupBy(_.name).mapValues(_.head)
+    val userMap = users.groupBy(_.name).view.mapValues(_.head).toMap
     val expected = events.groupBy(_.user).toSeq.flatMap { case (k, es) =>
       es.map(e => (k, (e, userMap(k))))
     }

--- a/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetEndToEndTest.scala
+++ b/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetEndToEndTest.scala
@@ -168,7 +168,7 @@ class ParquetEndToEndTest extends PipelineSpec {
           .read(new TupleTag[GenericRecord]("rhs"), userSchema)
           .from(usersDir.toString)
       )
-    val userMap = avroUsers.groupBy(_.get("name").toString).mapValues(_.head)
+    val userMap = avroUsers.groupBy(_.get("name").toString).view.mapValues(_.head).toMap
     val expected = avroEvents.groupBy(_.get("user").toString).toSeq.flatMap { case (k, es) =>
       es.map(e => (k, (e, userMap(k))))
     }

--- a/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFSequenceExampleIOTest.scala
+++ b/scio-tensorflow/src/test/scala/com/spotify/scio/tensorflow/TFSequenceExampleIOTest.scala
@@ -33,7 +33,7 @@ object TFSequenceExampleIOTest {
         "i",
         Feature
           .newBuilder()
-          .setInt64List(Int64List.newBuilder().addValue(r.i).build())
+          .setInt64List(Int64List.newBuilder().addValue(r.i.toLong).build())
           .build()
       )
       .build()

--- a/scio-test/src/main/scala/com/spotify/scio/testing/Pretty.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/Pretty.scala
@@ -26,6 +26,8 @@ import pprint.PPrinter
 import com.google.api.client.json.GenericJson
 import org.apache.beam.sdk.extensions.gcp.util.Transport
 
+import scala.collection.compat._ // scalafix:ok
+
 @registerSysProps
 object PrettySysProps {
   val PrettyPrint: SysProp =
@@ -48,7 +50,7 @@ object Pretty {
         printer.defaultIndent
       )
     def render(tree: Tree): Str =
-      Str.join(renderer.rec(tree, 0, 0).iter.toIterable)
+      Str.join(renderer.rec(tree, 0, 0).iter.iterator.to(Iterable))
     Tree.Lazy { _ =>
       val fields =
         for {

--- a/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
@@ -49,7 +49,7 @@ final private case class TestWrapper[T: Eq](get: T) {
   override def equals(other: Any): Boolean =
     other match {
       case TestWrapper(o: T @unchecked) => Eq[T].eqv(get, o)
-      case o                            => get.equals(o)
+      case o                            => get == o
     }
 }
 

--- a/scio-test/src/main/scala/com/spotify/scio/testing/TransformOverride.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/TransformOverride.scala
@@ -59,7 +59,6 @@ object TransformOverride {
   )
 
   private def typeValidation[A, B](failMsg: String, aIn: Class[A], bIn: Class[B]): Unit = {
-    import scala.language.existentials
     // get normal java types instead of primitives
     val (a, b) = (primitiveMapping.getOrElse(aIn, aIn), primitiveMapping.getOrElse(bIn, bIn))
     if (!a.isAssignableFrom(b))

--- a/scio-test/src/test/scala/com/spotify/scio/ScioResultTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/ScioResultTest.scala
@@ -37,7 +37,7 @@ class ScioResultTest extends PipelineSpec {
       val c = ScioMetrics.counter("c")
       val d = ScioMetrics.distribution("d")
       val g = ScioMetrics.gauge("g")
-      sc.parallelize(Seq(1, 2, 3))
+      sc.parallelize(Seq(1L, 2L, 3L))
         .map { x =>
           c.inc()
           d.update(x)

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -101,7 +101,7 @@ object PrivateClass {
 case class UsesPrivateClass(privateClass: PrivateClass)
 
 // proto
-case class ClassWithProtoEnum(s: String, enum: OuterClassForProto.EnumExample)
+case class ClassWithProtoEnum(s: String, `enum`: OuterClassForProto.EnumExample)
 
 // serial UID
 @SerialVersionUID(1)
@@ -118,7 +118,7 @@ final case class AnyValExample(value: String) extends AnyVal
 final case class NonDeterministic(a: Double, b: Double)
 
 final class CoderTest extends AnyFlatSpec with Matchers {
-  val userId: UserId = UserId(Array[Byte](1, 2, 3, 4))
+  val userId: UserId = UserId(Seq[Byte](1, 2, 3, 4))
   val user: User = User(userId, "johndoe", "johndoe@spotify.com")
 
   def materialize[T](coder: Coder[T]): BCoder[T] =
@@ -605,7 +605,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
 
   it should "optimize for AnyVal" in {
     coderIsSerializable[AnyValExample]
-    Coder[AnyValExample] shouldBe a[Transform[String, AnyValExample]]
+    Coder[AnyValExample] shouldBe a[Transform[_, _]]
   }
 
   it should "support Algebird's Moments" in {

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -216,9 +216,9 @@ final class CoderTest extends AnyFlatSpec with Matchers {
 
   it should "have a Coder for Nothing" in {
     val bnc = CoderMaterializer.beamWithDefault[Nothing](Coder[Nothing])
-    bnc
-      .asInstanceOf[BCoder[Any]]
-      .encode(null, null) shouldBe () // make sure the code does nothing
+    noException shouldBe thrownBy {
+      bnc.asInstanceOf[BCoder[Any]].encode(null, null)
+    }
     an[IllegalStateException] should be thrownBy {
       bnc.decode(new ByteArrayInputStream(Array()))
     }

--- a/scio-test/src/test/scala/com/spotify/scio/hash/MutableScalableBloomFilterTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/hash/MutableScalableBloomFilterTest.scala
@@ -23,7 +23,9 @@ import scala.util.Random
 
 class MutableScalableBloomFilterTest extends PipelineSpec {
   def compoundedErrorRate(fpProb: Double, tighteningRatio: Double, numFilters: Int): Double =
-    1 - (0 to numFilters).foldLeft(1.0)(_ * 1 - fpProb * math.pow(tighteningRatio, _))
+    1 - (0 to numFilters).foldLeft(1.0)((e, i) =>
+      e * 1 - fpProb * math.pow(tighteningRatio, i.toDouble)
+    )
 
   "A MutableScalableBloomFilter" should "not grow for repeated items" in {
     val sbf = MutableScalableBloomFilter[String](256, 0.01)
@@ -53,7 +55,7 @@ class MutableScalableBloomFilterTest extends PipelineSpec {
   }
 
   it should "grow at the given growth rate" in {
-    val initialCapacity = 2
+    val initialCapacity = 2L
     val sbf = MutableScalableBloomFilter[String](initialCapacity, 0.001, 2, 1.0)
     assert(sbf.numFilters == 0)
 
@@ -85,7 +87,7 @@ class MutableScalableBloomFilterTest extends PipelineSpec {
   }
 
   it should "round-trip serialization" in {
-    val initialCapacity = 1000
+    val initialCapacity = 1000L
     val sbf = MutableScalableBloomFilter[String](initialCapacity)
     (0 until 100).foreach(i => sbf += ("item" + i))
 

--- a/scio-test/src/test/scala/com/spotify/scio/hash/PartitionSettingsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/hash/PartitionSettingsTest.scala
@@ -29,7 +29,7 @@ class PartitionSettingsTest extends AnyFlatSpec with Matchers {
     val actualInsertions = (expectedInsertions / 1.1).toLong // to prevent filter saturation
     val settings = c.partitionSettings(expectedInsertions, fpp, maxBytes)
     val filters = (0 until settings.partitions).map { i =>
-      val part = Range.Long(i, actualInsertions, settings.partitions)
+      val part = Range.Long(i.toLong, actualInsertions, settings.partitions.toLong)
       c.create(part, settings.expectedInsertions, fpp)
     }
 

--- a/scio-test/src/test/scala/com/spotify/scio/io/FileFormatTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/FileFormatTest.scala
@@ -33,7 +33,7 @@ class FileFormatTest extends PipelineSpec {
   private val protobufs = (1 to 100)
     .map(x =>
       com.google.protobuf.Timestamp.newBuilder
-        .setSeconds(x * 1000)
+        .setSeconds(x * 1000L)
         .setNanos(x)
         .build
     )

--- a/scio-test/src/test/scala/com/spotify/scio/io/TapTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/TapTest.scala
@@ -20,8 +20,6 @@ package com.spotify.scio.io
 import java.io._
 import java.nio.ByteBuffer
 import java.util.UUID
-
-import com.google.api.client.util.Charsets
 import com.spotify.scio._
 import com.spotify.scio.avro._
 import com.spotify.scio.avro.AvroUtils._
@@ -32,12 +30,13 @@ import com.spotify.scio.util.ScioUtil
 import org.apache.beam.sdk.util.SerializableUtils
 import org.apache.commons.compress.compressors.CompressorStreamFactory
 import org.apache.commons.io.{FileUtils, IOUtils}
-
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.options.ScioOptions
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.generic.GenericData
 import org.apache.avro.Schema
+
+import java.nio.charset.StandardCharsets
 
 trait TapSpec extends PipelineSpec {
   def verifyTap[T: Coder](tap: Tap[T], expected: Set[T]): Unit = {
@@ -155,7 +154,7 @@ class TapTest extends TapSpec {
         val file = new File(dir, "part-%05d-%05d.%s".format(i, nFiles, ext))
         val os = new CompressorStreamFactory()
           .createCompressorOutputStream(cType, new FileOutputStream(file))
-        data(i).foreach(l => IOUtils.write(l + "\n", os, Charsets.UTF_8))
+        data(i).foreach(l => IOUtils.write(l + "\n", os, StandardCharsets.UTF_8))
         os.close()
       }
       verifyTap(TextTap(ScioUtil.addPartSuffix(dir.getPath, ext)), data.flatten.toSet)

--- a/scio-test/src/test/scala/com/spotify/scio/io/TapTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/TapTest.scala
@@ -164,9 +164,9 @@ class TapTest extends TapSpec {
 
   it should "support saveAsProtobuf proto version 2" in {
     val dir = tmpDir
-    val data = Seq(("a", 1), ("b", 2), ("c", 3))
+    val data = Seq(("a", 1L), ("b", 2L), ("c", 3L))
     // use java protos otherwise we would have to pull in pb-scala
-    def mkProto(t: (String, Int)): SimplePBV2 =
+    def mkProto(t: (String, Long)): SimplePBV2 =
       SimplePBV2
         .newBuilder()
         .setPlays(t._2)
@@ -183,7 +183,7 @@ class TapTest extends TapSpec {
   }
 
   // use java protos otherwise we would have to pull in pb-scala
-  private def mkProto3(t: (String, Int)): SimplePBV3 =
+  private def mkProto3(t: (String, Long)): SimplePBV3 =
     SimplePBV3
       .newBuilder()
       .setPlays(t._2)
@@ -192,7 +192,7 @@ class TapTest extends TapSpec {
 
   it should "support saveAsProtobuf proto version 3" in {
     val dir = tmpDir
-    val data = Seq(("a", 1), ("b", 2), ("c", 3))
+    val data = Seq(("a", 1L), ("b", 2L), ("c", 3L))
     val t = runWithFileFuture {
       _.parallelize(data)
         .map(mkProto3)
@@ -205,7 +205,7 @@ class TapTest extends TapSpec {
 
   it should "support saveAsProtobuf write with nullableCoders" in {
     val dir = tmpDir
-    val data = Seq(("a", 1), ("b", 2), ("c", 3))
+    val data = Seq(("a", 1L), ("b", 2L), ("c", 3L))
     val actual = data.map(mkProto3)
     val t = runWithFileFuture { sc =>
       sc.optionsAs[ScioOptions].setNullableCoders(true)
@@ -224,7 +224,7 @@ class TapTest extends TapSpec {
 
   it should "support saveAsProtobuf read with nullableCoders" in {
     val dir = tmpDir
-    val data = Seq(("a", 1), ("b", 2), ("c", 3))
+    val data = Seq(("a", 1L), ("b", 2L), ("c", 3L))
     val actual = data.map(mkProto3)
     val t = runWithFileFuture {
       _.parallelize(actual)

--- a/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
@@ -70,7 +70,7 @@ class DynamicFileTest extends PipelineSpec {
       .parallelize(1 to 10)
       // Explicit optional arguments `Duration.Zero` and `WindowOptions()` as a workaround for the
       // mysterious "Could not find proxy for val sc1" compiler error
-      .timestampBy(x => new Instant(x * 60000), Duration.ZERO)
+      .timestampBy(x => new Instant(x * 60000L), Duration.ZERO)
       .withFixedWindows(Duration.standardMinutes(1), Duration.ZERO, WindowOptions())
       .saveAsDynamicTextFile(tmpDir.toString, 1)(s => (s.toInt % 2).toString)
     sc1.run()
@@ -85,8 +85,8 @@ class DynamicFileTest extends PipelineSpec {
     lines1 should containInAnyOrder((1 to 10).filter(_ % 2 == 1).map(_.toString))
     (1 to 10).foreach { x =>
       val p = x % 2
-      val t1 = new Instant(x * 60000)
-      val t2 = t1.plus(60000)
+      val t1 = new Instant(x * 60000L)
+      val t2 = t1.plus(60000L)
       val lines = sc2.textFile(s"$tmpDir/$p/part-$t1-$t2-*.txt")
       lines should containSingleValue(x.toString)
     }
@@ -144,7 +144,7 @@ class DynamicFileTest extends PipelineSpec {
       .map(newSpecificRecord)
       // Explicit optional arguments `Duration.Zero` and `WindowOptions()` as a workaround for the
       // mysterious "Could not find proxy for val sc1" compiler error
-      .timestampBy(x => new Instant(x.getIntField * 60000), Duration.ZERO)
+      .timestampBy(x => new Instant(x.getIntField * 60000L), Duration.ZERO)
       .withFixedWindows(Duration.standardMinutes(1), Duration.ZERO, WindowOptions())
       .saveAsDynamicAvroFile(tmpDir.toString, 1)(r => (r.getIntField % 2).toString)
     sc1.run()
@@ -159,8 +159,8 @@ class DynamicFileTest extends PipelineSpec {
     records1 should containInAnyOrder((1 to 10).filter(_ % 2 == 1).map(newSpecificRecord))
     (1 to 10).foreach { x =>
       val p = x % 2
-      val t1 = new Instant(x * 60000)
-      val t2 = t1.plus(60000)
+      val t1 = new Instant(x * 60000L)
+      val t2 = t1.plus(60000L)
       val records = sc2.avroFile[TestRecord](s"$tmpDir/$p/part-$t1-$t2-*.avro")
       records should containSingleValue(newSpecificRecord(x))
     }
@@ -172,9 +172,9 @@ class DynamicFileTest extends PipelineSpec {
     val tmpDir = Files.createTempDirectory("dynamic-io-")
     val sc1 = ScioContext()
 
-    val mkProto = (x: Int) => SimplePB.newBuilder().setPlays(x).setTrackId(s"track$x").build()
+    val mkProto = (x: Long) => SimplePB.newBuilder().setPlays(x).setTrackId(s"track$x").build()
     sc1
-      .parallelize(1 to 10)
+      .parallelize(1L to 10L)
       .map(mkProto)
       .saveAsDynamicProtobufFile(tmpDir.toString)(r => (r.getPlays % 2).toString)
     sc1.run()
@@ -183,8 +183,8 @@ class DynamicFileTest extends PipelineSpec {
     val sc2 = ScioContext()
     val lines0 = sc2.protobufFile[SimplePB](s"$tmpDir/0/*.protobuf")
     val lines1 = sc2.protobufFile[SimplePB](s"$tmpDir/1/*.protobuf")
-    lines0 should containInAnyOrder((1 to 10).filter(_ % 2 == 0).map(mkProto))
-    lines1 should containInAnyOrder((1 to 10).filter(_ % 2 == 1).map(mkProto))
+    lines0 should containInAnyOrder((1L to 10L).filter(_ % 2 == 0).map(mkProto))
+    lines1 should containInAnyOrder((1L to 10L).filter(_ % 2 == 1).map(mkProto))
     sc2.run()
     FileUtils.deleteDirectory(tmpDir.toFile)
   }

--- a/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/JobTestTest.scala
@@ -280,7 +280,7 @@ object MetricsJob {
 
   def main(cmdlineArgs: Array[String]): Unit = {
     val (sc, _) = ContextAndArgs(cmdlineArgs)
-    sc.parallelize(1 to 10)
+    sc.parallelize(1L to 10L)
       .map { x =>
         counter.inc()
         distribution.update(x)

--- a/scio-test/src/test/scala/com/spotify/scio/transforms/AsyncDoFnSpec.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/transforms/AsyncDoFnSpec.scala
@@ -196,7 +196,7 @@ abstract class AsyncDoFnTester[P[_], F[_]] extends BaseDoFnTester {
     override def outputWithTimestamp[T](tag: TupleTag[T], output: T, timestamp: Instant): Unit = ???
 
     // test input
-    override def timestamp(): Instant = new Instant(nextElement)
+    override def timestamp(): Instant = new Instant(nextElement.toLong)
     override def element(): Int = nextElement
     override def output(output: String): Unit = outputBuffer.append(output)
   }

--- a/scio-test/src/test/scala/com/spotify/scio/transforms/AsyncDoFnTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/transforms/AsyncDoFnTest.scala
@@ -86,7 +86,7 @@ class AsyncDoFnTest extends PipelineSpec {
 private object Client {
   def process(input: Int): String = {
     require(input >= 0, "input must be >= 0")
-    Thread.sleep(input * 10)
+    Thread.sleep(input * 10L)
     "output-" + input
   }
 }

--- a/scio-test/src/test/scala/com/spotify/scio/util/random/RandomSamplerTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/util/random/RandomSamplerTest.scala
@@ -24,6 +24,7 @@ import org.apache.beam.sdk.transforms.windowing.PaneInfo
 import org.apache.beam.sdk.values.{PCollectionView, TupleTag}
 import org.joda.time.Instant
 
+import scala.collection.compat._ // scalafix:ok
 import scala.collection.mutable.{Buffer => MBuffer}
 
 class RandomSamplerTest extends PipelineSpec {
@@ -115,11 +116,13 @@ class RandomSamplerTest extends PipelineSpec {
 
     val actual = test(sampler, keyedPopulation)
       .groupBy(_._1)
+      .view
       .mapValues { vs =>
         val a = vs.map(_._2).toArray
         scala.util.Sorting.quickSort(a)
         a
       }
+      .toMap
     val k1 = medianKSD(gaps(expected("a")), gaps(actual("a")))
     val k2 = medianKSD(gaps(expected("b")), gaps(actual("b")))
     (k1, k2)

--- a/scio-test/src/test/scala/com/spotify/scio/values/ClosureTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/ClosureTest.scala
@@ -138,7 +138,7 @@ class NestedClosuresNotSerializable {
   def closure(name: String)(body: => Int => Int): Int => Int = body
   def getMapFn: Int => Int = closure("one") {
     @nowarn("msg=local method x in method getMapFn is never used")
-    def x = irrelevantInt // scalafix:ok
+    def x = irrelevantInt
     def y = 2
     val fn = { a: Int => a + y }
     fn

--- a/scio-test/src/test/scala/com/spotify/scio/values/ClosureTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/ClosureTest.scala
@@ -19,6 +19,8 @@ package com.spotify.scio.values
 
 import com.spotify.scio.testing.PipelineSpec
 
+import scala.annotation.nowarn
+
 class ClosureTest extends PipelineSpec {
   "SCollection" should "support lambda" in {
     runWithContext { sc =>
@@ -132,8 +134,10 @@ class NotSerializableObj {
 
 class NestedClosuresNotSerializable {
   val irrelevantInt: Int = 1
+  @nowarn("msg=parameter value name in method closure is never used")
   def closure(name: String)(body: => Int => Int): Int => Int = body
   def getMapFn: Int => Int = closure("one") {
+    @nowarn("msg=local method x in method getMapFn is never used")
     def x = irrelevantInt // scalafix:ok
     def y = 2
     val fn = { a: Int => a + y }

--- a/scio-test/src/test/scala/com/spotify/scio/values/DistCacheTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/DistCacheTest.scala
@@ -49,7 +49,7 @@ object SimpleDistCacheJob {
 class NonSerializable(val noDefaultCntr: String) extends Serializable {
   // make sure it's not kryo/java serializable
   @nowarn("msg=private val t in class NonSerializable is never used")
-  private val t = new Thread() // scalafix:ok
+  private val t = new Thread()
 }
 
 object NonSerializableDistCacheJob {

--- a/scio-test/src/test/scala/com/spotify/scio/values/DistCacheTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/DistCacheTest.scala
@@ -25,6 +25,7 @@ import com.spotify.scio.avro._
 import com.spotify.sparkey.SparkeyReader.Entry
 import com.spotify.sparkey.{IndexHeader, LogHeader, Sparkey, SparkeyReader}
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 import scala.io.Source
 
@@ -47,6 +48,7 @@ object SimpleDistCacheJob {
 
 class NonSerializable(val noDefaultCntr: String) extends Serializable {
   // make sure it's not kryo/java serializable
+  @nowarn("msg=private val t in class NonSerializable is never used")
   private val t = new Thread() // scalafix:ok
 }
 

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -395,7 +395,7 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
 
   it should "support batchByKey" in {
     runWithContext { sc =>
-      val batchSize = 2
+      val batchSize = 2L
       val nonEmpty = sc
         .parallelize(Seq(("a", 1), ("a", 10), ("b", 2), ("b", 20)))
         .batchByKey(batchSize)

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -19,8 +19,6 @@ package com.spotify.scio.values
 
 import java.io.PrintStream
 import java.nio.file.Files
-
-import com.google.api.client.util.Charsets
 import com.spotify.scio.ScioContext
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.util.MockedPrintStream
@@ -42,6 +40,8 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.schemas.Schema
+
+import java.nio.charset.StandardCharsets
 
 class SCollectionTest extends PipelineSpec {
 
@@ -763,7 +763,7 @@ class SCollectionTest extends PipelineSpec {
         r should containInAnyOrder(Seq(1, 2, 3))
       }
     }
-    Files.readAllLines(outFile, Charsets.UTF_8) should contain theSameElementsAs Seq("1", "2", "3")
+    Files.readAllLines(outFile, StandardCharsets.UTF_8) should contain theSameElementsAs Seq("1", "2", "3")
   }
 
   it should "support Combine.globally() with default value" in {

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -583,7 +583,10 @@ class SCollectionTest extends PipelineSpec {
   it should "support withFixedWindows()" in {
     runWithContext { sc =>
       val p =
-        sc.parallelizeTimestamped(Seq("a", "b", "c", "d", "e", "f"), (0 to 5).map(new Instant(_)))
+        sc.parallelizeTimestamped(
+          Seq("a", "b", "c", "d", "e", "f"),
+          (0L to 5L).map(new Instant(_))
+        )
       val r = p.withFixedWindows(Duration.millis(3)).top(10).map(_.toSet)
       r should containInAnyOrder(Seq(Set("a", "b", "c"), Set("d", "e", "f")))
     }
@@ -591,8 +594,10 @@ class SCollectionTest extends PipelineSpec {
 
   it should "support withSlidingWindows()" in {
     runWithContext { sc =>
-      val p =
-        sc.parallelizeTimestamped(Seq("a", "b", "c", "d", "e", "f"), (0 to 5).map(new Instant(_)))
+      val p = sc.parallelizeTimestamped(
+        Seq("a", "b", "c", "d", "e", "f"),
+        (0L to 5L).map(new Instant(_))
+      )
       val r = p
         .withSlidingWindows(Duration.millis(2), Duration.millis(2))
         .top(10)
@@ -602,8 +607,10 @@ class SCollectionTest extends PipelineSpec {
   }
 
   it should "#2745: not throw an exception for valid values" in runWithContext { sc =>
-    val p =
-      sc.parallelizeTimestamped(Seq("a", "b", "c", "d", "e", "f"), (0 to 5).map(new Instant(_)))
+    val p = sc.parallelizeTimestamped(
+      Seq("a", "b", "c", "d", "e", "f"),
+      (0L to 5L).map(new Instant(_))
+    )
     val r = p
       .withSlidingWindows(
         size = Duration.standardHours(24),
@@ -620,7 +627,7 @@ class SCollectionTest extends PipelineSpec {
       val p =
         sc.parallelizeTimestamped(
           Seq("a", "b", "c", "d", "e"),
-          Seq(0, 5, 10, 44, 55).map(new Instant(_))
+          Seq(0L, 5L, 10L, 44L, 55L).map(new Instant(_))
         )
       val r = p
         .withSessionWindows(Duration.millis(10))
@@ -632,8 +639,10 @@ class SCollectionTest extends PipelineSpec {
 
   it should "support withGlobalWindow()" in {
     runWithContext { sc =>
-      val p =
-        sc.parallelizeTimestamped(Seq("a", "b", "c", "d", "e", "f"), (0 to 5).map(new Instant(_)))
+      val p = sc.parallelizeTimestamped(
+        Seq("a", "b", "c", "d", "e", "f"),
+        (0L to 5L).map(new Instant(_))
+      )
       val r = p
         .withFixedWindows(Duration.millis(3))
         .withGlobalWindow()
@@ -646,7 +655,10 @@ class SCollectionTest extends PipelineSpec {
   it should "support withPaneInfo" in {
     runWithContext { sc =>
       val pane = PaneInfo.createPane(true, true, Timing.UNKNOWN, 0, 0)
-      val p = sc.parallelizeTimestamped(Seq("a", "b", "c"), Seq(1, 2, 3).map(new Instant(_)))
+      val p = sc.parallelizeTimestamped(
+        Seq("a", "b", "c"),
+        Seq(1L, 2L, 3L).map(new Instant(_))
+      )
       val r = p.withPaneInfo.map(kv => (kv._1, kv._2))
       r should containInAnyOrder(Seq(("a", pane), ("b", pane), ("c", pane)))
     }
@@ -654,7 +666,10 @@ class SCollectionTest extends PipelineSpec {
 
   it should "support withTimestamp" in {
     runWithContext { sc =>
-      val p = sc.parallelizeTimestamped(Seq("a", "b", "c"), Seq(1, 2, 3).map(new Instant(_)))
+      val p = sc.parallelizeTimestamped(
+        Seq("a", "b", "c"),
+        Seq(1L, 2L, 3L).map(new Instant(_))
+      )
       val r = p.withTimestamp.map(kv => (kv._1, kv._2.getMillis))
       r should containInAnyOrder(Seq(("a", 1L), ("b", 2L), ("c", 3L)))
     }
@@ -664,9 +679,10 @@ class SCollectionTest extends PipelineSpec {
     def w2s(window: BoundedWindow): String = window match {
       case w: GlobalWindow   => s"GlobalWindow(${w.maxTimestamp()})"
       case w: IntervalWindow => s"IntervalWindow(${w.start()}, ${w.end()})"
+      case _                 => ???
     }
 
-    val timestamps = Seq(1, 2, 3).map(t => new Instant(t * DateTimeConstants.MILLIS_PER_MINUTE))
+    val timestamps = Seq(1L, 2L, 3L).map(t => new Instant(t * DateTimeConstants.MILLIS_PER_MINUTE))
 
     runWithContext { sc =>
       val p = sc.parallelizeTimestamped(Seq("a", "b", "c"), timestamps)
@@ -702,7 +718,7 @@ class SCollectionTest extends PipelineSpec {
     runWithContext { sc =>
       val p = sc.parallelize(Seq(1, 2, 3))
       val r = p
-        .timestampBy(new Instant(_))
+        .timestampBy(t => new Instant(t.toLong))
         .withTimestamp
         .map(kv => (kv._1, kv._2.getMillis))
       r should containInAnyOrder(Seq((1, 1L), (2, 2L), (3, 3L)))
@@ -713,7 +729,7 @@ class SCollectionTest extends PipelineSpec {
     runWithContext { sc =>
       val p = sc.parallelize(Seq(1, 2, 3))
       val r = p
-        .timestampBy(new Instant(_), Duration.millis(1))
+        .timestampBy(t => new Instant(t.toLong), Duration.millis(1))
         .withTimestamp
         .map(kv => (kv._1, kv._2.getMillis))
       r should containInAnyOrder(Seq((1, 1L), (2, 2L), (3, 3L)))
@@ -763,7 +779,11 @@ class SCollectionTest extends PipelineSpec {
         r should containInAnyOrder(Seq(1, 2, 3))
       }
     }
-    Files.readAllLines(outFile, StandardCharsets.UTF_8) should contain theSameElementsAs Seq("1", "2", "3")
+    Files.readAllLines(outFile, StandardCharsets.UTF_8) should contain theSameElementsAs Seq(
+      "1",
+      "2",
+      "3"
+    )
   }
 
   it should "support Combine.globally() with default value" in {

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideInputTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideInputTest.scala
@@ -193,7 +193,7 @@ class SCollectionWithSideInputTest extends PipelineSpec {
   }
 
   val timestampedData: IndexedSeq[(Int, Instant)] =
-    (1 to 100).map(x => (x, new Instant(x * DateTimeConstants.MILLIS_PER_SECOND)))
+    (1 to 100).map(x => (x, new Instant(x.toLong * DateTimeConstants.MILLIS_PER_SECOND)))
 
   it should "support windowed asSingletonSideInput" in {
     runWithContext { sc =>

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideInputTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideInputTest.scala
@@ -112,7 +112,7 @@ class SCollectionWithSideInputTest extends PipelineSpec {
           .asMultiMapSingletonSideInput
       val s = p1
         .withSideInputs(p2)
-        .flatMap((_, s) => s(p2).mapValues(_.toSet))
+        .flatMap((_, s) => s(p2).map { case (k, v) => k -> v.toSet })
         .toSCollection
       s should containInAnyOrder(sideData.map(kv => (kv._1, Set(kv._2, kv._2 + 10))))
     }
@@ -338,7 +338,7 @@ class SCollectionWithSideInputTest extends PipelineSpec {
       val p2 = SideInput.wrapMultiMap(i2)
       val s = p1
         .withSideInputs(p2)
-        .flatMap((_, s) => s(p2).mapValues(_.toSet))
+        .flatMap((_, s) => s(p2).map { case (k, v) => k -> v.toSet })
         .toSCollection
       s should containInAnyOrder(sideData.map(kv => (kv._1, Set(kv._2, kv._2 + 10))))
     }

--- a/scio-test/src/test/scala/com/spotify/scio/values/WindowedSCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/WindowedSCollectionTest.scala
@@ -24,7 +24,7 @@ class WindowedSCollectionTest extends PipelineSpec {
   "WindowedSCollection" should "support filter()" in {
     runWithContext { sc =>
       val p =
-        sc.parallelizeTimestamped(Seq("a", "b", "c", "d"), Seq(1, 2, 3, 4).map(new Instant(_)))
+        sc.parallelizeTimestamped(Seq("a", "b", "c", "d"), Seq(1L, 2L, 3L, 4L).map(new Instant(_)))
       val r = p.toWindowed
         .filter(v => v.timestamp.getMillis % 2 == 0)
         .toSCollection
@@ -37,7 +37,7 @@ class WindowedSCollectionTest extends PipelineSpec {
   it should "support flatMap()" in {
     runWithContext { sc =>
       val p =
-        sc.parallelizeTimestamped(Seq("a", "b"), Seq(1, 2).map(new Instant(_)))
+        sc.parallelizeTimestamped(Seq("a", "b"), Seq(1L, 2L).map(new Instant(_)))
       val r = p.toWindowed
         .flatMap(v => Seq(v.copy(v.value + "1"), v.copy(v.value + "2")))
         .toSCollection
@@ -50,7 +50,7 @@ class WindowedSCollectionTest extends PipelineSpec {
   it should "support keyBy()" in {
     runWithContext { sc =>
       val p =
-        sc.parallelizeTimestamped(Seq("a", "b"), Seq(1, 2).map(new Instant(_)))
+        sc.parallelizeTimestamped(Seq("a", "b"), Seq(1L, 2L).map(new Instant(_)))
       val r =
         p.toWindowed.keyBy(v => v.value + v.timestamp.getMillis).toSCollection
       r should containInAnyOrder(Seq(("a1", "a"), ("b2", "b")))
@@ -60,7 +60,7 @@ class WindowedSCollectionTest extends PipelineSpec {
   it should "support map()" in {
     runWithContext { sc =>
       val p =
-        sc.parallelizeTimestamped(Seq("a", "b"), Seq(1, 2).map(new Instant(_)))
+        sc.parallelizeTimestamped(Seq("a", "b"), Seq(1L, 2L).map(new Instant(_)))
       val r = p.toWindowed
         .map(v => v.copy(v.value + v.timestamp.getMillis))
         .toSCollection


### PR DESCRIPTION
This is an attempt to reduce numbers of compilation warnings, and delegate best configuration of the compiler flags to the `sbt-tpolecat` plugin from the `typelevel` organisation 