### PR TITLE
Don't forget to fan out

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -67,6 +67,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   )(f: KV[K, UI] => (K, UO)): SCollection[(K, UO)] = {
     self.transform(
       _.withName("TupleToKv").toKV
+        .withName(t.getName) // propagate transform name
         .applyTransform(t)
         .withName("KvToTuple")
         .map(f)
@@ -89,7 +90,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    *   intermediate node.
    */
   def withHotKeyFanout(hotKeyFanout: K => Int): SCollectionWithHotKeyFanout[K, V] =
-    new SCollectionWithHotKeyFanout(context, this, Left(hotKeyFanout))
+    new SCollectionWithHotKeyFanout(this, Left(hotKeyFanout))
 
   /**
    * Convert this SCollection to an [[SCollectionWithHotKeyFanout]] that uses an intermediate node
@@ -98,7 +99,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    *   constant value for every key
    */
   def withHotKeyFanout(hotKeyFanout: Int): SCollectionWithHotKeyFanout[K, V] =
-    new SCollectionWithHotKeyFanout(context, this, Right(hotKeyFanout))
+    new SCollectionWithHotKeyFanout(this, Right(hotKeyFanout))
 
   // =======================================================================
   // CoGroups

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -89,7 +89,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    *   intermediate node.
    */
   def withHotKeyFanout(hotKeyFanout: K => Int): SCollectionWithHotKeyFanout[K, V] =
-    new SCollectionWithHotKeyFanout(this, Left(hotKeyFanout))
+    new SCollectionWithHotKeyFanout(context, this, Left(hotKeyFanout))
 
   /**
    * Convert this SCollection to an [[SCollectionWithHotKeyFanout]] that uses an intermediate node
@@ -98,7 +98,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
    *   constant value for every key
    */
   def withHotKeyFanout(hotKeyFanout: Int): SCollectionWithHotKeyFanout[K, V] =
-    new SCollectionWithHotKeyFanout(this, Right(hotKeyFanout))
+    new SCollectionWithHotKeyFanout(context, this, Right(hotKeyFanout))
 
   // =======================================================================
   // CoGroups

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -67,8 +67,7 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   )(f: KV[K, UI] => (K, UO)): SCollection[(K, UO)] = {
     self.transform(
       _.withName("TupleToKv").toKV
-        .withName(t.getName) // propagate transform name
-        .applyTransform(t)
+        .applyTransform(t.getName, t)
         .withName("KvToTuple")
         .map(f)
     )

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -202,16 +202,13 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
     name: Option[String],
     transform: PTransform[_ >: PCollection[T], PCollection[U]]
   ): SCollection[U] = {
-    val t =
-      if (
-        (classOf[Combine.Globally[T, U]] isAssignableFrom transform.getClass)
-        && ScioUtil.isWindowed(this)
-      ) {
-        // In case PCollection is windowed
-        transform.asInstanceOf[Combine.Globally[T, U]].withoutDefaults()
-      } else {
-        transform
-      }
+    val isCombineGlobally = classOf[Combine.Globally[T, U]].isAssignableFrom(transform.getClass)
+    val t = if (isCombineGlobally && ScioUtil.isWindowed(this)) {
+      // In case PCollection is windowed
+      transform.asInstanceOf[Combine.Globally[T, U]].withoutDefaults()
+    } else {
+      transform
+    }
     context.wrap(this.applyInternal(name, t))
   }
 

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithFanout.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithFanout.scala
@@ -51,7 +51,7 @@ class SCollectionWithFanout[T] private[values] (coll: SCollection[T], fanout: In
   def aggregate[A: Coder, U: Coder](aggregator: Aggregator[T, A, U]): SCollection[U] = {
     val a = aggregator // defeat closure
     coll.transform { in =>
-      new SCollectionWithFanout(coll.map(a.prepare), fanout)
+      new SCollectionWithFanout(in.map(a.prepare), fanout)
         .sum(a.semigroup)
         .map(a.present)
     }
@@ -61,7 +61,7 @@ class SCollectionWithFanout[T] private[values] (coll: SCollection[T], fanout: In
   def aggregate[A: Coder, U: Coder](aggregator: MonoidAggregator[T, A, U]): SCollection[U] = {
     val a = aggregator // defeat closure
     coll.transform { in =>
-      new SCollectionWithFanout(coll.map(a.prepare), fanout)
+      new SCollectionWithFanout(in.map(a.prepare), fanout)
         .fold(a.monoid)
         .map(a.present)
     }

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithFanout.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithFanout.scala
@@ -50,13 +50,21 @@ class SCollectionWithFanout[T] private[values] (coll: SCollection[T], fanout: In
   /** [[SCollection.aggregate[A,U]* SCollection.aggregate]] with fan out. */
   def aggregate[A: Coder, U: Coder](aggregator: Aggregator[T, A, U]): SCollection[U] = {
     val a = aggregator // defeat closure
-    coll.transform(_.map(a.prepare).sum(a.semigroup).map(a.present))
+    coll.transform { in =>
+      new SCollectionWithFanout(coll.map(a.prepare), fanout)
+        .sum(a.semigroup)
+        .map(a.present)
+    }
   }
 
   /** [[SCollection.aggregate[A,U]* SCollection.aggregate]] with fan out. */
   def aggregate[A: Coder, U: Coder](aggregator: MonoidAggregator[T, A, U]): SCollection[U] = {
     val a = aggregator // defeat closure
-    coll.transform(_.map(a.prepare).fold(a.monoid).map(a.present))
+    coll.transform { in =>
+      new SCollectionWithFanout(coll.map(a.prepare), fanout)
+        .fold(a.monoid)
+        .map(a.present)
+    }
   }
 
   /** [[SCollection.combine]] with fan out. */
@@ -85,7 +93,9 @@ class SCollectionWithFanout[T] private[values] (coll: SCollection[T], fanout: In
 
   /** [[SCollection.fold(implicit* SCollection.fold]] with fan out. */
   def fold(implicit mon: Monoid[T]): SCollection[T] =
-    coll.pApply(Combine.globally(Functions.reduceFn(context, mon)).withFanout(fanout))
+    coll.pApply(
+      Combine.globally(Functions.reduceFn(context, mon)).withFanout(fanout)
+    )
 
   /** [[SCollection.reduce]] with fan out. */
   def reduce(op: (T, T) => T): SCollection[T] =
@@ -100,7 +110,10 @@ class SCollectionWithFanout[T] private[values] (coll: SCollection[T], fanout: In
         "Consider aggregate/fold instead."
     )
     coll.pApply(
-      Combine.globally(Functions.reduceFn(context, sg)).withoutDefaults().withFanout(fanout)
+      Combine
+        .globally(Functions.reduceFn(context, sg))
+        .withoutDefaults()
+        .withFanout(fanout)
     )
   }
 }

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithFanout.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithFanout.scala
@@ -93,9 +93,7 @@ class SCollectionWithFanout[T] private[values] (coll: SCollection[T], fanout: In
 
   /** [[SCollection.fold(implicit* SCollection.fold]] with fan out. */
   def fold(implicit mon: Monoid[T]): SCollection[T] =
-    coll.pApply(
-      Combine.globally(Functions.reduceFn(context, mon)).withFanout(fanout)
-    )
+    coll.pApply(Combine.globally(Functions.reduceFn(context, mon)).withFanout(fanout))
 
   /** [[SCollection.reduce]] with fan out. */
   def reduce(op: (T, T) => T): SCollection[T] =
@@ -110,10 +108,7 @@ class SCollectionWithFanout[T] private[values] (coll: SCollection[T], fanout: In
         "Consider aggregate/fold instead."
     )
     coll.pApply(
-      Combine
-        .globally(Functions.reduceFn(context, sg))
-        .withoutDefaults()
-        .withFanout(fanout)
+      Combine.globally(Functions.reduceFn(context, sg)).withoutDefaults().withFanout(fanout)
     )
   }
 }

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithHotKeyFanout.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollectionWithHotKeyFanout.scala
@@ -61,12 +61,10 @@ class SCollectionWithHotKeyFanout[K, V] private[values] (
    */
   def aggregateByKey[U: Coder](
     zeroValue: U
-  )(seqOp: (U, V) => U, combOp: (U, U) => U): SCollection[(K, U)] =
-    self.applyPerKey(
-      withFanout(Combine.perKey(Functions.aggregateFn(context, zeroValue)(seqOp, combOp)))
-    )(
-      kvToTuple
-    )
+  )(seqOp: (U, V) => U, combOp: (U, U) => U): SCollection[(K, U)] = {
+    val cmb = Combine.perKey[K, V, U](Functions.aggregateFn(context, zeroValue)(seqOp, combOp))
+    self.applyPerKey(withFanout(cmb))(kvToTuple)
+  }
 
   /**
    * [[PairSCollectionFunctions.aggregateByKey[A,U]* PairSCollectionFunctions.aggregateByKey]] with
@@ -75,7 +73,7 @@ class SCollectionWithHotKeyFanout[K, V] private[values] (
   def aggregateByKey[A: Coder, U: Coder](aggregator: Aggregator[V, A, U]): SCollection[(K, U)] =
     self.self.context.wrap(self.self.internal).transform { in =>
       val a = aggregator // defeat closure
-      in.mapValues(a.prepare)
+      new SCollectionWithHotKeyFanout(context, in.mapValues(a.prepare), hotKeyFanout)
         .sumByKey(a.semigroup)
         .mapValues(a.present)
     }
@@ -89,7 +87,7 @@ class SCollectionWithHotKeyFanout[K, V] private[values] (
   ): SCollection[(K, U)] =
     self.self.context.wrap(self.self.internal).transform { in =>
       val a = aggregator // defeat closure
-      in.mapValues(a.prepare)
+      new SCollectionWithHotKeyFanout(context, in.mapValues(a.prepare), hotKeyFanout)
         .foldByKey(a.monoid)
         .mapValues(a.present)
     }

--- a/scio-test/src/test/scala/com/spotify/scio/values/NamedTransformTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/NamedTransformTest.scala
@@ -52,6 +52,15 @@ trait NamedTransformSpec extends PipelineSpec {
     }
   }
 
+  def assertGraphContainsStepRegex(p: PCollectionWrapper[_], tfNameRegex: String): Assertion = {
+    val visitor = new NameAccumulatingVisitor()
+    p.context.pipeline.traverseTopologically(visitor)
+    val allNodes = visitor.nodes.sorted.mkString("", "\n", "\n")
+    withClue(s"$tfNameRegex did not match a step in any of the following nodes: $allNodes") {
+      visitor.nodes.flatMap(_.split('/')).toSet.filter(_.matches(tfNameRegex)) should not be empty
+    }
+  }
+
   class AssertTransformNameVisitor(pcoll: PCollection[_], tfName: String)
       extends Pipeline.PipelineVisitor.Defaults {
     val prefix: List[String] = tfName.split("[(/]").toList

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithFanoutTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithFanoutTest.scala
@@ -17,12 +17,10 @@
 
 package com.spotify.scio.values
 
-import com.spotify.scio.testing.PipelineSpec
 import com.twitter.algebird.{Aggregator, Semigroup}
-
 import com.spotify.scio.coders.Coder
 
-class SCollectionWithFanoutTest extends PipelineSpec {
+class SCollectionWithFanoutTest extends NamedTransformSpec {
   "SCollectionWithFanout" should "support aggregate()" in {
     runWithContext { sc =>
       val p = sc.parallelize(1 to 100).withFanout(10)
@@ -72,5 +70,44 @@ class SCollectionWithFanoutTest extends PipelineSpec {
       sum(1.0, 2.0, 3.0) should containSingleValue(6.0)
       sum(1 to 100: _*) should containSingleValue(5050)
     }
+  }
+
+  private def shouldFanOut[T](fn: SCollectionWithFanout[Int] => SCollection[T]) = {
+    runWithContext { sc =>
+      val p = fn(sc.parallelize(1 to 100).withFanout(10))
+      assertGraphContainsStep(p, "Combine.perKeyWithFanout(Anonymous)")
+    }
+  }
+
+  it should "fan out with aggregate(zeroValue)(seqOp)" in {
+    shouldFanOut(_.aggregate(0.0)(_ + _, _ + _))
+  }
+
+  it should "fan out with aggregate(Aggregator)" in {
+    shouldFanOut(_.aggregate(Aggregator.max[Int]))
+  }
+
+  it should "fan out with aggregate(MonoidAggregator)" in {
+    shouldFanOut(_.aggregate(Aggregator.immutableSortedReverseTake[Int](5)))
+  }
+
+  it should "fan out with combine()" in {
+    shouldFanOut(_.combine(_.toDouble)(_ + _)(_ + _))
+  }
+
+  it should "fan out with fold(zeroValue)(op)" in {
+    shouldFanOut(_.fold(0)(_ + _))
+  }
+
+  it should "fan out with fold(Monoid)" in {
+    shouldFanOut(_.fold)
+  }
+
+  it should "fan out with reduce()" in {
+    shouldFanOut(_.reduce(_ + _))
+  }
+
+  it should "fan out with sum()" in {
+    shouldFanOut(_.sum)
   }
 }

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithFanoutTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithFanoutTest.scala
@@ -75,7 +75,7 @@ class SCollectionWithFanoutTest extends NamedTransformSpec {
   private def shouldFanOut[T](fn: SCollectionWithFanout[Int] => SCollection[T]) = {
     runWithContext { sc =>
       val p = fn(sc.parallelize(1 to 100).withFanout(10))
-      assertGraphContainsStep(p, "Combine.perKeyWithFanout(Anonymous)")
+      assertGraphContainsStepRegex(p, "Combine\\.perKeyWithFanout\\([^)]*\\)")
     }
   }
 

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithHotKeyFanoutTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithHotKeyFanoutTest.scala
@@ -100,7 +100,7 @@ class SCollectionWithHotKeyFanoutTest extends NamedTransformSpec {
       val p1 = sc.parallelize(1 to 100).map(("a", _))
       val p2 = sc.parallelize(1 to 10).map(("b", _))
       val p = (p1 ++ p2).withHotKeyFanout(10)
-      assertGraphContainsStep(fn(p), "Combine.perKeyWithFanout(Anonymous)")
+      assertGraphContainsStepRegex(fn(p), "Combine\\.perKeyWithFanout\\([^)]*\\)")
     }
   }
 


### PR DESCRIPTION
Fixes `aggregate` transforms in `withFanout` and `withHotKeyFanout` where the wrapped SCollection was inadvertently converted back to a normal SCollection, thereby dropping the fanout. 