### PR TITLE
Unwrap internal SCollection coders to be reused in transforms

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
@@ -20,6 +20,7 @@ package com.spotify.scio.coders
 import com.spotify.scio.coders.{instances => scio}
 import com.spotify.scio.values.{SCollection, SideInput}
 import org.apache.beam.sdk.{coders => beam}
+import org.apache.beam.sdk.values.PCollection
 
 import scala.annotation.tailrec
 
@@ -33,22 +34,32 @@ private[scio] object BeamCoders {
       case _                        => coder
     }
 
+  @inline
+  private def coderElement[T](productCoder: RecordCoder[_])(n: Int): beam.Coder[T] =
+    productCoder.cs(n)._2.asInstanceOf[beam.Coder[T]]
+
+  /** Get coder from an `PCollection[T]`. */
+  def getCoder[T](coll: PCollection[T]): Coder[T] = Coder.beam(unwrap(coll.getCoder))
+
+  /** Get coder from an `SCollection[T]`. */
+  def getCoder[T](coll: SCollection[T]): Coder[T] = getCoder(coll.internal)
+
   /** Get key-value coders from an `SCollection[(K, V)]`. */
   def getTupleCoders[K, V](coll: SCollection[(K, V)]): (Coder[K], Coder[V]) = {
     val coder = coll.internal.getCoder
     val (k, v) = unwrap(coder) match {
-      case c: scio.Tuple2Coder[K, V] => (c.ac, c.bc)
+      case c: scio.Tuple2Coder[K, V] =>
+        (c.ac, c.bc)
       case c: RecordCoder[(K, V)] =>
-        (
-          c.cs.find(_._1 == "_1").get._2.asInstanceOf[beam.Coder[K]],
-          c.cs.find(_._1 == "_2").get._2.asInstanceOf[beam.Coder[V]]
-        )
+        val ac = coderElement[K](c)(0)
+        val bc = coderElement[V](c)(1)
+        (ac, bc)
       case _ =>
         throw new IllegalArgumentException(
           s"Failed to extract key-value coders from Coder[(K, V)]: $coder"
         )
     }
-    (Coder.beam(k), Coder.beam(v))
+    (Coder.beam(unwrap(k)), Coder.beam(unwrap(v)))
   }
 
   def getTuple3Coders[A, B, C](coll: SCollection[(A, B, C)]): (Coder[A], Coder[B], Coder[C]) = {
@@ -56,15 +67,16 @@ private[scio] object BeamCoders {
     val (a, b, c) = unwrap(coder) match {
       case c: scio.Tuple3Coder[A, B, C] => (c.ac, c.bc, c.cc)
       case c: RecordCoder[(A, B, C)] =>
-        (
-          c.cs.find(_._1 == "_1").get._2.asInstanceOf[beam.Coder[A]],
-          c.cs.find(_._1 == "_2").get._2.asInstanceOf[beam.Coder[B]],
-          c.cs.find(_._1 == "_3").get._2.asInstanceOf[beam.Coder[C]]
-        )
+        val ac = coderElement[A](c)(0)
+        val bc = coderElement[B](c)(1)
+        val cc = coderElement[C](c)(2)
+        (ac, bc, cc)
       case _ =>
-        throw new IllegalArgumentException(s"Failed to extract tuples coders from: $coder")
+        throw new IllegalArgumentException(
+          s"Failed to extract tupled coders from Coder[(A, B, C)]: $coder"
+        )
     }
-    (Coder.beam(a), Coder.beam(b), Coder.beam(c))
+    (Coder.beam(unwrap(a)), Coder.beam(unwrap(b)), Coder.beam(unwrap(c)))
   }
 
   def getTuple4Coders[A, B, C, D](
@@ -74,21 +86,22 @@ private[scio] object BeamCoders {
     val (a, b, c, d) = unwrap(coder) match {
       case c: scio.Tuple4Coder[A, B, C, D] => (c.ac, c.bc, c.cc, c.dc)
       case c: RecordCoder[(A, B, C, D)] =>
-        (
-          c.cs.find(_._1 == "_1").get._2.asInstanceOf[beam.Coder[A]],
-          c.cs.find(_._1 == "_2").get._2.asInstanceOf[beam.Coder[B]],
-          c.cs.find(_._1 == "_3").get._2.asInstanceOf[beam.Coder[C]],
-          c.cs.find(_._1 == "_4").get._2.asInstanceOf[beam.Coder[D]]
-        )
+        val ac = coderElement[A](c)(0)
+        val bc = coderElement[B](c)(1)
+        val cc = coderElement[C](c)(2)
+        val dc = coderElement[D](c)(3)
+        (ac, bc, cc, dc)
       case _ =>
-        throw new IllegalArgumentException(s"Failed to extract tuples coders from: $coder")
+        throw new IllegalArgumentException(
+          s"Failed to extract tupled coders from Coder[(A, B, C, D)]: $coder"
+        )
     }
-    (Coder.beam(a), Coder.beam(b), Coder.beam(c), Coder.beam(d))
+    (Coder.beam(unwrap(a)), Coder.beam(unwrap(b)), Coder.beam(unwrap(c)), Coder.beam(unwrap(d)))
   }
 
   private def getIterableV[V](coder: beam.Coder[Iterable[V]]): beam.Coder[V] =
     unwrap(coder) match {
-      case (c: scio.BaseSeqLikeCoder[Iterable, V] @unchecked) => c.elemCoder
+      case c: scio.BaseSeqLikeCoder[Iterable, V] @unchecked => c.elemCoder
       case _ =>
         throw new IllegalArgumentException(
           s"Failed to extract value coder from Coder[Iterable[V]]: $coder"
@@ -100,14 +113,14 @@ private[scio] object BeamCoders {
     val coder = si.view.getPCollection.getCoder
     val (k, v) = unwrap(coder) match {
       // Beam's `View.asMultiMap`
-      case (c: beam.KvCoder[K, V] @unchecked) => (c.getKeyCoder, c.getValueCoder)
+      case c: beam.KvCoder[K, V] @unchecked => (c.getKeyCoder, c.getValueCoder)
       // `asMapSingletonSideInput`
-      case (c: scio.MapCoder[K, Iterable[V]] @unchecked) => (c.kc, getIterableV(c.vc))
+      case c: scio.MapCoder[K, Iterable[V]] @unchecked => (c.kc, getIterableV(c.vc))
       case _ =>
         throw new IllegalArgumentException(
-          s"Failed to extract value coder from Coder[Map[K, Iterable[V]]]: $coder"
+          s"Failed to extract key-value coders from Coder[Map[K, Iterable[V]]: $coder"
         )
     }
-    (Coder.beam(k), Coder.beam(v))
+    (Coder.beam(unwrap(k)), Coder.beam(unwrap(v)))
   }
 }

--- a/scio-core/src/main/scala/com/spotify/scio/values/PCollectionWrapper.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PCollectionWrapper.scala
@@ -18,7 +18,7 @@
 package com.spotify.scio.values
 
 import com.spotify.scio.ScioContext
-import com.spotify.scio.coders.Coder
+import com.spotify.scio.coders.{BeamCoders, Coder}
 import org.apache.beam.sdk.transforms.PTransform
 import org.apache.beam.sdk.values.{PCollection, POutput}
 
@@ -27,7 +27,7 @@ private[values] trait PCollectionWrapper[T] extends TransformNameable {
   /** The [[org.apache.beam.sdk.values.PCollection PCollection]] being wrapped internally. */
   val internal: PCollection[T]
 
-  implicit def coder: Coder[T] = Coder.beam(internal.getCoder)
+  implicit def coder: Coder[T] = BeamCoders.getCoder(internal)
 
   /**
    * The [[ScioContext]] associated with this

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -17,16 +17,33 @@
 
 package com.spotify.scio.values
 
+import com.spotify.scio.coders.{Beam, Coder}
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.util.random.RandomSamplerUtils
 import com.spotify.scio.hash._
+import com.spotify.scio.options.ScioOptions
 import com.twitter.algebird.Aggregator
 import magnolify.guava.auto._
+import org.apache.beam.sdk.coders.{StringUtf8Coder, VarIntCoder}
 
 import scala.collection.mutable
 
 class PairSCollectionFunctionsTest extends PipelineSpec {
-  "PairSCollection" should "support cogroup()" in {
+  "PairSCollection" should "propagate unwrapped coders" in {
+    runWithContext { sc =>
+      sc.optionsAs[ScioOptions].setNullableCoders(true)
+
+      val coll = sc.empty[(String, Int)]()
+      coll.keyCoder shouldBe a[Beam[String]]
+      // No WrappedCoder nor NullableCoder
+      coll.keyCoder.asInstanceOf[Beam[String]].beam shouldBe StringUtf8Coder.of()
+
+      coll.valueCoder shouldBe a[Beam[Int]]
+      coll.valueCoder.asInstanceOf[Beam[Int]].beam shouldBe VarIntCoder.of()
+    }
+  }
+
+  it should "support cogroup()" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq(("a", 1), ("b", 2), ("c", 3)))
       val p2 = sc.parallelize(Seq(("a", 11L), ("b", 12L), ("d", 14L)))

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.values
 
-import com.spotify.scio.coders.{Beam, Coder}
+import com.spotify.scio.coders.Beam
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.util.random.RandomSamplerUtils
 import com.spotify.scio.hash._


### PR DESCRIPTION
When `NullableCoders` is tuned on, users could get the following error
```log
java.lang.IllegalArgumentException: Failed to extract key-value coders from Coder[(K, V)]: 
  NullableCoder(NullableCode(...
```

This happens when `keyBy` is used. It only requires the key coder as implicit. The value coder is propagated for the materialized coder set on the internal collection.
When using pre-materialized coders, We should make sure those are completely unwrapped.