### PR TITLE
Changed processElement to newer annotated style in scio-avro, scio-core

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/FileDownloadDoFn.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/FileDownloadDoFn.java
@@ -22,7 +22,6 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
-import org.apache.beam.sdk.values.KV;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/scio-core/src/main/java/com/spotify/scio/transforms/PipeDoFn.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/PipeDoFn.java
@@ -212,14 +212,17 @@ public class PipeDoFn extends DoFn<String, String> {
   }
 
   @ProcessElement
-  public void processElement(ProcessContext c) {
+  public void processElement(
+      @Element String element,
+      OutputReceiver<String> outputReceiver
+  ) {
     if (isNewBundle) {
       try {
         pipeProcess = Runtime.getRuntime().exec(cmdArray, envp, dir);
         stdIn = new BufferedWriter(new OutputStreamWriter(pipeProcess.getOutputStream()));
         BufferedReader out =
             new BufferedReader(new InputStreamReader(pipeProcess.getInputStream()));
-        stdOut = CompletableFuture.runAsync(() -> out.lines().forEach(c::output), executorService);
+        stdOut = CompletableFuture.runAsync(() -> out.lines().forEach(outputReceiver::output), executorService);
         LOG.info("Process started: {}", ProcessUtil.join(cmdArray));
       } catch (IOException e) {
         throw new UncheckedIOException(e);
@@ -228,7 +231,7 @@ public class PipeDoFn extends DoFn<String, String> {
     }
 
     try {
-      stdIn.write(c.element());
+      stdIn.write(element);
       stdIn.newLine();
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/scio-core/src/main/java/com/spotify/scio/transforms/RateLimiterDoFn.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/RateLimiterDoFn.java
@@ -35,9 +35,12 @@ public class RateLimiterDoFn<InputT> extends DoFnWithResource<InputT, InputT, Ra
   }
 
   @ProcessElement
-  public void processElement(ProcessContext c) {
+  public void processElement(
+      @Element InputT element,
+      OutputReceiver<InputT> outputReceiver
+  ) {
     getResource().acquire();
-    c.output(c.element());
+    outputReceiver.output(element);
   }
 
   @Override

--- a/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
@@ -18,7 +18,6 @@
 package com.spotify.scio.io
 
 import java.util.UUID
-
 import com.spotify.scio.coders.{AvroBytesUtil, Coder, CoderMaterializer}
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
@@ -27,7 +26,7 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.beam.sdk.coders.{Coder => BCoder}
 import org.apache.beam.sdk.io.AvroIO
 import org.apache.beam.sdk.transforms.DoFn
-import org.apache.beam.sdk.transforms.DoFn.ProcessElement
+import org.apache.beam.sdk.transforms.DoFn.{Element, OutputReceiver, ProcessElement}
 
 /**
  * Placeholder to an external data set that can either be load into memory as an iterator or opened
@@ -105,8 +104,11 @@ private[scio] class MaterializeTap[T: Coder] private (val path: String, coder: B
   private def dofn =
     new DoFn[GenericRecord, T] {
       @ProcessElement
-      private[scio] def processElement(c: DoFn[GenericRecord, T]#ProcessContext): Unit =
-        c.output(AvroBytesUtil.decode(coder, c.element()))
+      private[scio] def processElement(
+        @Element element: GenericRecord,
+        outputReceiver: OutputReceiver[T]
+      ): Unit =
+        outputReceiver.output(AvroBytesUtil.decode(coder, element))
     }
 
   override def open(sc: ScioContext): SCollection[T] = sc.requireNotClosed {

--- a/scio-core/src/main/scala/com/spotify/scio/transforms/WithResourceDoFns.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/transforms/WithResourceDoFns.scala
@@ -17,10 +17,8 @@
 package com.spotify.scio.transforms
 
 import com.spotify.scio.transforms.DoFnWithResource.ResourceType
-
 import com.twitter.chill.ClosureCleaner
-import org.apache.beam.sdk.transforms.DoFn.ProcessElement
-import org.apache.beam.sdk.transforms.DoFn
+import org.apache.beam.sdk.transforms.DoFn.{Element, OutputReceiver, ProcessElement}
 
 import scala.collection.compat._ // scalafix:ok
 
@@ -36,9 +34,9 @@ class CollectFnWithResource[T, U, R] private[transforms] (
   val isDefined: ((R, T)) => Boolean = ClosureCleaner.clean(pfn.isDefinedAt) // defeat closure
   val g: PartialFunction[(R, T), U] = ClosureCleaner.clean(pfn)
   @ProcessElement
-  def processElement(c: DoFn[T, U]#ProcessContext): Unit =
-    if (isDefined((getResource, c.element()))) {
-      c.output(g((getResource, c.element())))
+  def processElement(@Element element: T, outputReceiver: OutputReceiver[U]): Unit =
+    if (isDefined((getResource, element))) {
+      outputReceiver.output(g((getResource, element)))
     }
 }
 
@@ -54,8 +52,11 @@ class MapFnWithResource[T, U, R] private[transforms] (
   val g: (R, T) => U = ClosureCleaner.clean(f)
 
   @ProcessElement
-  def processElement(c: DoFn[T, U]#ProcessContext): Unit =
-    c.output(g(getResource, c.element()))
+  def processElement(
+    @Element element: T,
+    outputReceiver: OutputReceiver[U]
+  ): Unit =
+    outputReceiver.output(g(getResource, element))
 }
 
 class FlatMapFnWithResource[T, U, R] private[transforms] (
@@ -69,9 +70,12 @@ class FlatMapFnWithResource[T, U, R] private[transforms] (
 
   val g: (R, T) => TraversableOnce[U] = ClosureCleaner.clean(f)
   @ProcessElement
-  def processElement(c: DoFn[T, U]#ProcessContext): Unit = {
-    val i = g(getResource, c.element()).iterator
-    while (i.hasNext) c.output(i.next())
+  def processElement(
+    @Element element: T,
+    outputReceiver: OutputReceiver[U]
+  ): Unit = {
+    val i = g(getResource, element).iterator
+    while (i.hasNext) outputReceiver.output(i.next())
   }
 }
 
@@ -86,8 +90,8 @@ class FilterFnWithResource[T, R] private[transforms] (
 
   val g: (R, T) => Boolean = ClosureCleaner.clean(f)
   @ProcessElement
-  def processElement(c: DoFn[T, T]#ProcessContext): Unit =
-    if (g(getResource, c.element())) {
-      c.output(c.element())
+  def processElement(@Element element: T, outputReceiver: OutputReceiver[T]): Unit =
+    if (g(getResource, element)) {
+      outputReceiver.output(element)
     }
 }

--- a/scio-core/src/main/scala/com/spotify/scio/util/ArtisanJoin.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/ArtisanJoin.scala
@@ -19,12 +19,11 @@ package com.spotify.scio.util
 
 import java.lang.{Iterable => JIterable}
 import java.util.{Iterator => JIterator}
-
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.options.ScioOptions
 import com.spotify.scio.options.ScioOptions.CheckEnabled
 import com.spotify.scio.values.SCollection
-import org.apache.beam.sdk.transforms.DoFn.ProcessElement
+import org.apache.beam.sdk.transforms.DoFn.{Element, OutputReceiver, ProcessElement}
 import org.apache.beam.sdk.transforms.join.{CoGbkResult, CoGroupByKey, KeyedPCollectionTuple}
 import org.apache.beam.sdk.transforms.{DoFn, ParDo}
 import org.apache.beam.sdk.values.{KV, TupleTag}
@@ -44,7 +43,7 @@ private[scio] object ArtisanJoin {
       KEY,
       JIterable[A],
       JIterable[B],
-      DoFn[KV[KEY, CoGbkResult], (KEY, (A1, B1))]#ProcessContext
+      OutputReceiver[(KEY, (A1, B1))]
     ) => Unit
   ): SCollection[(KEY, (A1, B1))] = {
     if (a.state.postGbkOp || b.state.postGbkOp) {
@@ -80,13 +79,15 @@ private[scio] object ArtisanJoin {
       .withName(name)
       .applyTransform(ParDo.of(new DF {
         @ProcessElement
-        private[util] def processElement(c: DF#ProcessContext): Unit = {
-          val kv = c.element()
-          val key = kv.getKey
-          val result = kv.getValue
+        private[util] def processElement(
+          @Element element: KV[KEY, CoGbkResult],
+          outputReceiver: OutputReceiver[(KEY, (A1, B1))]
+        ): Unit = {
+          val key = element.getKey
+          val result = element.getValue
           val as = result.getAll(tagA)
           val bs = result.getAll(tagB)
-          fn(key, as, bs, c)
+          fn(key, as, bs, outputReceiver)
         }
       }))
       .withState(_.copy(postGbkOp = true))
@@ -100,14 +101,14 @@ private[scio] object ArtisanJoin {
     leftFn: JIterator[A] => JIterator[A1],
     rightFn: JIterator[B] => JIterator[B1]
   ): SCollection[(KEY, (A1, B1))] =
-    cogroupImpl[KEY, A, B, A1, B1](name, a, b) { case (key, as, bs, c) =>
+    cogroupImpl[KEY, A, B, A1, B1](name, a, b) { case (key, as, bs, out) =>
       val bi = rightFn(bs.iterator())
       while (bi.hasNext) {
         val b = bi.next()
         val ai = leftFn(as.iterator())
         while (ai.hasNext) {
           val a = ai.next()
-          c.output((key, (a, b)))
+          out.output((key, (a, b)))
         }
       }
     }.withState(_.copy(postGbkOp = true))
@@ -117,8 +118,8 @@ private[scio] object ArtisanJoin {
     a: SCollection[(KEY, A)],
     b: SCollection[(KEY, B)]
   ): SCollection[(KEY, (Iterable[A], Iterable[B]))] =
-    cogroupImpl[KEY, A, B, Iterable[A], Iterable[B]](name, a, b) { case (key, a, b, c) =>
-      c.output((key, (a.asScala, b.asScala)))
+    cogroupImpl[KEY, A, B, Iterable[A], Iterable[B]](name, a, b) { case (key, a, b, out) =>
+      out.output((key, (a.asScala, b.asScala)))
     }(Coder.iterableCoder(a.valueCoder), Coder.iterableCoder(b.valueCoder))
 
   def apply[KEY, A, B](

--- a/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
@@ -19,7 +19,6 @@ package com.spotify.scio.util
 
 import java.lang.{Iterable => JIterable}
 import java.util.{ArrayList => JArrayList, List => JList}
-
 import com.spotify.scio.ScioContext
 import com.spotify.scio.options.ScioOptions
 import com.spotify.scio.coders.{Coder, CoderMaterializer}
@@ -28,7 +27,7 @@ import com.twitter.algebird.{Monoid, Semigroup}
 import org.apache.beam.sdk.coders.{Coder => BCoder, CoderRegistry}
 import org.apache.beam.sdk.options.PipelineOptionsFactory
 import org.apache.beam.sdk.transforms.Combine.{CombineFn => BCombineFn}
-import org.apache.beam.sdk.transforms.DoFn.ProcessElement
+import org.apache.beam.sdk.transforms.DoFn.{Element, OutputReceiver, ProcessElement}
 import org.apache.beam.sdk.transforms.Partition.PartitionFn
 import org.apache.beam.sdk.transforms.{DoFn, ProcessFunction, SerializableFunction, SimpleFunction}
 
@@ -232,9 +231,12 @@ private[scio] object Functions {
     new NamedDoFn[T, U] {
       private[this] val g = ClosureCleaner.clean(f) // defeat closure
       @ProcessElement
-      private[scio] def processElement(c: DoFn[T, U]#ProcessContext): Unit = {
-        val i = g(c.element()).iterator
-        while (i.hasNext) c.output(i.next())
+      private[scio] def processElement(
+        @Element element: T,
+        outputReceiver: OutputReceiver[U]
+      ): Unit = {
+        val i = g(element).iterator
+        while (i.hasNext) outputReceiver.output(i.next())
       }
     }
 
@@ -260,8 +262,8 @@ private[scio] object Functions {
   def mapFn[T, U](f: T => U): DoFn[T, U] = new NamedDoFn[T, U] {
     private[this] val g = ClosureCleaner.clean(f) // defeat closure
     @ProcessElement
-    private[scio] def processElement(c: DoFn[T, U]#ProcessContext): Unit =
-      c.output(g(c.element()))
+    private[scio] def processElement(@Element element: T, outputReceiver: OutputReceiver[U]): Unit =
+      outputReceiver.output(g(element))
   }
 
   def partitionFn[T](f: T => Int): PartitionFn[T] =

--- a/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithSideInput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithSideInput.scala
@@ -35,6 +35,10 @@ private[scio] object FunctionsWithSideInput {
   def filterFn[T](f: (T, SideInputContext[T]) => Boolean): DoFn[T, T] =
     new SideInputDoFn[T, T] {
       val g = ClosureCleaner.clean(f) // defeat closure
+
+      /*
+       * ProcessContext is required as an argument because it is passed to SideInputContext
+       * */
       @ProcessElement
       private[scio] def processElement(c: DoFn[T, T]#ProcessContext, w: BoundedWindow): Unit =
         if (g(c.element(), sideInputContext(c, w))) {
@@ -45,6 +49,10 @@ private[scio] object FunctionsWithSideInput {
   def flatMapFn[T, U](f: (T, SideInputContext[T]) => TraversableOnce[U]): DoFn[T, U] =
     new SideInputDoFn[T, U] {
       val g = ClosureCleaner.clean(f) // defeat closure
+
+      /*
+       * ProcessContext is required as an argument because it is passed to SideInputContext
+       * */
       @ProcessElement
       private[scio] def processElement(c: DoFn[T, U]#ProcessContext, w: BoundedWindow): Unit = {
         val i = g(c.element(), sideInputContext(c, w)).iterator
@@ -55,6 +63,10 @@ private[scio] object FunctionsWithSideInput {
   def mapFn[T, U](f: (T, SideInputContext[T]) => U): DoFn[T, U] =
     new SideInputDoFn[T, U] {
       val g = ClosureCleaner.clean(f) // defeat closure
+
+      /*
+       * ProcessContext is required as an argument because it is passed to SideInputContext
+       * */
       @ProcessElement
       private[scio] def processElement(c: DoFn[T, U]#ProcessContext, w: BoundedWindow): Unit =
         c.output(g(c.element(), sideInputContext(c, w)))

--- a/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithSideOutput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithSideOutput.scala
@@ -39,6 +39,10 @@ private[scio] object FunctionsWithSideOutput {
   def mapFn[T, U](f: (T, SideOutputContext[T]) => U): DoFn[T, U] =
     new SideOutputFn[T, U] {
       val g = ClosureCleaner.clean(f) // defeat closure
+
+      /*
+       * ProcessContext is required as an argument because it is passed to SideOutputContext
+       * */
       @ProcessElement
       private[scio] def processElement(c: DoFn[T, U]#ProcessContext): Unit =
         c.output(g(c.element(), sideOutputContext(c)))
@@ -47,6 +51,10 @@ private[scio] object FunctionsWithSideOutput {
   def flatMapFn[T, U](f: (T, SideOutputContext[T]) => TraversableOnce[U]): DoFn[T, U] =
     new SideOutputFn[T, U] {
       val g = ClosureCleaner.clean(f) // defeat closure
+
+      /*
+       * ProcessContext is required as an argument because it is passed to SideOutputContext
+       * */
       @ProcessElement
       private[scio] def processElement(c: DoFn[T, U]#ProcessContext): Unit = {
         val i = g(c.element(), sideOutputContext(c)).iterator

--- a/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithWindowedValue.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithWindowedValue.scala
@@ -19,9 +19,10 @@ package com.spotify.scio.util
 
 import com.spotify.scio.values.WindowedValue
 import org.apache.beam.sdk.transforms.DoFn
-import org.apache.beam.sdk.transforms.DoFn.ProcessElement
-import org.apache.beam.sdk.transforms.windowing.BoundedWindow
+import org.apache.beam.sdk.transforms.DoFn.{Element, OutputReceiver, ProcessElement, Timestamp}
+import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, PaneInfo}
 import com.twitter.chill.ClosureCleaner
+import org.joda.time.Instant
 
 import scala.collection.compat._ // scalafix:ok
 
@@ -31,11 +32,14 @@ private[scio] object FunctionsWithWindowedValue {
       val g = ClosureCleaner.clean(f) // defeat closure
       @ProcessElement
       private[scio] def processElement(
-        c: DoFn[T, T]#ProcessContext,
+        @Element element: T,
+        @Timestamp timestamp: Instant,
+        outputReceiver: OutputReceiver[T],
+        pane: PaneInfo,
         window: BoundedWindow
       ): Unit = {
-        val wv = WindowedValue(c.element(), c.timestamp(), window, c.pane())
-        if (g(wv)) c.output(c.element())
+        val wv = WindowedValue(element, timestamp, window, pane)
+        if (g(wv)) outputReceiver.output(element)
       }
     }
 
@@ -44,14 +48,17 @@ private[scio] object FunctionsWithWindowedValue {
       val g = ClosureCleaner.clean(f) // defeat closure
       @ProcessElement
       private[scio] def processElement(
-        c: DoFn[T, U]#ProcessContext,
+        @Element element: T,
+        @Timestamp timestamp: Instant,
+        outputReceiver: OutputReceiver[U],
+        pane: PaneInfo,
         window: BoundedWindow
       ): Unit = {
-        val wv = WindowedValue(c.element(), c.timestamp(), window, c.pane())
+        val wv = WindowedValue(element, timestamp, window, pane)
         val i = g(wv).iterator
         while (i.hasNext) {
           val v = i.next()
-          c.outputWithTimestamp(v.value, v.timestamp)
+          outputReceiver.outputWithTimestamp(v.value, v.timestamp)
         }
       }
     }
@@ -61,11 +68,14 @@ private[scio] object FunctionsWithWindowedValue {
       val g = ClosureCleaner.clean(f) // defeat closure
       @ProcessElement
       private[scio] def processElement(
-        c: DoFn[T, U]#ProcessContext,
+        @Element element: T,
+        @Timestamp timestamp: Instant,
+        outputReceiver: OutputReceiver[U],
+        pane: PaneInfo,
         window: BoundedWindow
       ): Unit = {
-        val wv = g(WindowedValue(c.element(), c.timestamp(), window, c.pane()))
-        c.outputWithTimestamp(wv.value, wv.timestamp)
+        val wv = g(WindowedValue(element, timestamp, window, pane))
+        outputReceiver.outputWithTimestamp(wv.value, wv.timestamp)
       }
     }
 }

--- a/scio-core/src/main/scala/com/spotify/scio/util/ParallelLimitedFn.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/ParallelLimitedFn.scala
@@ -38,6 +38,9 @@ abstract private[scio] class ParallelLimitedFn[T, U](maxDoFns: Int)
 
   def parallelProcessElement(x: DoFn[T, U]#ProcessContext): Unit
 
+  /*
+   * ProcessContext is required as an argument because it is passed to public via parallelProcessElement
+   * */
   @ProcessElement def processElement(x: DoFn[T, U]#ProcessContext): Unit = {
     val semaphore = getResource
     try {

--- a/scio-core/src/main/scala/com/spotify/scio/util/random/RandomSampler.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/random/RandomSampler.scala
@@ -20,9 +20,8 @@
 package com.spotify.scio.util.random
 
 import java.util.{Random => JRandom}
-
 import org.apache.beam.sdk.transforms.DoFn
-import org.apache.beam.sdk.transforms.DoFn.{ProcessElement, StartBundle}
+import org.apache.beam.sdk.transforms.DoFn.{Element, OutputReceiver, ProcessElement, StartBundle}
 import org.apache.commons.math3.distribution.{IntegerDistribution, PoissonDistribution}
 
 import scala.annotation.nowarn
@@ -50,12 +49,11 @@ abstract private[scio] class RandomSampler[T, R] extends DoFn[T, T] {
   def startBundle(c: DoFn[T, T]#StartBundleContext): Unit = rng = init
 
   @ProcessElement
-  def processElement(c: DoFn[T, T]#ProcessContext): Unit = {
-    val element = c.element()
+  def processElement(@Element element: T, outputReceiver: OutputReceiver[T]): Unit = {
     val count = samples
     var i = 0
     while (i < count) {
-      c.output(element)
+      outputReceiver.output(element)
       i += 1
     }
   }
@@ -144,12 +142,12 @@ abstract private[scio] class RandomValueSampler[K, V, R](val fractions: Map[K, D
     }.toMap
 
   @ProcessElement
-  def processElement(c: DoFn[(K, V), (K, V)]#ProcessContext): Unit = {
-    val (key, value) = c.element()
+  def processElement(@Element element: (K, V), outputReceiver: OutputReceiver[(K, V)]): Unit = {
+    val (key, value) = element
     val count = samples(fractions(key), rngs(key))
     var i = 0
     while (i < count) {
-      c.output((key, value))
+      outputReceiver.output((key, value))
       i += 1
     }
   }

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithSideInput.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithSideInput.scala
@@ -106,6 +106,9 @@ class SCollectionWithSideInput[T] private[values] (
       new SideInputDoFn[T, T] {
         val g = ClosureCleaner.clean(f) // defeat closure
 
+        /*
+         * ProcessContext is required as an argument because it is passed to SideInputContext
+         * */
         @ProcessElement
         private[scio] def processElement(c: DoFn[T, T]#ProcessContext, w: BoundedWindow): Unit = {
           val elem = c.element()

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -216,8 +216,9 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
     }
 
     @ProcessElement
-    public void processElement(ProcessContext c) throws IOException {
-      final Iterator<MergedBucket> mergedBuckets = c.element().iterator();
+    public void processElement(@Element Iterable<MergedBucket> element,
+                               MultiOutputReceiver outputReceiver) throws IOException {
+      final Iterator<MergedBucket> mergedBuckets = element.iterator();
       final Map<BucketShardId, ResourceId> writtenBuckets = new HashMap<>();
 
       BucketMetadata<?, ?, ?> bucketMetadata = null;
@@ -240,8 +241,8 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
           writtenBuckets,
           dstFileAssignment,
           fileOperations,
-          bucketDst -> c.output(BUCKETS_TAG, bucketDst),
-          metadataDst -> c.output(METADATA_TAG, metadataDst),
+          bucketDst -> outputReceiver.get(BUCKETS_TAG).output(bucketDst),
+          metadataDst -> outputReceiver.get(METADATA_TAG).output(metadataDst),
           false); // Don't include null-key bucket in output
     }
   }
@@ -438,6 +439,9 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
               .collect(Collectors.toList()));
     }
 
+    /*
+    * ProcessContext is required as an argument because it is passed to TransformWithSides
+    * .outputTransform where it is passed to externally provided function */
     @ProcessElement
     public void processElement(
         @Element BucketItem e,

--- a/scio-test/src/test/scala/com/spotify/scio/transforms/AsyncDoFnSpec.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/transforms/AsyncDoFnSpec.scala
@@ -18,20 +18,19 @@
 package com.spotify.scio.transforms
 
 import java.util.concurrent.CompletableFuture
-
 import com.google.common.util.concurrent.{ListenableFuture, SettableFuture}
 import com.spotify.scio.transforms.DoFnWithResource.ResourceType
 import org.apache.beam.sdk.options.PipelineOptions
-import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, PaneInfo}
-import org.apache.beam.sdk.values.{PCollectionView, TupleTag}
-import org.joda.time.Instant
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow
+import org.apache.beam.sdk.values.TupleTag
+import org.joda.time.{DateTime, Instant}
 import org.scalacheck.Prop.propBoolean
 import org.scalacheck._
 import org.scalacheck.commands.Commands
 
 import scala.collection.mutable.{Buffer => MBuffer}
 import scala.concurrent.{Future, Promise}
-
 import scala.util.Try
 
 object AsyncDoFnSpec extends Properties("AsyncDoFn") {
@@ -186,21 +185,6 @@ abstract class AsyncDoFnTester[P[_], F[_]] extends BaseDoFnTester {
     f
   }
 
-  private val processContext = new fn.ProcessContext {
-    override def getPipelineOptions: PipelineOptions = ???
-    override def sideInput[T](view: PCollectionView[T]): T = ???
-    override def pane(): PaneInfo = ???
-    override def output[T](tag: TupleTag[T], output: T): Unit = ???
-    override def outputWithTimestamp(output: String, timestamp: Instant): Unit =
-      ???
-    override def outputWithTimestamp[T](tag: TupleTag[T], output: T, timestamp: Instant): Unit = ???
-
-    // test input
-    override def timestamp(): Instant = new Instant(nextElement.toLong)
-    override def element(): Int = nextElement
-    override def output(output: String): Unit = outputBuffer.append(output)
-  }
-
   private val finishBundleContext = new fn.FinishBundleContext {
     override def getPipelineOptions: PipelineOptions = ???
     override def output[T](
@@ -215,7 +199,14 @@ abstract class AsyncDoFnTester[P[_], F[_]] extends BaseDoFnTester {
 
   // make a new request
   override def request(): Unit = {
-    fn.processElement(processContext, null)
+    val input: Int = nextElement
+    val timestamp = DateTime.parse("2022-08-31").toInstant
+    val outputReceiver = new OutputReceiver[String] {
+      override def output(output: String): Unit = outputBuffer.append(output)
+      override def outputWithTimestamp(output: String, timestamp: Instant): Unit = ???
+    }
+    val window: BoundedWindow = null
+    fn.processElement(input, timestamp, outputReceiver, window)
     nextElement += 1
   }
 

--- a/scio-test/src/test/scala/com/spotify/scio/util/random/RandomSamplerTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/util/random/RandomSamplerTest.scala
@@ -18,10 +18,7 @@
 package com.spotify.scio.util.random
 
 import com.spotify.scio.testing.PipelineSpec
-import org.apache.beam.sdk.options.PipelineOptions
-import org.apache.beam.sdk.transforms.DoFn
-import org.apache.beam.sdk.transforms.windowing.PaneInfo
-import org.apache.beam.sdk.values.{PCollectionView, TupleTag}
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver
 import org.joda.time.Instant
 
 import scala.collection.compat._ // scalafix:ok
@@ -33,31 +30,21 @@ class RandomSamplerTest extends PipelineSpec {
   private def test[T](sampler: RandomSampler[T, _], xs: Seq[T]): Seq[T] = {
     sampler.startBundle(null)
     val buffer = MBuffer.empty[T]
-    xs.foreach(x => sampler.processElement(newContext[T](sampler, x, buffer)))
+    xs.foreach(x => sampler.processElement(x, newOutputReceiver(buffer)))
     buffer.toSeq
   }
 
   private def test[K, V](sampler: RandomValueSampler[K, V, _], xs: Seq[(K, V)]): Seq[(K, V)] = {
     sampler.startBundle(null)
     val buffer = MBuffer.empty[(K, V)]
-    xs.foreach(x => sampler.processElement(newContext[(K, V)](sampler, x, buffer)))
+    xs.foreach(x => sampler.processElement(x, newOutputReceiver(buffer)))
     buffer.toSeq
   }
 
-  private def newContext[T](f: DoFn[T, T], e: T, buffer: MBuffer[T]) =
-    new f.ProcessContext {
-      override def element(): T = e
-      override def sideInput[U](view: PCollectionView[U]): U = ???
-      override def timestamp(): Instant = ???
-      override def pane(): PaneInfo = ???
-      override def getPipelineOptions: PipelineOptions = ???
-      override def output(output: T): Unit = buffer.append(output)
-      override def output[U](tag: TupleTag[U], output: U): Unit = ???
-      override def outputWithTimestamp(output: T, timestamp: Instant): Unit =
-        ???
-      override def outputWithTimestamp[U](tag: TupleTag[U], output: U, timestamp: Instant): Unit =
-        ???
-    }
+  private def newOutputReceiver[T](buffer: MBuffer[T]) = new OutputReceiver[T] {
+    override def output(output: T): Unit = buffer.append(output)
+    override def outputWithTimestamp(output: T, timestamp: Instant): Unit = ???
+  }
 
   def testSampler(
     withReplacement: Boolean,


### PR DESCRIPTION
Original request:
> Beam's new way of writing custom do function is to use annotations in the @ProcessElement function.
>
> Check that ProcessContext is only used where relevant
> Update to newer beam style when possible or indicate in code why we still require to access the ProcessContext

I have committed only one change to discuss and elaborate request details:
SortedBucketTransform.processElement signature is changed from ProcessContext argument to "element" and "outputReceiver"

[Original ticket](https://github.com/spotify/scio/issues/4497.)
