### PR TITLE
Don't re-use Configuration objects in Parquet SMB

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
@@ -48,8 +48,6 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
  */
 public class ParquetAvroFileOperations<ValueT> extends FileOperations<ValueT> {
   static final CompressionCodecName DEFAULT_COMPRESSION = CompressionCodecName.GZIP;
-  static final Configuration DEFAULT_CONFIGURATION = new Configuration();
-
   private final SerializableSchemaSupplier schemaSupplier;
   private final CompressionCodecName compression;
   private final SerializableConfiguration conf;
@@ -73,7 +71,7 @@ public class ParquetAvroFileOperations<ValueT> extends FileOperations<ValueT> {
 
   public static <V extends GenericRecord> ParquetAvroFileOperations<V> of(
       Schema schema, CompressionCodecName compression) {
-    return of(schema, compression, DEFAULT_CONFIGURATION);
+    return of(schema, compression, new Configuration());
   }
 
   public static <V extends GenericRecord> ParquetAvroFileOperations<V> of(
@@ -83,7 +81,7 @@ public class ParquetAvroFileOperations<ValueT> extends FileOperations<ValueT> {
 
   public static <V extends GenericRecord> ParquetAvroFileOperations<V> of(
       Schema schema, FilterPredicate predicate) {
-    return of(schema, predicate, DEFAULT_CONFIGURATION);
+    return of(schema, predicate, new Configuration());
   }
 
   public static <V extends GenericRecord> ParquetAvroFileOperations<V> of(

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
@@ -34,6 +34,7 @@ import java.nio.channels.{ReadableByteChannel, WritableByteChannel}
 
 object ParquetTypeFileOperations {
   val DefaultCompression = CompressionCodecName.GZIP
+  val DefaultConfiguration = null
 
   def apply[T: Coder: ParquetType](): ParquetTypeFileOperations[T] = apply(DefaultCompression)
 

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
@@ -34,7 +34,7 @@ import java.nio.channels.{ReadableByteChannel, WritableByteChannel}
 
 object ParquetTypeFileOperations {
   val DefaultCompression = CompressionCodecName.GZIP
-  val DefaultConfiguration = null
+  val DefaultConfiguration: Configuration = null
 
   def apply[T: Coder: ParquetType](): ParquetTypeFileOperations[T] = apply(DefaultCompression)
 

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
@@ -34,14 +34,13 @@ import java.nio.channels.{ReadableByteChannel, WritableByteChannel}
 
 object ParquetTypeFileOperations {
   val DefaultCompression = CompressionCodecName.GZIP
-  val DefaultConfiguration = new Configuration()
 
   def apply[T: Coder: ParquetType](): ParquetTypeFileOperations[T] = apply(DefaultCompression)
 
   def apply[T: Coder: ParquetType](
     compression: CompressionCodecName
   ): ParquetTypeFileOperations[T] =
-    apply(compression, DefaultConfiguration)
+    apply(compression, new Configuration())
 
   def apply[T: Coder: ParquetType](
     compression: CompressionCodecName,
@@ -50,7 +49,7 @@ object ParquetTypeFileOperations {
     ParquetTypeFileOperations(compression, new SerializableConfiguration(conf), null)
 
   def apply[T: Coder: ParquetType](predicate: FilterPredicate): ParquetTypeFileOperations[T] =
-    apply(predicate, DefaultConfiguration)
+    apply(predicate, new Configuration())
 
   def apply[T: Coder: ParquetType](
     predicate: FilterPredicate,


### PR DESCRIPTION
Minor bugfix for Parquet-SMB that creates new Configuration objects for each Parquet read/write rather than re-using a single default object. We made a similar fix in the scio-parquet module for the 0.12.x release because we encountered a few cases of users doing multiple Parquet reads who found that the configuration they applied to one read was also getting applied to the other.

Thankfully, I don't think this bug has had any actual impact, since `ParquetAvroSortedBucketIO` and `ParquetTypeSortedBucketIO` always set a fresh Configuration object in the builder methods, and users don't typically interact with the *FileOperations classes directly :)