### PR TITLE
Fix SMB producer compatibility issues

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -75,7 +75,12 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.hash.Hashing;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisplayData {
 
-  @JsonIgnore public static final int CURRENT_VERSION = 1;
+  /**
+   * The VERSION parameter is included in the metadata.json file for every SMB. Take extreme care in
+   * bumping version: Scio versions prior to 0.12.1 perform a version compatibility check on SMB
+   * partitions which may fail if the SMB producer bumps to an incompatible version.
+   */
+  @JsonIgnore public static final int CURRENT_VERSION = 0;
 
   // Represents the current major version of the Beam SMB module. Storage format may differ
   // across versions and require internal code branching to ensure backwards compatibility.
@@ -206,8 +211,6 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
 
   boolean isCompatibleWith(BucketMetadata other) {
     return other != null
-        // version 1 is backwards compatible with version 0
-        && (this.version <= 1 && other.version <= 1)
         && this.hashType == other.hashType
         // This check should be redundant since power of two is checked in BucketMetadata
         // constructor, but it's cheap to double-check.

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -211,6 +211,7 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
 
   boolean isCompatibleWith(BucketMetadata other) {
     return other != null
+        && this.version == other.version
         && this.hashType == other.hashType
         // This check should be redundant since power of two is checked in BucketMetadata
         // constructor, but it's cheap to double-check.

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -79,6 +79,8 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
    * The VERSION parameter is included in the metadata.json file for every SMB. Take extreme care in
    * bumping version: Scio versions prior to 0.12.1 perform a version compatibility check on SMB
    * partitions which may fail if the SMB producer bumps to an incompatible version.
+   * 
+   * The next version bump should be to: 2
    */
   @JsonIgnore public static final int CURRENT_VERSION = 0;
 
@@ -211,7 +213,8 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
 
   boolean isCompatibleWith(BucketMetadata other) {
     return other != null
-        && this.version == other.version
+        // version 1 is backwards compatible with version 0
+        && (this.version <= 1 && other.version <= 1)
         && this.hashType == other.hashType
         // This check should be redundant since power of two is checked in BucketMetadata
         // constructor, but it's cheap to double-check.

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -79,8 +79,8 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
    * The VERSION parameter is included in the metadata.json file for every SMB. Take extreme care in
    * bumping version: Scio versions prior to 0.12.1 perform a version compatibility check on SMB
    * partitions which may fail if the SMB producer bumps to an incompatible version.
-   * 
-   * The next version bump should be to: 2
+   *
+   * <p>The next version bump should be to: 2
    */
   @JsonIgnore public static final int CURRENT_VERSION = 0;
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
@@ -134,17 +134,11 @@ public class BucketMetadataTest {
         new TestBucketMetadata(0, 1, 1, HashType.MURMUR3_128, DEFAULT_FILENAME_PREFIX);
     final TestBucketMetadata m5 =
         new TestBucketMetadata(1, 1, 1, HashType.MURMUR3_32, DEFAULT_FILENAME_PREFIX);
-    final TestBucketMetadata m6 =
-        new TestBucketMetadata(2, 1, 1, HashType.MURMUR3_32, DEFAULT_FILENAME_PREFIX);
 
     Assert.assertTrue(m1.isCompatibleWith(m2));
     Assert.assertTrue(m1.isCompatibleWith(m3));
     Assert.assertFalse(m1.isCompatibleWith(m4));
-    Assert.assertTrue("version 0 and version 1 should be compatible", m1.isCompatibleWith(m5));
-    Assert.assertFalse(
-        "version 0 and version 2 are presumed incompatible", m1.isCompatibleWith(m6));
-    Assert.assertFalse(
-        "version 1 and version 2 are presumed incompatible", m5.isCompatibleWith(m6));
+    Assert.assertFalse(m1.isCompatibleWith(m5));
   }
 
   @Test

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/BucketMetadataTest.java
@@ -134,11 +134,17 @@ public class BucketMetadataTest {
         new TestBucketMetadata(0, 1, 1, HashType.MURMUR3_128, DEFAULT_FILENAME_PREFIX);
     final TestBucketMetadata m5 =
         new TestBucketMetadata(1, 1, 1, HashType.MURMUR3_32, DEFAULT_FILENAME_PREFIX);
+    final TestBucketMetadata m6 =
+        new TestBucketMetadata(2, 1, 1, HashType.MURMUR3_32, DEFAULT_FILENAME_PREFIX);
 
     Assert.assertTrue(m1.isCompatibleWith(m2));
     Assert.assertTrue(m1.isCompatibleWith(m3));
     Assert.assertFalse(m1.isCompatibleWith(m4));
-    Assert.assertFalse(m1.isCompatibleWith(m5));
+    Assert.assertTrue("version 0 and version 1 should be compatible", m1.isCompatibleWith(m5));
+    Assert.assertFalse(
+        "version 0 and version 2 are presumed incompatible", m1.isCompatibleWith(m6));
+    Assert.assertFalse(
+        "version 1 and version 2 are presumed incompatible", m5.isCompatibleWith(m6));
   }
 
   @Test


### PR DESCRIPTION
Unfortunately the concept of "version" in scio-smb was not well designed to start with so we find ourselves running into issues where consumers on older versions will break on producer updates. This is not an ideal solution but we can go forward with the mandate that all changes to the SMB metadata format *must* be backwards compatible... at least pending a thorough reworking of versioning semantics.