### PR TITLE
Safe coder unwrap

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
@@ -17,6 +17,7 @@
 
 package com.spotify.scio.coders
 
+import com.spotify.scio.coders.CoderMaterializer.CoderOptions
 import com.spotify.scio.coders.{instances => scio}
 import com.spotify.scio.values.{SCollection, SideInput}
 import org.apache.beam.sdk.{coders => beam}
@@ -27,100 +28,109 @@ import scala.annotation.tailrec
 /** Utility for extracting [[Coder]]s from Scio types. */
 private[scio] object BeamCoders {
   @tailrec
-  private def unwrap[T](coder: beam.Coder[T]): beam.Coder[T] =
+  private def unwrap[T](options: CoderOptions, coder: beam.Coder[T]): beam.Coder[T] =
     coder match {
-      case c: WrappedCoder[T]       => unwrap(c.bcoder)
-      case c: beam.NullableCoder[T] => c.getValueCoder
-      case _                        => coder
+      case c: MaterializedCoder[T]                            => unwrap(options, c.bcoder)
+      case c: beam.NullableCoder[T] if options.nullableCoders => c.getValueCoder
+      case _                                                  => coder
     }
 
-  @inline
-  private def coderElement[T](productCoder: RecordCoder[_])(n: Int): beam.Coder[T] =
-    productCoder.cs(n)._2.asInstanceOf[beam.Coder[T]]
-
   /** Get coder from an `PCollection[T]`. */
-  def getCoder[T](coll: PCollection[T]): Coder[T] = Coder.beam(unwrap(coll.getCoder))
+  def getCoder[T](coll: PCollection[T]): Coder[T] = {
+    val options = CoderOptions(coll.getPipeline.getOptions)
+    Coder.beam(unwrap(options, coll.getCoder))
+  }
 
   /** Get coder from an `SCollection[T]`. */
   def getCoder[T](coll: SCollection[T]): Coder[T] = getCoder(coll.internal)
 
   /** Get key-value coders from an `SCollection[(K, V)]`. */
   def getTupleCoders[K, V](coll: SCollection[(K, V)]): (Coder[K], Coder[V]) = {
+    val options = CoderOptions(coll.context.options)
     val coder = coll.internal.getCoder
-    val (k, v) = unwrap(coder) match {
+    val (k, v) = unwrap(options, coder) match {
       case c: scio.Tuple2Coder[K, V] =>
         (c.ac, c.bc)
-      case c: RecordCoder[(K, V)] =>
-        val ac = coderElement[K](c)(0)
-        val bc = coderElement[V](c)(1)
-        (ac, bc)
       case _ =>
         throw new IllegalArgumentException(
           s"Failed to extract key-value coders from Coder[(K, V)]: $coder"
         )
     }
-    (Coder.beam(unwrap(k)), Coder.beam(unwrap(v)))
+    (
+      Coder.beam(unwrap(options, k)),
+      Coder.beam(unwrap(options, v))
+    )
   }
 
   def getTuple3Coders[A, B, C](coll: SCollection[(A, B, C)]): (Coder[A], Coder[B], Coder[C]) = {
+    val options = CoderOptions(coll.context.options)
     val coder = coll.internal.getCoder
-    val (a, b, c) = unwrap(coder) match {
+    val (a, b, c) = unwrap(options, coder) match {
       case c: scio.Tuple3Coder[A, B, C] => (c.ac, c.bc, c.cc)
-      case c: RecordCoder[(A, B, C)] =>
-        val ac = coderElement[A](c)(0)
-        val bc = coderElement[B](c)(1)
-        val cc = coderElement[C](c)(2)
-        (ac, bc, cc)
       case _ =>
         throw new IllegalArgumentException(
           s"Failed to extract tupled coders from Coder[(A, B, C)]: $coder"
         )
     }
-    (Coder.beam(unwrap(a)), Coder.beam(unwrap(b)), Coder.beam(unwrap(c)))
+    (
+      Coder.beam(unwrap(options, a)),
+      Coder.beam(unwrap(options, b)),
+      Coder.beam(unwrap(options, c))
+    )
   }
 
   def getTuple4Coders[A, B, C, D](
     coll: SCollection[(A, B, C, D)]
   ): (Coder[A], Coder[B], Coder[C], Coder[D]) = {
+    val options = CoderOptions(coll.context.options)
     val coder = coll.internal.getCoder
-    val (a, b, c, d) = unwrap(coder) match {
+    val (a, b, c, d) = unwrap(options, coder) match {
       case c: scio.Tuple4Coder[A, B, C, D] => (c.ac, c.bc, c.cc, c.dc)
-      case c: RecordCoder[(A, B, C, D)] =>
-        val ac = coderElement[A](c)(0)
-        val bc = coderElement[B](c)(1)
-        val cc = coderElement[C](c)(2)
-        val dc = coderElement[D](c)(3)
-        (ac, bc, cc, dc)
       case _ =>
         throw new IllegalArgumentException(
           s"Failed to extract tupled coders from Coder[(A, B, C, D)]: $coder"
         )
     }
-    (Coder.beam(unwrap(a)), Coder.beam(unwrap(b)), Coder.beam(unwrap(c)), Coder.beam(unwrap(d)))
+    (
+      Coder.beam(unwrap(options, a)),
+      Coder.beam(unwrap(options, b)),
+      Coder.beam(unwrap(options, c)),
+      Coder.beam(unwrap(options, d))
+    )
   }
 
-  private def getIterableV[V](coder: beam.Coder[Iterable[V]]): beam.Coder[V] =
-    unwrap(coder) match {
+  private def getIterableV[V](
+    options: CoderOptions,
+    coder: beam.Coder[Iterable[V]]
+  ): beam.Coder[V] = {
+    unwrap(options, coder) match {
       case c: scio.BaseSeqLikeCoder[Iterable, V] @unchecked => c.elemCoder
       case _ =>
         throw new IllegalArgumentException(
           s"Failed to extract value coder from Coder[Iterable[V]]: $coder"
         )
     }
+  }
 
   /** Get key-value coders from a `SideInput[Map[K, Iterable[V]]]`. */
   def getMultiMapKV[K, V](si: SideInput[Map[K, Iterable[V]]]): (Coder[K], Coder[V]) = {
+    val options = CoderOptions(si.view.getPCollection.getPipeline.getOptions)
     val coder = si.view.getPCollection.getCoder
-    val (k, v) = unwrap(coder) match {
-      // Beam's `View.asMultiMap`
-      case c: beam.KvCoder[K, V] @unchecked => (c.getKeyCoder, c.getValueCoder)
-      // `asMapSingletonSideInput`
-      case c: scio.MapCoder[K, Iterable[V]] @unchecked => (c.kc, getIterableV(c.vc))
+    val (k, v) = unwrap(options, coder) match {
+      case c: beam.KvCoder[K, V] @unchecked =>
+        // Beam's `View.asMultiMap`
+        (c.getKeyCoder, c.getValueCoder)
+      case c: scio.MapCoder[K, Iterable[V]] @unchecked =>
+        // `asMapSingletonSideInput`
+        (c.kc, getIterableV(options, c.vc))
       case _ =>
         throw new IllegalArgumentException(
           s"Failed to extract key-value coders from Coder[Map[K, Iterable[V]]: $coder"
         )
     }
-    (Coder.beam(unwrap(k)), Coder.beam(unwrap(v)))
+    (
+      Coder.beam(unwrap(options, k)),
+      Coder.beam(unwrap(options, v))
+    )
   }
 }

--- a/scio-test/src/main/scala/com/spotify/scio/testing/BigtableMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/BigtableMatchers.scala
@@ -21,7 +21,6 @@ import com.google.bigtable.v2.Mutation
 import com.google.bigtable.v2.Mutation.MutationCase
 import com.google.protobuf.ByteString
 import com.spotify.scio.values.SCollection
-import com.spotify.scio.coders.Coder
 
 import org.scalatest.matchers.{MatchResult, Matcher}
 
@@ -33,8 +32,6 @@ trait BigtableMatchers extends SCollectionMatchers {
 
   type BTRow = (ByteString, Iterable[Mutation])
   type BTCollection = SCollection[BTRow]
-
-  implicit val btCollCoder: Coder[BTRow] = Coder.tuple2Coder[ByteString, Iterable[Mutation]]
 
   /** Provide an implicit BT serializer for common cell value type String. */
   implicit def stringBTSerializer(s: String): ByteString =

--- a/scio-test/src/main/scala/com/spotify/scio/testing/BigtableMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/BigtableMatchers.scala
@@ -34,9 +34,7 @@ trait BigtableMatchers extends SCollectionMatchers {
   type BTRow = (ByteString, Iterable[Mutation])
   type BTCollection = SCollection[BTRow]
 
-  // Needed because scalac is an idiot
-  implicit def btCollCoder: Coder[BTRow] =
-    Coder.gen[(ByteString, Iterable[Mutation])]
+  implicit val btCollCoder: Coder[BTRow] = Coder.tuple2Coder[ByteString, Iterable[Mutation]]
 
   /** Provide an implicit BT serializer for common cell value type String. */
   implicit def stringBTSerializer(s: String): ByteString =

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -17,29 +17,74 @@
 
 package com.spotify.scio.values
 
-import com.spotify.scio.coders.Beam
+import com.spotify.scio.coders.{Beam, MaterializedCoder}
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.util.random.RandomSamplerUtils
 import com.spotify.scio.hash._
 import com.spotify.scio.options.ScioOptions
 import com.twitter.algebird.Aggregator
 import magnolify.guava.auto._
-import org.apache.beam.sdk.coders.{StringUtf8Coder, VarIntCoder}
+import org.apache.beam.sdk.coders.{
+  KvCoder,
+  NullableCoder,
+  StringUtf8Coder,
+  StructuredCoder,
+  VarIntCoder
+}
 
 import scala.collection.mutable
 
 class PairSCollectionFunctionsTest extends PipelineSpec {
-  "PairSCollection" should "propagate unwrapped coders" in {
+  "PairSCollection" should "propagates unwrapped coders" in {
+    runWithContext { sc =>
+      val coll = sc.empty[(String, Int)]()
+      // internal is wrapped
+      val internalCoder = coll.internal.getCoder
+      internalCoder shouldBe a[MaterializedCoder[_]]
+      val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
+      materializedCoder.bcoder shouldBe a[StructuredCoder[_]]
+      val tupleCoder = materializedCoder.bcoder.asInstanceOf[StructuredCoder[_]]
+      val keyCoder = tupleCoder.getComponents.get(0)
+      keyCoder shouldBe StringUtf8Coder.of()
+      val valueCoder = tupleCoder.getComponents.get(1)
+      valueCoder shouldBe VarIntCoder.of()
+      // implicit SCollection key and value coder aren't
+      coll.keyCoder shouldBe a[Beam[_]]
+      val beamKeyCoder = coll.keyCoder.asInstanceOf[Beam[_]]
+      beamKeyCoder.beam shouldBe StringUtf8Coder.of()
+
+      coll.valueCoder shouldBe a[Beam[Int]]
+      val beamValueCoder = coll.valueCoder.asInstanceOf[Beam[Int]]
+      beamValueCoder.beam shouldBe VarIntCoder.of()
+    }
+  }
+
+  it should "propagate unwrapped nullable coders" in {
     runWithContext { sc =>
       sc.optionsAs[ScioOptions].setNullableCoders(true)
 
       val coll = sc.empty[(String, Int)]()
-      coll.keyCoder shouldBe a[Beam[String]]
-      // No WrappedCoder nor NullableCoder
-      coll.keyCoder.asInstanceOf[Beam[String]].beam shouldBe StringUtf8Coder.of()
+      // internal is wrapped
+      val internalCoder = coll.internal.getCoder
+      internalCoder shouldBe a[MaterializedCoder[_]]
+      val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
+      materializedCoder.bcoder shouldBe a[NullableCoder[_]]
+      val nullableTupleCoder = materializedCoder.bcoder.asInstanceOf[NullableCoder[_]]
+      val tupleCoder = nullableTupleCoder.getValueCoder.asInstanceOf[StructuredCoder[_]]
+      val keyCoder = tupleCoder.getComponents.get(0)
+      keyCoder shouldBe a[NullableCoder[_]]
+      keyCoder.asInstanceOf[NullableCoder[_]].getValueCoder shouldBe StringUtf8Coder.of()
+      val valueCoder = tupleCoder.getComponents.get(1)
+      valueCoder shouldBe a[NullableCoder[_]]
+      valueCoder.asInstanceOf[NullableCoder[_]].getValueCoder shouldBe VarIntCoder.of()
+      // implicit SCollection key and value coder aren't
+      coll.keyCoder shouldBe a[Beam[_]]
+      val beamKeyCoder = coll.keyCoder.asInstanceOf[Beam[_]]
+      beamKeyCoder.beam shouldBe StringUtf8Coder.of()
 
       coll.valueCoder shouldBe a[Beam[Int]]
-      coll.valueCoder.asInstanceOf[Beam[Int]].beam shouldBe VarIntCoder.of()
+      val beamValueCoder = coll.valueCoder.asInstanceOf[Beam[Int]]
+      beamValueCoder.beam shouldBe VarIntCoder.of()
     }
   }
 

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -24,13 +24,7 @@ import com.spotify.scio.hash._
 import com.spotify.scio.options.ScioOptions
 import com.twitter.algebird.Aggregator
 import magnolify.guava.auto._
-import org.apache.beam.sdk.coders.{
-  KvCoder,
-  NullableCoder,
-  StringUtf8Coder,
-  StructuredCoder,
-  VarIntCoder
-}
+import org.apache.beam.sdk.coders.{NullableCoder, StringUtf8Coder, StructuredCoder, VarIntCoder}
 
 import scala.collection.mutable
 
@@ -53,8 +47,8 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
       val beamKeyCoder = coll.keyCoder.asInstanceOf[Beam[_]]
       beamKeyCoder.beam shouldBe StringUtf8Coder.of()
 
-      coll.valueCoder shouldBe a[Beam[Int]]
-      val beamValueCoder = coll.valueCoder.asInstanceOf[Beam[Int]]
+      coll.valueCoder shouldBe a[Beam[_]]
+      val beamValueCoder = coll.valueCoder.asInstanceOf[Beam[_]]
       beamValueCoder.beam shouldBe VarIntCoder.of()
     }
   }
@@ -82,8 +76,8 @@ class PairSCollectionFunctionsTest extends PipelineSpec {
       val beamKeyCoder = coll.keyCoder.asInstanceOf[Beam[_]]
       beamKeyCoder.beam shouldBe StringUtf8Coder.of()
 
-      coll.valueCoder shouldBe a[Beam[Int]]
-      val beamValueCoder = coll.valueCoder.asInstanceOf[Beam[Int]]
+      coll.valueCoder shouldBe a[Beam[_]]
+      val beamValueCoder = coll.valueCoder.asInstanceOf[Beam[_]]
       beamValueCoder.beam shouldBe VarIntCoder.of()
     }
   }

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -38,7 +38,7 @@ import org.joda.time.{DateTimeConstants, Duration, Instant}
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
-import com.spotify.scio.coders.{Beam, Coder, MaterializedCoder, RefCoder}
+import com.spotify.scio.coders.{Beam, Coder, MaterializedCoder}
 import com.spotify.scio.options.ScioOptions
 import com.spotify.scio.schemas.Schema
 import org.apache.beam.sdk.coders.{NullableCoder, StringUtf8Coder}

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -38,10 +38,10 @@ import org.joda.time.{DateTimeConstants, Duration, Instant}
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
-import com.spotify.scio.coders.{Beam, Coder}
+import com.spotify.scio.coders.{Beam, Coder, MaterializedCoder, RefCoder}
 import com.spotify.scio.options.ScioOptions
 import com.spotify.scio.schemas.Schema
-import org.apache.beam.sdk.coders.StringUtf8Coder
+import org.apache.beam.sdk.coders.{NullableCoder, StringUtf8Coder}
 
 import java.nio.charset.StandardCharsets
 
@@ -54,14 +54,39 @@ class SCollectionTest extends PipelineSpec {
 
   import SCollectionTest._
 
-  "SCollection" should "propagate unwrapped coders" in {
+  "SCollection" should "propagates unwrapped coders" in {
+    runWithContext { sc =>
+      val coll = sc.empty[String]()
+      // internal is wrapped
+      val internalCoder = coll.internal.getCoder
+      internalCoder shouldBe a[MaterializedCoder[_]]
+      val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
+      materializedCoder.bcoder shouldBe StringUtf8Coder.of()
+      // implicit SCollection coder is not
+      val scioCoder = coll.coder
+      scioCoder shouldBe a[Beam[_]]
+      val beamCoder = scioCoder.asInstanceOf[Beam[_]]
+      beamCoder.beam shouldBe StringUtf8Coder.of()
+    }
+  }
+
+  it should "propagates unwrapped nullable coders" in {
     runWithContext { sc =>
       sc.optionsAs[ScioOptions].setNullableCoders(true)
 
       val coll = sc.empty[String]()
-      coll.coder shouldBe a[Beam[String]]
-      // No WrappedCoder nor NullableCoder
-      coll.coder.asInstanceOf[Beam[String]].beam shouldBe StringUtf8Coder.of()
+      // internal is wrapped
+      val internalCoder = coll.internal.getCoder
+      internalCoder shouldBe a[MaterializedCoder[_]]
+      val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
+      materializedCoder.bcoder shouldBe a[NullableCoder[_]]
+      val nullableCoder = materializedCoder.bcoder.asInstanceOf[NullableCoder[_]]
+      nullableCoder.getValueCoder shouldBe StringUtf8Coder.of()
+      // implicit SCollection coder is not
+      val scioCoder = coll.coder
+      scioCoder shouldBe a[Beam[_]]
+      val beamCoder = scioCoder.asInstanceOf[Beam[_]]
+      beamCoder.beam shouldBe StringUtf8Coder.of()
     }
   }
 


### PR DESCRIPTION
Unwrapping was don on `Ref` and `LazyCoder`. This was required to extract values from tuple coders when `RecordCoder` was used (materialization wraps into a `Ref`/`LazyCoder`)

IMHO, we should expect `TupleCoder` in those cases and fail if a `RecordCoder` was given.

We could then only unwrap `MaterlializedCoder` and `NullableCoder` (double check the option is enabled). implicit scio coders will get stable.

Probably a better fix than #4886 