### PR TITLE
update run instructions for examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # sbt
 dist/*
 target/
+scio-examples/project/
 lib_managed/
 src_managed/
 project/boot/

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/DebuggingWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/DebuggingWordCount.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.DebuggingWordCount
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount"`
 package com.spotify.scio.examples

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/MinimalWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/MinimalWordCount.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.MinimalWordCount
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/minimal_wordcount"`
 package com.spotify.scio.examples

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/MinimalWordCountPipelineOptionsExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/MinimalWordCountPipelineOptionsExample.scala
@@ -25,7 +25,7 @@ import org.apache.beam.sdk.options.Validation.Required
 // Usage:
 // `sbt "runMain
 // com.spotify.scio.examples.MinimalWordCountPipelineOptionsExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/minimal_wordcount"`
 object MinimalWordCountPipelineOptionsExample {

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/WindowedWordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/WindowedWordCount.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.WindowedWordCount
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount"`
 package com.spotify.scio.examples

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/WordCount.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/WordCount.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.WordCount
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount"`
 package com.spotify.scio.examples

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/AutoComplete.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/AutoComplete.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.complete.AutoComplete
-// --project=[PROJECT] --runner=DataflowPRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowPRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --outputToBigqueryTable=true --outputToDatastore=false --output=[DATASET].auto_complete"`
 package com.spotify.scio.examples.complete

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/StreamingWordExtract.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/StreamingWordExtract.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.complete.StreamingWordExtract
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=[DATASET].streaming_word_extract"`
 package com.spotify.scio.examples.complete

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TfIdf.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TfIdf.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.complete.TfIdf
-// --project=[PROJECT] --runner=DataflowPRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowPRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/?*.txt
 // --output=gs://[BUCKET]/[PATH]/tf_idf"`
 package com.spotify.scio.examples.complete

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TopWikipediaSessions.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TopWikipediaSessions.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.complete.TopWikipediaSessions
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/wikipedia_edits/wiki_data-*.json
 // --output=gs://[BUCKET]/[PATH]/top_wikipedia_sessions"`
 package com.spotify.scio.examples.complete

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficMaxLaneFlow.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficMaxLaneFlow.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.complete.TrafficMaxLaneFlow
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/traffic_sensor/Freeways-5Minaa2010-01-01_to_2010-02-15_test2.csv
 // --output=[DATASET].traffic_max_lane_flow"`
 package com.spotify.scio.examples.complete

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficRoutes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/TrafficRoutes.scala
@@ -19,7 +19,7 @@
 // Usage
 
 // `sbt "runMain com.spotify.scio.examples.complete.TrafficRoutes
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/traffic_sensor/Freeways-5Minaa2010-01-01_to_2010-02-15_test2.csv
 // --output=[DATASET].traffic_routes"`
 package com.spotify.scio.examples.complete

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/GameStats.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/GameStats.scala
@@ -20,7 +20,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.complete.game.GameStats
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --fixedWindowDuration=60
 // --sessionGap=5
 // --userActivityWindowDuration=30

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/HourlyTeamScore.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/HourlyTeamScore.scala
@@ -20,7 +20,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.complete.game.HourlyTeamScore
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --windowDuration=60
 // --startMin=2018-05-13-00-00
 // --stopMin=2018-05-14-00-00

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/LeaderBoard.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/LeaderBoard.scala
@@ -20,7 +20,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.complete.game.LeaderBoard
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --teamWindowDuration=60
 // --allowedLateness=120
 // --topic=[PUBSUB_TOPIC_NAME]

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/UserScore.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/complete/game/UserScore.scala
@@ -20,7 +20,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.complete.game.UserScore
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=bq://[PROJECT]/[DATASET]/mobile_game_user_score"`
 
 package com.spotify.scio.examples.complete.game

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/BigQueryTornadoes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/BigQueryTornadoes.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.cookbook.BigQueryTornadoes
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=clouddataflow-readonly:samples.weather_stations
 // --output=[DATASET].bigquery_tornadoes"`
 package com.spotify.scio.examples.cookbook

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/CombinePerKeyExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/CombinePerKeyExamples.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.cookbook.CombinePerKeyExamples
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=[DATASET].combine_per_key_examples"`
 package com.spotify.scio.examples.cookbook
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/DistinctByKeyExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/DistinctByKeyExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.cookbook.DistinctWithRepresentativeValueFnExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=[DATASET].distinct_by_key_example"`
 package com.spotify.scio.examples.cookbook
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/DistinctExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/DistinctExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.cookbook.DistinctExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=gs://[BUCKET]/output/path"`
 package com.spotify.scio.examples.cookbook
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/FilterExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/FilterExamples.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.cookbook.FilterExamples
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=[DATASET].filter_examples"`
 package com.spotify.scio.examples.cookbook
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/JoinExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/JoinExamples.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.cookbook.JoinExamples
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=gs://[BUCKET]/[PATH]/join_examples"`
 package com.spotify.scio.examples.cookbook
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/MaxPerKeyExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/MaxPerKeyExamples.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.cookbook.MaxPerKeyExamples
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=[DATASET].max_per_key_examples"`
 package com.spotify.scio.examples.cookbook
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/StorageBigQueryTornadoes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/StorageBigQueryTornadoes.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.StorageBigQueryTornadoes
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=[PROJECT]:[DATASET].[TABLE]"`
 package com.spotify.scio.examples.cookbook
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/TriggerExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/cookbook/TriggerExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.cookbook.TriggerExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/traffic_sensor/Freeways-5Minaa2010-01-01_to_2010-02-15_test2.csv
 // --output=[DATASET].trigger_example"`
 package com.spotify.scio.examples.cookbook

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AnnoyExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AnnoyExamples.scala
@@ -48,7 +48,7 @@ object AnnoyExamples {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.AnnoyIndexSaveExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 //--output=gs://[BUCKET]/[PATH]/annoy.tree"`
 object AnnoyIndexSaveExample {
   def main(cmdlineArgs: Array[String]): Unit = {
@@ -69,7 +69,7 @@ object AnnoyIndexSaveExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.AnnoySideInputExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://[BUCKET]/[PATH]/annoy.tree
 // --output=gs://[BUCKET]/[PATH]/otuput"`
 object AnnoySideInputExample {

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.AvroExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=[INPUT].avro --output=[OUTPUT].avro --method=[METHOD]"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroInOut.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/AvroInOut.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.AvroInOut
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=[INPUT].avro --output=[OUTPUT].avro --method=[METHOD]"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BeamExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BeamExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.BeamExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --inputTopic=[TOPIC] --outputTopic=[TOPIC]"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BigtableExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/BigtableExample.scala
@@ -55,7 +55,7 @@ object BigtableExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.BigtableWriteExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --bigtableProjectId=[BIG_TABLE_PROJECT_ID]
 // --bigtableInstanceId=[BIG_TABLE_INSTANCE_ID]
@@ -101,7 +101,7 @@ object BigtableWriteExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.BigtableReadExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --bigtableProjectId=[BIG_TABLE_PROJECT_ID]
 // --bigtableInstanceId=[BIG_TABLE_INSTANCE_ID]
 // --bigtableTableId=[BIG_TABLE_TABLE_ID]

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/DistCacheExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/DistCacheExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.DistCacheExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/wikipedia_edits/wiki_data-*.json
 // --output=gs://[BUCKET]/[PATH]/dist_cache_example"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/DoFnExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/DoFnExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.DoFnExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/do_fn_example"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ElasticsearchMinimalExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ElasticsearchMinimalExample.scala
@@ -23,7 +23,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.ElasticsearchMinimalExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=[INPUT] --index=[INDEX] --esHost=[HOST] --esPort=[PORT]"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/JavaConvertersExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/JavaConvertersExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.JavaConvertersExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=gs://[OUTPUT] --converter=[CONVERTER]"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyAvroExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyAvroExample.scala
@@ -40,7 +40,7 @@ object MagnolifyAvroExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.MagnolifyAvroWriteExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount-avro"`
 object MagnolifyAvroWriteExample {
@@ -65,7 +65,7 @@ object MagnolifyAvroWriteExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.MagnolifyAvroReadExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://[BUCKET]/[PATH]/wordcount-avro
 // --output=gs://[BUCKET]/[PATH]/wordcount"`
 object MagnolifyAvroReadExample {

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyBigtableExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyBigtableExample.scala
@@ -47,7 +47,7 @@ object MagnolifyBigtableExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.MagnolifyBigtableWriteExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --bigtableProjectId=[BIG_TABLE_PROJECT_ID]
 // --bigtableInstanceId=[BIG_TABLE_INSTANCE_ID]
@@ -85,7 +85,7 @@ object MagnolifyBigtableWriteExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.MagnolifyBigtableReadExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --bigtableProjectId=[BIG_TABLE_PROJECT_ID]
 // --bigtableInstanceId=[BIG_TABLE_INSTANCE_ID]
 // --bigtableTableId=[BIG_TABLE_TABLE_ID]

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyDatastoreExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyDatastoreExample.scala
@@ -43,7 +43,7 @@ object MagnolifyDatastoreExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.MagnolifyDatastoreWriteExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=[PROJECT]"`
 object MagnolifyDatastoreWriteExample {
@@ -74,7 +74,7 @@ object MagnolifyDatastoreWriteExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.MagnolifyDatastoreReadExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=[PROJECT]
 // --output=gs://[BUCKET]/[PATH]/wordcount"`
 object MagnolifyDatastoreReadExample {

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyTensorFlowExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyTensorFlowExample.scala
@@ -45,7 +45,7 @@ object MagnolifyTensorFlowExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.MagnolifyTensorFlowWriteExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount-tf"`
 object MagnolifyTensorFlowWriteExample {
@@ -70,7 +70,7 @@ object MagnolifyTensorFlowWriteExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.MagnolifyTensorFlowReadExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://[BUCKET]/[PATH]/wordcount-tf
 // --output=gs://[BUCKET]/[PATH]/wordcount"`
 object MagnolifyTensorFlowReadExample {

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MetricsExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MetricsExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.MetricsExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]"`
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]"`
 package com.spotify.scio.examples.extra
 
 import com.spotify.scio._

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ProtobufExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ProtobufExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.ProtobufExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://[INPUT].proto --output=gs://[OUTPUT].avro"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
@@ -33,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.RedisReadStringsExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --redisHost=[REDIS_HOST]
 // --redisPort=[REDIS_PORT]
 // --keyPattern=[KEY_PATTERN]
@@ -64,7 +64,7 @@ object RedisReadStringsExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.RedisWriteBatchExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --redisHost=[REDIS_HOST]
 // --redisPort=[REDIS_PORT]`
 object RedisWriteBatchExample {
@@ -95,7 +95,7 @@ object RedisWriteBatchExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.RedisWriteStreamingExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --subscription=[PUBSUB_SUBSCRIPTION]
 // --redisHost=[REDIS_HOST]
 // --redisPort=[REDIS_PORT]`
@@ -133,7 +133,7 @@ object RedisWriteStreamingExample {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.RedisLookUpStringsExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --redisHost=[REDIS_HOST]
 // --redisPort=[REDIS_PORT]
 object RedisLookUpStringsExample {

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RefreshingSideInputExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RefreshingSideInputExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "scio-examples/runMain com.spotify.scio.examples.extra.RefreshingSideInputExample
-// --project=[PROJECT] --runner=[RUNNER] --zone=[ZONE] --input=[PUBSUB_SUBSCRIPTION]"`
+// --project=[PROJECT] --runner=[RUNNER] --region=[REGION NAME] --input=[PUBSUB_SUBSCRIPTION]"`
 package com.spotify.scio.examples.extra
 
 import com.spotify.scio._

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SafeFlatMapExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SafeFlatMapExample.scala
@@ -19,7 +19,7 @@
 
 // Usage:
 // `sbt "runMain com.spotify.scio.examples.extra.SafeFlatMapExample
-//  --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+//  --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 //  --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 //  --output=gs://[BUCKET]/[PATH]/safe_flat_map"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SideInOutExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SideInOutExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.SideInOutExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --stopWords=[STOP_WORDS_URI]
 // --output1=gs://[BUCKET]/[PATH]/output1

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SingleGZipFileExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SingleGZipFileExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.SingleGZipFileExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=[INPUT.txt] --output=[OUTPUT]"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/StatefulExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/StatefulExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.StatefulExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]"`
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]"`
 package com.spotify.scio.examples.extra
 
 import java.lang.{Integer => JInt}

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TableRowJsonInOut.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TableRowJsonInOut.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.TableRowJsonInOut
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/wikipedia_edits/wiki_data-*.json
 // --output=gs://[BUCKET]/[PATH]/wikipedia"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TapOutputExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TapOutputExample.scala
@@ -26,7 +26,7 @@ import com.spotify.scio._
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.TapOutputExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=gs://[OUTPUT] --method=[METHOD]"`
 object TapOutputExample {
   def main(cmdlineArgs: Array[String]): Unit = {

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TemplateExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TemplateExample.scala
@@ -22,7 +22,7 @@
 
 // To upload the template:
 // `sbt "runMain com.spotify.scio.examples.extra.TemplateExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --stagingLocation=gs://[BUCKET]/staging --templateLocation=gs://[BUCKET]/TemplateExample"`
 
 // To run the template, e.g. from gcloud:
@@ -32,7 +32,7 @@
 
 // To run the job directly:
 // `sbt "runMain com.spotify.scio.examples.extra.TemplateExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --inputSub=projects/[PROJECT]/subscriptions/sub
 // --outputTopic=projects/[PROJECT]/topics/[TOPIC]"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TsvExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TsvExample.scala
@@ -26,7 +26,7 @@ import org.apache.beam.sdk.{io => beam}
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.TsvExampleWrite
-//   --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+//   --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 //   --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 //   --output=gs://[BUCKET]/[PATH]/wordcount"`
 object TsvExampleWrite {
@@ -71,7 +71,7 @@ object TsvExampleWrite {
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.TsvExampleRead
-//   --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+//   --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 //   --input=gs://[BUCKET]/word_count_data.tsv
 //   --output=gs://[BUCKET]/[PATH]/word_count_sum"`
 object TsvExampleRead {

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedBigQueryTornadoes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedBigQueryTornadoes.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.TypedBigQueryTornadoes
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=[PROJECT]:[DATASET].[TABLE]"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedStorageBigQueryTornadoes.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TypedStorageBigQueryTornadoes.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.TypedStorageBigQueryTornadoes
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=[PROJECT]:[DATASET].[TABLE]"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WordCountOrchestration.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WordCountOrchestration.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.WordCountOrchestration
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --output=gs://[BUCKET]/[PATH]/wordcount"`
 package com.spotify.scio.examples.extra
 

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WordCountScioIO.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WordCountScioIO.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.WordCountScioIO
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount"`
 package com.spotify.scio.examples.extra

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/WriteDynamicExample.scala
@@ -19,7 +19,7 @@
 // Usage:
 
 // `sbt "runMain com.spotify.scio.examples.extra.WriteDynamicExample
-// --project=[PROJECT] --runner=DataflowRunner --zone=[ZONE]
+// --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[OUTPUT]"`
 package com.spotify.scio.examples.extra

--- a/site/src/main/paradox/Getting-Started.md
+++ b/site/src/main/paradox/Getting-Started.md
@@ -59,11 +59,11 @@ neville@localhost scio $ sbt
 [info] ...
 > runMain com.spotify.scio.examples.WordCount
 --project=<PROJECT ID>
---zone=<GCE AVAILABILITY ZONE> --runner=DataflowRunner
+--region=<GCE AVAILABILITY ZONE> --runner=DataflowRunner
 --input=<FILE PATTERN> --output=<DIRECTORY>
 ```
 
-The Cloud Platform `project` refers to its name (not number). GCE availability `zone` should be in the same region as the BigQuery datasets and GCS bucket.
+The Cloud Platform `project` refers to its name (not number). GCE availability `region` should be in the same region as the BigQuery datasets and GCS bucket.
 
 By default only `DirectRunner` is in the library dependencies list. Use `set beamRunners := "<runners>"` to specify additional runner dependencies as a comma separated list, i.e. "DataflowRunner,FlinkRunner".
 
@@ -104,7 +104,7 @@ sbt -Dbigquery.project=<PROJECT-ID>
 The following options should be specified when running a job on Google Cloud Dataflow service.
 
 - `--project` - The project ID for your Google Cloud Project. This is required if you want to run your pipeline using the Cloud Dataflow managed service.
-- `--zone` - The Compute Engine [availability zone](https://cloud.google.com/compute/docs/zones) for launching worker instances to run your pipeline.
+- `--region` - The Compute Engine [regional endpoint](https://cloud.google.com/dataflow/docs/resources/locations) for launching worker instances to run your pipeline.
 
 For pipeline execution parameters and optimization, see the following documents.
 


### PR DESCRIPTION
in the instructions to run example codes zone/region are set by `--zone` argument, while it is expected to set `--region` from [this list](https://cloud.google.com/dataflow/docs/resources/locations). `Getting started` page is updated accordingly