### PR TITLE
Pass dataModel to AvroParquetWriter.Builder

### DIFF
--- a/scio-parquet/src/main/java/com/spotify/scio/parquet/avro/ParquetAvroFileBasedSink.java
+++ b/scio-parquet/src/main/java/com/spotify/scio/parquet/avro/ParquetAvroFileBasedSink.java
@@ -27,7 +27,11 @@ import org.apache.beam.sdk.io.hadoop.SerializableConfiguration;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.util.MimeTypes;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.parquet.avro.AvroDataSupplier;
 import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.avro.AvroWriteSupport;
+import org.apache.parquet.avro.SpecificDataSupplier;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
@@ -107,9 +111,21 @@ public class ParquetAvroFileBasedSink<T> extends FileBasedSink<T, Void, T> {
     @Override
     protected void prepareWrite(WritableByteChannel channel) throws Exception {
       BeamOutputFile outputFile = BeamOutputFile.of(channel);
+      Configuration configuration = conf.get();
+
+      // Workaround for PARQUET-2265
+      Class<? extends AvroDataSupplier> dataModelSupplier =
+          configuration.getClass(
+              AvroWriteSupport.AVRO_DATA_SUPPLIER,
+              SpecificDataSupplier.class,
+              AvroDataSupplier.class);
+
       AvroParquetWriter.Builder<T> builder =
-          AvroParquetWriter.<T>builder(outputFile).withSchema(schema);
-      writer = WriterUtils.build(builder, conf.get(), compression);
+          AvroParquetWriter.<T>builder(outputFile)
+              .withSchema(schema)
+              .withDataModel(ReflectionUtils.newInstance(dataModelSupplier, configuration).get());
+
+      writer = WriterUtils.build(builder, configuration, compression);
     }
 
     @Override


### PR DESCRIPTION
Context: `AvroParquetWriter` doesn't load its data-model from the `parquet.avro.write.data.supplier` Configuration param, but instead must be passed in directly to the Builder or else it'll default to `SpecificData.get()`.

Since we don't set `.withDataModel` in Scio's `AvroParquetWriter.Builder`, users effectively cannot override the data supplier used in their Avro write. I filed a [ticket](https://issues.apache.org/jira/browse/PARQUET-2265) on the Parquet JIRA to change this behavior on the Parquet side, but for now we'll have to workaround it by setting `.withDataModel` based on the value of `parquet.avro.write.data.supplier`.

Note: this doesn't replace #4772. Whereas 4772 would address the most common use cases (datetime logical types in Avro 1.8), users with more advanced use cases (i.e., using Avro 1.11+logical types) will still need this PR in order to override data supplier.