### PR TITLE
Respecting required  field of inner case classes in Coder macro

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
@@ -89,7 +89,7 @@ object LowPriorityCoderDerivation {
           Trampoline
             .call(instantiateWithOuterFields(outerClass))
             .map(invokeConstructorWithOuter(cls, outerClass, _))
-        /* If $outer field is absent T is not an inner class */
+        /* If $outer field is absent T is not an inner class, the last step of recursion */
         case None =>
           Trampoline(ClosureCleaner.instantiateClass(cls))
       }

--- a/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
@@ -59,12 +59,12 @@ object LowPriorityCoderDerivation {
       try {
         if (cls == ctxClass) {
           // class that implements CaseClass[] is anonymous and has a single constructor
-          ctxClass.getConstructors.head.newInstance(outerValue, null, null)
+          ctxClass.getConstructors.head.newInstance(outerValue.asInstanceOf[Object], null, null)
         } else {
           // class that wraps CaseClass[] implementation has a single constructor with 1 param
           cls
             .getConstructor(outerClass)
-            .newInstance(outerValue)
+            .newInstance(outerValue.asInstanceOf[Object])
         }
       } catch {
         case e @ (_: NoSuchMethodException | _: IllegalArgumentException) =>

--- a/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
@@ -57,9 +57,9 @@ object LowPriorityCoderDerivation {
         case Some(_) =>
           throw new Throwable(
             s"Found an $$outer field in $ctxClass. Possibly it is an attempt to use inner case " +
-              s"class in a Scio transformation. Inner case classes are not supported in Scio " +
-              s"auto-derived macros. Move the case class to the package level or define a custom " +
-              s"coder."
+              "class in a Scio transformation. Inner case classes are not supported in Scio " +
+              "auto-derived macros. Move the case class to the package level or define a custom " +
+              "coder."
           )
         /* If "$outer" field is absent then T is not an inner class, we create an empty instance
         of ctx */

--- a/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/DerivedCoder.scala
@@ -46,7 +46,7 @@ object LowPriorityCoderDerivation {
     private val className: String
   ) extends Serializable {
 
-    @transient lazy val ctxClass = Class.forName(className)
+    @transient lazy val ctxClass: Class[_] = Class.forName(className)
 
     @transient lazy val ctx: CaseClass[Coder, T] =
       instantiateWithOuterFields(ctxClass).get.asInstanceOf[CaseClass[Coder, T]]

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -197,7 +197,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     CoderProperties.structuralValueConsistentWithEquals(bmc, m, m)
   }
 
-  "Coders" should "not support inner class cases in classes" in {
+  "Coders" should "not support inner case classes" in {
     {
       the[Throwable] thrownBy {
         InnerObject coderShould roundtrip()

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -148,28 +148,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     4.5 coderShould roundtrip()
   }
 
-  "Coders" should "not support inner objects" in {
-    val thrown = the[Throwable] thrownBy {
-      InnerObject coderShould roundtrip()
-    }
-
-    thrown.getMessage should include(
-      "Can't find suitable constructor to instantiate class com.spotify.scio.coders.CoderTest$$"
-    )
-  }
-
-  "Coders" should "support inner classes" in {
-    InnerCaseClass("42") coderShould roundtripWithCustomAssert() { case (original, result) =>
-      original.str should ===(result.str)
-    }
-
-    InnerObject.InnerCaseClass("42") coderShould roundtripWithCustomAssert() {
-      case (original, result) =>
-        original.str should ===(result.str)
-    }
-  }
-
-  it should "support Scala collections" in {
+  "Coders" should "support Scala collections" in {
     import scala.collection.BitSet
 
     val nil: Seq[String] = Nil
@@ -200,6 +179,27 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     val bmc = CoderMaterializer.beamWithDefault(Coder[Map[String, String]])
     CoderProperties.testByteCount(bmc, BCoder.Context.OUTER, Array(m))
     CoderProperties.structuralValueConsistentWithEquals(bmc, m, m)
+  }
+
+  "Coders" should "not support inner objects" in {
+    val thrown = the[Throwable] thrownBy {
+      InnerObject coderShould roundtrip()
+    }
+
+    thrown.getMessage should include(
+      "Can't find suitable constructor to instantiate class com.spotify.scio.coders.CoderTest$$"
+    )
+  }
+
+  "Coders" should "support inner classes" in {
+    InnerCaseClass("42") coderShould roundtripWithCustomAssert() { case (original, result) =>
+      original.str should ===(result.str)
+    }
+
+    InnerObject.InnerCaseClass("42") coderShould roundtripWithCustomAssert() {
+      case (original, result) =>
+        original.str should ===(result.str)
+    }
   }
 
   it should "support tuples" in {


### PR DESCRIPTION
Fixing [bug #4643](https://github.com/spotify/scio/issues/4643):
- When Scala case class is compiled to Java byte code it contains a required synthetic field `$outer` as a reference to the instance where it is created;
- Coder Magnolia macro emits anonymous implementation of `magnolia1.CaseClass[Typeclass[_], Type]` that:
  - has a constructor that accepts a reference to `$outer`
  - creates a case class via `rawConstruct` method, passing a reference to `$outer`
  - private class CaseClassConstructor is intended to be serializable factory of `magnolia1.CaseClass` implementation
**The problem** was that `CaseClassConstructor` created `magnolia1.CaseClass` using:
`ClosureCleaner.instantiateClass(cls)`
That created an instance without constructor and left `$outer` field null. If `$outer` **is null Scala case class constructor throws exception**.

**The fix:**
- In short: instantiate empty instance of `$outer` object and create an instance of `magnolia1.CaseClass[Typeclass[_], Type]` using constructor.
- Longer story: there could be multiple synthetic classes generated by a compiler wrapping Scala case class (they have only one constructor that accepts `$outer`), so the recursion (Trampoline-d) is used to reach the first package-level class