### PR TITLE
Concurrently support legacy Parquet reads for 0.12.x

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/ParquetExample.scala
@@ -30,8 +30,8 @@ import com.spotify.scio.parquet.tensorflow._
 import com.spotify.scio.avro.{Account, AccountStatus}
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.ClosedTap
+import com.spotify.scio.parquet.ParquetConfiguration
 import me.lyh.parquet.tensorflow.{Schema => ExampleSchema}
-import org.apache.hadoop.conf.Configuration
 import org.apache.avro.generic.GenericRecord
 import org.tensorflow.proto.example.{BytesList, Example, Feature, Features, FloatList}
 
@@ -50,12 +50,10 @@ object ParquetExample {
    *
    * See more here: https://spotify.github.io/scio/io/Parquet.html#performance-tuning
    */
-  private val fineTunedParquetWriterConfig: Configuration = {
-    val conf: Configuration = new Configuration()
-    conf.setInt("parquet.block.size", 1073741824) // 1 * 1024 * 1024 * 1024 = 1 GiB
-    conf.set("fs.gs.inputstream.fadvise", "RANDOM")
-    conf
-  }
+  private val fineTunedParquetWriterConfig = ParquetConfiguration.of(
+    "parquet.block.size" -> 1073741824, // 1 * 1024 * 1024 * 1024 = 1 GiB
+    "fs.gs.inputstream.fadvise" -> "RANDOM"
+  )
 
   private[extra] val fakeData: Iterable[Account] =
     (1 to 100)

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -250,9 +250,7 @@ object ParquetAvroIO {
       val transform = HadoopFormatIO
         .read[JBoolean, T]()
         // Hadoop input always emit key-value, and `Void` causes NPE in Beam coder
-        .withKeyTranslation(new SimpleFunction[Void, JBoolean]() {
-          override def apply(input: Void): JBoolean = true
-        })
+        .withKeyTranslation(Functions.simpleFn[Void, JBoolean](_ => true))
         .withValueTranslation(new SimpleFunction[A, T]() {
           // Workaround for incomplete Avro objects
           // `SCollection#map` might throw NPE on incomplete Avro objects when the runner tries

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -172,7 +172,12 @@ object ParquetAvroIO {
 
     def read(sc: ScioContext, path: String)(implicit coder: Coder[T]): SCollection[T] = {
       val jobConf = Option(conf).getOrElse(new Configuration())
-      if (jobConf.getBoolean(ParquetReadConfiguration.UseSplittableDoFn, false)) {
+      if (
+        jobConf.getBoolean(
+          ParquetReadConfiguration.UseSplittableDoFn,
+          ParquetReadConfiguration.UseSplittableDoFnDefault
+        )
+      ) {
         readSplittableDoFn(sc, jobConf, path)(coder)
       } else {
         readLegacy(sc, jobConf, path)(coder)

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -31,7 +31,6 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.reflect.ReflectData
 import org.apache.avro.specific.SpecificRecordBase
-import org.apache.beam.sdk.coders
 import org.apache.beam.sdk.io._
 import org.apache.beam.sdk.transforms.SerializableFunctions
 import org.apache.beam.sdk.transforms.SimpleFunction
@@ -218,10 +217,6 @@ object ParquetAvroIO {
       ).setCoder(tCoder)
     }
 
-    @deprecated(
-      "Reading Parquet using HadoopFormatIO is deprecated and will be removed in future Scio versions. " +
-        "Please set scio.parquet.read.useSplittableDoFn to True in your Parquet config."
-    )
     private def readLegacy(sc: ScioContext, conf: Configuration, path: String)(implicit
       coder: Coder[T]
     ): SCollection[T] = {

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -17,26 +17,37 @@
 
 package com.spotify.scio.parquet.avro
 
+import java.lang.{Boolean => JBoolean}
 import com.spotify.scio.ScioContext
 import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.io.{ScioIO, Tap, TapOf, TapT}
-import com.spotify.scio.parquet.read.{ParquetRead, ReadSupportFactory}
+import com.spotify.scio.parquet.read.{ParquetRead, ParquetReadConfiguration, ReadSupportFactory}
 import com.spotify.scio.parquet.{BeamInputFile, GcsConnectorUtil}
 import com.spotify.scio.testing.TestDataManager
 import com.spotify.scio.util.{FilenamePolicySupplier, Functions, ScioUtil}
 import com.spotify.scio.values.SCollection
 import com.twitter.chill.ClosureCleaner
 import org.apache.avro.Schema
+import org.apache.avro.generic.GenericRecord
 import org.apache.avro.reflect.ReflectData
 import org.apache.avro.specific.SpecificRecordBase
+import org.apache.beam.sdk.coders
 import org.apache.beam.sdk.io._
 import org.apache.beam.sdk.transforms.SerializableFunctions
+import org.apache.beam.sdk.transforms.SimpleFunction
 import org.apache.beam.sdk.io.fs.ResourceId
 import org.apache.beam.sdk.io.hadoop.SerializableConfiguration
+import org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider
+import org.apache.beam.sdk.values.TypeDescriptor
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.Job
-import org.apache.parquet.avro.{AvroParquetReader, AvroReadSupport, GenericDataSupplier}
+import org.apache.parquet.avro.{
+  AvroParquetInputFormat,
+  AvroParquetReader,
+  AvroReadSupport,
+  GenericDataSupplier
+}
 import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.hadoop.ParquetInputFormat
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
@@ -52,9 +63,9 @@ final case class ParquetAvroIO[T: ClassTag: Coder](path: String) extends ScioIO[
   private val cls = ScioUtil.classOf[T]
 
   override protected def read(sc: ScioContext, params: ReadP): SCollection[T] = {
-    val coder = CoderMaterializer.beam(sc, Coder[T])
-    sc.pipeline.getCoderRegistry.registerCoderForClass(ScioUtil.classOf[T], coder)
-    params.read(sc, path)
+    val bCoder = CoderMaterializer.beam(sc, Coder[T])
+    sc.pipeline.getCoderRegistry.registerCoderForClass(ScioUtil.classOf[T], bCoder)
+    params.read(sc, path)(Coder[T])
   }
 
   override protected def readTest(sc: ScioContext, params: ReadP): SCollection[T] = {
@@ -159,37 +170,100 @@ object ParquetAvroIO {
     val readSchema: Schema =
       if (isSpecific) ReflectData.get().getSchema(avroClass) else projection
 
-    def read(sc: ScioContext, path: String): SCollection[T] = {
-      val hadoopConf = Option(conf).getOrElse(new Configuration())
+    def read(sc: ScioContext, path: String)(implicit coder: Coder[T]): SCollection[T] = {
+      val jobConf = Option(conf).getOrElse(new Configuration())
+      if (jobConf.getBoolean(ParquetReadConfiguration.UseSplittableDoFn, false)) {
+        readSplittableDoFn(sc, jobConf, path)(coder)
+      } else {
+        readLegacy(sc, jobConf, path)(coder)
+      }
+    }
+
+    private def readSplittableDoFn(sc: ScioContext, conf: Configuration, path: String)(implicit
+      coder: Coder[T]
+    ): SCollection[T] = {
       // Needed to make GenericRecord read by parquet-avro work with Beam's
       // org.apache.beam.sdk.coders.AvroCoder.
       if (!isSpecific) {
-        hadoopConf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, false)
-        hadoopConf.set(
+        conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, false)
+        conf.set(
           AvroReadSupport.AVRO_DATA_SUPPLIER,
           classOf[GenericDataSupplier].getCanonicalName
         )
       }
 
-      AvroReadSupport.setAvroReadSchema(hadoopConf, readSchema)
+      AvroReadSupport.setAvroReadSchema(conf, readSchema)
       if (projection != null) {
-        AvroReadSupport.setRequestedProjection(hadoopConf, projection)
+        AvroReadSupport.setRequestedProjection(conf, projection)
       }
       if (predicate != null) {
-        ParquetInputFormat.setFilterPredicate(hadoopConf, predicate)
+        ParquetInputFormat.setFilterPredicate(conf, predicate)
       }
 
-      val tCoder = sc.pipeline.getCoderRegistry.getCoder(ScioUtil.classOf[T])
+      val tCoder = CoderMaterializer.beam(sc, coder)
       val cleanedProjectionFn = ClosureCleaner.clean(projectionFn)
 
       sc.applyTransform(
         ParquetRead.read[A, T](
           ReadSupportFactory.avro,
-          new SerializableConfiguration(hadoopConf),
+          new SerializableConfiguration(conf),
           path,
           Functions.serializableFn(cleanedProjectionFn)
         )
       ).setCoder(tCoder)
+    }
+
+    @deprecated(
+      "Reading Parquet using HadoopFormatIO is deprecated and will be removed in future Scio versions. " +
+        "Please set scio.parquet.read.useSplittableDoFn to True in your Parquet config."
+    )
+    private def readLegacy(sc: ScioContext, conf: Configuration, path: String)(implicit
+      coder: Coder[T]
+    ): SCollection[T] = {
+      val job = Job.getInstance(conf)
+      GcsConnectorUtil.setInputPaths(sc, job, path)
+      job.setInputFormatClass(classOf[AvroParquetInputFormat[T]])
+      job.getConfiguration.setClass("key.class", classOf[Void], classOf[Void])
+      job.getConfiguration.setClass("value.class", avroClass, avroClass)
+
+      // Needed to make GenericRecord read by parquet-avro work with Beam's
+      // org.apache.beam.sdk.coders.AvroCoder.
+      if (ScioUtil.classOf[A] == classOf[GenericRecord]) {
+        job.getConfiguration.setBoolean("parquet.avro.compatible", false)
+        job.getConfiguration.set(
+          "parquet.avro.data.supplier",
+          "org.apache.parquet.avro.GenericDataSupplier"
+        )
+      }
+
+      AvroParquetInputFormat.setAvroReadSchema(job, readSchema)
+      if (projection != null) {
+        AvroParquetInputFormat.setRequestedProjection(job, projection)
+      }
+      if (predicate != null) {
+        ParquetInputFormat.setFilterPredicate(job.getConfiguration, predicate)
+      }
+
+      val g = ClosureCleaner.clean(projectionFn) // defeat closure
+      val aCls = avroClass
+      val oCls = ScioUtil.classOf[T]
+      val transform = HadoopFormatIO
+        .read[JBoolean, T]()
+        // Hadoop input always emit key-value, and `Void` causes NPE in Beam coder
+        .withKeyTranslation(new SimpleFunction[Void, JBoolean]() {
+          override def apply(input: Void): JBoolean = true
+        })
+        .withValueTranslation(new SimpleFunction[A, T]() {
+          // Workaround for incomplete Avro objects
+          // `SCollection#map` might throw NPE on incomplete Avro objects when the runner tries
+          // to serialized them. Lifting the mapping function here fixes the problem.
+          override def apply(input: A): T = g(input)
+          override def getInputTypeDescriptor = TypeDescriptor.of(aCls)
+          override def getOutputTypeDescriptor = TypeDescriptor.of(oCls)
+        })
+        .withConfiguration(job.getConfiguration)
+
+      sc.applyTransform(transform).map(_.getValue)
     }
   }
 

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/package.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/package.scala
@@ -16,6 +16,7 @@
 
 package com.spotify.scio
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.io.{OutputFile, PositionOutputStream}
 
 import java.io.OutputStream
@@ -47,5 +48,23 @@ package object parquet {
     override def createOrOverwrite(blockSizeHint: Long) = new ParquetOutputStream(
       Channels.newOutputStream(channel)
     )
+  }
+
+  object ParquetConfiguration {
+    def of(entries: (String, Any)*): Configuration = {
+      val conf = new Configuration()
+      entries.foreach { case (k, v) =>
+        v match {
+          case b: Boolean => conf.setBoolean(k, b)
+          case f: Float   => conf.setFloat(k, f)
+          case d: Double  => conf.setDouble(k, d)
+          case i: Int     => conf.setInt(k, i)
+          case l: Long    => conf.setLong(k, l)
+          case s: String  => conf.set(k, s)
+          case _          => conf.set(k, v.toString)
+        }
+      }
+      conf
+    }
   }
 }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadConfiguration.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadConfiguration.scala
@@ -35,4 +35,5 @@ object ParquetReadConfiguration {
 
   // SplittableDoFn
   val UseSplittableDoFn = "scio.parquet.read.useSplittableDoFn"
+  private[scio] val UseSplittableDoFnDefault = false
 }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadConfiguration.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadConfiguration.scala
@@ -26,8 +26,11 @@ object ParquetReadConfiguration {
   val SplitGranularityRowGroup = "rowgroup"
 
   // HadoopFormatIO
-  @deprecated("scio.parquet.read.skipClone is deprecated and will be removed once HadoopFormatIO support is dropped " +
-    "in Parquet reads.", since = "0.12.0")
+  @deprecated(
+    "scio.parquet.read.skipClone is deprecated and will be removed once HadoopFormatIO support is dropped " +
+      "in Parquet reads.",
+    since = "0.12.0"
+  )
   val SkipClone = "scio.parquet.read.skipClone"
 
   // SplittableDoFn

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadConfiguration.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadConfiguration.scala
@@ -35,5 +35,5 @@ object ParquetReadConfiguration {
 
   // SplittableDoFn
   val UseSplittableDoFn = "scio.parquet.read.useSplittableDoFn"
-  private[scio] val UseSplittableDoFnDefault = false
+  private[scio] val UseSplittableDoFnDefault = true
 }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadConfiguration.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadConfiguration.scala
@@ -27,11 +27,11 @@ object ParquetReadConfiguration {
 
   // HadoopFormatIO
   @deprecated(
-    "scio.parquet.read.skipClone is deprecated and will be removed once HadoopFormatIO support is dropped " +
+    "scio.parquet.read.typed.skipClone is deprecated and will be removed once HadoopFormatIO support is dropped " +
       "in Parquet reads.",
     since = "0.12.0"
   )
-  val SkipClone = "scio.parquet.read.skipClone"
+  val SkipClone = "scio.parquet.read.typed.skipClone"
 
   // SplittableDoFn
   val UseSplittableDoFn = "scio.parquet.read.useSplittableDoFn"

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadConfiguration.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadConfiguration.scala
@@ -24,4 +24,12 @@ object ParquetReadConfiguration {
   // Values
   val SplitGranularityFile = "file"
   val SplitGranularityRowGroup = "rowgroup"
+
+  // HadoopFormatIO
+  @deprecated("scio.parquet.read.skipClone is deprecated and will be removed once HadoopFormatIO support is dropped " +
+    "in Parquet reads.", since = "0.12.0")
+  val SkipClone = "scio.parquet.read.skipClone"
+
+  // SplittableDoFn
+  val UseSplittableDoFn = "scio.parquet.read.useSplittableDoFn"
 }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -57,12 +57,12 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
 
   override protected def read(sc: ScioContext, params: ReadP): SCollection[Example] = {
     val conf = Option(params.conf).getOrElse(new Configuration())
-    if (
-      conf.getBoolean(
-        ParquetReadConfiguration.UseSplittableDoFn,
-        ParquetReadConfiguration.UseSplittableDoFnDefault
-      )
-    ) {
+    val useSplittableDoFn = conf.getBoolean(
+      ParquetReadConfiguration.UseSplittableDoFn,
+      ParquetReadConfiguration.UseSplittableDoFnDefault
+    )
+
+    if (useSplittableDoFn) {
       readSplittableDoFn(sc, conf, params)
     } else {
       readLegacy(sc, conf, params)

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -24,8 +24,7 @@ import com.spotify.scio.io.{ScioIO, Tap, TapOf, TapT}
 import com.spotify.scio.parquet.read.{ParquetRead, ParquetReadConfiguration, ReadSupportFactory}
 import com.spotify.scio.parquet.{BeamInputFile, GcsConnectorUtil}
 import com.spotify.scio.testing.TestDataManager
-import com.spotify.scio.util.ScioUtil
-import com.spotify.scio.util.FilenamePolicySupplier
+import com.spotify.scio.util.{FilenamePolicySupplier, Functions, ScioUtil}
 import com.spotify.scio.values.SCollection
 import me.lyh.parquet.tensorflow.{
   ExampleParquetInputFormat,
@@ -118,9 +117,7 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
     val source = HadoopFormatIO
       .read[JBoolean, Example]()
       // Hadoop input always emit key-value, and `Void` causes NPE in Beam coder
-      .withKeyTranslation(new SimpleFunction[Void, JBoolean]() {
-        override def apply(input: Void): JBoolean = true
-      })
+      .withKeyTranslation(Functions.simpleFn[Void, JBoolean](_ => true))
       .withConfiguration(job.getConfiguration)
     sc.applyTransform(source).map(_.getValue)
   }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -38,7 +38,6 @@ import org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO
 import org.apache.beam.sdk.transforms.SimpleFunction
 import org.apache.beam.sdk.io._
 import org.apache.beam.sdk.io.fs.ResourceId
-import org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider
 import org.apache.beam.sdk.transforms.SerializableFunctions
 import org.apache.hadoop.conf.Configuration

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -96,10 +96,7 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
       )
     ).setCoder(coder)
   }
-  @deprecated(
-    "Reading Parquet using HadoopFormatIO is deprecated and will be removed in future Scio versions. " +
-      "Please set scio.parquet.read.useSplittableDoFn to True in your Parquet config."
-  )
+
   private def readLegacy(
     sc: ScioContext,
     conf: Configuration,

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -57,7 +57,12 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
 
   override protected def read(sc: ScioContext, params: ReadP): SCollection[Example] = {
     val conf = Option(params.conf).getOrElse(new Configuration())
-    if (conf.getBoolean(ParquetReadConfiguration.UseSplittableDoFn, false)) {
+    if (
+      conf.getBoolean(
+        ParquetReadConfiguration.UseSplittableDoFn,
+        ParquetReadConfiguration.UseSplittableDoFnDefault
+      )
+    ) {
       readSplittableDoFn(sc, conf, params)
     } else {
       readLegacy(sc, conf, params)

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -17,19 +17,28 @@
 
 package com.spotify.scio.parquet.tensorflow
 
+import java.lang.{Boolean => JBoolean}
 import com.spotify.scio.ScioContext
 import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.io.{ScioIO, Tap, TapOf, TapT}
-import com.spotify.scio.parquet.read.{ParquetRead, ReadSupportFactory}
+import com.spotify.scio.parquet.read.{ParquetRead, ParquetReadConfiguration, ReadSupportFactory}
 import com.spotify.scio.parquet.{BeamInputFile, GcsConnectorUtil}
 import com.spotify.scio.testing.TestDataManager
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.util.FilenamePolicySupplier
 import com.spotify.scio.values.SCollection
-import me.lyh.parquet.tensorflow.{ExampleParquetInputFormat, ExampleParquetReader, Schema}
+import me.lyh.parquet.tensorflow.{
+  ExampleParquetInputFormat,
+  ExampleParquetReader,
+  ExampleReadSupport,
+  Schema
+}
 import org.apache.beam.sdk.io.hadoop.SerializableConfiguration
+import org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO
+import org.apache.beam.sdk.transforms.SimpleFunction
 import org.apache.beam.sdk.io._
 import org.apache.beam.sdk.io.fs.ResourceId
+import org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider
 import org.apache.beam.sdk.transforms.SerializableFunctions
 import org.apache.hadoop.conf.Configuration
@@ -48,6 +57,18 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
 
   override protected def read(sc: ScioContext, params: ReadP): SCollection[Example] = {
     val conf = Option(params.conf).getOrElse(new Configuration())
+    if (conf.getBoolean(ParquetReadConfiguration.UseSplittableDoFn, false)) {
+      readSplittableDoFn(sc, conf, params)
+    } else {
+      readLegacy(sc, conf, params)
+    }
+  }
+
+  private def readSplittableDoFn(
+    sc: ScioContext,
+    conf: Configuration,
+    params: ReadP
+  ): SCollection[Example] = {
     val job = Job.getInstance(conf)
 
     Option(params.projection).foreach { projection =>
@@ -69,6 +90,38 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
         identity[Example]
       )
     ).setCoder(coder)
+  }
+  @deprecated(
+    "Reading Parquet using HadoopFormatIO is deprecated and will be removed in future Scio versions. " +
+      "Please set scio.parquet.read.useSplittableDoFn to True in your Parquet config."
+  )
+  private def readLegacy(
+    sc: ScioContext,
+    conf: Configuration,
+    params: ReadP
+  ): SCollection[Example] = {
+    val job = Job.getInstance(conf)
+    GcsConnectorUtil.setInputPaths(sc, job, path)
+    job.setInputFormatClass(classOf[ExampleParquetInputFormat])
+    job.getConfiguration.setClass("key.class", classOf[Void], classOf[Void])
+    job.getConfiguration.setClass("value.class", classOf[Example], classOf[Example])
+
+    ParquetInputFormat.setReadSupportClass(job, classOf[ExampleReadSupport])
+    if (params.projection != null) {
+      ExampleParquetInputFormat.setFields(job, params.projection.asJava)
+    }
+    if (params.predicate != null) {
+      ParquetInputFormat.setFilterPredicate(job.getConfiguration, params.predicate)
+    }
+
+    val source = HadoopFormatIO
+      .read[JBoolean, Example]()
+      // Hadoop input always emit key-value, and `Void` causes NPE in Beam coder
+      .withKeyTranslation(new SimpleFunction[Void, JBoolean]() {
+        override def apply(input: Void): JBoolean = true
+      })
+      .withConfiguration(job.getConfiguration)
+    sc.applyTransform(source).map(_.getValue)
   }
 
   override protected def readTest(sc: ScioContext, params: ReadP): SCollection[Example] = {

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -34,7 +34,6 @@ import me.lyh.parquet.tensorflow.{
 }
 import org.apache.beam.sdk.io.hadoop.SerializableConfiguration
 import org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO
-import org.apache.beam.sdk.transforms.SimpleFunction
 import org.apache.beam.sdk.io._
 import org.apache.beam.sdk.io.fs.ResourceId
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -55,13 +55,12 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
 
   override protected def read(sc: ScioContext, params: ReadP): SCollection[T] = {
     val conf = Option(params.conf).getOrElse(new Configuration())
+    val useSplittableDoFn = conf.getBoolean(
+      ParquetReadConfiguration.UseSplittableDoFn,
+      ParquetReadConfiguration.UseSplittableDoFnDefault
+    )
 
-    if (
-      conf.getBoolean(
-        ParquetReadConfiguration.UseSplittableDoFn,
-        ParquetReadConfiguration.UseSplittableDoFnDefault
-      )
-    ) {
+    if (useSplittableDoFn) {
       readSplittableDoFn(sc, conf, params)
     } else {
       readLegacy(sc, conf, params)

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -56,7 +56,12 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
   override protected def read(sc: ScioContext, params: ReadP): SCollection[T] = {
     val conf = Option(params.conf).getOrElse(new Configuration())
 
-    if (conf.getBoolean(ParquetReadConfiguration.UseSplittableDoFn, false)) {
+    if (
+      conf.getBoolean(
+        ParquetReadConfiguration.UseSplittableDoFn,
+        ParquetReadConfiguration.UseSplittableDoFnDefault
+      )
+    ) {
       readSplittableDoFn(sc, conf, params)
     } else {
       readLegacy(sc, conf, params)

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -23,8 +23,7 @@ import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.io.{ScioIO, Tap, TapOf, TapT}
 import com.spotify.scio.parquet.read.{ParquetRead, ParquetReadConfiguration, ReadSupportFactory}
 import com.spotify.scio.parquet.{BeamInputFile, GcsConnectorUtil}
-import com.spotify.scio.util.ScioUtil
-import com.spotify.scio.util.FilenamePolicySupplier
+import com.spotify.scio.util.{FilenamePolicySupplier, Functions, ScioUtil}
 import com.spotify.scio.values.SCollection
 import magnolify.parquet.ParquetType
 import org.apache.beam.sdk.io.fs.ResourceId
@@ -103,9 +102,7 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
     val source = HadoopFormatIO
       .read[JBoolean, T]
       // Hadoop input always emit key-value, and `Void` causes NPE in Beam coder
-      .withKeyTranslation(new SimpleFunction[Void, JBoolean]() {
-        override def apply(input: Void): JBoolean = true
-      })
+      .withKeyTranslation(Functions.simpleFn[Void, JBoolean](_ => true))
       .withValueTranslation(
         new SimpleFunction[T, T]() {
           override def apply(input: T): T = input

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -89,10 +89,6 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
     ).setCoder(coder)
   }
 
-  @deprecated(
-    "Reading Parquet using HadoopFormatIO is deprecated and will be removed in future Scio versions. " +
-      "Please set scio.parquet.read.useSplittableDoFn to True in your Parquet config."
-  )
   private def readLegacy(sc: ScioContext, conf: Configuration, params: ReadP): SCollection[T] = {
     val cls = ScioUtil.classOf[T]
     val job = Job.getInstance(conf)

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -63,7 +63,11 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
     }
   }
 
-  private def readSplittableDoFn(sc: ScioContext, conf: Configuration, params: ReadP): SCollection[T] = {
+  private def readSplittableDoFn(
+    sc: ScioContext,
+    conf: Configuration,
+    params: ReadP
+  ): SCollection[T] = {
     if (params.predicate != null) {
       ParquetInputFormat.setFilterPredicate(conf, params.predicate)
     }
@@ -80,8 +84,10 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
     ).setCoder(coder)
   }
 
-  @deprecated("Reading Parquet using HadoopFormatIO is deprecated and will be removed in future Scio versions. " +
-    "Please set scio.parquet.read.useSplittableDoFn to True in your Parquet config.")
+  @deprecated(
+    "Reading Parquet using HadoopFormatIO is deprecated and will be removed in future Scio versions. " +
+      "Please set scio.parquet.read.useSplittableDoFn to True in your Parquet config."
+  )
   private def readLegacy(sc: ScioContext, conf: Configuration, params: ReadP): SCollection[T] = {
     val cls = ScioUtil.classOf[T]
     val job = Job.getInstance(conf)

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/read/ParquetReadFnTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/read/ParquetReadFnTest.scala
@@ -18,9 +18,7 @@ package com.spotify.scio.parquet.read
 
 import com.spotify.scio.ScioContext
 import com.spotify.scio.parquet.ParquetConfiguration
-import com.spotify.scio.parquet.read.ParquetReadConfiguration
 import com.spotify.scio.parquet.types._
-import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/read/ParquetReadFnTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/read/ParquetReadFnTest.scala
@@ -62,6 +62,7 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       ParquetReadConfiguration.SplitGranularity,
       ParquetReadConfiguration.SplitGranularityFile
     )
+    granularityConf.set(ParquetReadConfiguration.UseSplittableDoFn, "true")
 
     val sc = ScioContext()
     val tap = sc
@@ -79,6 +80,7 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       ParquetReadConfiguration.SplitGranularity,
       ParquetReadConfiguration.SplitGranularityFile
     )
+    granularityConf.set(ParquetReadConfiguration.UseSplittableDoFn, "true")
 
     val sc = ScioContext()
     val tap = sc
@@ -96,6 +98,7 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       ParquetReadConfiguration.SplitGranularity,
       ParquetReadConfiguration.SplitGranularityRowGroup
     )
+    granularityConf.set(ParquetReadConfiguration.UseSplittableDoFn, "true")
 
     val sc = ScioContext()
     val tap = sc
@@ -113,6 +116,7 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       ParquetReadConfiguration.SplitGranularity,
       ParquetReadConfiguration.SplitGranularityRowGroup
     )
+    granularityConf.set(ParquetReadConfiguration.UseSplittableDoFn, "true")
 
     val sc = ScioContext()
     val tap = sc

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/read/ParquetReadFnTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/read/ParquetReadFnTest.scala
@@ -17,6 +17,7 @@
 package com.spotify.scio.parquet.read
 
 import com.spotify.scio.ScioContext
+import com.spotify.scio.parquet.ParquetConfiguration
 import com.spotify.scio.parquet.read.ParquetReadConfiguration
 import com.spotify.scio.parquet.types._
 import org.apache.hadoop.conf.Configuration
@@ -40,12 +41,10 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
 
   override def beforeAll(): Unit = {
     // Multiple row-groups
-    val multiRowGroupConf = new Configuration()
-    multiRowGroupConf.setInt("parquet.block.size", 16)
+    val multiRowGroupConf = ParquetConfiguration.of("parquet.block.size" -> 16)
 
     // Single row-group
-    val singleRowGroupConf = new Configuration()
-    singleRowGroupConf.setInt("parquet.block.size", 1073741824)
+    val singleRowGroupConf = ParquetConfiguration.of("parquet.block.size" -> 1073741824)
 
     val sc = ScioContext()
     val data = sc.parallelize(records)
@@ -57,12 +56,10 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
   }
 
   "Parquet ReadFn" should "read at file-level granularity for files with multiple row groups" in {
-    val granularityConf = new Configuration()
-    granularityConf.set(
-      ParquetReadConfiguration.SplitGranularity,
-      ParquetReadConfiguration.SplitGranularityFile
+    val granularityConf = ParquetConfiguration.of(
+      ParquetReadConfiguration.SplitGranularity -> ParquetReadConfiguration.SplitGranularityFile,
+      ParquetReadConfiguration.UseSplittableDoFn -> true
     )
-    granularityConf.setBoolean(ParquetReadConfiguration.UseSplittableDoFn, true)
 
     val sc = ScioContext()
     val tap = sc
@@ -75,12 +72,10 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
   }
 
   it should "read at file-level granularity for files with a single row group" in {
-    val granularityConf = new Configuration()
-    granularityConf.set(
-      ParquetReadConfiguration.SplitGranularity,
-      ParquetReadConfiguration.SplitGranularityFile
+    val granularityConf = ParquetConfiguration.of(
+      ParquetReadConfiguration.SplitGranularity -> ParquetReadConfiguration.SplitGranularityFile,
+      ParquetReadConfiguration.UseSplittableDoFn -> true
     )
-    granularityConf.setBoolean(ParquetReadConfiguration.UseSplittableDoFn, true)
 
     val sc = ScioContext()
     val tap = sc
@@ -93,12 +88,10 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
   }
 
   it should "read at row-group granularity for files with multiple row groups" in {
-    val granularityConf = new Configuration()
-    granularityConf.set(
-      ParquetReadConfiguration.SplitGranularity,
-      ParquetReadConfiguration.SplitGranularityRowGroup
+    val granularityConf = ParquetConfiguration.of(
+      ParquetReadConfiguration.SplitGranularity -> ParquetReadConfiguration.SplitGranularityRowGroup,
+      ParquetReadConfiguration.UseSplittableDoFn -> true
     )
-    granularityConf.setBoolean(ParquetReadConfiguration.UseSplittableDoFn, true)
 
     val sc = ScioContext()
     val tap = sc
@@ -111,12 +104,10 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
   }
 
   it should "read at row-group granularity for files with a single row groups" in {
-    val granularityConf = new Configuration()
-    granularityConf.set(
-      ParquetReadConfiguration.SplitGranularity,
-      ParquetReadConfiguration.SplitGranularityRowGroup
+    val granularityConf = ParquetConfiguration.of(
+      ParquetReadConfiguration.SplitGranularity -> ParquetReadConfiguration.SplitGranularityRowGroup,
+      ParquetReadConfiguration.UseSplittableDoFn -> true
     )
-    granularityConf.setBoolean(ParquetReadConfiguration.UseSplittableDoFn, true)
 
     val sc = ScioContext()
     val tap = sc

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/read/ParquetReadFnTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/read/ParquetReadFnTest.scala
@@ -62,7 +62,7 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       ParquetReadConfiguration.SplitGranularity,
       ParquetReadConfiguration.SplitGranularityFile
     )
-    granularityConf.set(ParquetReadConfiguration.UseSplittableDoFn, "true")
+    granularityConf.setBoolean(ParquetReadConfiguration.UseSplittableDoFn, true)
 
     val sc = ScioContext()
     val tap = sc
@@ -80,7 +80,7 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       ParquetReadConfiguration.SplitGranularity,
       ParquetReadConfiguration.SplitGranularityFile
     )
-    granularityConf.set(ParquetReadConfiguration.UseSplittableDoFn, "true")
+    granularityConf.setBoolean(ParquetReadConfiguration.UseSplittableDoFn, true)
 
     val sc = ScioContext()
     val tap = sc
@@ -98,7 +98,7 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       ParquetReadConfiguration.SplitGranularity,
       ParquetReadConfiguration.SplitGranularityRowGroup
     )
-    granularityConf.set(ParquetReadConfiguration.UseSplittableDoFn, "true")
+    granularityConf.setBoolean(ParquetReadConfiguration.UseSplittableDoFn, true)
 
     val sc = ScioContext()
     val tap = sc
@@ -116,7 +116,7 @@ class ParquetReadFnTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       ParquetReadConfiguration.SplitGranularity,
       ParquetReadConfiguration.SplitGranularityRowGroup
     )
-    granularityConf.set(ParquetReadConfiguration.UseSplittableDoFn, "true")
+    granularityConf.setBoolean(ParquetReadConfiguration.UseSplittableDoFn, true)
 
     val sc = ScioContext()
     val tap = sc

--- a/site/src/main/paradox/io/Parquet.md
+++ b/site/src/main/paradox/io/Parquet.md
@@ -188,3 +188,9 @@ Here are some other recommended settings.
 
 - `numShards` - This should be explicitly set so that the size of each output file is smaller than but close to `parquet.block.size`, i.e. 1 GiB. This guarantees that each file contains 1 row group only and reduces seeks.
 - `compression` - `SNAPPY` and `GZIP` work out of the box. Snappy is less CPU intensive but has lower compression ratio. In our benchmarks GZIP seem to work better on GCS.
+
+## Parquet Reads in Scio 0.12.0+
+
+Parquet read internals have been reworked in Scio 0.12.0. As of 0.12.0, you can opt-into the new Parquet read implementation,
+backed by the new Beam [SplittableDoFn](https://beam.apache.org/blog/splittable-do-fn/) API, by following the instructions
+@ref:[here](../migrations/v0.12.0-Migration-Guide.md#parquet-reads).

--- a/site/src/main/paradox/migrations/v0.12.0-Migration-Guide.md
+++ b/site/src/main/paradox/migrations/v0.12.0-Migration-Guide.md
@@ -79,3 +79,35 @@ case class MyClass(s: String, i: Int)
 val scoll: SCollection[MyClass] = ???
 scoll.saveAsDynamicParquetAvroFile("gs://output/") { m => s"/${m.s}/${m.i}"}
 ```
+
+## Parquet Reads
+
+Alongside the existing Parquet read implementation ("legacy Parquet"), we're concurrently offering a new Parquet read implementation that uses Beam's new [SplittableDoFn](https://beam.apache.org/blog/splittable-do-fn/)
+API. Legacy Parquet is still the default read format, but can enable the new implementation in your `Configuration`:
+
+```scala
+import com.spotify.scio.parquet._
+
+sc.typedParquetFile[T](path, conf = ParquetConfiguration.of("scio.parquet.read.useSplittableDoFn" -> true))
+sc.parquetAvroFile[T](path, conf = ParquetConfiguration.of("scio.parquet.read.useSplittableDoFn" -> true))
+sc.parquetExampleFile(path, conf = ParquetConfiguration.of("scio.parquet.read.useSplittableDoFn" -> true))
+```
+
+Additionally, you can enable it for all Scio jobs in your project by adding it to your project's `src/main/resources/core-site.xml` file:
+
+```xml
+<configuration>
+  <property>
+    <name>scio.parquet.read.useSplittableDoFn</name>
+    <value>true</value>
+    <description>Use SplittableDoFn implementation for Parquet reads</description>
+  </property>
+</configuration>
+```
+
+Note that if you're using DataflowRunner, you'll get the best performance (in terms of worker scaling and overall resource usage)
+out of a SplittableDoFn-based read by enabling [Dataflow Runner V2](https://cloud.google.com/dataflow/docs/guides/deploying-a-pipeline#dataflow-runner-v2).
+You can enable this in your Dataflow pipeline by supplying the pipeline argument `--experiments=use_runner_v2` to your job.
+
+Our plan is to support Legacy Parquet for all Scio 0.12.x versions, but fully deprecate and remove support by 0.13.x.
+


### PR DESCRIPTION
To make the 0.12.x migration easier, we're letting users opt into the new SDF-based Parquet implementation, while keeping the legacy implementation as the default throughout 0.12.x. Hopefully we can fully deprecate+remove legacy code by 0.13.x.

the `ParquetConfiguration` convenience method is a little out of scope of this PR, I can move it into a new PR if that's easier - I was just getting annoyed at constructing `Configuration` objects in Scala....