### PR TITLE
Update CustomCoders usages to implement verifyDeterministic

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/AvroCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/AvroCoders.scala
@@ -95,6 +95,8 @@ final private class SpecificFixedCoder[A <: SpecificFixed](cls: Class[A]) extend
   override def consistentWithEquals(): Boolean = true
 
   override def structuralValue(value: A): AnyRef = value
+
+  override def verifyDeterministic(): Unit = {}
 }
 
 private object SpecificFixedCoder {

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/GuavaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/GuavaCoders.scala
@@ -28,6 +28,7 @@ class GuavaBloomFilterCoder[T](implicit val funnel: g.Funnel[T])
     value.writeTo(outStream)
   override def decode(inStream: InputStream): BloomFilter[T] =
     BloomFilter.readFrom[T](inStream, funnel)
+  override def verifyDeterministic(): Unit = {}
 }
 
 trait GuavaCoders {

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -628,7 +628,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     )
   }
 
-  it should "support Guava Funnels" in {
+  it should "support Guava Bloom Filters" in {
     import com.google.common.hash.{BloomFilter, Funnels}
 
     implicit val funnel = Funnels.stringFunnel(Charset.forName("UTF-8"))

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -632,7 +632,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     import com.google.common.hash.{BloomFilter, Funnels}
 
     implicit val funnel = Funnels.stringFunnel(Charset.forName("UTF-8"))
-    val bloomFilter = BloomFilter.create(funnel, 5)
+    val bloomFilter = BloomFilter.create(funnel, 5L)
 
     bloomFilter coderShould roundtrip()
     bloomFilter coderShould beDeterministic()


### PR DESCRIPTION
fix non-deterministic exceptions coming from [updating](https://github.com/spotify/scio/commit/e6bd75f9510d57a6d3dcf387e2a32a86b1fa52a3) SpecificFixedCoder and Guava BF Coder to implement `CustomCoder` instead of `AtomicCoder`.