### PR TITLE
Make SeqExampleSCollectionOps consistent

### DIFF
--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
@@ -198,7 +198,15 @@ final class SeqExampleSCollectionOps[T <: Example](private val self: SCollection
       TFExampleIO.WriteParam.DefaultFilenamePolicySupplier
   ): ClosedTap[Example] =
     new ExampleSCollectionOps(self.map(SeqExampleSCollectionOps.mergeExamples))
-      .saveAsTfRecordFile(path, suffix, compression, numShards, shardNameTemplate, tempDirectory, filenamePolicySupplier)
+      .saveAsTfRecordFile(
+        path,
+        suffix,
+        compression,
+        numShards,
+        shardNameTemplate,
+        tempDirectory,
+        filenamePolicySupplier
+      )
 }
 
 final class TFRecordSCollectionOps[T <: Array[Byte]](private val self: SCollection[T])

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/syntax/SCollectionSyntax.scala
@@ -191,10 +191,14 @@ final class SeqExampleSCollectionOps[T <: Example](private val self: SCollection
     path: String,
     suffix: String = TFExampleIO.WriteParam.DefaultSuffix,
     compression: Compression = TFExampleIO.WriteParam.DefaultCompression,
-    numShards: Int = TFExampleIO.WriteParam.DefaultNumShards
+    numShards: Int = TFExampleIO.WriteParam.DefaultNumShards,
+    shardNameTemplate: String = TFExampleIO.WriteParam.DefaultShardNameTemplate,
+    tempDirectory: String = TFExampleIO.WriteParam.DefaultTempDirectory,
+    filenamePolicySupplier: FilenamePolicySupplier =
+      TFExampleIO.WriteParam.DefaultFilenamePolicySupplier
   ): ClosedTap[Example] =
     new ExampleSCollectionOps(self.map(SeqExampleSCollectionOps.mergeExamples))
-      .saveAsTfRecordFile(path, suffix, compression, numShards)
+      .saveAsTfRecordFile(path, suffix, compression, numShards, shardNameTemplate, tempDirectory, filenamePolicySupplier)
 }
 
 final class TFRecordSCollectionOps[T <: Array[Byte]](private val self: SCollection[T])


### PR DESCRIPTION
Wasn't consistent with other `saveAs*` APIs in this package -- in particular didn't have `tempDirectory` :)