### PR TITLE
Add fanout for CMS hot key computation in skewed joins

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSkewedSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSkewedSCollectionFunctions.scala
@@ -59,14 +59,14 @@ object HotKeyMethod {
 object SkewedJoins {
 
   // some sensible defaults for skewed joins
-  val DefaultHotKeyThreshold = 9000
-  val DefaultHotKeyMethod = HotKeyMethod.Threshold(DefaultHotKeyThreshold)
-  val DefaultHotKeyFanout = 5
-  val DefaultCmsEpsilon = 0.001
-  val DefaultCmsDelta = 1e-10
-  val DefaultCmsSeed = 42
-  val DefaultSampleFraction = 1.0
-  val DefaultSampleWithReplacement = true
+  val DefaultHotKeyThreshold: Int = 9000
+  val DefaultHotKeyMethod: HotKeyMethod.Threshold = HotKeyMethod.Threshold(DefaultHotKeyThreshold)
+  val DefaultHotKeyFanout: Int = 5
+  val DefaultCmsEpsilon: Double = 0.001
+  val DefaultCmsDelta: Double = 1e-10
+  val DefaultCmsSeed: Int = 42
+  val DefaultSampleFraction: Double = 1.0
+  val DefaultSampleWithReplacement: Boolean = true
 
   private[scio] def union[T](hot: SCollection[T], chill: SCollection[T]): SCollection[T] =
     hot.withName("Union hot and chill join results").union(chill)

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSkewedSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSkewedSCollectionFunctions.scala
@@ -61,7 +61,7 @@ object SkewedJoins {
   // some sensible defaults for skewed joins
   val DefaultHotKeyThreshold: Int = 9000
   val DefaultHotKeyMethod: HotKeyMethod.Threshold = HotKeyMethod.Threshold(DefaultHotKeyThreshold)
-  val DefaultHotKeyFanout: Int = 5
+  val DefaultHotKeyFanout: Int = 1
   val DefaultCmsEpsilon: Double = 0.001
   val DefaultCmsDelta: Double = 1e-10
   val DefaultCmsSeed: Int = 42

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSkewedSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSkewedSCollectionFunctions.scala
@@ -60,6 +60,7 @@ object SkewedJoins {
 
   // some sensible defaults for skewed joins
   val DefaultHotKeyThreshold = 9000
+  val DefaultHotKeyMethod = HotKeyMethod.Threshold(DefaultHotKeyThreshold)
   val DefaultHotKeyFanout = 5
   val DefaultCmsEpsilon = 0.001
   val DefaultCmsDelta = 1e-10

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSkewedSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSkewedSCollectionFunctionsTest.scala
@@ -24,11 +24,6 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPropertyChecks {
   import com.twitter.algebird.CMSHasherImplicits._
 
-  private val skewSeed = 42
-  private val skewEps = 0.001d
-  private val skewDelta = 1e-10
-  private val skewWithReplacement = true
-
   private val joinSetup = Table(
     ("lhs", "rhs", "out"),
     // no duplicate keys
@@ -126,11 +121,12 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
               pLhs.skewedJoin(
                 pRhs,
                 method,
-                skewEps,
-                skewSeed,
-                skewDelta,
+                SkewedJoins.DefaultHotKeyFanout,
+                SkewedJoins.DefaultCmsEpsilon,
+                SkewedJoins.DefaultCmsSeed,
+                SkewedJoins.DefaultCmsDelta,
                 sampleFraction,
-                skewWithReplacement
+                SkewedJoins.DefaultSampleWithReplacement
               )
             p should containInAnyOrder(out)
           }
@@ -150,11 +146,12 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
               pLhs.skewedLeftOuterJoin(
                 pRhs,
                 method,
-                skewEps,
-                skewSeed,
-                skewDelta,
+                SkewedJoins.DefaultHotKeyFanout,
+                SkewedJoins.DefaultCmsEpsilon,
+                SkewedJoins.DefaultCmsSeed,
+                SkewedJoins.DefaultCmsDelta,
                 sampleFraction,
-                skewWithReplacement
+                SkewedJoins.DefaultSampleWithReplacement
               )
             p should containInAnyOrder(out)
           }
@@ -173,11 +170,12 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
             val p = pLhs.skewedFullOuterJoin(
               pRhs,
               method,
-              skewEps,
-              skewSeed,
-              skewDelta,
+              SkewedJoins.DefaultHotKeyFanout,
+              SkewedJoins.DefaultCmsEpsilon,
+              SkewedJoins.DefaultCmsSeed,
+              SkewedJoins.DefaultCmsDelta,
               sampleFraction,
-              skewWithReplacement
+              SkewedJoins.DefaultSampleWithReplacement
             )
             p should containInAnyOrder(out)
           }
@@ -193,8 +191,12 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
     runWithContext { sc =>
       val pLhs = sc.parallelize(lhs)
       val pRhs = sc.parallelize(rhs)
-      val aggregator = CMS.aggregator[String](skewEps, skewDelta, skewSeed)
-      val cms = CMSOperations.aggregate(pLhs.map(_._1), aggregator)
+      val aggregator = CMS.aggregator[String](
+        SkewedJoins.DefaultCmsEpsilon,
+        SkewedJoins.DefaultCmsDelta,
+        SkewedJoins.DefaultCmsSeed
+      )
+      val cms = CMSOperations.aggregate(pLhs.map(_._1), aggregator, 2)
       val (l, r) = CMSOperations.partition(pLhs, pRhs, cms, threshold)
 
       // hot key is a
@@ -215,8 +217,13 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
     runWithContext { sc =>
       val pLhs = sc.parallelize(lhs)
       val pRhs = sc.parallelize(rhs)
-      val aggregator = TopPctCMS.aggregator[String](skewEps, skewDelta, skewSeed, pct)
-      val cms = CMSOperations.aggregate(pLhs.map(_._1), aggregator)
+      val aggregator = TopPctCMS.aggregator[String](
+        SkewedJoins.DefaultCmsEpsilon,
+        SkewedJoins.DefaultCmsDelta,
+        SkewedJoins.DefaultCmsSeed,
+        pct
+      )
+      val cms = CMSOperations.aggregate(pLhs.map(_._1), aggregator, 2)
       val (l, r) = CMSOperations.partition(pLhs, pRhs, cms)
 
       // hot key is a
@@ -237,8 +244,13 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
     runWithContext { sc =>
       val pLhs = sc.parallelize(lhs)
       val pRhs = sc.parallelize(rhs)
-      val aggregator = TopNCMS.aggregator[String](skewEps, skewDelta, skewSeed, count)
-      val cms = CMSOperations.aggregate(pLhs.map(_._1), aggregator)
+      val aggregator = TopNCMS.aggregator[String](
+        SkewedJoins.DefaultCmsEpsilon,
+        SkewedJoins.DefaultCmsDelta,
+        SkewedJoins.DefaultCmsSeed,
+        count
+      )
+      val cms = CMSOperations.aggregate(pLhs.map(_._1), aggregator, 2)
       val (l, r) = CMSOperations.partition(pLhs, pRhs, cms)
 
       // hot key is a

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSkewedSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSkewedSCollectionFunctionsTest.scala
@@ -123,8 +123,8 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
                 method,
                 SkewedJoins.DefaultHotKeyFanout,
                 SkewedJoins.DefaultCmsEpsilon,
-                SkewedJoins.DefaultCmsSeed,
                 SkewedJoins.DefaultCmsDelta,
+                SkewedJoins.DefaultCmsSeed,
                 sampleFraction,
                 SkewedJoins.DefaultSampleWithReplacement
               )
@@ -148,8 +148,8 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
                 method,
                 SkewedJoins.DefaultHotKeyFanout,
                 SkewedJoins.DefaultCmsEpsilon,
-                SkewedJoins.DefaultCmsSeed,
                 SkewedJoins.DefaultCmsDelta,
+                SkewedJoins.DefaultCmsSeed,
                 sampleFraction,
                 SkewedJoins.DefaultSampleWithReplacement
               )
@@ -172,8 +172,8 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
               method,
               SkewedJoins.DefaultHotKeyFanout,
               SkewedJoins.DefaultCmsEpsilon,
-              SkewedJoins.DefaultCmsSeed,
               SkewedJoins.DefaultCmsDelta,
+              SkewedJoins.DefaultCmsSeed,
               sampleFraction,
               SkewedJoins.DefaultSampleWithReplacement
             )
@@ -196,7 +196,7 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
         SkewedJoins.DefaultCmsDelta,
         SkewedJoins.DefaultCmsSeed
       )
-      val cms = CMSOperations.aggregate(pLhs.map(_._1), aggregator, 2)
+      val cms = CMSOperations.aggregate(pLhs.map(_._1), 2, aggregator)
       val (l, r) = CMSOperations.partition(pLhs, pRhs, cms, threshold)
 
       // hot key is a
@@ -223,7 +223,7 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
         SkewedJoins.DefaultCmsSeed,
         pct
       )
-      val cms = CMSOperations.aggregate(pLhs.map(_._1), aggregator, 2)
+      val cms = CMSOperations.aggregate(pLhs.map(_._1), 2, aggregator)
       val (l, r) = CMSOperations.partition(pLhs, pRhs, cms)
 
       // hot key is a
@@ -250,7 +250,7 @@ class PairSkewedSCollectionFunctionsTest extends PipelineSpec with ScalaCheckPro
         SkewedJoins.DefaultCmsSeed,
         count
       )
-      val cms = CMSOperations.aggregate(pLhs.map(_._1), aggregator, 2)
+      val cms = CMSOperations.aggregate(pLhs.map(_._1), 2, aggregator)
       val (l, r) = CMSOperations.partition(pLhs, pRhs, cms)
 
       // hot key is a


### PR DESCRIPTION
Add fanout when computing the CMS for the hot keys in skewed joins.

- on deprecated API, use a fanout of 5 (we can't expose without breaking compatibility)
- expose fanout parameter in new API