### PR TITLE
Leverage sbt-project-matrix to test all scalafix rules in isolation

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -136,7 +136,7 @@ lazy val tests = projectMatrix
     scalaVersions = Seq(V.scala212),
     axisValues = Seq(scio0_7, VirtualAxis.jvm),
     _.settings(
-      moduleName := name.value + "-0_7",
+      moduleName := name.value + scio0_7.idSuffix,
       scalafixTestkitOutputSourceDirectories := (`output-0_7` / Compile / sourceDirectories).value,
       scalafixTestkitInputSourceDirectories := (`input-0_7` / Compile / sourceDirectories).value,
       scalafixTestkitInputClasspath := (`input-0_7` / Compile / fullClasspath).value
@@ -146,7 +146,7 @@ lazy val tests = projectMatrix
     scalaVersions = Seq(V.scala212),
     axisValues = Seq(scio0_8, VirtualAxis.jvm),
     _.settings(
-      moduleName := name.value + "-0_8",
+      moduleName := name.value + scio0_8.idSuffix,
       scalafixTestkitOutputSourceDirectories := (`output-0_8` / Compile / sourceDirectories).value,
       scalafixTestkitInputSourceDirectories := (`input-0_8` / Compile / sourceDirectories).value,
       scalafixTestkitInputClasspath := (`input-0_8` / Compile / fullClasspath).value
@@ -156,7 +156,7 @@ lazy val tests = projectMatrix
     scalaVersions = Seq(V.scala212),
     axisValues = Seq(scio0_10, VirtualAxis.jvm),
     _.settings(
-      moduleName := name.value + "-0_10",
+      moduleName := name.value + scio0_10.idSuffix,
       scalafixTestkitOutputSourceDirectories := (`output-0_10` / Compile / sourceDirectories).value,
       scalafixTestkitInputSourceDirectories := (`input-0_10` / Compile / sourceDirectories).value,
       scalafixTestkitInputClasspath := (`input-0_10` / Compile / fullClasspath).value
@@ -166,7 +166,7 @@ lazy val tests = projectMatrix
     scalaVersions = Seq(V.scala212),
     axisValues = Seq(scio0_12, VirtualAxis.jvm),
     _.settings(
-      moduleName := name.value + "-0_12",
+      moduleName := name.value + scio0_12.idSuffix,
       scalafixTestkitOutputSourceDirectories := (`output-0_12` / Compile / sourceDirectories).value,
       scalafixTestkitInputSourceDirectories := (`input-0_12` / Compile / sourceDirectories).value,
       scalafixTestkitInputClasspath := (`input-0_12` / Compile / fullClasspath).value
@@ -176,7 +176,7 @@ lazy val tests = projectMatrix
     scalaVersions = Seq(V.scala212),
     axisValues = Seq(scio0_13, VirtualAxis.jvm),
     _.settings(
-      moduleName := name.value + "-0_13",
+      moduleName := name.value + scio0_13.idSuffix,
       scalafixTestkitOutputSourceDirectories := (`output-0_13` / Compile / sourceDirectories).value,
       scalafixTestkitInputSourceDirectories := (`input-0_13` / Compile / sourceDirectories).value,
       scalafixTestkitInputClasspath := (`input-0_13` / Compile / fullClasspath).value

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -6,9 +6,10 @@ inThisBuild(
   List(
     organization := "com.spotify",
     scalaVersion := V.scala212,
-    addCompilerPlugin(scalafixSemanticdb),
     scalacOptions ++= List("-Yrangepos"),
     publish / skip := true,
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision,
     scalafmtOnCompile := false,
     scalafmtConfig := baseDirectory.value / ".." / ".scalafmt.conf",
     // discard scala-xml conflict for old scio releases
@@ -17,6 +18,30 @@ inThisBuild(
     )
   )
 )
+
+lazy val root = project
+  .in(file("."))
+  .aggregate(
+    tests.projectRefs ++ Seq[sbt.ProjectReference](
+      // 0.7
+      `input-0_7`,
+      `output-0_7`,
+      // 0.8
+      `input-0_8`,
+      `output-0_8`,
+      // 0.10
+      `input-0_10`,
+      `output-0_10`,
+      // 0.12
+      `input-0_12`,
+      `output-0_12`,
+      // 0.13
+      `input-0_13`,
+      `output-0_13`,
+      // scalafix
+      rules
+    ): _*,
+  )
 
 lazy val rules = project
   .settings(
@@ -88,46 +113,72 @@ lazy val `output-0_12` = project
     libraryDependencies ++= scio(Scio.`0.12`)
   )
 
-//lazy val `input-0_13` = project
-//  .settings(
-//    libraryDependencies ++= scio(Scio.`0.12`)
-//  )
-//
-//lazy val `output-0_13` = project
-//  .settings(
-//    libraryDependencies ++= scio(Scio.`0.13`)
-//  )
-
-lazy val tests = project
-  .enablePlugins(ScalafixTestkitPlugin)
-  .dependsOn(rules)
+lazy val `input-0_13` = project
   .settings(
-    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
-    Compile / compile := (Compile / compile)
-      .dependsOn(
-        `input-0_7` / Compile / compile,
-        `input-0_8` / Compile / compile,
-        `input-0_10` / Compile / compile,
-        `input-0_12` / Compile / compile,
-        // `input-0_13` / Compile / compile
-      )
-      .value,
-    scalafixTestkitOutputSourceDirectories :=
-      (`output-0_7` / Compile / sourceDirectories).value ++
-        (`output-0_8` / Compile / sourceDirectories).value ++
-        (`output-0_10` / Compile / sourceDirectories).value ++
-        (`output-0_12` / Compile / sourceDirectories).value,
-        // (`output-0_13` / Compile / sourceDirectories).value,
-    scalafixTestkitInputSourceDirectories :=
-      (`input-0_7` / Compile / sourceDirectories).value ++
-        (`input-0_8` / Compile / sourceDirectories).value ++
-        (`input-0_10` / Compile / sourceDirectories).value ++
-        (`input-0_12` / Compile / sourceDirectories).value,
-        // (`input-0_13` / Compile / sourceDirectories).value,
-    scalafixTestkitInputClasspath :=
-      (`input-0_7` / Compile / fullClasspath).value ++
-        (`input-0_8` / Compile / fullClasspath).value ++
-        (`input-0_10` / Compile / fullClasspath).value ++
-        (`input-0_12` / Compile / fullClasspath).value // ++
-        // (`input-0_13` / Compile / fullClasspath).value
+    libraryDependencies ++= scio(Scio.`0.12`)
+  )
+
+lazy val `output-0_13` = project
+  .settings(
+    libraryDependencies ++= scio(Scio.`0.13`)
+  )
+
+lazy val scio0_7 = ConfigAxis("-scio-0_7", "-0_7-")
+lazy val scio0_8 = ConfigAxis("-scio-0_8", "-0_8-")
+lazy val scio0_10 = ConfigAxis("-scio-0_10", "-0_10-")
+lazy val scio0_12 = ConfigAxis("-scio-0_12", "-0_12-")
+lazy val scio0_13 = ConfigAxis("-scio-0_13", "-0_13-")
+
+lazy val tests = projectMatrix
+  .in(file("tests"))
+  .enablePlugins(ScalafixTestkitPlugin)
+  .customRow(
+    scalaVersions = Seq(V.scala212),
+    axisValues = Seq(scio0_7, VirtualAxis.jvm),
+    _.settings(
+      moduleName := name.value + "-0_7",
+      scalafixTestkitOutputSourceDirectories := (`output-0_7` / Compile / sourceDirectories).value,
+      scalafixTestkitInputSourceDirectories := (`input-0_7` / Compile / sourceDirectories).value,
+      scalafixTestkitInputClasspath := (`input-0_7` / Compile / fullClasspath).value
+    ).dependsOn(rules)
+  )
+  .customRow(
+    scalaVersions = Seq(V.scala212),
+    axisValues = Seq(scio0_8, VirtualAxis.jvm),
+    _.settings(
+      moduleName := name.value + "-0_8",
+      scalafixTestkitOutputSourceDirectories := (`output-0_8` / Compile / sourceDirectories).value,
+      scalafixTestkitInputSourceDirectories := (`input-0_8` / Compile / sourceDirectories).value,
+      scalafixTestkitInputClasspath := (`input-0_8` / Compile / fullClasspath).value
+    ).dependsOn(rules)
+  )
+  .customRow(
+    scalaVersions = Seq(V.scala212),
+    axisValues = Seq(scio0_10, VirtualAxis.jvm),
+    _.settings(
+      moduleName := name.value + "-0_10",
+      scalafixTestkitOutputSourceDirectories := (`output-0_10` / Compile / sourceDirectories).value,
+      scalafixTestkitInputSourceDirectories := (`input-0_10` / Compile / sourceDirectories).value,
+      scalafixTestkitInputClasspath := (`input-0_10` / Compile / fullClasspath).value
+    ).dependsOn(rules)
+  )
+  .customRow(
+    scalaVersions = Seq(V.scala212),
+    axisValues = Seq(scio0_12, VirtualAxis.jvm),
+    _.settings(
+      moduleName := name.value + "-0_12",
+      scalafixTestkitOutputSourceDirectories := (`output-0_12` / Compile / sourceDirectories).value,
+      scalafixTestkitInputSourceDirectories := (`input-0_12` / Compile / sourceDirectories).value,
+      scalafixTestkitInputClasspath := (`input-0_12` / Compile / fullClasspath).value
+    ).dependsOn(rules)
+  )
+  .customRow(
+    scalaVersions = Seq(V.scala212),
+    axisValues = Seq(scio0_13, VirtualAxis.jvm),
+    _.settings(
+      moduleName := name.value + "-0_13",
+      scalafixTestkitOutputSourceDirectories := (`output-0_13` / Compile / sourceDirectories).value,
+      scalafixTestkitInputSourceDirectories := (`input-0_13` / Compile / sourceDirectories).value,
+      scalafixTestkitInputClasspath := (`input-0_13` / Compile / fullClasspath).value
+    ).dependsOn(rules)
   )

--- a/scalafix/project/ConfigAxis.scala
+++ b/scalafix/project/ConfigAxis.scala
@@ -1,0 +1,2 @@
+import sbt._
+case class ConfigAxis(idSuffix: String, directorySuffix: String) extends VirtualAxis.WeakAxis {}

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,3 +1,4 @@
 resolvers += Resolver.sonatypeRepo("releases")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.9.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")


### PR DESCRIPTION
Previous setup had a classpath conflict and may construct wrong symbol information in testing.