### PR TITLE
Support Parquet in BQ ExtractOps

### DIFF
--- a/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/BigQueryClientIT.scala
+++ b/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/BigQueryClientIT.scala
@@ -23,7 +23,7 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
 import com.google.cloud.storage.Storage.BlobListOption
 import com.google.cloud.storage.{Blob, StorageOptions}
-import com.spotify.scio.bigquery.client.BigQuery
+import com.spotify.scio.bigquery.client.{BigQuery, ParquetCompression}
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
@@ -240,6 +240,18 @@ class BigQueryClientIT extends AnyFlatSpec with Matchers {
       s"gs://$bucket/$prefix"
     )
     bq.extract.asAvro(sourceTable, destination)
+    GcsUtils.exists(bucket, prefix) shouldBe true
+    GcsUtils.remove(bucket, prefix)
+  }
+
+  "extract.asParquet" should "work" in {
+    val sourceTable = "bigquery-public-data:samples.shakespeare"
+    val (bucket, prefix) = ("data-integration-test-eu", s"extract/parquet/${UUID.randomUUID}")
+    GcsUtils.exists(bucket, prefix) shouldBe false
+    val destination = List(
+      s"gs://$bucket/$prefix"
+    )
+    bq.extract.asParquet(sourceTable, destination, compression = ParquetCompression.Zstd())
     GcsUtils.exists(bucket, prefix) shouldBe true
     GcsUtils.remove(bucket, prefix)
   }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/ExtractOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/ExtractOps.scala
@@ -45,6 +45,10 @@ sealed trait SnappyT extends CompressionT {
   case class Snappy() extends Compression(Some("SNAPPY"))
 }
 
+sealed trait ZstdT extends CompressionT {
+  case class Zstd() extends Compression(Some("ZSTD"))
+}
+
 sealed trait NoCompressionT extends CompressionT {
   case class NoCompression() extends Compression(None)
 }
@@ -52,6 +56,7 @@ sealed trait NoCompressionT extends CompressionT {
 object CsvCompression extends NoCompressionT with GzipT
 object AvroCompression extends NoCompressionT with DeflateT with SnappyT
 object JsonCompression extends NoCompressionT with GzipT
+object ParquetCompression extends NoCompressionT with GzipT with SnappyT with ZstdT
 
 final private[client] class ExtractOps(client: Client, jobService: JobOps) {
   import ExtractOps._
@@ -95,6 +100,18 @@ final private[client] class ExtractOps(client: Client, jobService: JobOps) {
       sourceTable = sourceTable,
       destinationUris = destinationUris,
       format = "AVRO",
+      compression = compression.name
+    )
+
+  def asParquet(
+    sourceTable: String,
+    destinationUris: List[String],
+    compression: ParquetCompression.Compression = ParquetCompression.NoCompression()
+  ): Unit =
+    exportTable(
+      sourceTable = sourceTable,
+      destinationUris = destinationUris,
+      format = "PARQUET",
       compression = compression.name
     )
 


### PR DESCRIPTION
Adds Parquet supports to `ExtractOpts`, configured according to Google spec: https://cloud.google.com/bigquery/docs/exporting-data#export_formats_and_compression_types