### PR TITLE
Relax transform coder equality

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -359,26 +359,17 @@ final private[scio] class TransformCoder[T, U](
   from: U => T
 ) extends CustomCoder[T] {
 
-  // save original functions hashCodes to be sure we uniquely identify TransformCoders after serialization
-  // on deserialization, those won't be recomputed even if the function objects aren't equal
-  private val toHash: Int = to.hashCode()
-  private val fromHash: Int = from.hashCode()
-
   override def toString: String = s"TransformCoder[$typeName]($bcoder)"
 
   override def equals(obj: Any): Boolean = obj match {
     case that: TransformCoder[_, _] =>
-      typeName == that.typeName && bcoder == that.bcoder && toHash == that.toHash && fromHash == that.fromHash
+      // Assume that all TransformCoder from typeName using bcoder are equal
+      typeName == that.typeName && bcoder == that.bcoder
     case _ =>
       false
   }
 
-  override def hashCode(): Int = Objects.hash(
-    typeName,
-    bcoder,
-    toHash: java.lang.Integer,
-    fromHash: java.lang.Integer
-  )
+  override def hashCode(): Int = Objects.hash(typeName, bcoder)
   override def encode(value: T, os: OutputStream): Unit =
     bcoder.encode(to(value), os)
 

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -17,31 +17,29 @@
 
 package com.spotify.scio.coders
 
-import com.spotify.scio.proto.OuterClassForProto
-import com.spotify.scio.testing.CoderAssertions._
-import org.apache.avro.generic.GenericRecord
-import org.apache.beam.sdk.coders.{Coder => BCoder, CoderException, NullableCoder, StringUtf8Coder}
-import org.apache.beam.sdk.coders.Coder.NonDeterministicException
-import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
-import org.scalactic.Equality
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
-import org.apache.beam.sdk.util.SerializableUtils
-
-import scala.jdk.CollectionConverters._
-import scala.collection.{mutable => mut}
-import java.io.{ByteArrayInputStream, ObjectOutputStream, ObjectStreamClass}
-import org.apache.beam.sdk.testing.CoderProperties
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
 import com.spotify.scio.options.ScioOptions
+import com.spotify.scio.proto.OuterClassForProto
+import com.spotify.scio.testing.CoderAssertions._
 import com.twitter.algebird.Moments
+import org.apache.avro.generic.GenericRecord
+import org.apache.beam.sdk.coders.Coder.NonDeterministicException
+import org.apache.beam.sdk.coders.{Coder => BCoder, CoderException, NullableCoder, StringUtf8Coder}
+import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
+import org.apache.beam.sdk.testing.CoderProperties
+import org.apache.beam.sdk.util.SerializableUtils
 import org.apache.commons.io.output.NullOutputStream
+import org.scalactic.Equality
 import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
+import java.io.{ByteArrayInputStream, ObjectOutputStream, ObjectStreamClass}
 import java.nio.charset.Charset
-import java.time.{Instant, LocalDate}
+import java.time.Instant
 import java.util.UUID
-import java.time.format.DateTimeFormatter
+import scala.collection.{mutable => mut}
+import scala.jdk.CollectionConverters._
 
 // record
 final case class UserId(bytes: Seq[Byte])
@@ -68,6 +66,7 @@ object TestObject1 {
 case class CaseClassWithExplicitCoder(i: Int, s: String)
 object CaseClassWithExplicitCoder {
   import org.apache.beam.sdk.coders.{AtomicCoder, StringUtf8Coder, VarIntCoder}
+
   import java.io.{InputStream, OutputStream}
   implicit val caseClassWithExplicitCoderCoder: Coder[CaseClassWithExplicitCoder] =
     Coder.beam(new AtomicCoder[CaseClassWithExplicitCoder] {
@@ -335,7 +334,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
   }
 
   it should "support Java collections" in {
-    import java.util.{List => jList, Map => jMap, ArrayList => jArrayList}
+    import java.util.{ArrayList => jArrayList, List => jList, Map => jMap}
     val is = 1 to 10
     val s: jList[String] = is.map(_.toString).asJava
     val m: jMap[String, Int] = is
@@ -403,10 +402,10 @@ final class CoderTest extends AnyFlatSpec with Matchers {
 
   // FIXME: implement the missing coders
   it should "support all the already supported types" in {
+    import org.apache.beam.sdk.transforms.windowing.IntervalWindow
+
     import java.math.{BigInteger, BigDecimal => jBigDecimal}
     import java.nio.file.FileSystems
-
-    import org.apache.beam.sdk.transforms.windowing.IntervalWindow
 
     // TableRowJsonCoder
     // SpecificRecordBase
@@ -448,10 +447,10 @@ final class CoderTest extends AnyFlatSpec with Matchers {
   }
 
   it should "Serialize Row" in {
-    import java.lang.{Double => jDouble, Integer => jInt, String => jString}
-
     import org.apache.beam.sdk.schemas.{Schema => bSchema}
     import org.apache.beam.sdk.values.Row
+
+    import java.lang.{Double => jDouble, Integer => jInt, String => jString}
 
     val beamSchema =
       bSchema

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -36,7 +36,6 @@ import org.scalatest.matchers.should.Matchers
 
 import java.io.{ByteArrayInputStream, ObjectOutputStream, ObjectStreamClass}
 import java.nio.charset.Charset
-import java.time.format.DateTimeFormatter
 import java.time._
 import java.util.UUID
 import scala.collection.{mutable => mut}

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -754,18 +754,6 @@ final class CoderTest extends AnyFlatSpec with Matchers {
       Coder.xmap[String, Int](Coder[String])(_.toInt, _.toString),
       Coder.xmap[Int, String](Coder[Int])(_.toString, _.toInt)
     )
-
-    // For transform, even if parameters are equal, hashCodes must be different
-    hashCodesAreDifferent(
-      Coder.xmap[String, LocalDate](Coder[String])(
-        LocalDate.parse(_, DateTimeFormatter.ISO_LOCAL_DATE),
-        _.toString
-      ),
-      Coder.xmap[String, LocalDate](Coder[String])(
-        LocalDate.parse(_, DateTimeFormatter.ISO_WEEK_DATE),
-        _.toString
-      )
-    )
   }
 
   it should "support Guava Bloom Filters" in {


### PR DESCRIPTION
Streaming pipeline using coders created with `xmap` fail to update with:
```
Workflow failed. Causes: The new job is not compatible with xxx. The original job (if it existed) has not been aborted., The Coder or type for step xxx has changed.
```

`TransformCoder` was defined the same way as [DelegateCoder](https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DelegateCoder.java) from beam, making sure underlying functions were equal.

This is very unlikely that user define several coders with same type signature with xmap (and will likely result in implicit conflict).

Relax the serialization/equality so pipeline upgrade pass the validation.