### PR TITLE
Increase apache.avro version to aling with Magnolify

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ val beamVersion = "2.41.0"
 // https://github.com/apache/beam/blob/master/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
 val autoServiceVersion = "1.0.1"
 val autoValueVersion = "1.9"
-val avroVersion = "1.8.2"
+val avroVersion = "1.11.0"
 val bigdataossVersion = "2.2.6"
 val bigtableClientVersion = "1.26.3"
 val commonsCodecVersion = "1.15"


### PR DESCRIPTION
Magnolify depends on the newer version of org.apache.avro. Updating the current one to the latest.

Assuming that it is fully backward compatible with "1.8.2". After implementing TypedParquet annotations Magnolify code depends on some new features of org.apache.avro and fails with MethodNotFound in the current Scio. This can be quickly fixed by explicit dependency in users' pipeline