### PR TITLE
Detect and retrieve GCP temp location (fixes #4535)

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
@@ -120,7 +120,7 @@ private[scio] object ScioUtil {
       .orElse(Option(sc.options.getTempLocation))
       .orElse(Try(sc.optionsAs[GcpOptions]).toOption.flatMap(x => Option(x.getGcpTempLocation)))
       .map(toResourceId)
-      .getOrElse(throw new IllegalStateException("Unable to find any temp location"))
+      .getOrElse(throw new IllegalArgumentException("No temporary location was specified. Specify a temporary location via --tempLocation or PipelineOptions.setTempLocation."))
   }
 
   def isWindowed(coll: SCollection[_]): Boolean =

--- a/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/ScioUtil.scala
@@ -120,7 +120,11 @@ private[scio] object ScioUtil {
       .orElse(Option(sc.options.getTempLocation))
       .orElse(Try(sc.optionsAs[GcpOptions]).toOption.flatMap(x => Option(x.getGcpTempLocation)))
       .map(toResourceId)
-      .getOrElse(throw new IllegalArgumentException("No temporary location was specified. Specify a temporary location via --tempLocation or PipelineOptions.setTempLocation."))
+      .getOrElse(
+        throw new IllegalArgumentException(
+          "No temporary location was specified. Specify a temporary location via --tempLocation or PipelineOptions.setTempLocation."
+        )
+      )
   }
 
   def isWindowed(coll: SCollection[_]): Boolean =


### PR DESCRIPTION
Detects if pipeline options is a `GcpOptions` and retrieve `gcpTempLocation` instead of `tempLocation` if it is the case.