### PR TITLE
(bugfix) typed-Parquet sink wasn't using user-supplied Configuration

### DIFF
--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -86,7 +86,7 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
   }
 
   override protected def write(data: SCollection[T], params: WriteP): Tap[T] = {
-    val job = Job.getInstance()
+    val job = Job.getInstance(params.conf)
     if (ScioUtil.isLocalRunner(data.context.options.getRunner)) {
       GcsConnectorUtil.setCredentials(job)
     }


### PR DESCRIPTION
this fixes a bug in typed parquet writes only. It isn't an issue in [Avro-Parquet](https://github.com/spotify/scio/blob/main/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala#L77) or [Tensorflow-Parquet](https://github.com/spotify/scio/blob/main/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala#L105).