### PR TITLE
Fix NullPointerException in DataflowResult

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowResult.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowResult.scala
@@ -157,5 +157,5 @@ object DataflowResult {
     override def expand(input: PInput): POutput = ???
   }
 
-  private class EmptyPipeline extends Pipeline(null)
+  private class EmptyPipeline extends Pipeline(PipelineOptionsFactory.create())
 }


### PR DESCRIPTION
I think the "empty pipeline" must have a non-null options object. Possibly this was not the case when this code was written. There is an [integration test](https://github.com/spotify/scio/blob/2babb9e3d5f56259ece2e13e7c5e2f49516fe90b/scio-test/src/it/scala/com/spotify/DataflowIT.scala#L63-L74) that exercises this code path but it seems to not trigger the NPE.

I could not run tests locally, otherwise I would have tried writing a failing test first. Instead I only have some production code that fails: `DataflowResult("project", "region", "job-id")`.

<details><summary>Stack trace:</summary>

```stacktrace
Exception in thread "main" java.lang.NullPointerException
	at org.apache.beam.sdk.transforms.resourcehints.ResourceHints.fromOptions(ResourceHints.java:86)
	at org.apache.beam.sdk.Pipeline.<init>(Pipeline.java:523)
	at com.spotify.scio.runners.dataflow.DataflowResult$EmptyPipeline.<init>(DataflowResult.scala:160)
	at com.spotify.scio.runners.dataflow.DataflowResult$.com$spotify$scio$runners$dataflow$DataflowResult$$newAppliedPTransform(DataflowResult.scala:153)
	at com.spotify.scio.runners.dataflow.DataflowResult$$anonfun$1$$anonfun$apply$1.apply(DataflowResult.scala:100)
	at com.spotify.scio.runners.dataflow.DataflowResult$$anonfun$1$$anonfun$apply$1.apply(DataflowResult.scala:99)
	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at scala.collection.TraversableLike.map(TraversableLike.scala:286)
	at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
	at scala.collection.AbstractTraversable.map(Traversable.scala:108)
	at com.spotify.scio.runners.dataflow.DataflowResult$$anonfun$1.apply(DataflowResult.scala:99)
	at com.spotify.scio.runners.dataflow.DataflowResult$$anonfun$1.apply(DataflowResult.scala:97)
	at scala.collection.Iterator$$anon$11.nextCur(Iterator.scala:486)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:492)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
	at scala.collection.generic.Growable.$plus$plus$eq(Growable.scala:62)
	at scala.collection.generic.Growable.$plus$plus$eq$(Growable.scala:53)
	at scala.collection.immutable.Map$MapBuilderImpl.$plus$plus$eq(Map.scala:648)
	at scala.collection.immutable.Map$MapBuilderImpl.$plus$plus$eq(Map.scala:595)
	at scala.collection.TraversableOnce.toMap(TraversableOnce.scala:372)
	at scala.collection.TraversableOnce.toMap$(TraversableOnce.scala:370)
	at scala.collection.AbstractIterator.toMap(Iterator.scala:1431)
	at com.spotify.scio.runners.dataflow.DataflowResult$.apply(DataflowResult.scala:105)
	at com.spotify.scio.runners.dataflow.DataflowResult$.apply(DataflowResult.scala:89)
…
[my code somewhere here]
```

</details>