### PR TITLE
Added a custom Kryo serializer for Avro schema

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/KryoAtomicCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/KryoAtomicCoder.scala
@@ -20,7 +20,6 @@ package com.spotify.scio.coders
 import java.io.{EOFException, InputStream, OutputStream}
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
-
 import com.esotericsoftware.kryo.KryoException
 import com.esotericsoftware.kryo.io.{InputChunked, OutputChunked}
 import com.esotericsoftware.kryo.serializers.JavaSerializer
@@ -30,6 +29,7 @@ import com.spotify.scio.options.ScioOptions
 import com.twitter.chill._
 import com.twitter.chill.algebird.AlgebirdRegistrar
 import com.twitter.chill.protobuf.ProtobufSerializer
+import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.specific.SpecificRecordBase
 import org.apache.beam.sdk.coders.{AtomicCoder, CoderException => BCoderException, InstantCoder}
@@ -123,6 +123,7 @@ final private class ScioKryoRegistrar extends IKryoRegistrar {
     k.forClass[LocalTime](new JodaLocalTimeSerializer)
     k.forClass[LocalDateTime](new JodaLocalDateTimeSerializer)
     k.forClass[DateTime](new JodaDateTimeSerializer)
+    k.forSubclass[Schema](new SchemaSerializer)
     k.forSubclass[Path](new JPathSerializer)
     k.forSubclass[ByteString](new ByteStringSerializer)
     k.forClass(new KVSerializer)

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/kryo/SchemaSerializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/kryo/SchemaSerializer.scala
@@ -1,0 +1,16 @@
+package com.spotify.scio.coders.instances.kryo
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.{Input, Output}
+import com.twitter.chill.KSerializer
+import org.apache.avro.Schema
+
+private[coders] class SchemaSerializer extends KSerializer[Schema] {
+  private lazy val parser = new Schema.Parser()
+
+  override def write(kryo: Kryo, output: Output, schema: Schema): Unit =
+    output.writeString(schema.toString)
+
+  override def read(kryo: Kryo, input: Input, tpe: Class[Schema]): Schema =
+    parser.parse(input.readString())
+}

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/kryo/SchemaSerializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/kryo/SchemaSerializer.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2023 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.scio.coders.instances.kryo
 
 import com.esotericsoftware.kryo.Kryo

--- a/scio-test/src/test/scala/com/spotify/scio/coders/KryoAtomicCoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/KryoAtomicCoderTest.scala
@@ -58,6 +58,10 @@ class KryoAtomicCoderTest extends PipelineSpec {
     ("hello", (10, 10.0)) kryoCoderShould roundtrip()
   }
 
+  it should "support Avro Schema" in {
+    Avro.user.getSchema kryoCoderShould roundtrip()
+  }
+
   it should "support Scala case classes" in {
     Pair("record", 10) kryoCoderShould roundtrip()
   }


### PR DESCRIPTION
In Java17 kryo fails to serialize Avro schema with:
```
Caused by: java.lang.IllegalAccessException: class com.twitter.chill.Instantiators$ cannot access a member of class org.apache.avro.Schema$StringSchema with modifiers "public"
```
This affects our users. Instead of enforcing them to avoid serialization of Avro schema, this easy fix allows them to migrate to java 17