### PR TITLE
Remove scala-xml override

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -52,9 +52,5 @@ updates.pin = [
   { groupId = "org.apache.cassandra", version = "3." },
 
   # caffeine v3 requires Java >= 11
-  { groupId = "com.github.ben-manes.caffeine", version = "2." },
-
-  # org.scala-lang:scala-compiler_2.12 depends on scala-xml v1
-  # see https://github.com/scalatest/scalatest/issues/2092
-  { groupId = "org.scala-lang.modules", artifactId = "scala-xml", version = "1." }
+  { groupId = "com.github.ben-manes.caffeine", version = "2." }
 ]

--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,6 @@ val scalaCollectionCompatVersion = "2.8.1"
 val scalacticVersion = "3.2.14"
 val scalaMacrosVersion = "2.1.1"
 val scalatestVersion = "3.2.13"
-val scalaXmlVersion = "1.3.0"
 val shapelessVersion = "2.3.10"
 val slf4jVersion = "1.7.36"
 val sparkeyVersion = "3.2.4"
@@ -1438,6 +1437,5 @@ ThisBuild / dependencyOverrides ++= Seq(
   "io.opencensus" % "opencensus-contrib-grpc-metrics" % opencensusVersion,
   "org.checkerframework" % "checker-qual" % checkerFrameworkVersion,
   "org.codehaus.mojo" % "animal-sniffer-annotations" % animalSnifferAnnotationsVersion,
-  "org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion,
   "org.threeten" % "threetenbp" % threetenbpVersion
 )


### PR DESCRIPTION
`scala-xml` v2 is pulled since `scala` 2.12.17. We do not need the override anymore