### PR TITLE
Restore .toIterator usages for Scala 2.12 compat

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/transforms/WithResourceDoFns.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/transforms/WithResourceDoFns.scala
@@ -74,7 +74,7 @@ class FlatMapFnWithResource[T, U, R] private[transforms] (
     @Element element: T,
     out: OutputReceiver[U]
   ): Unit = {
-    val i = g(getResource, element).iterator
+    val i = g(getResource, element).toIterator
     while (i.hasNext) out.output(i.next())
   }
 }

--- a/scio-core/src/main/scala/com/spotify/scio/transforms/syntax/SCollectionSafeSyntax.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/transforms/syntax/SCollectionSafeSyntax.scala
@@ -56,7 +56,7 @@ trait SCollectionSafeSyntax {
         ): Unit = {
           val i =
             try {
-              g(element).iterator
+              g(element).toIterator
             } catch {
               case e: Throwable =>
                 out.get[(T, Throwable)](errorTag).output((element, e))

--- a/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
@@ -241,7 +241,7 @@ private[scio] object Functions {
         @Element element: T,
         out: OutputReceiver[U]
       ): Unit = {
-        val i = g(element).iterator
+        val i = g(element).toIterator
         while (i.hasNext) out.output(i.next())
       }
     }

--- a/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithWindowedValue.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/FunctionsWithWindowedValue.scala
@@ -55,7 +55,7 @@ private[scio] object FunctionsWithWindowedValue {
         window: BoundedWindow
       ): Unit = {
         val wv = WindowedValue(element, timestamp, window, pane)
-        val i = g(wv).iterator
+        val i = g(wv).toIterator
         while (i.hasNext) {
           val v = i.next()
           out.outputWithTimestamp(v.value, v.timestamp)


### PR DESCRIPTION
Scala 2.12 compilation was failing [CI](https://github.com/spotify/scio/actions/runs/3275382561/jobs/5390318521#step:6:163) for Scala 2.12; this PR restores `.toIterator` usages.