### PR TITLE
Add java sql Date and Time coder

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -664,6 +664,8 @@ object Coder
   implicit val jDurationCoder: Coder[java.time.Duration] = JavaCoders.jDurationCoder
   implicit val jPeriodCoder: Coder[java.time.Period] = JavaCoders.jPeriodCoder
   implicit val jSqlTimestamp: Coder[java.sql.Timestamp] = JavaCoders.jSqlTimestamp
+  implicit val jSqDate: Coder[java.sql.Date] = JavaCoders.jSqlDate
+  implicit val jSqlTime: Coder[java.sql.Time] = JavaCoders.jSqlTime
   implicit def coderJEnum[E <: java.lang.Enum[E]: ClassTag]: Coder[E] = JavaCoders.coderJEnum
 
   def fallback[T](implicit lp: shapeless.LowPriority): Coder[T] =

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
@@ -148,6 +148,12 @@ trait JavaCoders extends JavaBeanCoders {
   implicit def jSqlTimestamp: Coder[java.sql.Timestamp] =
     Coder.xmap(jInstantCoder)(java.sql.Timestamp.from, _.toInstant())
 
+  implicit def jSqlDate: Coder[java.sql.Date] =
+    Coder.xmap(jLocalDateCoder)(java.sql.Date.valueOf, _.toLocalDate())
+
+  implicit def jSqlTime: Coder[java.sql.Time] =
+    Coder.xmap(jLocalTimeCoder)(java.sql.Time.valueOf, _.toLocalTime())
+
   implicit def coderJEnum[E <: java.lang.Enum[E]: ClassTag]: Coder[E] =
     Coder.xmap(Coder[String])(
       value => java.lang.Enum.valueOf(ScioUtil.classOf[E], value),


### PR DESCRIPTION
Some failures were experienced for models containing `java.sql.Date` where the `javaBeanCoder` was used.
Those types are common enough to deserve a dedicated coder 