### PR TITLE
fix BigQueryType.fromQuery query string formatting examples

### DIFF
--- a/site/src/main/paradox/io/BigQuery.md
+++ b/site/src/main/paradox/io/BigQuery.md
@@ -76,7 +76,7 @@ import com.spotify.scio.bigquery.types.BigQueryType
 class Row
 
 // generate new query strings at runtime
-val newQuery = Row.query(args(0))
+val newQuery = Row.query.format(args(0))
 ```
 
 There's also a `$LATEST` placeholder for table partitions. The latest common partition for all tables with the placeholder will be used.
@@ -91,7 +91,7 @@ import com.spotify.scio.bigquery.types.BigQueryType
 class Row
 
 // generate new query strings at runtime
-val newQuery = Row.query(args(0), args(0))
+val newQuery = Row.query.format(args(0), args(0))
 ```
 
 ### BigQueryType.fromSchema


### PR DESCRIPTION
Since `Row.query` is a string, you have to call `Row.query.format(args(0))`, etc.