### PR TITLE
Fix SMB metadata compatibility issues

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import java.util.Map;
@@ -39,7 +40,7 @@ import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 public class AvroBucketMetadata<K1, K2, V extends GenericRecord> extends BucketMetadata<K1, K2, V> {
 
   @JsonProperty private final String keyField;
-  @JsonProperty private final String keyFieldSecondary;
+  @JsonProperty @JsonInclude(JsonInclude.Include.NON_NULL) private final String keyFieldSecondary;
 
   @JsonIgnore private final String[] keyPath;
   @JsonIgnore private final String[] keyPathSecondary;

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -40,7 +40,10 @@ import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 public class AvroBucketMetadata<K1, K2, V extends GenericRecord> extends BucketMetadata<K1, K2, V> {
 
   @JsonProperty private final String keyField;
-  @JsonProperty @JsonInclude(JsonInclude.Include.NON_NULL) private final String keyFieldSecondary;
+
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final String keyFieldSecondary;
 
   @JsonIgnore private final String[] keyPath;
   @JsonIgnore private final String[] keyPathSecondary;

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
@@ -325,7 +326,13 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
   // Serialization
   ////////////////////////////////////////
 
-  @JsonIgnore private static ObjectMapper objectMapper = new ObjectMapper();
+  @JsonIgnore private static ObjectMapper objectMapper = getObjectMapper();
+
+  private static ObjectMapper getObjectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    return objectMapper;
+  }
 
   public static <K1, K2, V> BucketMetadata<K1, K2, V> from(String src) throws IOException {
     return objectMapper.readerFor(BucketMetadata.class).readValue(src);

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -87,7 +87,9 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
 
   @JsonProperty private final Class<K1> keyClass;
 
-  @JsonProperty @JsonInclude(JsonInclude.Include.NON_NULL) private final Class<K2> keyClassSecondary;
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final Class<K2> keyClassSecondary;
 
   @JsonProperty private final HashType hashType;
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.extensions.smb;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -86,7 +87,7 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
 
   @JsonProperty private final Class<K1> keyClass;
 
-  @JsonProperty private final Class<K2> keyClassSecondary;
+  @JsonProperty @JsonInclude(JsonInclude.Include.NON_NULL) private final Class<K2> keyClassSecondary;
 
   @JsonProperty private final HashType hashType;
 
@@ -345,7 +346,6 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
 
   public static <K1, K2, V> void to(
       BucketMetadata<K1, K2, V> bucketMetadata, OutputStream outputStream) throws IOException {
-
     objectMapper.writeValue(outputStream, bucketMetadata);
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.api.services.bigquery.model.TableRow;
 import java.util.Arrays;
@@ -36,7 +37,7 @@ import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 public class JsonBucketMetadata<K1, K2> extends BucketMetadata<K1, K2, TableRow> {
 
   @JsonProperty private final String keyField;
-  @JsonProperty private final String keyFieldSecondary;
+  @JsonProperty @JsonInclude(JsonInclude.Include.NON_NULL) private final String keyFieldSecondary;
   @JsonIgnore private final String[] keyPath;
   @JsonIgnore private final String[] keyPathSecondary;
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadata.java
@@ -37,7 +37,11 @@ import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 public class JsonBucketMetadata<K1, K2> extends BucketMetadata<K1, K2, TableRow> {
 
   @JsonProperty private final String keyField;
-  @JsonProperty @JsonInclude(JsonInclude.Include.NON_NULL) private final String keyFieldSecondary;
+
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final String keyFieldSecondary;
+
   @JsonIgnore private final String[] keyPath;
   @JsonIgnore private final String[] keyPathSecondary;
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
@@ -37,7 +37,10 @@ import org.tensorflow.proto.example.Int64List;
 public class TensorFlowBucketMetadata<K1, K2> extends BucketMetadata<K1, K2, Example> {
 
   @JsonProperty private final String keyField;
-  @JsonProperty @JsonInclude(JsonInclude.Include.NON_NULL) private final String keyFieldSecondary;
+
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final String keyFieldSecondary;
 
   public TensorFlowBucketMetadata(
       int numBuckets,

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadata.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.extensions.smb;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.protobuf.ByteString;
 import javax.annotation.Nullable;
@@ -36,7 +37,7 @@ import org.tensorflow.proto.example.Int64List;
 public class TensorFlowBucketMetadata<K1, K2> extends BucketMetadata<K1, K2, Example> {
 
   @JsonProperty private final String keyField;
-  @JsonProperty private final String keyFieldSecondary;
+  @JsonProperty @JsonInclude(JsonInclude.Include.NON_NULL) private final String keyFieldSecondary;
 
   public TensorFlowBucketMetadata(
       int numBuckets,

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
@@ -455,24 +455,26 @@ public class AvroBucketMetadataTest {
   }
 
   @Test
-  public void skipsNullSecondaryKeys() throws CannotProvideCoderException, NonDeterministicException, IOException {
+  public void skipsNullSecondaryKeys()
+      throws CannotProvideCoderException, NonDeterministicException, IOException {
     final AvroBucketMetadata<String, Void, GenericRecord> metadata =
-            new AvroBucketMetadata<>(
-                    4,
-                    1,
-                    String.class,
-                    "favorite_color",
-                    null,
-                    null,
-                    HashType.MURMUR3_32,
-                    SortedBucketIO.DEFAULT_FILENAME_PREFIX,
-                    AvroGeneratedUser.SCHEMA$);
+        new AvroBucketMetadata<>(
+            4,
+            1,
+            String.class,
+            "favorite_color",
+            null,
+            null,
+            HashType.MURMUR3_32,
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+            AvroGeneratedUser.SCHEMA$);
 
     final ByteArrayOutputStream os = new ByteArrayOutputStream();
     BucketMetadata.to(metadata, os);
 
     Assert.assertFalse(os.toString().contains("keyFieldSecondary"));
-    Assert.assertNull(((AvroBucketMetadata) BucketMetadata.from(os.toString())).getKeyClassSecondary());
+    Assert.assertNull(
+        ((AvroBucketMetadata) BucketMetadata.from(os.toString())).getKeyClassSecondary());
   }
 
   private static Schema createUnionRecordOfTypes(Schema.Type... types) {

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
@@ -19,6 +19,8 @@ package org.apache.beam.sdk.extensions.smb;
 
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -450,6 +452,27 @@ public class AvroBucketMetadataTest {
                 HashType.MURMUR3_32,
                 SortedBucketIO.DEFAULT_FILENAME_PREFIX,
                 illegalUnionSchema2));
+  }
+
+  @Test
+  public void skipsNullSecondaryKeys() throws CannotProvideCoderException, NonDeterministicException, IOException {
+    final AvroBucketMetadata<String, Void, GenericRecord> metadata =
+            new AvroBucketMetadata<>(
+                    4,
+                    1,
+                    String.class,
+                    "favorite_color",
+                    null,
+                    null,
+                    HashType.MURMUR3_32,
+                    SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+                    AvroGeneratedUser.SCHEMA$);
+
+    final ByteArrayOutputStream os = new ByteArrayOutputStream();
+    BucketMetadata.to(metadata, os);
+
+    Assert.assertFalse(os.toString().contains("keyFieldSecondary"));
+    Assert.assertNull(((AvroBucketMetadata) BucketMetadata.from(os.toString())).getKeyClassSecondary());
   }
 
   private static Schema createUnionRecordOfTypes(Schema.Type... types) {

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
@@ -181,16 +181,26 @@ public class BucketMetadataTest {
   public void testOldBucketMetadataIgnoresExtraFields() throws Exception {
     final int futureVersion = BucketMetadata.CURRENT_VERSION + 1;
     final String serializedAvro =
-            "{\"type\":\"org.apache.beam.sdk.extensions.smb.AvroBucketMetadata\",\"version\":" + futureVersion + ",\"numBuckets\":2,\"numShards\":1,\"keyClass\":\"java.lang.String\",\"hashType\":\"MURMUR3_32\",\"keyField\":\"user_id\", \"extra_field\":\"foo\"}";
+        "{\"type\":\"org.apache.beam.sdk.extensions.smb.AvroBucketMetadata\",\"version\":"
+            + futureVersion
+            + ",\"numBuckets\":2,\"numShards\":1,\"keyClass\":\"java.lang.String\",\"hashType\":\"MURMUR3_32\",\"keyField\":\"user_id\", \"extra_field\":\"foo\"}";
     final String serializedJson =
-            "{\"type\":\"org.apache.beam.sdk.extensions.smb.JsonBucketMetadata\",\"version\":" + futureVersion + ",\"numBuckets\":2,\"numShards\":1,\"keyClass\":\"java.lang.String\",\"hashType\":\"MURMUR3_32\",\"keyField\":\"user_id\", \"extra_field\":\"foo\"}";
+        "{\"type\":\"org.apache.beam.sdk.extensions.smb.JsonBucketMetadata\",\"version\":"
+            + futureVersion
+            + ",\"numBuckets\":2,\"numShards\":1,\"keyClass\":\"java.lang.String\",\"hashType\":\"MURMUR3_32\",\"keyField\":\"user_id\", \"extra_field\":\"foo\"}";
     final String serializedTensorflow =
-            "{\"type\":\"org.apache.beam.sdk.extensions.smb.TensorFlowBucketMetadata\",\"version\":" + futureVersion + ",\"numBuckets\":2,\"numShards\":1,\"keyClass\":\"java.lang.String\",\"hashType\":\"MURMUR3_32\",\"keyField\":\"user_id\", \"extra_field\":\"foo\"}";
+        "{\"type\":\"org.apache.beam.sdk.extensions.smb.TensorFlowBucketMetadata\",\"version\":"
+            + futureVersion
+            + ",\"numBuckets\":2,\"numShards\":1,\"keyClass\":\"java.lang.String\",\"hashType\":\"MURMUR3_32\",\"keyField\":\"user_id\", \"extra_field\":\"foo\"}";
 
     // Assert that no exception is thrown decoding.
-    Assert.assertEquals(((JsonBucketMetadata) BucketMetadata.from(serializedJson)).getVersion(), futureVersion);
-    Assert.assertEquals(((AvroBucketMetadata) BucketMetadata.from(serializedAvro)).getVersion(), futureVersion);
-    Assert.assertEquals(((TensorFlowBucketMetadata) BucketMetadata.from(serializedTensorflow)).getVersion(), futureVersion);
+    Assert.assertEquals(
+        ((JsonBucketMetadata) BucketMetadata.from(serializedJson)).getVersion(), futureVersion);
+    Assert.assertEquals(
+        ((AvroBucketMetadata) BucketMetadata.from(serializedAvro)).getVersion(), futureVersion);
+    Assert.assertEquals(
+        ((TensorFlowBucketMetadata) BucketMetadata.from(serializedTensorflow)).getVersion(),
+        futureVersion);
   }
 
   @Test

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
@@ -178,6 +178,22 @@ public class BucketMetadataTest {
   }
 
   @Test
+  public void testOldBucketMetadataIgnoresExtraFields() throws Exception {
+    final int futureVersion = BucketMetadata.CURRENT_VERSION + 1;
+    final String serializedAvro =
+            "{\"type\":\"org.apache.beam.sdk.extensions.smb.AvroBucketMetadata\",\"version\":" + futureVersion + ",\"numBuckets\":2,\"numShards\":1,\"keyClass\":\"java.lang.String\",\"hashType\":\"MURMUR3_32\",\"keyField\":\"user_id\", \"extra_field\":\"foo\"}";
+    final String serializedJson =
+            "{\"type\":\"org.apache.beam.sdk.extensions.smb.JsonBucketMetadata\",\"version\":" + futureVersion + ",\"numBuckets\":2,\"numShards\":1,\"keyClass\":\"java.lang.String\",\"hashType\":\"MURMUR3_32\",\"keyField\":\"user_id\", \"extra_field\":\"foo\"}";
+    final String serializedTensorflow =
+            "{\"type\":\"org.apache.beam.sdk.extensions.smb.TensorFlowBucketMetadata\",\"version\":" + futureVersion + ",\"numBuckets\":2,\"numShards\":1,\"keyClass\":\"java.lang.String\",\"hashType\":\"MURMUR3_32\",\"keyField\":\"user_id\", \"extra_field\":\"foo\"}";
+
+    // Assert that no exception is thrown decoding.
+    Assert.assertEquals(((JsonBucketMetadata) BucketMetadata.from(serializedJson)).getVersion(), futureVersion);
+    Assert.assertEquals(((AvroBucketMetadata) BucketMetadata.from(serializedAvro)).getVersion(), futureVersion);
+    Assert.assertEquals(((TensorFlowBucketMetadata) BucketMetadata.from(serializedTensorflow)).getVersion(), futureVersion);
+  }
+
+  @Test
   public void testNullKeyEncoding() throws Exception {
     final TestBucketMetadata m =
         new TestBucketMetadata(0, 1, 1, HashType.MURMUR3_32, DEFAULT_FILENAME_PREFIX);

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
@@ -20,10 +20,18 @@ package org.apache.beam.sdk.extensions.smb;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 
 import com.google.api.services.bigquery.model.TableRow;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Arrays;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
+import org.apache.beam.sdk.io.AvroGeneratedUser;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -215,5 +223,25 @@ public class JsonBucketMetadataTest {
 
     Assert.assertTrue(metadata4.isPartitionCompatibleForPrimaryKey(metadata5));
     Assert.assertFalse(metadata4.isPartitionCompatibleForPrimaryAndSecondaryKey(metadata5));
+  }
+
+  @Test
+  public void skipsNullSecondaryKeys() throws CannotProvideCoderException, Coder.NonDeterministicException, IOException {
+    final JsonBucketMetadata<String, Void> metadata =
+            new JsonBucketMetadata<>(
+                    4,
+                    1,
+                    String.class,
+                    "favorite_color",
+                    null,
+                    null,
+                    HashType.MURMUR3_32,
+                    SortedBucketIO.DEFAULT_FILENAME_PREFIX);
+
+    final ByteArrayOutputStream os = new ByteArrayOutputStream();
+    BucketMetadata.to(metadata, os);
+
+    Assert.assertFalse(os.toString().contains("keyFieldSecondary"));
+    Assert.assertNull(((JsonBucketMetadata) BucketMetadata.from(os.toString())).getKeyClassSecondary());
   }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
@@ -20,18 +20,14 @@ package org.apache.beam.sdk.extensions.smb;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 
 import com.google.api.services.bigquery.model.TableRow;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
-
-import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
-import org.apache.beam.sdk.io.AvroGeneratedUser;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -226,22 +222,24 @@ public class JsonBucketMetadataTest {
   }
 
   @Test
-  public void skipsNullSecondaryKeys() throws CannotProvideCoderException, Coder.NonDeterministicException, IOException {
+  public void skipsNullSecondaryKeys()
+      throws CannotProvideCoderException, Coder.NonDeterministicException, IOException {
     final JsonBucketMetadata<String, Void> metadata =
-            new JsonBucketMetadata<>(
-                    4,
-                    1,
-                    String.class,
-                    "favorite_color",
-                    null,
-                    null,
-                    HashType.MURMUR3_32,
-                    SortedBucketIO.DEFAULT_FILENAME_PREFIX);
+        new JsonBucketMetadata<>(
+            4,
+            1,
+            String.class,
+            "favorite_color",
+            null,
+            null,
+            HashType.MURMUR3_32,
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     final ByteArrayOutputStream os = new ByteArrayOutputStream();
     BucketMetadata.to(metadata, os);
 
     Assert.assertFalse(os.toString().contains("keyFieldSecondary"));
-    Assert.assertNull(((JsonBucketMetadata) BucketMetadata.from(os.toString())).getKeyClassSecondary());
+    Assert.assertNull(
+        ((JsonBucketMetadata) BucketMetadata.from(os.toString())).getKeyClassSecondary());
   }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
@@ -21,8 +21,13 @@ import static org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 
 import com.google.protobuf.ByteString;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.Charset;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -227,5 +232,17 @@ public class TensorFlowBucketMetadataTest {
 
     Assert.assertTrue(metadata4.isPartitionCompatibleForPrimaryKey(metadata5));
     Assert.assertFalse(metadata4.isPartitionCompatibleForPrimaryAndSecondaryKey(metadata5));
+  }
+
+  @Test
+  public void skipsNullSecondaryKeys() throws CannotProvideCoderException, Coder.NonDeterministicException, IOException {
+    final TensorFlowBucketMetadata<String, Void> metadata =
+            new TensorFlowBucketMetadata<>(4, 1, String.class, "bar", HashType.MURMUR3_32, SortedBucketIO.DEFAULT_FILENAME_PREFIX);
+
+    final ByteArrayOutputStream os = new ByteArrayOutputStream();
+    BucketMetadata.to(metadata, os);
+
+    Assert.assertFalse(os.toString().contains("keyFieldSecondary"));
+    Assert.assertNull(((TensorFlowBucketMetadata) BucketMetadata.from(os.toString())).getKeyClassSecondary());
   }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketMetadataTest.java
@@ -21,7 +21,6 @@ import static org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 
 import com.google.protobuf.ByteString;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -235,14 +234,17 @@ public class TensorFlowBucketMetadataTest {
   }
 
   @Test
-  public void skipsNullSecondaryKeys() throws CannotProvideCoderException, Coder.NonDeterministicException, IOException {
+  public void skipsNullSecondaryKeys()
+      throws CannotProvideCoderException, Coder.NonDeterministicException, IOException {
     final TensorFlowBucketMetadata<String, Void> metadata =
-            new TensorFlowBucketMetadata<>(4, 1, String.class, "bar", HashType.MURMUR3_32, SortedBucketIO.DEFAULT_FILENAME_PREFIX);
+        new TensorFlowBucketMetadata<>(
+            4, 1, String.class, "bar", HashType.MURMUR3_32, SortedBucketIO.DEFAULT_FILENAME_PREFIX);
 
     final ByteArrayOutputStream os = new ByteArrayOutputStream();
     BucketMetadata.to(metadata, os);
 
     Assert.assertFalse(os.toString().contains("keyFieldSecondary"));
-    Assert.assertNull(((TensorFlowBucketMetadata) BucketMetadata.from(os.toString())).getKeyClassSecondary());
+    Assert.assertNull(
+        ((TensorFlowBucketMetadata) BucketMetadata.from(os.toString())).getKeyClassSecondary());
   }
 }


### PR DESCRIPTION
SMB BucketMetadata decoding was failing on an evolved metadata schema because we hadn't set `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` to false :( 

This is a tricky fix to deploy because basically, if a writer wants to add extra properties to their metadata.json file (i.e., if they want to use SMB secondary sort), all consumers will first have to upgrade to a version of Scio that includes this fix so that they won't break at read time. To ameliorate this somewhat, I set the BucketMetadata impls to _not_ write out `"keyClassSecondary":"null"` in the metadata.json file if the user hasn't set it. That way at least the default pathway won't be broken for consumers.