### PR TITLE
Make Parquet logical type support opt-in

### DIFF
--- a/scio-parquet/src/main/resources/core-site.xml
+++ b/scio-parquet/src/main/resources/core-site.xml
@@ -22,14 +22,4 @@
     <name>fs.gs.inputstream.fadvise</name>
     <value>RANDOM</value>
   </property>
-  <property>
-    <!-- Supplies logical type support for writes -->
-    <name>parquet.avro.write.data.supplier</name>
-    <value>com.spotify.scio.parquet.avro.LogicalTypeSupplier</value>
-  </property>
-  <property>
-    <!-- Supplies logical type support for reads -->
-    <name>parquet.avro.data.supplier</name>
-    <value>com.spotify.scio.parquet.avro.LogicalTypeSupplier</value>
-  </property>
 </configuration>

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -290,12 +290,12 @@ object ParquetAvroIO {
   }
 
   private[avro] def containsLogicalType(s: Schema): Boolean = {
-    s.getType match {
+    s.getLogicalType != null || s.getType match {
       case Schema.Type.RECORD => s.getFields.asScala.exists(f => containsLogicalType(f.schema()))
       case Schema.Type.ARRAY  => containsLogicalType(s.getElementType)
       case Schema.Type.UNION  => s.getTypes.asScala.exists(t => containsLogicalType(t))
       case Schema.Type.MAP    => containsLogicalType(s.getValueType)
-      case _                  => s.getLogicalType != null
+      case _                  => false
     }
   }
 

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -188,9 +188,10 @@ object ParquetAvroIO {
       val jobConf = Option(conf).getOrElse(new Configuration())
 
       if (
-        jobConf.get(AvroReadSupport.AVRO_DATA_SUPPLIER) == null && ParquetAvroIO.containsLogicalType(
-          readSchema
-        )
+        jobConf.get(AvroReadSupport.AVRO_DATA_SUPPLIER) == null && ParquetAvroIO
+          .containsLogicalType(
+            readSchema
+          )
       ) {
         log.warn(
           s"Detected a logical type in schema `$readSchema`, but Configuration key `${AvroReadSupport.AVRO_DATA_SUPPLIER}`" +

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -188,7 +188,7 @@ object ParquetAvroIO {
       val jobConf = Option(conf).getOrElse(new Configuration())
 
       if (
-        conf.get(AvroReadSupport.AVRO_DATA_SUPPLIER) == null && ParquetAvroIO.containsLogicalType(
+        jobConf.get(AvroReadSupport.AVRO_DATA_SUPPLIER) == null && ParquetAvroIO.containsLogicalType(
           readSchema
         )
       ) {

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -290,13 +290,13 @@ object ParquetAvroIO {
   }
 
   private[avro] def containsLogicalType(s: Schema): Boolean = {
-    s.getLogicalType != null || s.getType match {
+    s.getLogicalType != null || (s.getType match {
       case Schema.Type.RECORD => s.getFields.asScala.exists(f => containsLogicalType(f.schema()))
       case Schema.Type.ARRAY  => containsLogicalType(s.getElementType)
       case Schema.Type.UNION  => s.getTypes.asScala.exists(t => containsLogicalType(t))
       case Schema.Type.MAP    => containsLogicalType(s.getValueType)
       case _                  => false
-    }
+    })
   }
 
   object WriteParam {

--- a/scio-smb/src/main/resources/core-site.xml
+++ b/scio-smb/src/main/resources/core-site.xml
@@ -22,14 +22,4 @@
     <name>fs.gs.inputstream.fadvise</name>
     <value>RANDOM</value>
   </property>
-  <property>
-    <!-- Supplies logical type support for writes -->
-    <name>parquet.avro.write.data.supplier</name>
-    <value>org.apache.beam.sdk.extensions.smb.AvroLogicalTypeSupplier</value>
-  </property>
-  <property>
-    <!-- Supplies logical type support for reads -->
-    <name>parquet.avro.data.supplier</name>
-    <value>org.apache.beam.sdk.extensions.smb.AvroLogicalTypeSupplier</value>
-  </property>
 </configuration>

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
@@ -36,6 +36,10 @@ import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.MimeTypes;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.avro.AvroDataSupplier;
+import org.apache.parquet.avro.AvroReadSupport;
+import org.apache.parquet.avro.AvroWriteSupport;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -119,8 +123,15 @@ public class ParquetAvroFileOperationsTest {
 
   @Test
   public void testLogicalTypes() throws Exception {
+    final Configuration conf = new Configuration();
+    conf.setClass(
+        AvroWriteSupport.AVRO_DATA_SUPPLIER, AvroLogicalTypeSupplier.class, AvroDataSupplier.class);
+    conf.setClass(
+        AvroReadSupport.AVRO_DATA_SUPPLIER, AvroLogicalTypeSupplier.class, AvroDataSupplier.class);
+
     final ParquetAvroFileOperations<TestLogicalTypes> fileOperations =
-        ParquetAvroFileOperations.of(TestLogicalTypes.getClassSchema());
+        ParquetAvroFileOperations.of(
+            TestLogicalTypes.getClassSchema(), CompressionCodecName.UNCOMPRESSED, conf);
     final ResourceId file =
         fromFolder(output)
             .resolve("file.parquet", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);


### PR DESCRIPTION
Makes Parquet logical type support opt-in, rather than included by default. `scio-parquet` will warn if a logical type is detected in the schema but no logical type provider is configured.

The reasoning for this is that Avro logical type conversion classes are heavily tied to Avro version -- `TimeConversions.TimestampConversion` in Avro 1.8 is renamed to `TimeConversions.TimestampMillisConversion` in Avro 1.11, for example. So by including these converters by default, we're essentially hard-failing any Avro 1.11 users immediately, even if their schema doesn't have any logical types. 