### PR TITLE
Fix consistent casing for jlist

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -634,7 +634,9 @@ object Coder
   implicit val uriCoder: Coder[java.net.URI] = JavaCoders.uriCoder
   implicit val pathCoder: Coder[java.nio.file.Path] = JavaCoders.pathCoder
   implicit def jIterableCoder[T: Coder]: Coder[java.lang.Iterable[T]] = JavaCoders.jIterableCoder
-  implicit def jlistCoder[T: Coder]: Coder[JList[T]] = JavaCoders.jlistCoder
+  implicit def jListCoder[T: Coder]: Coder[JList[T]] = JavaCoders.jListCoder
+  @deprecated("Use jListCoder", since = "0.12.1")
+  def jlistCoder[T: Coder]: Coder[JList[T]] = jListCoder
   implicit def jArrayListCoder[T: Coder]: Coder[java.util.ArrayList[T]] = JavaCoders.jArrayListCoder
   implicit def jMapCoder[K: Coder, V: Coder]: Coder[java.util.Map[K, V]] = JavaCoders.jMapCoder
   implicit def jTryCoder[A](implicit c: Coder[Try[A]]): Coder[BaseAsyncLookupDoFn.Try[A]] =

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
@@ -61,11 +61,13 @@ trait JavaCoders extends JavaBeanCoders {
   implicit def pathCoder: Coder[java.nio.file.Path] =
     Coder.xmap(Coder.beam(StringUtf8Coder.of()))(s => java.nio.file.Paths.get(s), _.toString)
 
-  import java.lang.{Iterable => JIterable}
-  implicit def jIterableCoder[T](implicit c: Coder[T]): Coder[JIterable[T]] =
+  implicit def jIterableCoder[T](implicit c: Coder[T]): Coder[java.lang.Iterable[T]] =
     Coder.transform(c)(bc => Coder.beam(bcoders.IterableCoder.of(bc)))
 
-  implicit def jlistCoder[T](implicit c: Coder[T]): Coder[java.util.List[T]] =
+  @deprecated("Use jListCoder", since = "0.12.1")
+  def jlistCoder[T](implicit c: Coder[T]): Coder[java.util.List[T]] = jListCoder
+
+  implicit def jListCoder[T](implicit c: Coder[T]): Coder[java.util.List[T]] =
     Coder.transform(c)(bc => Coder.beam(bcoders.ListCoder.of(bc)))
 
   implicit def jArrayListCoder[T](implicit c: Coder[T]): Coder[java.util.ArrayList[T]] =


### PR DESCRIPTION
Set consistent casing for coder from `jlistCoder` to `jListCoder`