### PR TITLE
[Proposal] Make scio-smb's ADJUSTMENT_FACTOR a PipelineOption

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketOptions.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketOptions.java
@@ -34,4 +34,12 @@ public interface SortedBucketOptions extends PipelineOptions {
   int getSortedBucketReadDiskBufferMb();
 
   void setSortedBucketReadDiskBufferMb(int readDiskBufferMb);
+
+  @Description(
+      "Factor to multiply the runner-provided `desiredBundleSizeBytes` during SMB reads. A lower value "
+          + "results in more generated splits, which can improve scaling at read-time.")
+  @Default.Double(0.5D)
+  double getSortedBucketSplitAdjustmentFactor();
+
+  void setSortedBucketSplitAdjustmentFactor(double sortedBucketSplitAdjustmentFactor);
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -96,9 +96,6 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
     PRIMARY_AND_SECONDARY
   }
 
-  // Dataflow calls split() with a suggested byte size that assumes a higher throughput than
-  // SMB joins have. By adjusting this suggestion we can arrive at a more optimal parallelism.
-  static final Double DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR = 0.5;
   private static final Logger LOG = LoggerFactory.getLogger(SortedBucketSource.class);
   private static final AtomicInteger metricsId = new AtomicInteger(1);
 
@@ -216,7 +213,7 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
             targetParallelism,
             getEstimatedSizeBytes(options),
             desiredBundleSizeBytes,
-            DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR);
+            options.as(SortedBucketOptions.class).getSortedBucketSplitAdjustmentFactor());
     final long estSplitSize = estimatedSizeBytes / numSplits;
     final DecimalFormat sizeFormat = new DecimalFormat("0.00");
     LOG.info(

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketSourceTest.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.extensions.smb;
 
 import static org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput;
-import static org.apache.beam.sdk.extensions.smb.SortedBucketSource.DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR;
 import static org.apache.beam.sdk.extensions.smb.SortedBucketSource.PrimaryAndSecondaryKeyedBucktedInput;
 import static org.apache.beam.sdk.extensions.smb.SortedBucketSource.PrimaryKeyedBucketedInput;
 import static org.apache.beam.sdk.extensions.smb.TestUtils.fromFolder;
@@ -697,8 +696,7 @@ public class SortedBucketSourceTest {
       SortedBucketSource<String> source, int desiredByteSize) throws Exception {
     final PipelineOptions opts = PipelineOptionsFactory.create();
     final List<SortedBucketSource<String>> splitSources =
-        (List<SortedBucketSource<String>>)
-            source.split((long) (desiredByteSize / DESIRED_SIZE_BYTES_ADJUSTMENT_FACTOR), opts);
+        (List<SortedBucketSource<String>>) source.split((long) (desiredByteSize / 0.5D), opts);
     splitSources.sort(Comparator.comparingInt(SortedBucketSource::getBucketOffset));
 
     return splitSources;


### PR DESCRIPTION
Gives users an extra tuning knob for SMB reads. Different inputs types may benefit from more or less source splits (I.e., Parquet reads may run into memory issues with too few splits). By parameterizing it as a pipeline option, users can tweak the source splits to suit their use case.