### PR TITLE
Fix SingletonCoder serialization

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -140,7 +140,7 @@ final private class SingletonCoder[T](
   val typeName: String,
   supply: () => T
 ) extends CustomCoder[T] {
-  private lazy val singleton = supply()
+  @transient private lazy val singleton = supply()
 
   override def toString: String = s"SingletonCoder[$typeName]"
 
@@ -442,7 +442,7 @@ final private[scio] class RefCoder[T](var bcoder: BCoder[T]) extends WrappedCode
 final private[scio] class LazyCoder[T](val typeName: String, bc: => BCoder[T])
     extends WrappedCoder[T] {
 
-  override lazy val bcoder: BCoder[T] = bc
+  @transient override lazy val bcoder: BCoder[T] = bc
 
   override def toString: String = s"LazyCoder[$typeName]"
 


### PR DESCRIPTION
If `singleton` in `SingletonCoder` was initialized, the coder could not be deserialized.

```log
java.lang.IllegalArgumentException: unable to deserialize Custom DoFn With Execution Info
...
Cause: java.io.InvalidClassException: com.example.MyObject$; no valid constructor
```