### PR TITLE
Set provided name on transforms with side outputs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -188,25 +188,9 @@ def previousVersion(currentVersion: String): Option[String] = {
 
 lazy val mimaSettings = Def.settings(
   mimaBinaryIssueFilters := Seq(
-    // minor scio-tensorflow breaking changes for 0.12.6
+    // minor scio-core breaking changes for 0.12.8
     ProblemFilters.exclude[DirectMissingMethodProblem](
-      "com.spotify.scio.tensorflow.syntax.SeqExampleSCollectionOps.saveAsTfRecordFile"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "com.spotify.scio.tensorflow.syntax.SeqExampleSCollectionOps.saveAsTfRecordFile$extension"
-    ),
-    // minor scio-grpc breaking changes for 0.12.6
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "com.spotify.scio.grpc.GrpcSCollectionOps.grpcLookup"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "com.spotify.scio.grpc.GrpcSCollectionOps.grpcLookup$extension"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "com.spotify.scio.grpc.GrpcSCollectionOps.grpcLookupStream"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "com.spotify.scio.grpc.GrpcSCollectionOps.grpcLookupStream$extension"
+      "com.spotify.scio.values.SCollectionWithSideOutput.this"
     )
   ),
   mimaPreviousArtifacts :=

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -1148,7 +1148,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    * @group side
    */
   def withSideOutputs(sides: SideOutput[_]*): SCollectionWithSideOutput[T] =
-    new SCollectionWithSideOutput[T](internal, context, sides)
+    new SCollectionWithSideOutput[T](this, sides)
 
   // =======================================================================
   // Windowing operations

--- a/scio-core/src/main/scala/com/spotify/scio/values/TransformNameable.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/TransformNameable.scala
@@ -40,7 +40,7 @@ trait TransformNameable {
       nameProvider.getClass != classOf[ConstNameProvider],
       s"withName() has already been used to set '$tfName' as the name for the next transform."
     )
-    nameProvider = new ConstNameProvider(name)
+    nameProvider = ConstNameProvider(name)
     this
   }
 }

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideOutputTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideOutputTest.scala
@@ -18,7 +18,6 @@
 package com.spotify.scio.values
 
 import com.spotify.scio.ScioContext
-import com.spotify.scio.testing.PipelineSpec
 
 class SCollectionWithSideOutputTest extends NamedTransformSpec {
   "SCollectionWithSideOutput" should "support custom transform name set before application" in {

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideOutputTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionWithSideOutputTest.scala
@@ -17,10 +17,35 @@
 
 package com.spotify.scio.values
 
+import com.spotify.scio.ScioContext
 import com.spotify.scio.testing.PipelineSpec
 
-class SCollectionWithSideOutputTest extends PipelineSpec {
-  "SCollectionWithSideOutput" should "support map()" in {
+class SCollectionWithSideOutputTest extends NamedTransformSpec {
+  "SCollectionWithSideOutput" should "support custom transform name set before application" in {
+    val sc = ScioContext()
+    val p1 = sc.parallelize(Seq("a", "b", "c"))
+    val p2 = SideOutput[String]()
+    val (main, _) = p1
+      .withName("MapWithSideOutputs")
+      .withSideOutputs(p2)
+      .map { (x, s) => s.output(p2, x + "2"); x + "1" }
+
+    assertTransformNameStartsWith(main, "MapWithSideOutputs")
+  }
+
+  it should "support custom transform name set after application" in {
+    val sc = ScioContext()
+    val p1 = sc.parallelize(Seq("a", "b", "c"))
+    val p2 = SideOutput[String]()
+    val (main, _) = p1
+      .withSideOutputs(p2)
+      .withName("MapWithSideOutputs")
+      .map { (x, s) => s.output(p2, x + "2"); x + "1" }
+
+    assertTransformNameStartsWith(main, "MapWithSideOutputs")
+  }
+
+  it should "support map()" in {
     runWithContext { sc =>
       val p1 = sc.parallelize(Seq("a", "b", "c"))
       val p2 = SideOutput[String]()


### PR DESCRIPTION
Fix #4777 

Do not run scio context when only asserting on names to speedup testing