### PR TITLE
Propagate internal coder in tap()

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -945,8 +945,8 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    *
    * @group debug
    */
-  def tap[U](f: T => U): SCollection[T] =
-    map { elem => f(elem); elem }(Coder.beam(internal.getCoder))
+  def tap(f: T => Any): SCollection[T] =
+    pApply(ParDo.of(Functions.mapFn[T, T] { elem => f(elem); elem })).setCoder(internal.getCoder)
 
   // =======================================================================
   // Side input operations

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -786,6 +786,19 @@ class SCollectionTest extends PipelineSpec {
     )
   }
 
+  it should "support tap()" in {
+    runWithContext { sc =>
+      // tap should not modify internal coder
+      val original = sc.parallelize(Seq(1, 2, 3))
+      val tapped = original.tap(println)
+
+      val originalCoder = original.internal.getCoder
+      val tappedCoder = tapped.internal.getCoder
+
+      originalCoder shouldBe tappedCoder
+    }
+  }
+
   it should "support Combine.globally() with default value" in {
     runWithContext { sc =>
       val p = sc.parallelize(Seq.empty[Int])


### PR DESCRIPTION
Fix #4494 

`Coder.beam` is there to use a `org.apache.beam.sdk.coders.Coder` in Scio.
This was abused here to reuse an already materialized Scio coder.

Also, `tap` does not need to be parameterized. as `f` return type is not used, we can simply put `Any`
