### PR TITLE
Improve KV batch API

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -803,7 +803,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   /**
    * Batches inputs to a desired weight. Batches will contain only elements of a single key.
    *
-   * The weight of each element is computer from the provided function.
+   * The weight of each element is computer from the provided cost function.
    *
    * Elements are buffered until the weight is reached, at which point they are outputed to the
    * output [[SCollection]].
@@ -815,7 +815,8 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * buffered can be set. Once a batch is flushed to output, the timer is reset. The provided limit
    * must be a positive duration or zero; a zero buffering duration effectively means no limit.
    *
-   * @param batchByteSize
+   * @param weight
+   * @param cost
    * @param maxBufferingDuration
    *
    * @group per_key

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -826,7 +826,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
     cost: V => Long,
     maxBufferingDuration: Duration = Duration.ZERO
   ): SCollection[(K, Iterable[V])] = {
-    val weigher: SerializableFunction[V, java.lang.Long] = cost(_).asInstanceOf[java.lang.Long]
+    val weigher = Functions.serializableFn(cost.andThen(_.asInstanceOf[java.lang.Long]))
     val groupIntoBatches = GroupIntoBatches
       .ofByteSize[K, V](weight, weigher)
       .withMaxBufferingDuration(maxBufferingDuration)

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -31,6 +31,7 @@ import com.spotify.scio.util.random.{BernoulliValueSampler, PoissonValueSampler}
 import com.twitter.algebird.{Aggregator, Monoid, MonoidAggregator, Semigroup}
 import org.apache.beam.sdk.transforms._
 import org.apache.beam.sdk.values.{KV, PCollection}
+import org.joda.time.Duration
 import org.slf4j.LoggerFactory
 
 import scala.collection.compat._ // scalafix:ok
@@ -749,12 +750,87 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    * Windows are preserved (batches contain elements from the same window). Batches may contain
    * elements from more than one bundle.
    *
+   * A time limit (in processing time) on how long an incomplete batch of elements is allowed to be
+   * buffered can be set. Once a batch is flushed to output, the timer is reset. The provided limit
+   * must be a positive duration or zero; a zero buffering duration effectively means no limit.
+   *
    * @param batchSize
+   * @param maxBufferingDuration
    *
    * @group per_key
    */
-  def batchByKey(batchSize: Long): SCollection[(K, Iterable[V])] =
-    this.applyPerKey(GroupIntoBatches.ofSize(batchSize))(kvIterableToTuple)
+  def batchByKey(
+    batchSize: Long,
+    maxBufferingDuration: Duration = Duration.ZERO
+  ): SCollection[(K, Iterable[V])] = {
+    val groupIntoBatches = GroupIntoBatches
+      .ofSize[K, V](batchSize)
+      .withMaxBufferingDuration(maxBufferingDuration)
+    this.applyPerKey(groupIntoBatches)(kvIterableToTuple)
+  }
+
+  /**
+   * Batches inputs to a desired batch of byte size. Batches will contain only elements of a single
+   * key.
+   *
+   * The value coder is used to determine the byte size of each element.
+   *
+   * Elements are buffered until there are an estimated batchByteSize bytes buffered, at which point
+   * they are outputed to the output [[SCollection]].
+   *
+   * Windows are preserved (batches contain elements from the same window). Batches may contain
+   * elements from more than one bundle.
+   *
+   * A time limit (in processing time) on how long an incomplete batch of elements is allowed to be
+   * buffered can be set. Once a batch is flushed to output, the timer is reset. The provided limit
+   * must be a positive duration or zero; a zero buffering duration effectively means no limit.
+   *
+   * @param batchByteSize
+   * @param maxBufferingDuration
+   *
+   * @group per_key
+   */
+  def batchByteSizedByKey(
+    batchByteSize: Long,
+    maxBufferingDuration: Duration = Duration.ZERO
+  ): SCollection[(K, Iterable[V])] = {
+    val groupIntoBatches = GroupIntoBatches
+      .ofByteSize[K, V](batchByteSize)
+      .withMaxBufferingDuration(maxBufferingDuration)
+    this.applyPerKey(groupIntoBatches)(kvIterableToTuple)
+  }
+
+  /**
+   * Batches inputs to a desired weight. Batches will contain only elements of a single key.
+   *
+   * The weight of each element is computer from the provided function.
+   *
+   * Elements are buffered until the weight is reached, at which point they are outputed to the
+   * output [[SCollection]].
+   *
+   * Windows are preserved (batches contain elements from the same window). Batches may contain
+   * elements from more than one bundle.
+   *
+   * A time limit (in processing time) on how long an incomplete batch of elements is allowed to be
+   * buffered can be set. Once a batch is flushed to output, the timer is reset. The provided limit
+   * must be a positive duration or zero; a zero buffering duration effectively means no limit.
+   *
+   * @param batchByteSize
+   * @param maxBufferingDuration
+   *
+   * @group per_key
+   */
+  def batchWeightedByKey(
+    weight: Long,
+    cost: V => Long,
+    maxBufferingDuration: Duration = Duration.ZERO
+  ): SCollection[(K, Iterable[V])] = {
+    val weigher: SerializableFunction[V, java.lang.Long] = cost(_).asInstanceOf[java.lang.Long]
+    val groupIntoBatches = GroupIntoBatches
+      .ofByteSize[K, V](weight, weigher)
+      .withMaxBufferingDuration(maxBufferingDuration)
+    this.applyPerKey(groupIntoBatches)(kvIterableToTuple)
+  }
 
   /**
    * Return an SCollection with the pairs from `this` whose keys are in `rhs`.

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -383,7 +383,7 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support groupByKey" in {
+  it should "support groupByKey()" in {
     runWithContext { sc =>
       val p = sc
         .parallelize(Seq(("a", 1), ("a", 10), ("b", 2), ("b", 20)))
@@ -393,7 +393,7 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
-  it should "support batchByKey" in {
+  it should "support batchByKey()" in {
     runWithContext { sc =>
       val batchSize = 2L
       val nonEmpty = sc
@@ -404,6 +404,26 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
 
       val empty = sc.empty[(String, Int)]().batchByKey(batchSize)
       empty should beEmpty
+    }
+  }
+
+  it should "support batchByteSizedByKey()" in {
+    runWithContext { sc =>
+      val p = sc
+        .parallelize(Seq("a" -> '1', "a" -> '2', "a" -> '3', "b" -> '1', "b" -> '2', "c" -> '1'))
+        .batchByteSizedByKey(2) // element size given by the charCoder is 1
+        .mapValues(_.size)
+      p should containInAnyOrder(Seq("a" -> 2, "a" -> 1, "b" -> 2, "c" -> 1))
+    }
+  }
+
+  it should "support batchWeightedByKey()" in {
+    runWithContext { sc =>
+      val p = sc
+        .parallelize(Seq("a" -> 2, "a" -> 3, "a" -> 4, "b" -> 2, "b" -> 3, "c" -> 1, "c" -> 1))
+        .batchWeightedByKey(2, _.toLong)
+        .mapValues(_.size)
+      p should containInAnyOrder(Seq("a" -> 1, "a" -> 1, "a" -> 1, "b" -> 1, "b" -> 1, "c" -> 2))
     }
   }
 


### PR DESCRIPTION
I realized that sio is only having an API for beam `GroupIntoBatches` with `ofSize`

1. this can be problematic in streaming pipelines when keys have few elements and batch takes time to fill. Adding the `maxBufferingDuration` to the API
2. `GroupIntoBatches` also allows to batch by byte size, using by default the coder size
3. 'Abusing' byteSize with custom weight, so users can batch on arbitrary element metric