### PR TITLE
Do not reference scio coder after materialization

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
@@ -28,7 +28,7 @@ private[scio] object BeamCoders {
   @tailrec
   private def unwrap[T](coder: beam.Coder[T]): beam.Coder[T] =
     coder match {
-      case c: DelegatingCoder[T]    => unwrap(c.bcoder)
+      case c: WrappedCoder[T]       => unwrap(c.bcoder)
       case c: beam.NullableCoder[T] => c.getValueCoder
       case _                        => coder
     }

--- a/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
@@ -28,8 +28,7 @@ private[scio] object BeamCoders {
   @tailrec
   private def unwrap[T](coder: beam.Coder[T]): beam.Coder[T] =
     coder match {
-      case c: WrappedBCoder[T]      => unwrap(c.u)
-      case c: LazyCoder[T]          => unwrap(c.bcoder)
+      case c: DelegatingCoder[T]    => unwrap(c.bcoder)
       case c: beam.NullableCoder[T] => c.getValueCoder
       case _                        => coder
     }

--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -429,7 +429,7 @@ sealed trait CoderGrammar {
   ): Coder[T] =
     Record[T](typeName, cs, construct, destruct)
 
-  def disjunction[T, Id: Coder](typeName: String, coder: Map[Id, Coder[T]])(id: T => Id): Coder[T] =
+  def disjunction[T, Id: Coder](typeName: String, id: T => Id, coder: Map[Id, Coder[T]]): Coder[T] =
     Disjunction(typeName, Coder[Id], id, coder)
 
   /**

--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -293,7 +293,7 @@ final private[scio] case class RecordCoder[T](
     }
 
   override def encode(value: T, os: OutputStream): Unit = {
-    destruct(value).zip(cs).foreach { case (v, (l, c)) =>
+    destruct(value).zip(cs.iterator).foreach { case (v, (l, c)) =>
       onErrorMsg(
         s"Exception while trying to `encode` an instance of $typeName: Can't encode field $l value $v"
       ) {
@@ -347,7 +347,7 @@ final private[scio] case class RecordCoder[T](
       value.asInstanceOf[AnyRef]
     } else {
       val b = Seq.newBuilder[Any]
-      destruct(value).zip(cs).foreach { case (v, (l, c)) =>
+      destruct(value).zip(cs.iterator).foreach { case (v, (l, c)) =>
         val sv = onErrorMsg(s"Exception while trying to `encode` field $l with value $v") {
           c.structuralValue(v)
         }
@@ -358,14 +358,14 @@ final private[scio] case class RecordCoder[T](
 
   // delegate methods for byte size estimation
   override def isRegisterByteSizeObserverCheap(value: T): Boolean = {
-    destruct(value).zip(cs).foreach { case (v, (_, c)) =>
+    destruct(value).zip(cs.iterator).foreach { case (v, (_, c)) =>
       if (!c.isRegisterByteSizeObserverCheap(v)) return false
     }
     true
   }
 
   override def registerByteSizeObserver(value: T, observer: ElementByteSizeObserver): Unit = {
-    destruct(value).zip(cs).foreach { case (v, (_, c)) =>
+    destruct(value).zip(cs.iterator).foreach { case (v, (_, c)) =>
       c.registerByteSizeObserver(v, observer)
     }
   }

--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -86,12 +86,12 @@ final case class Beam[T] private (beam: BCoder[T]) extends Coder[T]
 final case class Fallback[T] private (ct: ClassTag[T]) extends Coder[T] {
   override def toString: String = s"Fallback[$ct]"
 }
-final case class BeamTransform[T, U] private (
+final case class CoderTransform[T, U] private (
   typeName: String,
   c: Coder[U],
   f: BCoder[U] => Coder[T]
 ) extends Coder[T] {
-  override def toString: String = s"BeamTransform[$typeName]($c)"
+  override def toString: String = s"CoderTransform[$typeName]($c)"
 }
 final case class Transform[T, U] private (
   typeName: String,
@@ -540,7 +540,7 @@ sealed trait CoderGrammar {
     Singleton[T](typeName, constructor)
 
   def transform[U, T](c: Coder[U])(f: BCoder[U] => Coder[T])(implicit ct: ClassTag[T]): Coder[T] =
-    BeamTransform(ct.runtimeClass.getName, c, f)
+    CoderTransform(ct.runtimeClass.getName, c, f)
 
   private[scio] def ref[T](typeName: String)(value: => Coder[T]): Coder[T] =
     Ref(typeName, value)

--- a/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
@@ -79,8 +79,8 @@ object CoderMaterializer {
         beamImpl(o, from(underlying), refs)
       case Transform(typeName, c, t, f) =>
         new TransformCoder(typeName, beamImpl(o, c, refs), t, f)
-      case Singleton(typeName, constructor) =>
-        new SingletonCoder(typeName, constructor)
+      case Singleton(typeName, supply) =>
+        new SingletonCoder(typeName, supply)
       case Record(typeName, coders, construct, destruct) =>
         new RecordCoder(
           typeName,

--- a/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
@@ -77,8 +77,10 @@ object CoderMaterializer {
       case BeamTransform(_, coder, from) =>
         val underlying = beamImpl(o, coder, refs)
         beamImpl(o, from(underlying), refs)
-      case Transform(ct, c, t, f) =>
-        new TransformCoder(ct.runtimeClass.getName, beamImpl(o, c, refs), t, f)
+      case Transform(typeName, c, t, f) =>
+        new TransformCoder(typeName, beamImpl(o, c, refs), t, f)
+      case Singleton(typeName, constructor) =>
+        new SingletonCoder(typeName, constructor)
       case Record(typeName, coders, construct, destruct) =>
         new RecordCoder(
           typeName,

--- a/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
@@ -74,7 +74,7 @@ object CoderMaterializer {
         c
       case Fallback(_) =>
         new KryoAtomicCoder[T](o.kryo)
-      case BeamTransform(_, coder, from) =>
+      case CoderTransform(_, coder, from) =>
         val underlying = beamImpl(o, coder, refs)
         beamImpl(o, from(underlying), refs)
       case Transform(typeName, c, t, f) =>

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
@@ -38,9 +38,11 @@ import scala.jdk.CollectionConverters._
 
 import java.util.{List => JList}
 
-private object UnitCoder extends AtomicCoder[Unit] {
-  override def encode(value: Unit, os: OutputStream): Unit = ()
-  override def decode(is: InputStream): Unit = ()
+private[coders] class SingletonCoder[T](elem: => T) extends AtomicCoder[T] {
+  private lazy val value = elem
+  override def encode(value: T, os: OutputStream): Unit = ()
+  override def decode(is: InputStream): T = value
+  override def consistentWithEquals(): Boolean = true
 }
 
 private object NothingCoder extends AtomicCoder[Nothing] {
@@ -435,7 +437,7 @@ trait ScalaCoders {
 
   implicit def booleanCoder: Coder[Boolean] =
     Coder.beam(BooleanCoder.of().asInstanceOf[BCoder[Boolean]])
-  implicit def unitCoder: Coder[Unit] = Coder.beam(UnitCoder)
+  implicit def unitCoder: Coder[Unit] = Coder.singleton(())
   implicit def nothingCoder: Coder[Nothing] = Coder.beam[Nothing](NothingCoder)
 
   implicit def bigIntCoder: Coder[BigInt] =

--- a/scio-jmh/src/test/scala/com/spotify/scio/jmh/CoderBenchmark.scala
+++ b/scio-jmh/src/test/scala/com/spotify/scio/jmh/CoderBenchmark.scala
@@ -39,7 +39,7 @@ import org.openjdk.jmh.annotations._
 
 final case class UserId(bytes: Array[Byte])
 object UserId {
-  implicit def coderUserId: Coder[UserId] = Coder.gen[UserId]
+  implicit val CoderUserId: Coder[UserId] = Coder.gen[UserId]
 }
 final case class User(id: UserId, username: String, email: String)
 final case class SpecializedUser(id: UserId, username: String, email: String)

--- a/scio-macros/src/main/scala/com/spotify/scio/MagnoliaMacros.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/MagnoliaMacros.scala
@@ -40,32 +40,33 @@ private[scio] object MagnoliaMacros {
     // format: off
     // Remove annotations from magnolia since they are
     // not serializable and we don't use them anyway
-    val removeAnnotations = new Transformer {
-      override def transform(tree: Tree): c.universe.Tree = {
-        tree match {
-          case q"$caseClass($typeName, $isObject, $isValueClass, $parametersArray, $_, $_, $_)" if caseClass.symbol.name == TypeName("CaseClass") =>
-            super.transform(
-              q"$caseClass($typeName, $isObject, $isValueClass, $parametersArray, Array.empty[Any], Array.empty[Any], Array.empty[Any])"
-            )
-          case q"Param.apply[$tpTC, $tpT, $tpP]($name, $typeNameParam, $idx, $isRepeated, $typeclassParam, $defaultVal, $_, $_, $_)" =>
-            super.transform(
-              q"_root_.magnolia1.Param[$tpTC, $tpT, $tpP]($name, $typeNameParam, $idx, $isRepeated, $typeclassParam, $defaultVal, Array.empty[Any], Array.empty[Any], Array.empty[Any])"
-            )
-          case q"new SealedTrait($typeName, $subtypesArray, $_, $_, $_)" =>
-            super.transform(
-              q"new _root_.magnolia1.SealedTrait($typeName, $subtypesArray, Array.empty[Any], Array.empty[Any], Array.empty[Any])"
-            )
-          case q"Subtype[$tpTC, $tpT, $tpS]($name, $idx, $_, $_, $_, $tc, $isType, $asType)" =>
-            super.transform(
-              q"_root_.magnolia1.Subtype[$tpTC, $tpT, $tpS]($name, $idx, Array.empty[Any], Array.empty[Any], Array.empty[Any], $tc, $isType, $asType)"
-            )
-          case t =>
-            super.transform(t)
-        }
-      }
+    val removeAnnotations: PartialFunction[Tree, Tree] = {
+      case q"$caseClass($typeName, $isObject, $isValueClass, $parametersArray, $_, $_, $_)" if caseClass.symbol.name == TypeName("CaseClass") =>
+        q"$caseClass($typeName, $isObject, $isValueClass, $parametersArray, Array.empty[Any], Array.empty[Any], Array.empty[Any])"
+      case q"Param.apply[$tpTC, $tpT, $tpP]($name, $typeNameParam, $idx, $isRepeated, $typeclassParam, $defaultVal, $_, $_, $_)" =>
+        q"_root_.magnolia1.Param[$tpTC, $tpT, $tpP]($name, $typeNameParam, $idx, $isRepeated, $typeclassParam, $defaultVal, Array.empty[Any], Array.empty[Any], Array.empty[Any])"
+      case q"new SealedTrait($typeName, $subtypesArray, $_, $_, $_)" =>
+        q"new _root_.magnolia1.SealedTrait($typeName, $subtypesArray, Array.empty[Any], Array.empty[Any], Array.empty[Any])"
+      case q"Subtype[$tpTC, $tpT, $tpS]($name, $idx, $_, $_, $_, $tc, $isType, $asType)" =>
+        q"_root_.magnolia1.Subtype[$tpTC, $tpT, $tpS]($name, $idx, Array.empty[Any], Array.empty[Any], Array.empty[Any], $tc, $isType, $asType)"
+    }
+
+    // remove all outer references used in rawConstruct
+    // so method serialization do not take any closure
+    val inlineRawConstruct: PartialFunction[Tree, Tree] = {
+      case q"def rawConstruct(..$params): $tpT = {..$statements}" =>
+        val closureCleansed = if (statements.size > 1) statements.tail else statements
+        q"def rawConstruct(..$params): $tpT = {..$closureCleansed}"
     }
     // format: on
 
-    removeAnnotations.transform(magnoliaTree)
+    val scioTransformer = new Transformer {
+      override def transform(tree: Tree): Tree =
+        super.transform(
+          removeAnnotations.orElse(inlineRawConstruct).applyOrElse[Tree, Tree](tree, t => t)
+        )
+    }
+
+    scioTransformer.transform(magnoliaTree)
   }
 }

--- a/scio-redis/src/main/scala/com/spotify/scio/redis/instances/CoderInstances.scala
+++ b/scio-redis/src/main/scala/com/spotify/scio/redis/instances/CoderInstances.scala
@@ -31,7 +31,7 @@ trait CoderInstances {
   implicit def pfAddCoder[T: Coder: RedisType]: Coder[PFAdd[T]] = Coder.gen[PFAdd[T]]
   implicit def zAddCoder[T: Coder: RedisType]: Coder[ZAdd[T]] = Coder.gen[ZAdd[T]]
 
-  private[this] def coders: Map[Int, Coder[_]] = Map(
+  private val coders: Map[Int, Coder[_]] = Map(
     1 -> appendCoder[String],
     2 -> appendCoder[Array[Byte]],
     3 -> setCoder[String],
@@ -52,26 +52,33 @@ trait CoderInstances {
     18 -> zAddCoder[Array[Byte]]
   )
 
-  implicit def redisMutationCoder[T <: RedisMutation]: Coder[T] =
-    Coder.disjunction[T, Int]("RedisMutation", coders.asInstanceOf[Map[Int, Coder[T]]]) {
-      case RedisMutation(_: Append[String @unchecked], RedisType.StringRedisType)         => 1
-      case RedisMutation(_: Append[Array[Byte] @unchecked], RedisType.ByteArrayRedisType) => 2
-      case RedisMutation(_: Set[String @unchecked], RedisType.StringRedisType)            => 3
-      case RedisMutation(_: Set[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)    => 4
-      case RedisMutation(_: IncrBy[String @unchecked], RedisType.StringRedisType)         => 5
-      case RedisMutation(_: IncrBy[Array[Byte] @unchecked], RedisType.ByteArrayRedisType) => 6
-      case RedisMutation(_: DecrBy[String @unchecked], RedisType.StringRedisType)         => 7
-      case RedisMutation(_: DecrBy[Array[Byte] @unchecked], RedisType.ByteArrayRedisType) => 8
-      case RedisMutation(_: SAdd[String @unchecked], RedisType.StringRedisType)           => 9
-      case RedisMutation(_: SAdd[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)   => 10
-      case RedisMutation(_: LPush[String @unchecked], RedisType.StringRedisType)          => 11
-      case RedisMutation(_: LPush[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)  => 12
-      case RedisMutation(_: RPush[String @unchecked], RedisType.StringRedisType)          => 13
-      case RedisMutation(_: RPush[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)  => 14
-      case RedisMutation(_: PFAdd[String @unchecked], RedisType.StringRedisType)          => 15
-      case RedisMutation(_: PFAdd[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)  => 16
-      case RedisMutation(_: ZAdd[String @unchecked], RedisType.StringRedisType)           => 17
-      case RedisMutation(_: ZAdd[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)   => 18
-    }
+  private val coderId: PartialFunction[RedisMutation, Int] = {
+    case RedisMutation(_: Append[String @unchecked], RedisType.StringRedisType)         => 1
+    case RedisMutation(_: Append[Array[Byte] @unchecked], RedisType.ByteArrayRedisType) => 2
+    case RedisMutation(_: Set[String @unchecked], RedisType.StringRedisType)            => 3
+    case RedisMutation(_: Set[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)    => 4
+    case RedisMutation(_: IncrBy[String @unchecked], RedisType.StringRedisType)         => 5
+    case RedisMutation(_: IncrBy[Array[Byte] @unchecked], RedisType.ByteArrayRedisType) => 6
+    case RedisMutation(_: DecrBy[String @unchecked], RedisType.StringRedisType)         => 7
+    case RedisMutation(_: DecrBy[Array[Byte] @unchecked], RedisType.ByteArrayRedisType) => 8
+    case RedisMutation(_: SAdd[String @unchecked], RedisType.StringRedisType)           => 9
+    case RedisMutation(_: SAdd[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)   => 10
+    case RedisMutation(_: LPush[String @unchecked], RedisType.StringRedisType)          => 11
+    case RedisMutation(_: LPush[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)  => 12
+    case RedisMutation(_: RPush[String @unchecked], RedisType.StringRedisType)          => 13
+    case RedisMutation(_: RPush[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)  => 14
+    case RedisMutation(_: PFAdd[String @unchecked], RedisType.StringRedisType)          => 15
+    case RedisMutation(_: PFAdd[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)  => 16
+    case RedisMutation(_: ZAdd[String @unchecked], RedisType.StringRedisType)           => 17
+    case RedisMutation(_: ZAdd[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)   => 18
+  }
+
+  implicit def redisMutationCoder[T <: RedisMutation]: Coder[T] = {
+    Coder.disjunction[T, Int](
+      "RedisMutation",
+      coderId.asInstanceOf[PartialFunction[T, Int]],
+      coders.asInstanceOf[Map[Int, Coder[T]]]
+    )
+  }
 
 }

--- a/scio-redis/src/main/scala/com/spotify/scio/redis/instances/CoderInstances.scala
+++ b/scio-redis/src/main/scala/com/spotify/scio/redis/instances/CoderInstances.scala
@@ -73,12 +73,7 @@ trait CoderInstances {
     case RedisMutation(_: ZAdd[Array[Byte] @unchecked], RedisType.ByteArrayRedisType)   => 18
   }
 
-  implicit def redisMutationCoder[T <: RedisMutation]: Coder[T] = {
-    Coder.disjunction[T, Int](
-      "RedisMutation",
-      coderId.asInstanceOf[PartialFunction[T, Int]],
-      coders.asInstanceOf[Map[Int, Coder[T]]]
-    )
-  }
+  implicit def redisMutationCoder[T <: RedisMutation]: Coder[T] =
+    Coder.disjunction[T, Int]("RedisMutation", coders.asInstanceOf[Map[Int, Coder[T]]])(coderId)
 
 }

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -262,6 +262,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     coderIsSerializable[NestedA]
     // DisjunctionCoder equality fails due to function field
     // coderIsSerializable[SampleFieldType]
+
   }
 
   it should "support Avro's SpecificRecordBase" in {

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -603,6 +603,17 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     tableSchema coderShould roundtrip()
   }
 
+  it should "optimize for AnyVal" in {
+    coderIsSerializable[AnyValExample]
+    Coder[AnyValExample] shouldBe a[Transform[_, _]]
+  }
+
+  it should "optimize for objects" in {
+    SerializableUtils.ensureSerializable(CoderMaterializer.beamWithDefault(Coder[TestObject.type]))
+    coderIsSerializable[TestObject.type]
+    Coder[TestObject.type] shouldBe a[Beam[_]]
+  }
+
   it should "support Algebird's Moments" in {
     coderIsSerializable[Moments]
     new Moments(0.0, 0.0, 0.0, 0.0, 0.0) coderShould roundtrip()

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -260,9 +260,8 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     coderIsSerializable(Coder.gen[DummyCC])
     coderIsSerializable[com.spotify.scio.avro.User]
     coderIsSerializable[NestedA]
-    // DisjunctionCoder equality fails due to function field
-    // coderIsSerializable[SampleFieldType]
-
+    coderIsSerializable[Top]
+    coderIsSerializable[SampleField]
   }
 
   it should "support Avro's SpecificRecordBase" in {
@@ -440,8 +439,8 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     val leftCoder = materialize(Coder[scala.util.Left[Double, Int]]).toString
     val rightCoder = materialize(Coder[scala.util.Right[Double, Int]]).toString
 
-    val expectedMsg = s"DisjunctionCoder[scala.util.Either](" +
-      s"id -> BooleanCoder, false -> $leftCoder, true -> $rightCoder) is not deterministic"
+    val expectedMsg =
+      s"DisjunctionCoder[scala.util.Either](false -> $leftCoder, true -> $rightCoder) is not deterministic"
 
     caught.getMessage should startWith(expectedMsg)
     caught.getMessage should include(s"case false is using non-deterministic $leftCoder")
@@ -612,9 +611,8 @@ final class CoderTest extends AnyFlatSpec with Matchers {
   }
 
   it should "optimize for objects" in {
-    SerializableUtils.ensureSerializable(CoderMaterializer.beamWithDefault(Coder[TestObject.type]))
     coderIsSerializable[TestObject.type]
-    Coder[TestObject.type] shouldBe a[Beam[_]]
+    Coder[TestObject.type] shouldBe a[Transform[_, _]]
   }
 
   it should "support Algebird's Moments" in {

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -251,6 +251,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
   }
 
   it should "Derive serializable coders" in {
+    coderIsSerializable[Nothing]
     coderIsSerializable[Int]
     coderIsSerializable[String]
     coderIsSerializable[List[Int]]
@@ -259,7 +260,8 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     coderIsSerializable(Coder.gen[DummyCC])
     coderIsSerializable[com.spotify.scio.avro.User]
     coderIsSerializable[NestedA]
-    coderIsSerializable[Nothing]
+    // DisjunctionCoder equality fails due to function field
+    // coderIsSerializable[SampleFieldType]
   }
 
   it should "support Avro's SpecificRecordBase" in {

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -603,11 +603,6 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     tableSchema coderShould roundtrip()
   }
 
-  it should "optimize for AnyVal" in {
-    coderIsSerializable[AnyValExample]
-    Coder[AnyValExample] shouldBe a[Transform[_, _]]
-  }
-
   it should "support Algebird's Moments" in {
     coderIsSerializable[Moments]
     new Moments(0.0, 0.0, 0.0, 0.0, 0.0) coderShould roundtrip()

--- a/scio-test/src/test/scala/com/spotify/scio/testing/CoderAssertionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/CoderAssertionsTest.scala
@@ -72,9 +72,15 @@ class CoderAssertionsTest extends AnyFlatSpec with Matchers {
     coderIsSerializable[Foo]
     coderIsSerializable(Coder[Foo])
 
-    // Inner class's Coder is serializable
+    // Inner class's Coder is not serializable
     case class InnerCaseClass(id: String)
-    coderIsSerializable[InnerCaseClass]
-    coderIsSerializable(Coder[InnerCaseClass])
+
+    an[TestFailedException] should be thrownBy {
+      coderIsSerializable[InnerCaseClass]
+    }
+
+    an[TestFailedException] should be thrownBy {
+      coderIsSerializable(Coder[InnerCaseClass])
+    }
   }
 }

--- a/scio-test/src/test/scala/com/spotify/scio/testing/CoderAssertionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/CoderAssertionsTest.scala
@@ -72,15 +72,9 @@ class CoderAssertionsTest extends AnyFlatSpec with Matchers {
     coderIsSerializable[Foo]
     coderIsSerializable(Coder[Foo])
 
-    // Inner class's Coder is not serializable
+    // Inner class's Coder is serializable
     case class InnerCaseClass(id: String)
-
-    an[TestFailedException] should be thrownBy {
-      coderIsSerializable[InnerCaseClass]
-    }
-
-    an[TestFailedException] should be thrownBy {
-      coderIsSerializable(Coder[InnerCaseClass])
-    }
+    coderIsSerializable[InnerCaseClass]
+    coderIsSerializable(Coder[InnerCaseClass])
   }
 }


### PR DESCRIPTION
When materializing coders, we tried to cut ties with scio coders and macro generated magnolia typeclasses.
Unfortunately, the materialized beam coders contain lambda function with outer references to the scio coders.

At serialization time, everything gets written into the graph. we then have:
- large graph size (some users have already reached the dataflow graph size limit)
- streaming pipeline incompatibility. As serialized graph can change from builds (macro code identifiers), updating a streaming pipeline may fail with `The Coder or type for step ... has changed.` even if there wasn't any code change
- slow pipeline start: All the extra info has to be deseriallized by every worker on startup

Previous `xmap` coder transformation could also be problematic: 2 different transforms with the same type signature could be considered as equal. In dataflow v2, we saw that the runner can swap coders if they are equal