### PR TITLE
Do not wrap already nullable coders

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/CoderMaterializer.scala
@@ -48,11 +48,12 @@ object CoderMaterializer {
   ): BCoder[T] = beamImpl(CoderOptions(o), coder, refs = TrieMap.empty, topLevel = true)
 
   private def isNullableCoder(o: CoderOptions, c: Coder[_]): Boolean = c match {
-    case _: RawBeam[_]      => false // raw cannot be made nullable
-    case _: KVCoder[_, _]   => false // KV cannot be made nullable
-    case _: Transform[_, _] => false // nullability should be deferred to transformed coders
-    case _: Ref[_]          => false // nullability should be deferred to underlying coder
-    case _                  => o.nullableCoders
+    case Beam(_: NullableCoder[_]) => false // already nullable
+    case _: RawBeam[_]             => false // raw cannot be made nullable
+    case _: KVCoder[_, _]          => false // KV cannot be made nullable
+    case _: Transform[_, _]        => false // nullability should be deferred to transformed coders
+    case _: Ref[_]                 => false // nullability should be deferred to underlying coder
+    case _                         => o.nullableCoders
   }
 
   private def isWrappableCoder(topLevel: Boolean, c: Coder[_]): Boolean = c match {


### PR DESCRIPTION
When `nullableCoders` is enabled, we can end-up with multiple wrapping of the coder and failure to work on pair collections for instance:
```log
Failed to extract key-value coders from Coder[(K, V)]: NullableCoder(NullableCoder(...
```

This is mainly due to coder extraction on pair collections, where the unwrapped materialized code is reused. In this case, we should not re-wrap the coder if it is already nullable