### PR TITLE
BatchDoFn and sio batch API on SCollection

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/BatchDoFn.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/BatchDoFn.java
@@ -1,0 +1,120 @@
+package com.spotify.scio.transforms;
+
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * Batches input into a desired batch size.
+ *
+ * <p>Elements are buffered until there are enough elements for a batch,
+ * at which point they are emitted to the output PCollection
+ *
+ * <p>Windows are preserved (batches contain elements from the same window).
+ * Batches are not spanning over bundles. Once a bundle is finished, the batch is emitted even if not full.
+ * This function can only batch 10 parallel windows. If new element comes from an 11th window,
+ * the bigger batch will be emitted to give room for this new element.
+ *
+ * @param <InputT>
+ */
+public class BatchDoFn<InputT> extends DoFn<InputT, Iterable<InputT>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BatchDoFn.class);
+
+    private static final int MAX_LIVE_WINDOWS = 10;
+
+    private static class Buffer<InputT> {
+
+        private final List<InputT> elements;
+
+        private long weight;
+
+        Buffer() {
+            this.elements = new ArrayList<>();
+            this.weight = 0;
+        }
+
+        public List<InputT> getElements() {
+            return elements;
+        }
+
+        public long getWeight() {
+            return weight;
+        }
+
+        public void add(InputT element, long weight) {
+            elements.add(element);
+            this.weight += weight;
+        }
+    }
+
+    private final long maxWeight;
+    private final SerializableFunction<InputT, Long> weigher;
+    private transient Map<BoundedWindow, Buffer<InputT>> buffers;
+
+    public BatchDoFn(
+            long maxWeight,
+            SerializableFunction<InputT, Long> weigher
+    ) {
+        this.maxWeight = maxWeight;
+        this.weigher = weigher;
+    }
+
+    @Setup
+    public void setup() {
+        this.buffers = new HashMap<>();
+    }
+
+    @ProcessElement
+    public void processElement(
+            @Element InputT element,
+            BoundedWindow window,
+            OutputReceiver<Iterable<InputT>> receiver
+    ) {
+        LOG.debug("*** BATCH *** Add element for window {} ", window);
+        Buffer<InputT> buffer = buffers.computeIfAbsent(window, w -> new Buffer<>());
+        long weight = weigher.apply(element);
+        buffer.add(element, weight);
+
+        if (buffer.getWeight() >= maxWeight) {
+            LOG.debug("*** END OF BATCH *** for window {}", window);
+            flushBatch(window, buffer, receiver);
+        } else if (buffers.size() > MAX_LIVE_WINDOWS) {
+            // flush the biggest buffer if we get too many parallel windows
+            Map.Entry<BoundedWindow, Buffer<InputT>> discarded =
+                    Collections.max(buffers.entrySet(), Comparator.comparingLong(o -> o.getValue().getWeight()));
+            BoundedWindow discardedWindow = discarded.getKey();
+            Buffer<InputT> discardedBatch = discarded.getValue();
+            LOG.debug("*** END OF BATCH *** for window {}", discardedWindow);
+            flushBatch(discardedWindow, discardedBatch, receiver);
+        }
+    }
+
+    @FinishBundle
+    public void finishBundle(FinishBundleContext context) {
+        for (Map.Entry<BoundedWindow, Buffer<InputT>> wb : buffers.entrySet()) {
+            BoundedWindow window = wb.getKey();
+            Buffer<InputT> buffer = wb.getValue();
+            context.output(buffer.getElements(), window.maxTimestamp(), window);
+        }
+        buffers.clear();
+    }
+
+    private void flushBatch(
+            BoundedWindow window,
+            Buffer<InputT> buffer,
+            OutputReceiver<Iterable<InputT>> receiver
+    ) {
+        // Set the batch timestamp to the window's maxTimestamp
+        receiver.outputWithTimestamp(buffer.elements, window.maxTimestamp());
+        // prefer removing the window than clearing the buffer
+        // to avoid reaching MAX_LIVE_WINDOWS if no other element
+        // come for this window
+        buffers.remove(window);
+    }
+
+}

