### PR TITLE
Fix google-api-client evicted by mysql-socket-factory 1.7.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1333,6 +1333,7 @@ ThisBuild / dependencyOverrides ++= Seq(
   "com.google.api.grpc" % "proto-google-cloud-datastore-v1" % googleCloudDatastoreVersion,
   "com.google.api.grpc" % "proto-google-common-protos" % googleCommonsProtoVersion,
   "com.google.api.grpc" % "proto-google-iam-v1" % googleIAMVersion,
+  "com.google.api-client" % "google-api-client" % googleClientsVersion,
   "com.google.apis" % "google-api-services-storage" % googleApiServicesStorageVersion,
   "com.google.auth" % "google-auth-library-credentials" % googleAuthVersion,
   "com.google.auth" % "google-auth-library-oauth2-http" % googleAuthVersion,


### PR DESCRIPTION
`mysql-socket-factory` is pulling `google-api-client`  v2.0.0 which is not compatible.
Macro expansion in `scio-example` fail with 

```log
 java.lang.IllegalStateException: You are currently running with version 2.0.0 of google-api-client. You need at least version 1.31.1 of google-api-client to run version 1.32.1 of the BigQuery API library.
```