### PR TITLE
Ensures guava callback to complete chained futures

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/BaseAsyncLookupDoFn.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/BaseAsyncLookupDoFn.java
@@ -168,6 +168,7 @@ public abstract class BaseAsyncLookupDoFn<A, B, C, F, T>
       } else if (inFlight != null) {
         // pending request for the same element
         futures.put(uuid, handleOutput(inFlight, input, uuid, timestamp, window));
+        requestCount++;
       } else {
         // semaphore release is not performed on exception.
         // let beam retry the bundle. startBundle will reset the semaphore to the
@@ -179,8 +180,8 @@ public abstract class BaseAsyncLookupDoFn<A, B, C, F, T>
         // make sure semaphore are released when waiting for futures in finishBundle
         final F unlockedFuture = handleSemaphore(future);
         futures.put(uuid, handleOutput(unlockedFuture, input, uuid, timestamp, window));
+        requestCount++;
       }
-      requestCount++;
     } catch (InterruptedException e) {
       LOG.error("Failed to acquire semaphore", e);
       throw new RuntimeException("Failed to acquire semaphore", e);

--- a/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
@@ -45,7 +45,7 @@ public class FutureHandlers {
     default void waitForFutures(Iterable<ListenableFuture<V>> futures)
         throws InterruptedException, ExecutionException {
       // Futures#allAsList only works if all futures succeed
-      Futures.whenAllComplete(futures).run(() -> {}, MoreExecutors.directExecutor()).get();
+      Futures.successfulAsList(futures).get();
     }
 
     @Override
@@ -99,7 +99,7 @@ public class FutureHandlers {
         throws InterruptedException, ExecutionException {
       CompletableFuture[] array =
           StreamSupport.stream(futures.spliterator(), false).toArray(CompletableFuture[]::new);
-      CompletableFuture.allOf(array).get();
+      CompletableFuture.allOf(array).exceptionally(t -> null).get();
     }
 
     @Override

--- a/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
@@ -63,11 +63,18 @@ public class FutureHandlers {
             public void onSuccess(@Nullable V result) {
               try {
                 onSuccess.apply(result);
-              } catch (RuntimeException | Error e) {
+                f.set(result);
+              } catch (Exception e) {
+                // in case onSuccess callback fails,
+                // catch the exception ang propagate it
+                // to the returned future, Let error through
                 f.setException(e);
-                return;
+              } finally {
+                if (!f.isDone()) {
+                  // if we exit without completing future, force an exception
+                  f.setException(new Exception("Failed completing future"));
+                }
               }
-              f.set(result);
             }
 
             @Override

--- a/scio-test/src/test/scala/com/spotify/scio/transforms/AsyncLookupDoFnTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/transforms/AsyncLookupDoFnTest.scala
@@ -79,18 +79,10 @@ class AsyncLookupDoFnTest extends PipelineSpec {
 
   "BaseAsyncDoFn" should "deduplicate simultaneous lookups on the same item" in {
     val n = 100
-    val sc = ScioContext(PipelineOptionsFactory.fromArgs("--targetParallelism=1").create())
-    val f = sc
-      .parallelize(List.fill(n)(10))
-      .parDo(new CountingGuavaLookupDoFn)
-      .materialize
-    val result: ScioResult = sc.run().waitUntilFinish()
-    val maxOutput = result
-      .tap(f)
-      .value
-      .map(kv => kv.getValue.get())
-      .max
-    maxOutput should be < n
+    val output = runWithData(List.fill(n)(10)) {
+      _.parDo(new CountingGuavaLookupDoFn).map(_.getValue.get())
+    }
+    output.max should be < n
   }
 
   "GuavaAsyncLookupDoFn" should "work" in {

--- a/scio-test/src/test/scala/com/spotify/scio/transforms/AsyncLookupDoFnTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/transforms/AsyncLookupDoFnTest.scala
@@ -19,14 +19,12 @@ package com.spotify.scio.transforms
 
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.google.common.util.concurrent.{Futures, ListenableFuture, MoreExecutors}
-import com.spotify.scio._
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.testing._
 import com.spotify.scio.transforms.BaseAsyncLookupDoFn.CacheSupplier
 import com.spotify.scio.transforms.DoFnWithResource.ResourceType
 import com.spotify.scio.transforms.JavaAsyncConverters._
 import com.spotify.scio.util.TransformingCache.SimpleTransformingCache
-import org.apache.beam.sdk.options._
 
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{

--- a/scio-test/src/test/scala/com/spotify/scio/transforms/FutureHandlersTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/transforms/FutureHandlersTest.scala
@@ -145,7 +145,14 @@ class FutureHandlersTest extends AnyFlatSpec with Matchers {
       val ee = the[ExecutionException] thrownBy (access(chainedFuture))
       val cause = ee.getCause
       cause.getMessage shouldBe "failure"
-      cause.getSuppressed.headOption.map(_.getMessage) shouldBe Some("callback failure")
+      val expectedSuppressed = (handler, sys.props("java.version")) match {
+        case (_: JavaFutureHandler, v) if v.startsWith("1.8") =>
+          // java 1.8 is not setting the exception as suppressed
+          None
+        case _ =>
+          Some("callback failure")
+      }
+      cause.getSuppressed.headOption.map(_.getMessage) shouldBe expectedSuppressed
     }
   }
 

--- a/scio-test/src/test/scala/com/spotify/scio/transforms/FutureHandlersTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/transforms/FutureHandlersTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.spotify.scio.transforms
 
 import com.google.common.util.concurrent.{ListenableFuture, SettableFuture}

--- a/scio-test/src/test/scala/com/spotify/scio/transforms/FutureHandlersTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/transforms/FutureHandlersTest.scala
@@ -1,0 +1,157 @@
+package com.spotify.scio.transforms
+
+import com.google.common.util.concurrent.{ListenableFuture, SettableFuture}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.CompletableFuture
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent._
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
+
+class GuavaFutureHandler extends FutureHandlers.Guava[String]
+class JavaFutureHandler extends FutureHandlers.Java[String]
+
+class FutureHandlersTest extends AnyFlatSpec with Matchers {
+
+  def futureHandler[F, I <: F](
+    handler: FutureHandlers.Base[F, String],
+    create: () => I,
+    complete: I => String => Unit,
+    fail: I => Throwable => Unit,
+    access: F => String
+  ): Unit = {
+    it should "block until all futures complete" in {
+      val f1 = create()
+      val f2 = create()
+      val backgroundTask = Future {
+        handler.waitForFutures(List[F](f1, f2).asJava)
+      }
+
+      complete(f1)("f1 done")
+      backgroundTask.isCompleted shouldBe false
+      complete(f2)("f2 done")
+      Await.result(backgroundTask, 1.second)
+    }
+
+    it should "not fail if any future fails" in {
+      val f1 = create()
+      val f2 = create()
+      val backgroundTask = Future {
+        handler.waitForFutures(List[F](f1, f2).asJava)
+      }
+
+      fail(f1)(new Exception("f1 failed"))
+      backgroundTask.isCompleted shouldBe false
+      complete(f2)("f2 done")
+      noException shouldBe thrownBy {
+        Await.result(backgroundTask, 1.second)
+      }
+    }
+
+    it should "should execute onSuccess and propagate original future" in {
+      val f = create()
+      var result: Try[String] = null
+      val chainedFuture = handler.addCallback(
+        f,
+        { value =>
+          result = Success(value)
+          null
+        },
+        { e =>
+          result = Failure(e)
+          null
+        }
+      )
+      complete(f)("success")
+      result shouldBe Success("success")
+      access(chainedFuture) shouldBe "success"
+    }
+
+    it should "should execute onFailure and propagate original exception" in {
+      val f = create()
+      var result: Try[String] = null
+      val chainedFuture = handler.addCallback(
+        f,
+        { value =>
+          result = Success(value)
+          null
+        },
+        { e =>
+          result = Failure(e)
+          null
+        }
+      )
+      val e = new Exception("failed")
+      fail(f)(e)
+      result shouldBe Failure(e)
+      an[Exception] shouldBe thrownBy(access(chainedFuture))
+    }
+
+    it should "should execute onSuccess and propagate callback exception" in {
+      val f = create()
+      var result: Try[String] = null
+      val chainedFuture = handler.addCallback(
+        f,
+        { value =>
+          result = Success(value)
+          throw new Exception("callback failure")
+        },
+        { e =>
+          result = Failure(e)
+          null
+        }
+      )
+      complete(f)("success")
+      result shouldBe Success("success")
+      an[Exception] shouldBe thrownBy(access(chainedFuture))
+    }
+
+    it should "should execute onFailure and propagate original exception with suppressed callback" in {
+      val f = create()
+      var result: Try[String] = null
+      val chainedFuture = handler.addCallback(
+        f,
+        { value =>
+          result = Success(value)
+          null
+        },
+        { e =>
+          result = Failure(e)
+          throw new Exception("callback failure")
+        }
+      )
+      val e = new Exception("failure")
+      fail(f)(e)
+      result shouldBe Failure(e)
+      val ee = the[ExecutionException] thrownBy (access(chainedFuture))
+      val cause = ee.getCause
+      cause.getMessage shouldBe "failure"
+      cause.getSuppressed.headOption.map(_.getMessage) shouldBe Some("callback failure")
+    }
+  }
+
+  "Guava handler" should behave like futureHandler[
+    ListenableFuture[String],
+    SettableFuture[String]
+  ](
+    new GuavaFutureHandler,
+    SettableFuture.create[String],
+    _.set,
+    _.setException,
+    _.get()
+  )
+
+  "Java handler" should behave like futureHandler[
+    CompletableFuture[String],
+    CompletableFuture[String]
+  ](
+    new JavaFutureHandler,
+    () => new CompletableFuture[String](),
+    _.complete,
+    _.completeExceptionally,
+    _.get()
+  )
+}


### PR DESCRIPTION
- Catch all `Throwable` on Guava callbacks to ensure returned future is completed
- Move from `computeIfAbsent` to `put` or `putIfAbsent` since keys are UUIDs and lazy computation was useless
- Simplify semaphore and cache handling in `BaseAsyncLookupDoFn`
- Reset `inFlightRequests` and `semaphore` permits in `startBundle` to avoid leaks/locks
- Apply same code structure on `BaseAsyncDoFn`