### PR TITLE
ParquetBucketMetadata should not write null secondary keys

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetBucketMetadata.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.extensions.smb;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -36,7 +37,10 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditio
 public class ParquetBucketMetadata<K1, K2, V> extends BucketMetadata<K1, K2, V> {
 
   @JsonProperty private final String keyField;
-  @JsonProperty private final String keyFieldSecondary;
+
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final String keyFieldSecondary;
 
   @JsonIgnore private final String[] keyPath;
   @JsonIgnore private final String[] keyPathSecondary;

--- a/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetBucketMetadataTest.scala
+++ b/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetBucketMetadataTest.scala
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.transforms.display.DisplayData
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import scala.jdk.CollectionConverters._
@@ -286,5 +287,26 @@ class ParquetBucketMetadataTest extends AnyFlatSpec with Matchers {
         classOf[User]
       )
     }
+  }
+
+  it should "not write null secondary keys" in {
+    val metadata = new ParquetBucketMetadata[String, Void, AvroGeneratedUser](
+      2,
+      1,
+      classOf[String],
+      "name",
+      HashType.MURMUR3_32,
+      SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+      classOf[AvroGeneratedUser]
+    )
+
+    val os = new ByteArrayOutputStream
+    BucketMetadata.to(metadata, os)
+
+    os.toString should not include "keyFieldSecondary"
+    BucketMetadata
+      .from(os.toString)
+      .asInstanceOf[ParquetBucketMetadata[String, Void, GenericRecord]]
+      .getKeyClassSecondary should be(null)
   }
 }


### PR DESCRIPTION
it should match the behavior of other BucketMetadata implementations, i.e. [AvroBucketMetadata](https://github.com/spotify/scio/blob/main/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java#L46).