### PR TITLE
Set default JdkAddOpenModules for Java 17

### DIFF
--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: set JVM opts
         run: scripts/gha_setup.sh
       - name: Run Dataflow jobs

--- a/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowContext.scala
@@ -19,7 +19,7 @@ package com.spotify.scio.runners.dataflow
 
 import com.spotify.scio.RunnerContext
 import org.apache.beam.runners.dataflow.DataflowRunner
-import org.apache.beam.runners.dataflow.options.DataflowPipelineWorkerPoolOptions
+import org.apache.beam.runners.dataflow.options.{DataflowPipelineOptions, DataflowPipelineWorkerPoolOptions}
 import org.apache.beam.sdk.options.PipelineOptions
 
 import scala.jdk.CollectionConverters._
@@ -37,6 +37,12 @@ case object DataflowContext extends RunnerContext {
     val filesToStage = RunnerContext
       .filesToStage(options, classLoader, localArtifacts, artifacts)
       .asJavaCollection
+
+    // Required for Kryo w/ Java 17
+    if (sys.props("java.version").startsWith("17")) {
+      options.as(classOf[DataflowPipelineOptions]).setJdkAddOpenModules(
+        List("java.base/java.util=ALL-UNNAMED", "java.base/java.lang.invoke=ALL-UNNAMED").asJava)
+    }
 
     dataflowOptions.setFilesToStage(new java.util.ArrayList(filesToStage))
   }

--- a/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowContext.scala
@@ -19,7 +19,10 @@ package com.spotify.scio.runners.dataflow
 
 import com.spotify.scio.RunnerContext
 import org.apache.beam.runners.dataflow.DataflowRunner
-import org.apache.beam.runners.dataflow.options.{DataflowPipelineOptions, DataflowPipelineWorkerPoolOptions}
+import org.apache.beam.runners.dataflow.options.{
+  DataflowPipelineOptions,
+  DataflowPipelineWorkerPoolOptions
+}
 import org.apache.beam.sdk.options.PipelineOptions
 
 import scala.jdk.CollectionConverters._
@@ -39,9 +42,15 @@ case object DataflowContext extends RunnerContext {
       .asJavaCollection
 
     // Required for Kryo w/ Java 17
-    if (sys.props("java.version").startsWith("17")) {
-      options.as(classOf[DataflowPipelineOptions]).setJdkAddOpenModules(
-        List("java.base/java.util=ALL-UNNAMED", "java.base/java.lang.invoke=ALL-UNNAMED").asJava)
+    lazy val dataflowPipelineOpts = options.as(classOf[DataflowPipelineOptions])
+    if (
+      sys
+        .props("java.version")
+        .startsWith("17.") && dataflowPipelineOpts.getJdkAddOpenModules == null
+    ) {
+      dataflowPipelineOpts.setJdkAddOpenModules(
+        List("java.base/java.util=ALL-UNNAMED", "java.base/java.lang.invoke=ALL-UNNAMED").asJava
+      )
     }
 
     dataflowOptions.setFilesToStage(new java.util.ArrayList(filesToStage))


### PR DESCRIPTION
Required for Kryo coders to function.

If users sets the `JdkAddOpenModules` option in their job specifically, it will completely override these default options from Scio.