### PR TITLE
Make ZSTD default compression for Parquet writes

### DIFF
--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -303,7 +303,7 @@ object ParquetAvroIO {
     private[scio] val DefaultSchema = null
     private[scio] val DefaultNumShards = 0
     private[scio] val DefaultSuffix = ".parquet"
-    private[scio] val DefaultCompression = CompressionCodecName.GZIP
+    private[scio] val DefaultCompression = CompressionCodecName.ZSTD
     private[scio] val DefaultConfiguration = null
     private[scio] val DefaultShardNameTemplate = null
     private[scio] val DefaultTempDirectory = null

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -221,7 +221,7 @@ object ParquetExampleIO {
   object WriteParam {
     private[tensorflow] val DefaultNumShards = 0
     private[tensorflow] val DefaultSuffix = ".parquet"
-    private[tensorflow] val DefaultCompression = CompressionCodecName.GZIP
+    private[tensorflow] val DefaultCompression = CompressionCodecName.ZSTD
     private[tensorflow] val DefaultConfiguration = null
     private[tensorflow] val DefaultShardNameTemplate = null
     private[tensorflow] val DefaultTempDirectory = null

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -188,7 +188,7 @@ object ParquetTypeIO {
   object WriteParam {
     private[scio] val DefaultNumShards = 0
     private[scio] val DefaultSuffix = ".parquet"
-    private[scio] val DefaultCompression = CompressionCodecName.GZIP
+    private[scio] val DefaultCompression = CompressionCodecName.ZSTD
     private[scio] val DefaultConfiguration = null
     private[scio] val DefaultShardNameTemplate = null
     private[scio] val DefaultTempDirectory = null

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
@@ -51,7 +51,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
  * Avro records.
  */
 public class ParquetAvroFileOperations<ValueT> extends FileOperations<ValueT> {
-  static final CompressionCodecName DEFAULT_COMPRESSION = CompressionCodecName.GZIP;
+  static final CompressionCodecName DEFAULT_COMPRESSION = CompressionCodecName.ZSTD;
   private final SerializableSchemaSupplier schemaSupplier;
   private final CompressionCodecName compression;
   private final SerializableConfiguration conf;

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
@@ -33,7 +33,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import java.nio.channels.{ReadableByteChannel, WritableByteChannel}
 
 object ParquetTypeFileOperations {
-  val DefaultCompression = CompressionCodecName.GZIP
+  val DefaultCompression = CompressionCodecName.ZSTD
   val DefaultConfiguration: Configuration = null
 
   def apply[T: Coder: ParquetType](): ParquetTypeFileOperations[T] = apply(DefaultCompression)

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonFileOperationsTest.java
@@ -47,7 +47,7 @@ public class JsonFileOperationsTest {
 
   @Test
   public void testCompression() throws Exception {
-    test(Compression.GZIP);
+    test(Compression.ZSTD);
   }
 
   private void test(Compression compression) throws Exception {

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
@@ -217,13 +217,13 @@ public class ParquetAvroFileOperationsTest {
     MatcherAssert.assertThat(
         displayData, hasDisplayItem("compression", Compression.UNCOMPRESSED.toString()));
     MatcherAssert.assertThat(
-        displayData, hasDisplayItem("compressionCodecName", CompressionCodecName.GZIP.name()));
+        displayData, hasDisplayItem("compressionCodecName", CompressionCodecName.ZSTD.name()));
     MatcherAssert.assertThat(displayData, hasDisplayItem("schema", USER_SCHEMA.getFullName()));
   }
 
   private void writeFile(ResourceId file) throws IOException {
     final ParquetAvroFileOperations<GenericRecord> fileOperations =
-        ParquetAvroFileOperations.of(USER_SCHEMA, CompressionCodecName.GZIP);
+        ParquetAvroFileOperations.of(USER_SCHEMA, CompressionCodecName.ZSTD);
     final FileOperations.Writer<GenericRecord> writer = fileOperations.createWriter(file);
     for (GenericRecord record : USER_RECORDS) {
       writer.write(record);

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowFileOperationsTest.java
@@ -53,7 +53,7 @@ public class TensorFlowFileOperationsTest {
 
   @Test
   public void testCompressed() throws Exception {
-    test(Compression.GZIP);
+    test(Compression.ZSTD);
   }
 
   private void test(Compression compression) throws Exception {

--- a/site/src/main/paradox/io/Parquet.md
+++ b/site/src/main/paradox/io/Parquet.md
@@ -287,7 +287,9 @@ val parquetConf: Configuration = {
 Here are some other recommended settings.
 
 - `numShards` - This should be explicitly set so that the size of each output file is smaller than but close to `parquet.block.size`, i.e. 1 GiB. This guarantees that each file contains 1 row group only and reduces seeks.
-- `compression` - `SNAPPY` and `GZIP` work out of the box. Snappy is less CPU intensive but has lower compression ratio. In our benchmarks GZIP seem to work better on GCS.
+- `compression` - Parquet defaults to ZSTD compression with a level of 3; compression level can be set to any integer from 1-22 using the configuration option `parquet.compression.codec.zstd.level`. `SNAPPY` and `GZIP` compression types also work out of the box; Snappy is less CPU intensive but has lower compression ratio. In our benchmarks GZIP seem to work better than Snappy on GCS.
+
+A full list of Parquet configuration options can be found [here](https://github.com/apache/parquet-mr/blob/master/parquet-hadoop/README.md).
 
 ## Parquet Reads in Scio 0.12.0+
 


### PR DESCRIPTION
(fix #4698)

The Parquet Java library supports ZSTD with a default level of 3 ([doc](https://github.com/apache/parquet-mr/blob/master/parquet-hadoop/README.md#class-zstandardcodec)) based off the [zstd-jni](https://github.com/luben/zstd-jni) library; level can be customized using the Configuration `parquet.compression.codec.zstd.level`.

ZSTD has been [shown](https://www.uber.com/en-SE/blog/cost-efficiency-big-data/) to have moderate performance improvements over GZIP or Snappy, and is [supported](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-parquet#parquet_compression) for BigQuery loads.