### PR TITLE
Expose cache in scio-grpc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -190,13 +190,23 @@ lazy val mimaSettings = Def.settings(
   mimaBinaryIssueFilters := Seq(
     // minor scio-tensorflow breaking changes for 0.12.6
     ProblemFilters.exclude[DirectMissingMethodProblem](
-      "com.spotify.scio.tensorflow.syntax.SeqExampleSCollectionOps.saveAsTfRecordFile$extension"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
       "com.spotify.scio.tensorflow.syntax.SeqExampleSCollectionOps.saveAsTfRecordFile"
     ),
     ProblemFilters.exclude[DirectMissingMethodProblem](
       "com.spotify.scio.tensorflow.syntax.SeqExampleSCollectionOps.saveAsTfRecordFile$extension"
+    ),
+    // minor scio-grpc breaking changes for 0.12.6
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "com.spotify.scio.grpc.GrpcSCollectionOps.grpcLookup"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "com.spotify.scio.grpc.GrpcSCollectionOps.grpcLookup$extension"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "com.spotify.scio.grpc.GrpcSCollectionOps.grpcLookupStream"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "com.spotify.scio.grpc.GrpcSCollectionOps.grpcLookupStream$extension"
     )
   ),
   mimaPreviousArtifacts :=


### PR DESCRIPTION
Allow user to provide a `CacheSupplier` in scio-grpc API to cache responses