--- a/scio-core/src/main/java/com/spotify/scio/transforms/BatchDoFn.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/BatchDoFn.java
@@ -25,7 +25,7 @@ public class BatchDoFn<InputT> extends DoFn<InputT, Iterable<InputT>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(BatchDoFn.class);
 
-    private static final int DEFAULT_MAX_LIVE_WINDOWS = 10;
+    public static final int DEFAULT_MAX_LIVE_WINDOWS = 10;
 
     private static class Buffer<InputT> {
 

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -451,6 +451,20 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
       in.map(a.prepare).fold(a.monoid).map(a.present)
     }
 
+  /**
+   * Batches elements for amortized processing. Elements are batched per-window and batches emitted
+   * in the window corresponding to its contents.
+   *
+   * Batches are emitted even if the maximum size is not reached when bundle finishes or when there
+   * are too many live windows.
+   *
+   * @param batchSize
+   *   desired number of elements in a batch
+   * @param maxLiveWindows
+   *   maximum number of window buffering
+   *
+   * @group collection
+   */
   def batch(
     batchSize: Long,
     maxLiveWindows: Int = BatchDoFn.DEFAULT_MAX_LIVE_WINDOWS
@@ -461,6 +475,20 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
       .map(_.asScala)
   }
 
+  /**
+   * Batches elements for amortized processing. Elements are batched per-window and batches emitted
+   * in the window corresponding to its contents.
+   *
+   * Batches are emitted even if the maximum size is not reached when bundle finishes or when there
+   * are too many live windows.
+   *
+   * @param batchByteSize
+   *   desired batch size in bytes, estimated using the [[Coder]]
+   * @param maxLiveWindows
+   *   maximum number of window buffering
+   *
+   * @group collection
+   */
   def batchByteSized(
     batchByteSize: Long,
     maxLiveWindows: Int = BatchDoFn.DEFAULT_MAX_LIVE_WINDOWS
@@ -480,6 +508,21 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
       .map(_.asScala)
   }
 
