### PR TITLE
Pin neo4j driver to v4

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -41,6 +41,9 @@ updates.ignore = [
 ]
 
 updates.pin = [
+  # neo4j 5+ driver are released for java 17+
+ { groupId = "org.neo4j.driver", version = "4." },
+
   # Do not update major version of elasticsearch
   { groupId = "co.elastic.clients", version = "8."},
 


### PR DESCRIPTION
neo4j 5+ driver are released for java 17+. See [here](https://github.com/neo4j/neo4j-java-driver#supported-driver-series)