### PR TITLE
Follow-up: drop empty SMB key groups when predicate is provided

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/MultiSourceKeyGroupReader.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/MultiSourceKeyGroupReader.java
@@ -28,8 +28,7 @@ public class MultiSourceKeyGroupReader<FinalKeyT> {
 
   private enum KeyGroupOutputSize {
     EMPTY,
-    LAZY,
-    NONZERO
+    NONEMPTY
   }
 
   private KV<FinalKeyT, CoGbkResult> head = null;
@@ -113,10 +112,9 @@ public class MultiSourceKeyGroupReader<FinalKeyT> {
               .mapToObj(i -> new ArrayList<>())
               .collect(Collectors.toList());
 
-      // when predicates are applied to all outputs, a key group may have no values and should not
-      // be emitted. maintain counters of per-output record counts and if _all_ are EMPTY then do
-      // not emit the key group. LAZY outputs may be empty but cannot be assumed to be empty, so
-      // the key group will be emitted in this case.
+      // When predicates are applied, a sources containing a key may have no values after filtering.
+      // Sources containing minKey are by default known to be NONEMPTY. Once all sources are
+      // consumed, if all are known to be empty, the key group can be dropped.
       List<KeyGroupOutputSize> valueOutputSizes =
           IntStream.range(0, resultSchema.size())
               .mapToObj(i -> KeyGroupOutputSize.EMPTY)
@@ -145,7 +143,8 @@ public class MultiSourceKeyGroupReader<FinalKeyT> {
             int outputIndex = resultSchema.getIndex(src.tupleTag);
 
             if (!materialize) {
-              valueOutputSizes.set(outputIndex, KeyGroupOutputSize.LAZY);
+              // this source contains minKey, so is known to contain at least one value
+              valueOutputSizes.set(outputIndex, KeyGroupOutputSize.NONEMPTY);
               // lazy data iterator
               valueMap.set(
                   outputIndex,
@@ -173,7 +172,7 @@ public class MultiSourceKeyGroupReader<FinalKeyT> {
                     }
                   });
               KeyGroupOutputSize sz =
-                  values.isEmpty() ? KeyGroupOutputSize.EMPTY : KeyGroupOutputSize.NONZERO;
+                  values.isEmpty() ? KeyGroupOutputSize.EMPTY : KeyGroupOutputSize.NONEMPTY;
               valueOutputSizes.set(outputIndex, sz);
             }
           } else {
@@ -185,7 +184,7 @@ public class MultiSourceKeyGroupReader<FinalKeyT> {
       }
 
       if (acceptKeyGroup == AcceptKeyGroup.ACCEPT) {
-        // if _all_ outputs are known-empty, omit this key group
+        // if all outputs are known-empty, omit this key group
         boolean allEmpty = valueOutputSizes.stream().allMatch(s -> s == KeyGroupOutputSize.EMPTY);
         if (!allEmpty) {
           final KV<byte[], CoGbkResult> next =

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/MultiSourceKeyGroupReader.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/MultiSourceKeyGroupReader.java
@@ -112,7 +112,7 @@ public class MultiSourceKeyGroupReader<FinalKeyT> {
               .mapToObj(i -> new ArrayList<>())
               .collect(Collectors.toList());
 
-      // When predicates are applied, a sources containing a key may have no values after filtering.
+      // When a predicate is applied, a source containing a key may have no values after filtering.
       // Sources containing minKey are by default known to be NONEMPTY. Once all sources are
       // consumed, if all are known to be empty, the key group can be dropped.
       List<KeyGroupOutputSize> valueOutputSizes =

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
@@ -66,7 +66,8 @@ public class SortedBucketTransformTest {
   @Rule public final TemporaryFolder outputFolder = new TemporaryFolder();
 
   private static final List<String> inputLhs = ImmutableList.of("", "a1", "b1", "c1", "d1", "e1");
-  private static final List<String> inputRhs = ImmutableList.of("", "c2", "d2", "e2", "f2", "g2");
+  private static final List<String> inputRhs =
+      ImmutableList.of("", "c2", "d2", "e2", "f2", "g2", "h2");
   private static final List<Integer> inputSI = ImmutableList.of(1, 2, 3, 4, 5, 6);
   private static final List<String> inputSI2 = ImmutableList.of("z", "x", "y");
 
@@ -117,7 +118,7 @@ public class SortedBucketTransformTest {
 
     sinkPipeline.run().waitUntilFinish();
 
-    final Predicate<String> predicate = (xs, s) -> !s.startsWith("c");
+    final Predicate<String> predicate = (xs, s) -> !s.startsWith("c") && !s.startsWith("h");
 
     sources =
         ImmutableList.of(


### PR DESCRIPTION
Simplification of #4389, since all lazy iterators containing `minKey` are known to be NONEMPTY. We don't need to separately track LAZY.