### PR TITLE
Fix documentation generation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1205,7 +1205,7 @@ lazy val site: Project = project
     `scio-google-cloud-platform`,
     `scio-parquet`,
     `scio-smb`,
-    `scio-test`,
+    `scio-test` % "compile->test",
     `scio-extra`
   )
 

--- a/site/src/main/paradox/Scio-REPL.md
+++ b/site/src/main/paradox/Scio-REPL.md
@@ -418,7 +418,7 @@ def bq: BigQuery = ???
 
 def tornadoes = bq.getTypedRows[Row]()
 
-def result = tornadoes.next.month
+def result = tornadoes.next().month
 
 def write = bq.writeTypedRows("project-id:dataset-id.table-id", tornadoes.take(100).toList)
 ```
@@ -437,7 +437,7 @@ def sc: ScioContext = ???
 ```scala mdoc
 def closedTap: ClosedTap[String] = ???
 
-def result = sc.run().waitUntilDone().tap(closedTap).value.next
+def result = sc.run().waitUntilDone().tap(closedTap).value.next()
 // Exception in thread "main"
 // Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "main"
 ```

--- a/site/src/main/paradox/io/Parquet.md
+++ b/site/src/main/paradox/io/Parquet.md
@@ -67,7 +67,6 @@ You can also read Avro generic records by specifying a reader schema.
 import com.spotify.scio._
 import com.spotify.scio.parquet.avro._
 import com.spotify.scio.avro.TestRecord
-import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 
 object ParquetJob {


### PR DESCRIPTION
Documentation generation has been broken since the removal of `scio-schemas` module.
make `site` module depend on `scio-test % test` so the generated classes are still accessible

\+ some boy-scout warning fixes