### PR TITLE
feat(pubsub-client): extended PubsubIO functionality to support custom Pubsub clients

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -667,6 +667,7 @@ lazy val `scio-google-cloud-platform`: Project = project
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-extensions-google-cloud-platform-core" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion,
+      "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion % "test,it",
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
       "org.hamcrest" % "hamcrest-core" % hamcrestVersion % "test,it",
       "org.hamcrest" % "hamcrest-library" % hamcrestVersion % "test",

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
@@ -275,7 +275,8 @@ object PubsubWithAttributesJob {
 object PubsubWithOptionsJob {
   val timestampAttribute = "tsAttribute"
   val clientOptions: PubsubOptions = PipelineOptionsFactory.create().as(classOf[PubsubOptions])
-  val clientFn: (String, String, PubsubOptions) => PubsubClient = (time, id, opt) => PubsubJsonClient.FACTORY.newClient(time, id, opt)
+  val clientFn: (String, String, PubsubOptions) => PubsubClient = (time, id, opt) =>
+    PubsubJsonClient.FACTORY.newClient(time, id, opt)
 
   def main(cmdlineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdlineArgs)

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
@@ -26,6 +26,7 @@ import org.apache.beam.sdk.Pipeline.PipelineExecutionException
 import org.apache.beam.sdk.io.gcp.pubsub.{PubsubJsonClient, PubsubOptions}
 import org.apache.beam.sdk.options.PipelineOptionsFactory
 import org.joda.time.Instant
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient
 
 class PubsubIOTest extends PipelineSpec with ScioIOSpec {
   def readFn[T](
@@ -273,8 +274,8 @@ object PubsubWithAttributesJob {
 
 object PubsubWithOptionsJob {
   val timestampAttribute = "tsAttribute"
-  val clientOptions = PipelineOptionsFactory.create().as(classOf[PubsubOptions])
-  val clientFn = (time, id, opt) => PubsubJsonClient.FACTORY.newClient(time, id, opt)
+  val clientOptions: PubsubOptions = PipelineOptionsFactory.create().as(classOf[PubsubOptions])
+  val clientFn: (String, String, PubsubOptions) => PubsubClient = (time, id, opt) => PubsubJsonClient.FACTORY.newClient(time, id, opt)
 
   def main(cmdlineArgs: Array[String]): Unit = {
     val (sc, args) = ContextAndArgs(cmdlineArgs)


### PR DESCRIPTION
Scio previously didn't offer a clean way for developers to create their own custom Pubsub clients. A standard workaround that I'd done in the past was vendoring Apache Beam internals to get around the limitations of abstraction. After a discussion with Kellen internally, we decided that some of these changes were valuable and should be made publicly available.

This PR aims to make it so that `PubsubIO` can (optionally) accept `PubsubOptions` as well as a "client-generating function" that describes how to use those options to create a `PubsubClient`. This, in turn, makes it so that more exotic Pubsub clients can be used by Scio developers.

One example that comes to mind is overriding Google's default choice of globally-distributing Pubsub messages, and instead routing to regional endpoints.