### PR TITLE
revert Functions.simpleFn one-liners in Parquet

### DIFF
--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -250,7 +250,9 @@ object ParquetAvroIO {
       val transform = HadoopFormatIO
         .read[JBoolean, T]()
         // Hadoop input always emit key-value, and `Void` causes NPE in Beam coder
-        .withKeyTranslation(Functions.simpleFn[Void, JBoolean](_ => true))
+        .withKeyTranslation(new SimpleFunction[Void, JBoolean]() {
+          override def apply(input: Void): JBoolean = true
+        })
         .withValueTranslation(new SimpleFunction[A, T]() {
           // Workaround for incomplete Avro objects
           // `SCollection#map` might throw NPE on incomplete Avro objects when the runner tries

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -23,7 +23,8 @@ import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.io.{ScioIO, Tap, TapOf, TapT}
 import com.spotify.scio.parquet.read.{ParquetRead, ParquetReadConfiguration, ReadSupportFactory}
 import com.spotify.scio.parquet.{BeamInputFile, GcsConnectorUtil}
-import com.spotify.scio.util.{FilenamePolicySupplier, Functions, ScioUtil}
+import com.spotify.scio.util.ScioUtil
+import com.spotify.scio.util.FilenamePolicySupplier
 import com.spotify.scio.values.SCollection
 import magnolify.parquet.ParquetType
 import org.apache.beam.sdk.io.fs.ResourceId
@@ -102,7 +103,9 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
     val source = HadoopFormatIO
       .read[JBoolean, T]
       // Hadoop input always emit key-value, and `Void` causes NPE in Beam coder
-      .withKeyTranslation(Functions.simpleFn[Void, JBoolean](_ => true))
+      .withKeyTranslation(new SimpleFunction[Void, JBoolean]() {
+        override def apply(input: Void): JBoolean = true
+      })
       .withValueTranslation(
         new SimpleFunction[T, T]() {
           override def apply(input: T): T = input


### PR DESCRIPTION
Testing this out on dataflow (in both scala 2.12 and 2.13) with a case class read resulted in the following error:

```
[error] java.lang.IllegalArgumentException: Key translation's input type is not same as hadoop InputFormat : class org.apache.parquet.hadoop.ParquetInputFormat key class : class java.lang.Void
[error] 	at org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO$Read.validateTranslationFunction(HadoopFormatIO.java:586)
[error] 	at org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO$Read.validateTransform(HadoopFormatIO.java:569)
[error] 	at org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO$Read.expand(HadoopFormatIO.java:516)
[error] 	at org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO$Read.expand(HadoopFormatIO.java:376)
[error] 	at org.apache.beam.sdk.Pipeline.applyInternal(Pipeline.java:548)
[error] 	at org.apache.beam.sdk.Pipeline.applyTransform(Pipeline.java:499)
[error] 	at org.apache.beam.sdk.values.PBegin.apply(PBegin.java:56)
[error] 	at org.apache.beam.sdk.Pipeline.apply(Pipeline.java:192)
[error] 	at com.spotify.scio.ScioContext.applyInternal(ScioContext.scala:673)
[error] 	at com.spotify.scio.ScioContext.applyTransform(ScioContext.scala:690)
[error] 	at com.spotify.scio.ScioContext.applyTransform(ScioContext.scala:695)
[error] 	at com.spotify.scio.parquet.types.ParquetTypeIO.readLegacy(ParquetTypeIO.scala:115)
```

Reverting these one-liners fixed the issue. Not sure how this wasn't caught in CI 😬 