### PR TITLE
fix BigQueryType.fromQuery query string formatting examples

### DIFF
--- a/io/BigQuery.html
+++ b/io/BigQuery.html
@@ -292,7 +292,7 @@ class Row
 class Row
 
 // generate new query strings at runtime
-val newQuery = Row.query(args(0))
+val newQuery = Row.query.format(args(0))
 </code></pre>
 <p>There&rsquo;s also a <code>$LATEST</code> placeholder for table partitions. The latest common partition for all tables with the placeholder will be used.</p>
 <pre class="prettyprint"><code class="language-scala">import com.spotify.scio.bigquery.types.BigQueryType
@@ -304,7 +304,7 @@ val newQuery = Row.query(args(0))
 class Row
 
 // generate new query strings at runtime
-val newQuery = Row.query(args(0), args(0))
+val newQuery = Row.query.format(args(0), args(0))
 </code></pre>
 <h3><a href="#bigquerytype-fromschema" name="bigquerytype-fromschema" class="anchor"><span class="anchor-link"></span></a>BigQueryType.fromSchema</h3>
 <p>This annotation gets schema from a string parameter and is useful in tests.</p>


### PR DESCRIPTION
Since `Row.query` is a `string`, you have to call `Row.query.format(args(0))`, etc.