### PR TITLE
Force scio coders on all input SCollection

### DIFF
--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
@@ -173,9 +173,12 @@ final case class SpecificRecordIO[T <: SpecificRecord: ClassTag: Coder](path: St
    * file.
    */
   override protected def read(sc: ScioContext, params: ReadP): SCollection[T] = {
+    val coder = CoderMaterializer.beam(sc, Coder[T])
     val cls = ScioUtil.classOf[T]
     val t = beam.AvroIO.read(cls).from(path)
-    sc.applyTransform(t)
+    sc
+      .applyTransform(t)
+      .setCoder(coder)
   }
 
   /**
@@ -218,10 +221,13 @@ final case class GenericRecordIO(path: String, schema: Schema) extends AvroIO[Ge
    * file.
    */
   override protected def read(sc: ScioContext, params: ReadP): SCollection[GenericRecord] = {
+    val coder = CoderMaterializer.beam(sc, Coder.avroGenericRecordCoder(schema))
     val t = beam.AvroIO
       .readGenericRecords(schema)
       .from(path)
-    sc.applyTransform(t)
+    sc
+      .applyTransform(t)
+      .setCoder(coder)
   }
 
   /**

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -63,9 +63,7 @@ final class SCollectionTableRowOps[T <: TableRow](private val self: SCollection[
 
     self
       .covary[TableRow]
-      .write(
-        BigQueryTypedTable(table, Format.TableRow)(coders.tableRowCoder)
-      )(param)
+      .write(BigQueryTypedTable(table, Format.TableRow)(coders.tableRowCoder))(param)
   }
 
   /**

--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcIO.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/JdbcIO.scala
@@ -71,9 +71,10 @@ final case class JdbcSelect[T: Coder](readOptions: JdbcReadOptions[T]) extends J
   override def testId: String = s"JdbcIO(${JdbcIO.jdbcIoId(readOptions)})"
 
   override protected def read(sc: ScioContext, params: ReadP): SCollection[T] = {
+    val coder = CoderMaterializer.beam(sc, Coder[T])
     var transform = beam.JdbcIO
       .read[T]()
-      .withCoder(CoderMaterializer.beam(sc, Coder[T]))
+      .withCoder(coder)
       .withDataSourceConfiguration(JdbcIO.dataSourceConfiguration(readOptions.connectionOptions))
       .withQuery(readOptions.query)
       .withRowMapper(new beam.JdbcIO.RowMapper[T] {

--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/sharded/JdbcShardedSelect.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/sharded/JdbcShardedSelect.scala
@@ -34,11 +34,8 @@ final case class JdbcShardedSelect[T: Coder, S](
   override def testId: String = s"JdbcShardedSelect(${JdbcShardedSelect.jdbcIoId(readOptions)})"
 
   override protected def read(sc: ScioContext, params: ReadP): SCollection[T] = {
-
-    val transform = Read.from(
-      new JdbcShardedSource(readOptions, CoderMaterializer.beam(sc, Coder[T]))
-    )
-
+    val coder = CoderMaterializer.beam(sc, Coder[T])
+    val transform = Read.from(new JdbcShardedSource(readOptions, coder))
     sc.applyTransform(transform)
   }
 

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TFRecordIO.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TFRecordIO.scala
@@ -18,6 +18,7 @@
 package com.spotify.scio.tensorflow
 
 import com.spotify.scio.ScioContext
+import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.io.{ScioIO, Tap, TapOf}
 import com.spotify.scio.util.ScioUtil
 import com.spotify.scio.values.SCollection
@@ -42,8 +43,10 @@ final case class TFRecordIO(path: String) extends ScioIO[Array[Byte]] {
   override type WriteP = TFRecordIO.WriteParam
   override val tapT: TapT.Aux[Array[Byte], Array[Byte]] = TapOf[Array[Byte]]
 
-  override protected def read(sc: ScioContext, params: ReadP): SCollection[Array[Byte]] =
-    TFRecordMethods.read(sc, path, params)
+  override protected def read(sc: ScioContext, params: ReadP): SCollection[Array[Byte]] = {
+    val coder = CoderMaterializer.beam(sc, Coder.arrayByteCoder)
+    TFRecordMethods.read(sc, path, params).setCoder(coder)
+  }
 
   override protected def write(data: SCollection[Array[Byte]], params: WriteP): Tap[Array[Byte]] = {
     TFRecordMethods.write(data, path, params)


### PR DESCRIPTION
Some scio IOs were not seting scio coders on the underlying PCollection and relying on the default coder provided by beam. This can cause issues:
- coder options are not respected (Nullable)
- union may fail. Default beam coders are not 'wrapped'. The beam runtime check on coder equality fails.