### PR TITLE
Exposed ExternalSorter tempLocation as System Property

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/BufferedExternalSorter.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/BufferedExternalSorter.java
@@ -39,7 +39,7 @@ public class BufferedExternalSorter implements Sorter {
   private static Logger LOG = LoggerFactory.getLogger(BufferedExternalSorter.class);
 
   public static Options options() {
-    return new Options("/tmp", 100, SorterType.HADOOP);
+    return new Options(SorterSysProps.getTempLocation(), 100, SorterType.HADOOP);
   }
 
   /** Contains configuration for the sorter. */

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/ExternalSorter.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/ExternalSorter.java
@@ -93,7 +93,7 @@ public abstract class ExternalSorter implements Sorter {
   /** Returns a {@link Sorter} configured with the given {@link Options}. */
   public static ExternalSorter create(Options options) {
     checkArgument(
-        options.getSorterType() == Options.SorterType.NATIVE, "Only Native sorter is supported");
+        options.getSorterType() == Options.SorterType.NATIVE, "NativeExternalSorter is the only supported external sorter");
     return NativeExternalSorter.create(options);
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/ExternalSorter.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/ExternalSorter.java
@@ -92,8 +92,8 @@ public abstract class ExternalSorter implements Sorter {
 
   /** Returns a {@link Sorter} configured with the given {@link Options}. */
   public static ExternalSorter create(Options options) {
-    checkArgument(options.getSorterType() == Options.SorterType.NATIVE,
-        "Only Native sorter is supported");
+    checkArgument(
+        options.getSorterType() == Options.SorterType.NATIVE, "Only Native sorter is supported");
     return NativeExternalSorter.create(options);
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/ExternalSorter.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/ExternalSorter.java
@@ -28,7 +28,7 @@ public abstract class ExternalSorter implements Sorter {
 
   /** {@link Options} contains configuration of the sorter. */
   public static class Options implements Serializable {
-    private String tempLocation = "/tmp";
+    private String tempLocation = SorterSysProps.getTempLocation();
     private int memoryMB = 100;
     private SorterType sorterType = SorterType.HADOOP;
 
@@ -92,7 +92,8 @@ public abstract class ExternalSorter implements Sorter {
 
   /** Returns a {@link Sorter} configured with the given {@link Options}. */
   public static ExternalSorter create(Options options) {
-    checkArgument(options.getSorterType() == Options.SorterType.NATIVE);
+    checkArgument(options.getSorterType() == Options.SorterType.NATIVE,
+        "Only Native sorter is supported");
     return NativeExternalSorter.create(options);
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/SorterSysProps.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/SorterSysProps.java
@@ -1,0 +1,7 @@
+package org.apache.beam.sdk.extensions.sorter;
+
+public class SorterSysProps {
+  public static String getTempLocation() {
+    return System.getProperty("smb.sorter.tmpdir", "/tmp");
+  }
+}

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/SorterSysProps.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/sorter/SorterSysProps.java
@@ -1,6 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.beam.sdk.extensions.sorter;
 
 public class SorterSysProps {
+
+  /**
+   * The path to a temporary location where the sorter writes intermediate files. Defaults to
+   * "/tmp".
+   */
   public static String getTempLocation() {
     return System.getProperty("smb.sorter.tmpdir", "/tmp");
   }


### PR DESCRIPTION
Implementing [issue 4598](https://github.com/spotify/scio/issues/4598)

Question: do we also want to parametrize **sorter memory** option? It is more tricky:
- it is sourced in different places in the code
- there are different designations of memory option: for external sorter and in-memory sorted it means different things