### PR TITLE
Set typed table description when using scio BQ client

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
@@ -142,11 +142,15 @@ final class BigQuery private (val client: Client) {
       createDisposition
     )
 
-  def createTypedTable[T <: HasAnnotation: TypeTag](table: Table): Unit =
-    tables.create(table.setSchema(BigQueryType[T].schema))
+  def createTypedTable[T <: HasAnnotation: TypeTag](table: Table): Unit = {
+    val typedTable = table
+      .setSchema(BigQueryType[T].schema)
+      .setDescription(BigQueryType[T].tableDescription.orNull)
+    tables.create(typedTable)
+  }
 
   def createTypedTable[T <: HasAnnotation: TypeTag](table: TableReference): Unit =
-    tables.create(table, BigQueryType[T].schema)
+    tables.create(table, BigQueryType[T].schema, BigQueryType[T].tableDescription)
 
   def createTypedTable[T <: HasAnnotation: TypeTag](tableSpec: String): Unit =
     createTypedTable(beam.BigQueryHelpers.parseTableSpec(tableSpec))

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
@@ -193,9 +193,11 @@ final private[client] class TableOps(client: Client) {
   def create(table: Table): Unit =
     withBigQueryService(_.createTable(table))
 
-  def create(tableRef: TableReference,
-             schema: TableSchema,
-             description: Option[String] = None): Unit = {
+  def create(
+    tableRef: TableReference,
+    schema: TableSchema,
+    description: Option[String] = None
+  ): Unit = {
     val table = new Table()
       .setTableReference(tableRef)
       .setSchema(schema)

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/TableOps.scala
@@ -190,13 +190,18 @@ final private[client] class TableOps(client: Client) {
     b.result()
   }
 
-  def create(table: Table): Unit = withBigQueryService(_.createTable(table))
+  def create(table: Table): Unit =
+    withBigQueryService(_.createTable(table))
 
-  def create(table: TableReference, schema: TableSchema): Unit =
-    create(new Table().setTableReference(table).setSchema(schema))
-
-  def create(tableSpec: String, schema: TableSchema): Unit =
-    create(bq.BigQueryHelpers.parseTableSpec(tableSpec), schema)
+  def create(tableRef: TableReference,
+             schema: TableSchema,
+             description: Option[String] = None): Unit = {
+    val table = new Table()
+      .setTableReference(tableRef)
+      .setSchema(schema)
+      .setDescription(description.orNull)
+    create(table)
+  }
 
   /**
    * Check if table exists. Returns `true` if table exists, `false` is table definitely does not


### PR DESCRIPTION
Whne using client, we should have the same behavior as the typed BQ IO: using the `@description` annotation when creating the table