+  /**
+   * Batches elements for amortized processing. Elements are batched per-window and batches emitted
+   * in the window corresponding to its contents.
+   *
+   * Batches are emitted even if the maximum size is not reached when bundle finishes or when there
+   * are too many live windows.
+   *
+   * @param batchWeight
+   *   desired batch weight
+   * @param cost
+   *   function that associated a weight to an element
+   * @param maxLiveWindows
+   *   maximum number of window buffering
+   * @group collection
+   */
   def batchWeighted(
     batchWeight: Long,
     cost: T => Long,

--- a/scio-test/src/test/scala/com/spotify/scio/transforms/BatchDoFnTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/transforms/BatchDoFnTest.scala
@@ -1,0 +1,116 @@
+package com.spotify.scio.transforms
+
+import org.apache.beam.sdk.options.PipelineOptions
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver
+import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, GlobalWindow, IntervalWindow}
+import org.apache.beam.sdk.values.TupleTag
+import org.joda.time.Instant
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters._
+
+class BatchDoFnTest extends AnyFlatSpec with Matchers {
+
+  class TestReceiver[T] extends OutputReceiver[java.lang.Iterable[T]] {
+
+    private val builder = List.newBuilder[(Iterable[T], Instant)]
+
+    override def output(output: java.lang.Iterable[T]): Unit =
+      builder += ((output.asScala, Instant.now()))
+    override def outputWithTimestamp(output: java.lang.Iterable[T], timestamp: Instant): Unit =
+      builder += ((output.asScala, timestamp))
+
+    def values: List[Iterable[T]] = builder.result().map(_._1)
+    def valuesWithTimestamp: List[(Iterable[T], Instant)] = builder.result()
+  }
+
+  "BatchDoFn" should "batch items until wight is reached" in {
+    val batchFn = new BatchDoFn[Int](10, _.toLong)
+    batchFn.setup()
+
+    val receiver = new TestReceiver[Int]
+    batchFn.processElement(1, GlobalWindow.INSTANCE, receiver)
+    batchFn.processElement(2, GlobalWindow.INSTANCE, receiver)
+    batchFn.processElement(3, GlobalWindow.INSTANCE, receiver)
+    receiver.values shouldBe empty
+    batchFn.processElement(5, GlobalWindow.INSTANCE, receiver)
+    receiver.values should have size 1
+    receiver.values.head should contain theSameElementsAs Seq(1, 2, 3, 5)
+  }
+
+  it should "batch items per window" in {
+    val batchFn = new BatchDoFn[Int](10, _.toLong)
+    batchFn.setup()
+    val window1 = new IntervalWindow(Instant.ofEpochSecond(0), Instant.ofEpochSecond(10))
+    val window2 = new IntervalWindow(Instant.ofEpochSecond(10), Instant.ofEpochSecond(20))
+    val receiver = new TestReceiver[Int]
+    batchFn.processElement(1, window1, receiver)
+    batchFn.processElement(2, window1, receiver)
+    batchFn.processElement(3, window1, receiver)
+    batchFn.processElement(5, window2, receiver)
+    receiver.values shouldBe empty
+    batchFn.processElement(5, window1, receiver)
+    receiver.values should have size 1
+    receiver.values.head should contain theSameElementsAs Seq(1, 2, 3, 5)
+    batchFn.processElement(5, window2, receiver)
+    receiver.values should have size 2
+    receiver.values(1) should contain theSameElementsAs Seq(5, 5)
+  }
+
+  it should "flush all pending buffers on finishBundle" in {
+    val batchFn = new BatchDoFn[Int](10, _.toLong)
+    batchFn.setup()
+    val window1 = new IntervalWindow(Instant.ofEpochSecond(0), Instant.ofEpochSecond(10))
+    val window2 = new IntervalWindow(Instant.ofEpochSecond(10), Instant.ofEpochSecond(20))
+    val receiver = new TestReceiver[Int]
+
+    val builder = Map.newBuilder[BoundedWindow, Iterable[Int]]
+    val finishContext = new batchFn.FinishBundleContext {
+      override def getPipelineOptions: PipelineOptions = ???
+      override def output(
+        output: java.lang.Iterable[Int],
+        timestamp: Instant,
+        window: BoundedWindow
+      ): Unit = builder += (window -> output.asScala)
+      override def output[T](
+        tag: TupleTag[T],
+        output: T,
+        timestamp: Instant,
+        window: BoundedWindow
+      ): Unit = ???
+    }
+
+    batchFn.processElement(1, window1, receiver)
+    batchFn.processElement(2, window1, receiver)
+    batchFn.processElement(3, window1, receiver)
+    batchFn.processElement(5, window2, receiver)
+    receiver.values shouldBe empty
+    batchFn.finishBundle(finishContext)
+    val batches = builder.result()
+    batches should have size 2
+    batches(window1) should contain theSameElementsAs Seq(1, 2, 3)
+    batches(window2) should contain theSameElementsAs Seq(5)
+  }
+
+  it should "flush the biggest buffer when too many concurrent windows are opened" in {
+    val batchFn = new BatchDoFn[Int](10, _.toLong)
+    batchFn.setup()
+    val windows = (10L to 100L by 10L)
+      .map(i => new IntervalWindow(Instant.ofEpochSecond(i - 10L), Instant.ofEpochSecond(10)))
+    val extraWindow = new IntervalWindow(Instant.ofEpochSecond(100), Instant.ofEpochSecond(110))
+    val receiver = new TestReceiver[Int]
+
+    windows.foreach(w => batchFn.processElement(1, w, receiver))
+    batchFn.processElement(2, windows.head, receiver)
+    batchFn.processElement(3, windows.head, receiver)
+
+    receiver.values shouldBe empty
+    batchFn.processElement(5, extraWindow, receiver)
+    receiver.values should have size 1
+    val (values, timestamp) = receiver.valuesWithTimestamp.head
+    values should contain theSameElementsAs Seq(1, 2, 3)
+    timestamp shouldBe windows.head.maxTimestamp()
+  }
+
+}

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -40,8 +40,6 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.schemas.Schema
-import org.apache.beam.runners.direct.{DirectOptions, DirectRunner}
-import org.apache.beam.sdk.options.PipelineOptionsFactory
 
 import java.nio.charset.StandardCharsets
 

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -243,6 +243,37 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
+// bundles only contain 1 element
+//  it should "support batch() with size" in {
+//    runWithContext { sc =>
+//      val p = sc
+//        .parallelize(1 to 5)
+//        .batch(2)
+//        .map(_.size)
+//      p should containInAnyOrder(Seq(2, 2, 1))
+//    }
+//  }
+//
+//  it should "support batch() with byte size" in {
+//    runWithContext { sc =>
+//      val p = sc
+//        .parallelize(1L to 5L) // Long coder uses 8 bytes
+//        .batchByteSized(16)
+//        .map(_.size)
+//      p should containInAnyOrder(Seq(2, 2, 1))
+//    }
+//  }
+//
+//  it should "support batch() with custom weight" in {
+//    runWithContext { sc =>
+//      val p = sc
+//        .parallelize(1L to 5L)
+//        .batchWeighted(2, identity)
+//        .map(_.size)
+//      p should containInAnyOrder(Seq(2, 1, 1, 1))
+//    }
+//  }
+
   it should "support collect" in {
     runWithContext { sc =>
       val records = Seq(

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -40,6 +40,8 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.schemas.Schema
+import org.apache.beam.runners.direct.{DirectOptions, DirectRunner}
+import org.apache.beam.sdk.options.PipelineOptionsFactory
 
 import java.nio.charset.StandardCharsets
 
@@ -243,36 +245,39 @@ class SCollectionTest extends PipelineSpec {
     }
   }
 
-// bundles only contain 1 element
-//  it should "support batch() with size" in {
-//    runWithContext { sc =>
-//      val p = sc
-//        .parallelize(1 to 5)
-//        .batch(2)
-//        .map(_.size)
-//      p should containInAnyOrder(Seq(2, 2, 1))
-//    }
-//  }
-//
-//  it should "support batch() with byte size" in {
-//    runWithContext { sc =>
-//      val p = sc
-//        .parallelize(1L to 5L) // Long coder uses 8 bytes
-//        .batchByteSized(16)
-//        .map(_.size)
-//      p should containInAnyOrder(Seq(2, 2, 1))
-//    }
-//  }
-//
-//  it should "support batch() with custom weight" in {
-//    runWithContext { sc =>
-//      val p = sc
-//        .parallelize(1L to 5L)
-//        .batchWeighted(2, identity)
-//        .map(_.size)
-//      p should containInAnyOrder(Seq(2, 1, 1, 1))
-//    }
-//  }
+  it should "support batch() with size" in {
+    runWithContext { sc =>
+      val p = sc
+        .parallelize(Seq(Seq(1, 2, 3, 4, 5))) // SCollection with 1 element to get a single bundle
+        .flatten // flatten the elements in the bundle
+        .batch(2)
+        .map(_.size)
+      p should containInAnyOrder(Seq(2, 2, 1))
+    }
+  }
+
+  it should "support batchByteSized() with byte size" in {
+    val bytes = Array.fill[Byte](4)(0)
+    runWithContext { sc =>
+      val p = sc
+        .parallelize(Seq(Seq.fill(5)(bytes))) // SCollection with 1 element to get a single bundle
+        .flatten // flatten the elements in the bundle
+        .batchByteSized(8)
+        .map(_.size)
+      p should containInAnyOrder(Seq(2, 2, 1))
+    }
+  }
+
+  it should "support batchWeighted() with custom weight" in {
+    runWithContext { sc =>
+      val p = sc
+        .parallelize(Seq(Seq(1, 2, 3, 4, 5))) // SCollection with 1 element to get a single bundle
+        .flatten // flatten the elements in the bundle
+        .batchWeighted(2, identity[Int])
+        .map(_.size)
+      p should containInAnyOrder(Seq(2, 1, 1, 1))
+    }
+  }
 
   it should "support collect" in {
     runWithContext { sc =>


### PR DESCRIPTION
Amortize processing cost by local batching of elements
Batching respects windowing

This aims to give symetric API with the KV batching in #4458 
As the batch is emitted on `finishBundle`, no `maxBufferingDuration` is required