### PR TITLE
Fix compiler warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -710,7 +710,6 @@ lazy val `scio-google-cloud-platform`: Project = project
     description := "Scio add-on for Google Cloud Platform",
     libraryDependencies ++= Seq(
       // compile
-      "com.chuusai" %% "shapeless" % shapelessVersion,
       "com.esotericsoftware" % "kryo-shaded" % kryoVersion,
       "com.google.api" % "gax" % gaxVersion,
       "com.google.api" % "gax-grpc" % gaxVersion,
@@ -1032,7 +1031,6 @@ lazy val `scio-parquet`: Project = project
     ).reduce(_ | _),
     libraryDependencies ++= Seq(
       // compile
-      "com.chuusai" %% "shapeless" % shapelessVersion,
       "com.google.auth" % "google-auth-library-oauth2-http" % googleAuthVersion,
       "com.google.cloud.bigdataoss" % "util-hadoop" % s"hadoop2-$bigdataossVersion",
       "com.google.protobuf" % "protobuf-java" % protobufVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -152,6 +152,7 @@ ThisBuild / tpolecatDevModeOptions ~= { opts =>
     ScalacOptions.privateWarnDeadCode,
     ScalacOptions.privateWarnValueDiscard,
     ScalacOptions.warnDeadCode,
+    ScalacOptions.warnNonUnitStatement,
     ScalacOptions.warnValueDiscard
   )
 
@@ -163,7 +164,6 @@ ThisBuild / tpolecatDevModeOptions ~= { opts =>
     Scalac.privateBackendParallelism,
     Scalac.privateWarnMacrosOption,
     Scalac.release8,
-    Scalac.targetOption,
     Scalac.warnConfOption,
     Scalac.warnMacrosOption
   )

--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -44,9 +44,6 @@ object Scalac {
 
   val release8 = ScalacOptions.release("8")
 
-  // JVM
-  val targetOption = ScalacOptions.other("-target:jvm-1.8")
-
   // Warn
   val privateWarnMacrosOption = ScalacOptions.privateWarnOption(
     "macros:after",

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
@@ -350,7 +350,7 @@ object AvroIO {
 }
 
 object AvroTyped {
-  private[scio] def writeTransform[T <: HasAvroAnnotation: TypeTag: Coder]()
+  private[scio] def writeTransform[T <: HasAvroAnnotation: TypeTag]()
     : BAvroIO.TypedWrite[T, Void, GenericRecord] = {
     val avroT = AvroType[T]
     BAvroIO

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/types/types.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/types/types.scala
@@ -35,6 +35,6 @@ package object types {
    *                 @doc("user age") age: Int)
    * }}}
    */
-  @nowarn("msg=parameter value value in class doc is never used")
+  @nowarn("msg=parameter value in class doc is never used")
   class doc(value: String) extends StaticAnnotation
 }

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -563,7 +563,7 @@ class ScioContext private[scio] (
 
     if (_counters.nonEmpty) {
       val counters = _counters.toArray
-      this.parallelize(Seq(0)).withName("Initialize counters").map { _ =>
+      this.parallelize(Seq(0)).withName("Initialize counters").tap { _ =>
         counters.foreach(_.inc(0))
       }
     }

--- a/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
@@ -51,10 +51,13 @@ private[scio] object BeamCoders {
     Some(unwrap(options, coder))
       .collect { case c: StructuredCoder[_] => c }
       .map(_.getComponents.asScala.toList)
-      .collect { case (c1: BCoder[K]) :: (c2: BCoder[V]) :: Nil =>
-        val k = Coder.beam(unwrap(options, c1))
-        val v = Coder.beam(unwrap(options, c2))
-        k -> v
+      .collect {
+        case (c1: BCoder[K @unchecked]) ::
+            (c2: BCoder[V @unchecked]) ::
+            Nil =>
+          val k = Coder.beam(unwrap(options, c1))
+          val v = Coder.beam(unwrap(options, c2))
+          k -> v
       }
       .getOrElse {
         throw new IllegalArgumentException(
@@ -69,11 +72,15 @@ private[scio] object BeamCoders {
     Some(unwrap(options, coder))
       .collect { case c: StructuredCoder[_] => c }
       .map(_.getComponents.asScala.toList)
-      .collect { case (c1: BCoder[A]) :: (c2: BCoder[B]) :: (c3: BCoder[C]) :: Nil =>
-        val a = Coder.beam(unwrap(options, c1))
-        val b = Coder.beam(unwrap(options, c2))
-        val c = Coder.beam(unwrap(options, c3))
-        (a, b, c)
+      .collect {
+        case (c1: BCoder[A @unchecked]) ::
+            (c2: BCoder[B @unchecked]) ::
+            (c3: BCoder[C @unchecked]) ::
+            Nil =>
+          val a = Coder.beam(unwrap(options, c1))
+          val b = Coder.beam(unwrap(options, c2))
+          val c = Coder.beam(unwrap(options, c3))
+          (a, b, c)
       }
       .getOrElse {
         throw new IllegalArgumentException(
@@ -91,7 +98,11 @@ private[scio] object BeamCoders {
       .collect { case c: StructuredCoder[_] => c }
       .map(_.getComponents.asScala.toList)
       .collect {
-        case (c1: BCoder[A]) :: (c2: BCoder[B]) :: (c3: BCoder[C]) :: (c4: BCoder[D]) :: Nil =>
+        case (c1: BCoder[A @unchecked]) ::
+            (c2: BCoder[B @unchecked]) ::
+            (c3: BCoder[C @unchecked]) ::
+            (c4: BCoder[D @unchecked]) ::
+            Nil =>
           val a = Coder.beam(unwrap(options, c1))
           val b = Coder.beam(unwrap(options, c2))
           val c = Coder.beam(unwrap(options, c3))

--- a/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
@@ -66,6 +66,12 @@ private[scio] object BeamCoders {
       }
   }
 
+  /** Get key coder from an `SCollection[(K, V)]`. */
+  def getKeyCoder[K, V](coll: SCollection[(K, V)]): Coder[K] = getTupleCoders[K, V](coll)._1
+
+  /** Get value coder from an `SCollection[(K, V)]`. */
+  def getValueCoder[K, V](coll: SCollection[(K, V)]): Coder[V] = getTupleCoders[K, V](coll)._2
+
   def getTuple3Coders[A, B, C](coll: SCollection[(A, B, C)]): (Coder[A], Coder[B], Coder[C]) = {
     val options = CoderOptions(coll.context.options)
     val coder = coll.internal.getCoder

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/GuavaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/GuavaCoders.scala
@@ -22,7 +22,7 @@ import com.spotify.scio.coders.Coder
 import com.google.common.{hash => g}
 import org.apache.beam.sdk.coders.CustomCoder
 
-class GuavaBloomFilterCoder[T](implicit val funnel: g.Funnel[T])
+class GuavaBloomFilterCoder[T](implicit val funnel: g.Funnel[_ >: T])
     extends CustomCoder[g.BloomFilter[T]] {
   override def encode(value: BloomFilter[T], outStream: OutputStream): Unit =
     value.writeTo(outStream)
@@ -32,6 +32,6 @@ class GuavaBloomFilterCoder[T](implicit val funnel: g.Funnel[T])
 }
 
 trait GuavaCoders {
-  implicit def guavaBFCoder[T](implicit x: g.Funnel[T]): Coder[g.BloomFilter[T]] =
+  implicit def guavaBFCoder[T](implicit x: g.Funnel[_ >: T]): Coder[g.BloomFilter[T]] =
     Coder.beam(new GuavaBloomFilterCoder[T])
 }

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/JavaCoders.scala
@@ -71,7 +71,7 @@ trait JavaCoders extends JavaBeanCoders {
     Coder.transform(c)(bc => Coder.beam(bcoders.ListCoder.of(bc)))
 
   implicit def jArrayListCoder[T](implicit c: Coder[T]): Coder[java.util.ArrayList[T]] =
-    Coder.xmap(jlistCoder[T])(new java.util.ArrayList(_), identity)
+    Coder.xmap(jListCoder[T])(new java.util.ArrayList(_), identity)
 
   implicit def jMapCoder[K, V](implicit ck: Coder[K], cv: Coder[V]): Coder[java.util.Map[K, V]] =
     Coder.transform(ck)(bk => Coder.transform(cv)(bv => Coder.beam(bcoders.MapCoder.of(bk, bv))))

--- a/scio-core/src/main/scala/com/spotify/scio/estimators/ApproxDistinctCounter.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/estimators/ApproxDistinctCounter.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.estimators
 
-import com.spotify.scio.coders.{BeamCoders, Coder}
+import com.spotify.scio.coders.Coder
 import com.spotify.scio.util.TupleFunctions._
 import com.spotify.scio.values.SCollection
 import org.apache.beam.sdk.{transforms => beam}
@@ -60,7 +60,7 @@ case class ApproximateUniqueCounter[T](sampleSize: Int) extends ApproxDistinctCo
       .asInstanceOf[SCollection[Long]]
 
   override def estimateDistinctCountPerKey[K](in: SCollection[(K, T)]): SCollection[(K, Long)] = {
-    implicit val keyCoder: Coder[K] = BeamCoders.getTupleCoders(in)._1
+    implicit val keyCoder: Coder[K] = in.keyCoder
     in.toKV
       .applyTransform(beam.ApproximateUnique.perKey[K, T](sampleSize))
       .map(klToTuple)
@@ -83,7 +83,7 @@ case class ApproximateUniqueCounterByError[T](maximumEstimationError: Double = 0
       .asInstanceOf[SCollection[Long]]
 
   override def estimateDistinctCountPerKey[K](in: SCollection[(K, T)]): SCollection[(K, Long)] = {
-    implicit val keyCoder: Coder[K] = BeamCoders.getTupleCoders(in)._1
+    implicit val keyCoder: Coder[K] = in.keyCoder
     in.toKV
       .applyTransform(beam.ApproximateUnique.perKey[K, T](maximumEstimationError))
       .map(klToTuple)

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/instances/JavaInstances.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/instances/JavaInstances.scala
@@ -24,6 +24,7 @@ import com.spotify.scio.schemas.{ArrayType, MapType, RawRecord, Schema, Type}
 import org.apache.beam.sdk.schemas.JavaBeanSchema
 import org.apache.beam.sdk.schemas.Schema.{FieldType, LogicalType}
 
+import scala.annotation.nowarn
 import scala.reflect.ClassTag
 
 trait JavaInstances {
@@ -66,6 +67,9 @@ trait JavaInstances {
   ): Schema[java.util.Map[K, V]] =
     MapType(ks, vs, identity, identity)
 
+  @nowarn(
+    "msg=evidence parameter evidence.* of type com.spotify.scio.IsJavaBean\\[.\\] in .* is never used"
+  )
   implicit def javaBeanSchema[T: IsJavaBean: ClassTag]: RawRecord[T] =
     RawRecord[T](new JavaBeanSchema())
 

--- a/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/testing/TestDataManager.scala
@@ -36,7 +36,7 @@ sealed private[scio] trait JobInputSource[T] {
   val asIterable: Try[Iterable[T]]
 }
 
-final private[scio] case class TestStreamInputSource[T: Coder](
+final private[scio] case class TestStreamInputSource[T](
   stream: TestStream[T]
 ) extends JobInputSource[T] {
   override val asIterable: Try[Iterable[T]] = Failure(

--- a/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/Functions.scala
@@ -284,7 +284,7 @@ private[scio] object Functions {
       override def partitionFor(elem: T, numPartitions: Int): Int = g(elem)
     }
 
-  abstract private class ReduceFn[T: Coder] extends CombineFn[T, JList[T], T] {
+  abstract private class ReduceFn[T] extends CombineFn[T, JList[T], T] {
     override def createAccumulator(): JList[T] = new JArrayList[T]()
 
     override def addInput(accumulator: JList[T], input: T): JList[T] = {

--- a/scio-core/src/main/scala/com/spotify/scio/util/random/RandomSampler.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/random/RandomSampler.scala
@@ -133,7 +133,7 @@ abstract private[scio] class RandomValueSampler[K, V, R](val fractions: Map[K, D
   protected var seed: Long = -1
 
   // TODO: is it necessary to setSeed for each instance like Spark does?
-  @nowarn("msg=parameter value c in method startBundle is never used")
+  @nowarn("msg=parameter c in method startBundle is never used")
   @StartBundle
   def startBundle(c: DoFn[(K, V), (K, V)]#StartBundleContext): Unit =
     rngs = fractions.iterator.map { case (k, v) =>

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
@@ -28,8 +28,9 @@ import com.spotify.scio.coders.{BeamCoders, Coder}
  */
 class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
 
-  implicit private val keyCoder: Coder[K] = self.keyCoder
-  implicit private val valueCoder: Coder[V] = self.valueCoder
+  // set as private to avoid conflict with PairSCollectionFunctions keyCoder/valueCoder
+  implicit private lazy val keyCoder: Coder[K] = BeamCoders.getKeyCoder(self)
+  implicit private lazy val valueCoder: Coder[V] = BeamCoders.getValueCoder(self)
 
   /**
    * Perform an inner join by replicating `rhs` to all workers. The right side should be tiny and
@@ -40,7 +41,7 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   def hashJoin[W](
     rhs: SCollection[(K, W)]
   ): SCollection[(K, (V, W))] = {
-    implicit val wCoder = BeamCoders.getTupleCoders(rhs)._2
+    implicit val wCoder = rhs.valueCoder
     hashJoin(rhs.asMultiMapSingletonSideInput)
   }
 
@@ -87,7 +88,7 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   def hashLeftOuterJoin[W](
     rhs: SCollection[(K, W)]
   ): SCollection[(K, (V, Option[W]))] = {
-    implicit val wCoder: Coder[W] = BeamCoders.getTupleCoders(rhs)._2
+    implicit val wCoder: Coder[W] = BeamCoders.getValueCoder(rhs)
     hashLeftOuterJoin(rhs.asMultiMapSingletonSideInput)
   }
 
@@ -123,7 +124,7 @@ class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
   def hashFullOuterJoin[W](
     rhs: SCollection[(K, W)]
   ): SCollection[(K, (Option[V], Option[W]))] = {
-    implicit val wCoder: Coder[W] = BeamCoders.getTupleCoders(rhs)._2
+    implicit val wCoder: Coder[W] = BeamCoders.getValueCoder(rhs)
     hashFullOuterJoin(rhs.asMultiMapSingletonSideInput)
   }
 

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairHashSCollectionFunctions.scala
@@ -28,8 +28,8 @@ import com.spotify.scio.coders.{BeamCoders, Coder}
  */
 class PairHashSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
 
-  implicit private[this] val (keyCoder, valueCoder): (Coder[K], Coder[V]) =
-    (self.keyCoder, self.valueCoder)
+  implicit private val keyCoder: Coder[K] = self.keyCoder
+  implicit private val valueCoder: Coder[V] = self.valueCoder
 
   /**
    * Perform an inner join by replicating `rhs` to all workers. The right side should be tiny and

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -57,9 +57,8 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
 
   private[this] val context: ScioContext = self.context
 
-  private val kvCoder = BeamCoders.getTupleCoders(self)
-  implicit val keyCoder: Coder[K] = kvCoder._1
-  implicit val valueCoder: Coder[V] = kvCoder._2
+  implicit lazy val keyCoder: Coder[K] = BeamCoders.getKeyCoder(self)
+  implicit lazy val valueCoder: Coder[V] = BeamCoders.getValueCoder(self)
 
   private[scio] def toKV: SCollection[KV[K, V]] =
     self.map(kv => KV.of(kv._1, kv._2))

--- a/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/PairSCollectionFunctions.scala
@@ -57,7 +57,9 @@ class PairSCollectionFunctions[K, V](val self: SCollection[(K, V)]) {
 
   private[this] val context: ScioContext = self.context
 
-  implicit val (keyCoder, valueCoder): (Coder[K], Coder[V]) = BeamCoders.getTupleCoders(self)
+  private val kvCoder = BeamCoders.getTupleCoders(self)
+  implicit val keyCoder: Coder[K] = kvCoder._1
+  implicit val valueCoder: Coder[V] = kvCoder._2
 
   private[scio] def toKV: SCollection[KV[K, V]] =
     self.map(kv => KV.of(kv._1, kv._2))

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -21,7 +21,7 @@ import java.io.PrintStream
 import java.lang.{Boolean => JBoolean, Double => JDouble, Iterable => JIterable}
 import java.util.concurrent.ThreadLocalRandom
 import com.spotify.scio.ScioContext
-import com.spotify.scio.coders.{BeamCoders, Coder, CoderMaterializer}
+import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.estimators.{
   ApproxDistinctCounter,
   ApproximateUniqueCounter,
@@ -999,7 +999,7 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   def hashLookup[V](
     that: SCollection[(T, V)]
   ): SCollection[(T, Iterable[V])] = {
-    implicit val vCoder = BeamCoders.getTupleCoders(that)._2
+    implicit val vCoder = that.valueCoder
     this.transform { in =>
       val side = that.asMultiMapSingletonSideInput
       in.withSideInputs(side)

--- a/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
+++ b/scio-examples/src/it/scala/com/spotify/scio/examples/RunPreReleaseIT.scala
@@ -43,7 +43,7 @@ object RunPreReleaseIT {
     val runId = args("runId")
 
     try {
-      val jobs = List(parquet(runId), avro(runId), smb(runId), bigquery(runId))
+      val jobs = List(parquet(runId), avro(runId), smb(runId), bigquery())
       Await.result(Future.sequence(jobs), 1.hour)
     } catch {
       case t: Throwable =>
@@ -139,7 +139,7 @@ object RunPreReleaseIT {
     }
   }
 
-  private def bigquery(runId: String): Future[Unit] = {
+  private def bigquery(): Future[Unit] = {
     import com.spotify.scio.examples.extra.{TypedBigQueryTornadoes, TypedStorageBigQueryTornadoes}
     log.info("Starting BigQuery tests... ")
     val jobs = List(

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyAvroExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MagnolifyAvroExample.scala
@@ -23,7 +23,10 @@ package com.spotify.scio.examples.extra
 
 import com.spotify.scio._
 import com.spotify.scio.avro._
+import com.spotify.scio.coders.Coder
 import com.spotify.scio.examples.common.ExampleData
+import com.spotify.scio.examples.extra.MagnolifyAvroExample.wordCountType
+import org.apache.avro.generic.GenericRecord
 
 object MagnolifyAvroExample {
   // limit import scope to avoid polluting namespace
@@ -43,11 +46,14 @@ object MagnolifyAvroExample {
 // --input=gs://apache-beam-samples/shakespeare/kinglear.txt
 // --output=gs://[BUCKET]/[PATH]/wordcount-avro"`
 object MagnolifyAvroWriteExample {
+
+  implicit val genericCoder: Coder[GenericRecord] =
+    avroGenericRecordCoder(wordCountType.schema)
+
   def main(cmdlineArgs: Array[String]): Unit = {
     import MagnolifyAvroExample._
 
     val (sc, args) = ContextAndArgs(cmdlineArgs)
-    implicit def genericCoder = avroGenericRecordCoder(wordCountType.schema)
     sc.textFile(args.getOrElse("input", ExampleData.KING_LEAR))
       .flatMap(_.split("[^a-zA-Z']+").filter(_.nonEmpty))
       .countByValue

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MetricsExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/MetricsExample.scala
@@ -43,7 +43,7 @@ object MetricsExample {
   val gauge: Gauge = ScioMetrics.gauge[MetricsExample.type]("gauge")
 
   def main(cmdlineArgs: Array[String]): Unit = {
-    val (sc, args) = ContextAndArgs(cmdlineArgs)
+    val (sc, _) = ContextAndArgs(cmdlineArgs)
 
     // Create and initialize counters from ScioContext
     sc.initCounter("ctxcount")

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/StatefulExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/StatefulExample.scala
@@ -29,10 +29,13 @@ import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.transforms.DoFn.{Element, OutputReceiver, ProcessElement, StateId}
 import org.apache.beam.sdk.values.KV
 
+import scala.annotation.nowarn
+
 object StatefulExample {
   // States are persisted on a per-key-and-window basis
   type DoFnT = DoFn[KV[String, Int], KV[String, (Int, Int)]]
 
+  @nowarn("msg=private val count in class StatefulDoFn is never used")
   class StatefulDoFn extends DoFnT {
     // Declare mutable state
     @StateId("count") private val count = StateSpecs.value[JInt]()
@@ -52,7 +55,7 @@ object StatefulExample {
   }
 
   def main(cmdlineArgs: Array[String]): Unit = {
-    val (sc, args) = ContextAndArgs(cmdlineArgs)
+    val (sc, _) = ContextAndArgs(cmdlineArgs)
 
     val input = for {
       k <- Seq("a", "b")

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TapsExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/TapsExample.scala
@@ -38,7 +38,7 @@ object TapsExample {
       t2 <- taps.textFile("macbeth.txt")
     } yield {
       // execution logic when both taps are available
-      val (sc, args) = ContextAndArgs(cmdlineArgs)
+      val (sc, _) = ContextAndArgs(cmdlineArgs)
       val out = (t1.open(sc) ++ t2.open(sc))
         .flatMap(_.split("[^a-zA-Z']+").filter(_.nonEmpty))
         .countByValue

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/CloudSqlExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/CloudSqlExampleTest.scala
@@ -23,14 +23,13 @@ import com.spotify.scio.testing._
 
 class CloudSqlExampleTest extends PipelineSpec {
   "CloudSqlExample" should "work" in {
-    val args =
-      Array(
-        "--cloudSqlUsername=john",
-        "--cloudSqlPassword=secret",
-        "--cloudSqlDb=mydb",
-        "--cloudSqlInstanceConnectionName=project-id:zone:db-instance-name"
-      )
-    val (opts, _) = ScioContext.parseArguments[CloudSqlOptions](args)
+    val args = Seq(
+      "--cloudSqlUsername=john",
+      "--cloudSqlPassword=secret",
+      "--cloudSqlDb=mydb",
+      "--cloudSqlInstanceConnectionName=project-id:zone:db-instance-name"
+    )
+    val (opts, _) = ScioContext.parseArguments[CloudSqlOptions](args.toArray)
     val connOpts = CloudSqlExample.getConnectionOptions(opts)
     val query = "SELECT * FROM word_count"
     val statement = "INSERT INTO result_word_count values(?, ?)"

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/MagnolifyAvroExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/MagnolifyAvroExampleTest.scala
@@ -36,6 +36,7 @@ class MagnolifyAvroExampleTest extends PipelineSpec {
   val textOut: Seq[String] = wordCount.map(kv => kv._1 + ": " + kv._2)
 
   "MagnolifyAvroWriteExample" should "work" in {
+    import MagnolifyAvroWriteExample.genericCoder
     JobTest[com.spotify.scio.examples.extra.MagnolifyAvroWriteExample.type]
       .args("--input=in.txt", "--output=wc.avro")
       .input(TextIO("in.txt"), textIn)
@@ -44,6 +45,7 @@ class MagnolifyAvroExampleTest extends PipelineSpec {
   }
 
   "MagnolifyAvroReadExample" should "work" in {
+    import MagnolifyAvroWriteExample.genericCoder
     JobTest[com.spotify.scio.examples.extra.MagnolifyAvroReadExample.type]
       .args("--input=wc.avro", "--output=out.txt")
       .input(AvroIO[GenericRecord]("wc.avro"), records)

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/csv/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/csv/syntax/SCollectionSyntax.scala
@@ -42,7 +42,7 @@ trait SCollectionSyntax {
       filenamePolicySupplier: FilenamePolicySupplier =
         CsvIO.WriteParam.DefaultFilenamePolicySupplier,
       prefix: String = CsvIO.WriteParam.DefaultPrefix
-    )(implicit coder: Coder[T], enc: HeaderEncoder[T]): ClosedTap[Nothing] =
+    )(implicit enc: HeaderEncoder[T]): ClosedTap[Nothing] =
       self.write(CsvIO.Write[T](path))(
         CsvIO.WriteParam(
           compression = compression,

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/hll/sketching/SketchHllPlusPlus.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/hll/sketching/SketchHllPlusPlus.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.extra.hll.sketching
 
-import com.spotify.scio.coders.{BeamCoders, Coder}
+import com.spotify.scio.coders.Coder
 import com.spotify.scio.estimators.ApproxDistinctCounter
 import com.spotify.scio.util.TupleFunctions.klToTuple
 import com.spotify.scio.values.SCollection
@@ -61,7 +61,7 @@ case class SketchHllPlusPlus[T](p: Int, sp: Int) extends ApproxDistinctCounter[T
   override def estimateDistinctCountPerKey[K](
     in: SCollection[(K, T)]
   ): SCollection[(K, Long)] = {
-    implicit val keyCoder: Coder[K] = BeamCoders.getTupleCoders(in)._1
+    implicit val keyCoder: Coder[K] = in.keyCoder
 
     in.toKV
       .applyTransform(

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/hll/zetasketch/ZetaSketchHllPlusPlus.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/hll/zetasketch/ZetaSketchHllPlusPlus.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.extra.hll.zetasketch
 
-import com.spotify.scio.coders.{BeamCoders, Coder}
+import com.spotify.scio.coders.Coder
 import com.spotify.scio.estimators.ApproxDistinctCounter
 import com.spotify.scio.util.TupleFunctions.klToTuple
 import com.spotify.scio.values.SCollection
@@ -61,8 +61,7 @@ case class ZetaSketchHllPlusPlus[T](p: Int = HllCount.DEFAULT_PRECISION)(implici
    * estimated distinct count per each unique key.
    */
   override def estimateDistinctCountPerKey[K](in: SCollection[(K, T)]): SCollection[(K, Long)] = {
-    implicit val (keyCoder, _): (Coder[K], Coder[T]) =
-      BeamCoders.getTupleCoders(in)
+    implicit val keyCoder: Coder[K] = in.keyCoder
     in.toKV
       .applyTransform(
         zs.init(p)

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sorter/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sorter/syntax/SCollectionSyntax.scala
@@ -25,9 +25,15 @@ import org.apache.beam.sdk.extensions.sorter.ExternalSorter.Options.SorterType
 import org.apache.beam.sdk.extensions.sorter.{BufferedExternalSorter, SortValues}
 import org.apache.beam.sdk.values.KV
 
+import scala.annotation.nowarn
 import scala.collection.AbstractIterator
 import scala.jdk.CollectionConverters._
 
+@nowarn(
+  "msg=evidence parameter evidence.* " +
+    "of type com.spotify.scio.extra.sorter.SortingKey\\[K2\\] " +
+    "in class SorterOps is never used"
+)
 final class SorterOps[K1, K2: SortingKey, V](self: SCollection[(K1, Iterable[(K2, V)])]) {
 
   /**

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctions.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/PairLargeHashSCollectionFunctions.scala
@@ -36,8 +36,8 @@ import com.spotify.sparkey.CompressionType
  */
 class PairLargeHashSCollectionFunctions[K, V](private val self: SCollection[(K, V)]) {
 
-  implicit private[this] val (keyCoder, valueCoder): (Coder[K], Coder[V]) =
-    (self.keyCoder, self.valueCoder)
+  implicit private val keyCoder: Coder[K] = self.keyCoder
+  implicit private val valueCoder: Coder[V] = self.valueCoder
 
   /**
    * Perform an inner join by replicating `rhs` to all workers. The right side should be <<10x

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -205,6 +205,7 @@ package object sparkey extends SparkeyReaderInstances {
     import SparkeyPairSCollection._
 
     // set as private to avoid conflict with PairSCollectionFunctions keyCoder/valueCoder
+    implicit private lazy val coder: Coder[(K, V)] = BeamCoders.getCoder(self)
     implicit private lazy val keyCoder: Coder[K] = BeamCoders.getKeyCoder(self)
     implicit private lazy val valueCoder: Coder[V] = BeamCoders.getValueCoder(self)
 
@@ -525,7 +526,7 @@ package object sparkey extends SparkeyReaderInstances {
    * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with Sparkey methods.
    */
   implicit class SparkeySetSCollection[T](private val self: SCollection[T]) {
-    implicit val coder: Coder[T] = self.coder
+    implicit private lazy val coder: Coder[T] = BeamCoders.getCoder(self)
 
     /**
      * Convert this SCollection to a SideInput, mapping key-value pairs of each window to a

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -21,7 +21,7 @@ import java.lang.Math.floorMod
 import java.util.UUID
 import com.spotify.scio.ScioContext
 import com.spotify.scio.annotations.experimental
-import com.spotify.scio.coders.{BeamCoders, Coder, CoderMaterializer}
+import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.extra.sparkey.instances._
 import com.spotify.scio.util.{Cache, RemoteFileUtil}
 import com.spotify.scio.values.{SCollection, SideInput}
@@ -181,7 +181,7 @@ package object sparkey extends SparkeyReaderInstances {
     compressionType: CompressionType,
     compressionBlockSize: Int,
     elements: Iterable[(K, V)]
-  )(implicit w: SparkeyWritable[K, V], koder: Coder[K], voder: Coder[V]): SparkeyUri = {
+  )(implicit w: SparkeyWritable[K, V]): SparkeyUri = {
     val writer = new SparkeyWriter(uri, rfu, compressionType, compressionBlockSize, maxMemoryUsage)
     val it = elements.iterator
     while (it.hasNext) {
@@ -204,8 +204,8 @@ package object sparkey extends SparkeyReaderInstances {
 
     import SparkeyPairSCollection._
 
-    implicit val kvCoder: Coder[(K, V)] = BeamCoders.getCoder(self)
-    implicit val (keyCoder, valueCoder): (Coder[K], Coder[V]) = BeamCoders.getTupleCoders(self)
+    implicit val keyCoder: Coder[K] = self.keyCoder
+    implicit val valueCoder: Coder[V] = self.valueCoder
 
     /**
      * Write the key-value pairs of this SCollection as a Sparkey file to a specific location.

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -21,7 +21,7 @@ import java.lang.Math.floorMod
 import java.util.UUID
 import com.spotify.scio.ScioContext
 import com.spotify.scio.annotations.experimental
-import com.spotify.scio.coders.{Coder, CoderMaterializer}
+import com.spotify.scio.coders.{BeamCoders, Coder, CoderMaterializer}
 import com.spotify.scio.extra.sparkey.instances._
 import com.spotify.scio.util.{Cache, RemoteFileUtil}
 import com.spotify.scio.values.{SCollection, SideInput}
@@ -204,8 +204,9 @@ package object sparkey extends SparkeyReaderInstances {
 
     import SparkeyPairSCollection._
 
-    implicit val keyCoder: Coder[K] = self.keyCoder
-    implicit val valueCoder: Coder[V] = self.valueCoder
+    // set as private to avoid conflict with PairSCollectionFunctions keyCoder/valueCoder
+    implicit private lazy val keyCoder: Coder[K] = BeamCoders.getKeyCoder(self)
+    implicit private lazy val valueCoder: Coder[V] = BeamCoders.getValueCoder(self)
 
     /**
      * Write the key-value pairs of this SCollection as a Sparkey file to a specific location.

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/csv/CsvIOTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/csv/CsvIOTest.scala
@@ -203,7 +203,7 @@ class CsvIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterEach {
     )
   }
 
-  private def writeAsCsvAndReadLines[T: HeaderEncoder: Coder](dir: File)(
+  private def writeAsCsvAndReadLines(dir: File)(
     transform: (ScioContext, String) => ClosedTap[Nothing]
   ): List[String] = {
     val sc = ScioContext()
@@ -213,7 +213,7 @@ class CsvIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterEach {
     FileUtils.readLines(file, StandardCharsets.UTF_8).asScala.toList
   }
 
-  private def getFirstCsvFileFrom[T: HeaderEncoder: Coder](dir: File) =
+  private def getFirstCsvFileFrom(dir: File) =
     dir
       .listFiles(new FilenameFilter {
         override def accept(dir: File, name: String): Boolean = name.endsWith("csv")

--- a/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/types/StorageIT.scala
+++ b/scio-google-cloud-platform/src/it/scala/com/spotify/scio/bigquery/types/StorageIT.scala
@@ -66,12 +66,12 @@ class StorageIT extends AnyFlatSpec with Matchers {
     val expected = (0 until 10).map { i =>
       Optional(
         Some(true),
-        Some(i),
-        Some(i),
+        Some(i.toLong),
+        Some(i.toDouble),
         Some(BigDecimal(i)),
         Some(s"s$i"),
         Some(ByteString.copyFromUtf8(s"s$i")),
-        Some(t.plus(Duration.millis(i))),
+        Some(t.plus(Duration.millis(i.toLong))),
         Some(dt.toLocalDate.plusDays(i)),
         Some(dt.toLocalTime.plusMillis(i)),
         Some(dt.toLocalDateTime.plusMillis(i))

--- a/scio-google-cloud-platform/src/it/scala/com/spotify/scio/spanner/SpannerIOIT.scala
+++ b/scio-google-cloud-platform/src/it/scala/com/spotify/scio/spanner/SpannerIOIT.scala
@@ -37,7 +37,7 @@ object SpannerIOIT {
   private val config: SpannerConfig = SpannerConfig
     .create()
     .withProjectId(projectId)
-    .withDatabaseId(s"io_it_${Random.nextInt}")
+    .withDatabaseId(s"io_it_${Random.nextInt()}")
     .withInstanceId("spanner-it")
 
   private lazy val adminClient = Spanner.adminClient(projectId)

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
@@ -339,7 +339,7 @@ object Numeric {
       s"max allowed precision is $MaxNumericPrecision"
     )
 
-    BigDecimal(scaled.toString, new MathContext(MaxNumericPrecision))
+    scaled.round(new MathContext(MaxNumericPrecision))
   }
 
   // For BigQueryType macros only, do not use directly

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/MockBigQuery.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/MockBigQuery.scala
@@ -26,7 +26,6 @@ import com.spotify.scio.bigquery.types.BigQueryType.HasAnnotation
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers
 
 import scala.collection.mutable
-import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
 /** Companion object for [[MockBigQuery]]. */
@@ -116,7 +115,7 @@ class MockBigQuery private (private val bq: BigQuery) {
   /**
    * Get result of a live query against BigQuery service, substituting mocked tables with test data.
    */
-  def typedQueryResult[T <: HasAnnotation: ClassTag: TypeTag](
+  def typedQueryResult[T <: HasAnnotation: TypeTag](
     sqlQuery: String,
     flattenResults: Boolean = false
   ): Seq[T] = {
@@ -171,7 +170,7 @@ class MockTable(
   }
 
   /** Populate the table with mock data. */
-  def withTypedData[T <: HasAnnotation: ClassTag: TypeTag](rows: Seq[T]): Unit = {
+  def withTypedData[T <: HasAnnotation: TypeTag](rows: Seq[T]): Unit = {
     val bqt = BigQueryType[T]
     withData(rows.map(bqt.toTableRow))
   }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -43,7 +43,6 @@ import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.{
   WriteDisposition
 }
 
-import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 import com.spotify.scio.bigquery.BigQueryTypedTable.Format
 import com.spotify.scio.util.FilenamePolicySupplier
@@ -216,7 +215,7 @@ final class SCollectionTypedOps[T <: HasAnnotation](private val self: SCollectio
     sharding: Sharding = TableWriteParam.DefaultSharding,
     failedInsertRetryPolicy: InsertRetryPolicy = TableWriteParam.DefaultFailedInsertRetryPolicy,
     configOverride: TableWriteParam.ConfigOverride[T] = TableWriteParam.defaultConfigOverride
-  )(implicit tt: TypeTag[T], ct: ClassTag[T], coder: Coder[T]): ClosedTap[T] = {
+  )(implicit tt: TypeTag[T], coder: Coder[T]): ClosedTap[T] = {
     val param = TableWriteParam[T](
       method,
       writeDisposition,

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
@@ -34,7 +34,6 @@ import com.spotify.scio.bigquery.{
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.values._
 
-import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 import com.spotify.scio.bigquery.BigQueryTypedTable
 import com.spotify.scio.bigquery.BigQueryTypedTable.Format
@@ -118,15 +117,15 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   def bigQueryStorage(query: Query): SCollection[TableRow] =
     self.read(BigQueryStorageSelect(query))
 
-  def typedBigQuery[T <: HasAnnotation: ClassTag: TypeTag: Coder](): SCollection[T] =
+  def typedBigQuery[T <: HasAnnotation: TypeTag: Coder](): SCollection[T] =
     typedBigQuery(None)
 
-  def typedBigQuery[T <: HasAnnotation: ClassTag: TypeTag: Coder](
+  def typedBigQuery[T <: HasAnnotation: TypeTag: Coder](
     newSource: Source
   ): SCollection[T] = typedBigQuery(Option(newSource))
 
   /** Get a typed SCollection for BigQuery Table or a SELECT query using the Storage API. */
-  def typedBigQuery[T <: HasAnnotation: ClassTag: TypeTag: Coder](
+  def typedBigQuery[T <: HasAnnotation: TypeTag: Coder](
     newSource: Option[Source]
   ): SCollection[T] = {
     val bqt = BigQueryType[T]
@@ -147,7 +146,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
    * [[com.spotify.scio.bigquery.types.BigQueryType.fromSchema BigQueryType.fromStorage]] or
    * [[com.spotify.scio.bigquery.types.BigQueryType.fromQuery BigQueryType.fromQuery]]
    */
-  def typedBigQueryStorage[T <: HasAnnotation: ClassTag: TypeTag: Coder](): SCollection[T] = {
+  def typedBigQueryStorage[T <: HasAnnotation: TypeTag: Coder](): SCollection[T] = {
     val bqt = BigQueryType[T]
     if (bqt.isQuery) {
       self.read(BigQueryTyped.StorageQuery[T](Query(bqt.query.get)))
@@ -159,7 +158,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
     }
   }
 
-  def typedBigQueryStorage[T <: HasAnnotation: ClassTag: TypeTag: Coder](
+  def typedBigQueryStorage[T <: HasAnnotation: TypeTag: Coder](
     table: Table
   ): SCollection[T] =
     self.read(
@@ -170,7 +169,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
       )
     )
 
-  def typedBigQueryStorage[T <: HasAnnotation: ClassTag: TypeTag: Coder](
+  def typedBigQueryStorage[T <: HasAnnotation: TypeTag: Coder](
     rowRestriction: String
   ): SCollection[T] = {
     val bqt = BigQueryType[T]
@@ -184,7 +183,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
     )
   }
 
-  def typedBigQueryStorage[T <: HasAnnotation: ClassTag: TypeTag: Coder](
+  def typedBigQueryStorage[T <: HasAnnotation: TypeTag: Coder](
     table: Table,
     rowRestriction: String
   ): SCollection[T] =
@@ -196,7 +195,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
       )
     )
 
-  def typedBigQueryStorage[T <: HasAnnotation: ClassTag: TypeTag: Coder](
+  def typedBigQueryStorage[T <: HasAnnotation: TypeTag: Coder](
     table: Table,
     selectedFields: List[String],
     rowRestriction: String

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -423,8 +423,7 @@ private[types] object TypeProvider {
           case q"selectedFields = List(..$xs)" => namedArgs("selectedFields") = xs.map(str)
           case q"rowRestriction = $s"          => namedArgs("rowRestriction") = List(str(s))
           case q"List(..$xs)"                  => posList += xs.map(str)
-          case q"$s"                           => posList += List(str(s))
-          case _                               => throw new Exception("Invalid macro application")
+          case s                               => posList += List(str(s))
         }
         val posArgs = List("args", "selectedFields", "rowRestriction").zip(posList).toMap
         val dups = posArgs.keySet intersect namedArgs.keySet
@@ -436,6 +435,7 @@ private[types] object TypeProvider {
         val selectedFields = argMap.getOrElse("selectedFields", Nil)
         val rowRestriction = argMap.getOrElse("rowRestriction", Nil).headOption
         (table, args, selectedFields, rowRestriction)
+      case _ => throw new Exception("Invalid macro application")
     }
   }
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -32,7 +32,7 @@ package object types {
    *                 @description("user age") age: Int)
    * }}}
    */
-  @nowarn("msg=parameter value value in class description is never used")
+  @nowarn("msg=parameter value in class description is never used")
   final class description(value: String) extends StaticAnnotation with Serializable
 
   /**

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/pubsub/PubsubIO.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/pubsub/PubsubIO.scala
@@ -100,21 +100,21 @@ object PubsubIO {
   ): PubsubIO[T] =
     MessagePubsubIOWithoutAttributes[T](name, idAttribute, timestampAttribute)
 
-  def pubsub[T <: beam.PubsubMessage: ClassTag](
+  def pubsub[T <: beam.PubsubMessage](
     name: String,
     idAttribute: String = null,
     timestampAttribute: String = null
   ): PubsubIO[T] =
     PubSubMessagePubsubIOWithoutAttributes[T](name, idAttribute, timestampAttribute)
 
-  def coder[T: Coder: ClassTag](
+  def coder[T: Coder](
     name: String,
     idAttribute: String = null,
     timestampAttribute: String = null
   ): PubsubIO[T] =
     FallbackPubsubIOWithoutAttributes[T](name, idAttribute, timestampAttribute)
 
-  def withAttributes[T: ClassTag: Coder](
+  def withAttributes[T: Coder](
     name: String,
     idAttribute: String = null,
     timestampAttribute: String = null
@@ -291,7 +291,7 @@ final private case class FallbackPubsubIOWithoutAttributes[T: Coder](
   }
 }
 
-final private case class PubsubIOWithAttributes[T: ClassTag: Coder](
+final private case class PubsubIOWithAttributes[T: Coder](
   name: String,
   idAttribute: String,
   timestampAttribute: String

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/BigQueryIOTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/BigQueryIOTest.scala
@@ -17,7 +17,9 @@
 
 package com.spotify.scio.bigquery
 
+import com.spotify.scio.avro._
 import com.spotify.scio.bigquery.BigQueryTypedTable.Format
+import com.spotify.scio.coders.Coder
 import com.spotify.scio.{ContextAndArgs, ScioContext}
 import com.spotify.scio.testing._
 import org.apache.avro.generic.GenericRecord
@@ -84,6 +86,7 @@ final class BigQueryIOTest extends ScioIOSpec {
     val name = "saveAsBigQueryTable"
     val desc = "table-description"
     val sc = ScioContext()
+    implicit val coder: Coder[GenericRecord] = avroGenericRecordCoder
     val io = BigQueryTypedTable[GenericRecord](
       table = Table.Spec("project:dataset.out_table"),
       format = Format.GenericRecord

--- a/scio-grpc/src/test/scala/com/spotify/scio/grpc/GrpcDoFnTest.scala
+++ b/scio-grpc/src/test/scala/com/spotify/scio/grpc/GrpcDoFnTest.scala
@@ -23,6 +23,7 @@ import com.spotify.concat.v1.ConcatServiceGrpc.{
   ConcatServiceStub
 }
 import com.spotify.concat.v1._
+import com.spotify.scio.coders.Coder
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.transforms.BaseAsyncLookupDoFn.CacheSupplier
 import io.grpc.netty.NettyChannelBuilder
@@ -46,6 +47,9 @@ object GrpcDoFnTest {
   }
 
   val ServiceUri: String = s"dns:///localhost:$LocalPort"
+
+  implicit val coderRequest: Coder[ConcatRequest] = Coder.protoMessageCoder[ConcatRequest]
+  implicit val coderResponse: Coder[ConcatResponse] = Coder.protoMessageCoder[ConcatResponse]
 
   def concatOrdered(request: ConcatRequest): ConcatResponse = ConcatResponse
     .newBuilder()

--- a/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/syntax/ScioContextSyntax.scala
+++ b/scio-jdbc/src/main/scala/com/spotify/scio/jdbc/syntax/ScioContextSyntax.scala
@@ -63,7 +63,7 @@ final class JdbcScioContextOps(private val self: ScioContext) extends AnyVal {
    * @param configOverride
    *   function to override or replace a Read transform before applying it
    */
-  def jdbcSelect[T: ClassTag: Coder](
+  def jdbcSelect[T: Coder](
     connectionOptions: JdbcConnectionOptions,
     query: String,
     statementPreparator: PreparedStatement => Unit = ReadParam.DefaultStatementPreparator,

--- a/scio-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/coders/CoderMacros.scala
@@ -40,7 +40,7 @@ private[coders] object CoderMacros {
         """.stripMargin
     )
 
-  @nowarn("msg=parameter value lp in method issueFallbackWarning is never used")
+  @nowarn("msg=parameter lp in method issueFallbackWarning is never used")
   def issueFallbackWarning[T: c.WeakTypeTag](
     c: whitebox.Context
   )(lp: c.Expr[shapeless.LowPriority]): c.Tree = {

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -54,7 +54,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters._
-import scala.reflect.ClassTag
+import scala.reflect.{classTag, ClassTag}
 
 final case class ParquetAvroIO[T: ClassTag: Coder](path: String) extends ScioIO[T] {
   override type ReadP = ParquetAvroIO.ReadParam[_, T]
@@ -71,10 +71,9 @@ final case class ParquetAvroIO[T: ClassTag: Coder](path: String) extends ScioIO[
 
   override protected def readTest(sc: ScioContext, params: ReadP): SCollection[T] = {
     type AvroType = params.avroClass.type
-
     // The projection function is not part of the test input, so it must be applied directly
     TestDataManager
-      .getInput(sc.testId.get)(ParquetAvroIO[AvroType](path))
+      .getInput(sc.testId.get)(ParquetAvroIO[AvroType](path)(classTag, null))
       .toSCollection(sc)
       .map(params.projectionFn.asInstanceOf[AvroType => T])
   }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/dynamic/syntax/SCollectionSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/dynamic/syntax/SCollectionSyntax.scala
@@ -16,7 +16,6 @@
 
 package com.spotify.scio.parquet.avro.dynamic.syntax
 
-import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.dynamic.syntax.DynamicSCollectionOps.writeDynamic
 import com.spotify.scio.io.{ClosedTap, EmptyTap}
 import com.spotify.scio.parquet.ParquetConfiguration
@@ -48,7 +47,7 @@ final class DynamicParquetAvroSCollectionOps[T](
     prefix: String = ParquetAvroIO.WriteParam.DefaultPrefix
   )(
     destinationFn: T => String
-  )(implicit ct: ClassTag[T], coder: Coder[T]): ClosedTap[Nothing] = {
+  )(implicit ct: ClassTag[T]): ClosedTap[Nothing] = {
     if (self.context.isTest) {
       throw new NotImplementedError(
         "Parquet avro file with dynamic destinations cannot be used in a test context"

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/syntax/SCollectionSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/syntax/SCollectionSyntax.scala
@@ -83,7 +83,7 @@ class SCollectionOps[T](private val self: SCollection[T]) extends AnyVal {
 trait SCollectionSyntax {
   implicit def parquetAvroSCollectionOps[T](c: SCollection[T]): SCollectionOps[T] =
     new SCollectionOps[T](c)
-  implicit def parquetAvroSCollection[T: ClassTag: Coder](
+  implicit def parquetAvroSCollection[T: Coder](
     self: ParquetAvroFile[T]
   ): SCollectionOps[T] =
     new SCollectionOps[T](self.toSCollection)

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/package.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/package.scala
@@ -24,7 +24,7 @@ import java.nio.channels.{Channels, WritableByteChannel}
 
 package object parquet {
   class ParquetOutputStream(outputStream: OutputStream) extends PositionOutputStream {
-    private var position = 0
+    private var position = 0L
     override def getPos: Long = position
     override def write(b: Int): Unit = {
       position += 1

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetRead.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetRead.scala
@@ -72,7 +72,7 @@ object ParquetRead {
    * @param conf
    *   a Parquet [[Configuration]], if desired
    */
-  def readTyped[T: ClassTag: ParquetType](
+  def readTyped[T: ParquetType](
     predicate: FilterPredicate = null,
     conf: Configuration = null
   ): PTransform[PCollection[ReadableFile], PCollection[T]] = readTyped(
@@ -88,7 +88,7 @@ object ParquetRead {
    * @param projectionFn
    *   a function mapping T => R
    */
-  def readTyped[T: ClassTag: ParquetType, R](
+  def readTyped[T: ParquetType, R](
     projectionFn: T => R
   ): PTransform[PCollection[ReadableFile], PCollection[R]] = readTyped(
     projectionFn,
@@ -105,7 +105,7 @@ object ParquetRead {
    * @param predicate
    *   a Parquet [[FilterApi]] predicate
    */
-  def readTyped[T: ClassTag: ParquetType, R](
+  def readTyped[T: ParquetType, R](
     projectionFn: T => R,
     predicate: FilterPredicate
   ): PTransform[PCollection[ReadableFile], PCollection[R]] = readTyped(
@@ -123,7 +123,7 @@ object ParquetRead {
    * @param conf
    *   a Parquet [[Configuration]]
    */
-  def readTyped[T: ClassTag: ParquetType, R](
+  def readTyped[T: ParquetType, R](
     projectionFn: T => R,
     conf: Configuration
   ): PTransform[PCollection[ReadableFile], PCollection[R]] = readTyped(
@@ -143,7 +143,7 @@ object ParquetRead {
    * @param conf
    *   a Parquet [[Configuration]]
    */
-  def readTyped[T: ClassTag: ParquetType, R](
+  def readTyped[T: ParquetType, R](
     projectionFn: T => R,
     predicate: FilterPredicate,
     conf: Configuration

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadFn.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/read/ParquetReadFn.scala
@@ -78,7 +78,7 @@ class ParquetReadFn[T, R](
         } finally {
           reader.close()
         }
-      new OffsetRange(0, rowGroups)
+      new OffsetRange(0L, rowGroups.toLong)
   }
 
   @NewTracker def newTracker(@Restriction restriction: OffsetRange) =
@@ -284,7 +284,7 @@ class ParquetReadFn[T, R](
           val currentSize = size + rowGroup.getTotalByteSize
 
           if (currentSize > SplitLimit || endGroup - 1 == end) {
-            (new OffsetRange(start, end + 1) +: offsets, end + 1, 0.0)
+            (new OffsetRange(start.toLong, end + 1L) +: offsets, end + 1, 0.0)
           } else {
             (offsets, start, currentSize)
           }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/dynamic/syntax/SCollectionSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/dynamic/syntax/SCollectionSyntax.scala
@@ -16,7 +16,6 @@
 
 package com.spotify.scio.parquet.tensorflow.dynamic.syntax
 
-import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.dynamic.syntax.DynamicSCollectionOps.writeDynamic
 import com.spotify.scio.io.{ClosedTap, EmptyTap}
 import com.spotify.scio.parquet.ParquetConfiguration
@@ -28,8 +27,6 @@ import org.apache.beam.sdk.io.hadoop.SerializableConfiguration
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.tensorflow.proto.example.Example
-
-import scala.reflect.ClassTag
 
 final class DynamicParquetExampleSCollectionOps(
   private val self: SCollection[Example]
@@ -50,7 +47,7 @@ final class DynamicParquetExampleSCollectionOps(
     prefix: String = ParquetExampleIO.WriteParam.DefaultPrefix
   )(
     destinationFn: Example => String
-  )(implicit ct: ClassTag[Example], coder: Coder[Example]): ClosedTap[Nothing] = {
+  ): ClosedTap[Nothing] = {
     if (self.context.isTest) {
       throw new NotImplementedError(
         "Parquet example file with dynamic destinations cannot be used in a test context"

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/dynamic/syntax/SCollectionSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/dynamic/syntax/SCollectionSyntax.scala
@@ -16,7 +16,6 @@
 
 package com.spotify.scio.parquet.types.dynamic.syntax
 
-import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.dynamic.syntax.DynamicSCollectionOps.writeDynamic
 import com.spotify.scio.io.{ClosedTap, EmptyTap}
 import com.spotify.scio.parquet.ParquetConfiguration
@@ -26,8 +25,6 @@ import magnolify.parquet.ParquetType
 import org.apache.beam.sdk.io.hadoop.SerializableConfiguration
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
-
-import scala.reflect.ClassTag
 
 final class DynamicParquetTypeSCollectionOps[T](
   private val self: SCollection[T]
@@ -44,7 +41,7 @@ final class DynamicParquetTypeSCollectionOps[T](
     prefix: String = ParquetTypeIO.WriteParam.DefaultPrefix
   )(
     destinationFn: T => String
-  )(implicit ct: ClassTag[T], coder: Coder[T], pt: ParquetType[T]): ClosedTap[Nothing] = {
+  )(implicit pt: ParquetType[T]): ClosedTap[Nothing] = {
     if (self.context.isTest) {
       throw new NotImplementedError(
         "Typed parquet file with dynamic destinations cannot be used in a test context"

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/read/ParquetReadFnTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/read/ParquetReadFnTest.scala
@@ -199,8 +199,6 @@ class ParquetReadFnTest extends PipelineSpec with BeforeAndAfterAll {
 
   it should "work with a projection and projectionFn" in {
     val projection = Projection[Account](_.getId)
-
-    implicit val coder = avroGenericRecordCoder(projection)
     val sc = ScioContext()
     sc
       .parallelize(listFiles(s"${testSingleDir.getAbsolutePath}/avro"))
@@ -217,8 +215,6 @@ class ParquetReadFnTest extends PipelineSpec with BeforeAndAfterAll {
 
   it should "work with a projection and projectionFn on files with multiple row groups" in {
     val projection = Projection[Account](_.getId)
-
-    implicit val coder = avroGenericRecordCoder(projection)
     val sc = ScioContext()
     sc
       .parallelize(listFiles(s"${testMultiDir.getAbsolutePath}/avro"))

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketScioContextSyntax.scala
@@ -758,7 +758,7 @@ final class SortedBucketScioContext(@transient private val self: ScioContext) ex
     coGbk: Transformable[KeyType, K1, K2],
     toR: CoGbkResult => R
   ) extends Serializable {
-    def to[W: Coder](
+    def to[W](
       output: SortedBucketIO.TransformOutput[K1, K2, W]
     ): SortMergeTransformWriteBuilder[KeyType, R, W] =
       new SortMergeTransformWriteBuilder(coGbk.transform(output), toR)

--- a/scio-test/src/it/scala/com/spotify/scio/values/DistCacheIT.scala
+++ b/scio-test/src/it/scala/com/spotify/scio/values/DistCacheIT.scala
@@ -26,7 +26,6 @@ import org.apache.beam.sdk.io.FileSystems
 import org.apache.beam.sdk.util.MimeTypes
 
 import scala.jdk.CollectionConverters._
-import scala.reflect.ClassTag
 
 class DistCacheIT extends PipelineSpec {
   "GCS DistCache" should "work" in {
@@ -36,7 +35,7 @@ class DistCacheIT extends PipelineSpec {
     }
   }
 
-  def runWithDistCache[T: ClassTag](
+  def runWithDistCache[T](
     data: Iterable[String]
   )(fn: (ScioContext, DistCache[List[String]]) => T): ScioResult = {
     val sc = ScioContext()

--- a/scio-test/src/main/scala/com/spotify/scio/testing/EqInstances.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/EqInstances.scala
@@ -19,11 +19,13 @@ package com.spotify.scio.testing
 
 import cats.kernel.Eq
 
+import scala.annotation.nowarn
+
 sealed trait FallbackEqInstances {
   implicit def fallbackEq[A]: Eq[A] = new Eq[A] {
     def eqv(x: A, y: A): Boolean =
       (x, y) match {
-        case (x: Array[_], y: Array[_]) => x.sameElements(y)
+        case (x: Array[_], y: Array[_]) => x.sameElements(y): @nowarn
         case _                          => Eq.fromUniversalEquals[A].eqv(x, y)
       }
   }

--- a/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/JobTest.scala
@@ -119,7 +119,7 @@ object JobTest {
      * Feed an input in the form of a `PTransform[PBegin, PCollection[T]]` to the pipeline being
      * tested. Note that `PTransform` inputs may not be supported for all `TestIO[T]` types.
      */
-    def inputStream[T: Coder](io: ScioIO[T], stream: TestStream[T]): Builder =
+    def inputStream[T](io: ScioIO[T], stream: TestStream[T]): Builder =
       input(io, TestStreamInputSource(stream))
 
     private def input[T](io: ScioIO[T], value: JobInputSource[T]): Builder = {

--- a/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/PipelineTestUtils.scala
@@ -70,7 +70,7 @@ trait PipelineTestUtils {
    * } shouldBe Seq(6)
    * }}}
    */
-  def runWithData[T: Coder, U: Coder](
+  def runWithData[T: Coder, U](
     data: Iterable[T]
   )(fn: SCollection[T] => SCollection[U]): Seq[U] =
     runWithLocalOutput(sc => fn(sc.parallelize(data)))._2
@@ -91,7 +91,7 @@ trait PipelineTestUtils {
    * @return
    *   output data
    */
-  def runWithData[T1: Coder, T2: Coder, U: Coder](data1: Iterable[T1], data2: Iterable[T2])(
+  def runWithData[T1: Coder, T2: Coder, U](data1: Iterable[T1], data2: Iterable[T2])(
     fn: (SCollection[T1], SCollection[T2]) => SCollection[U]
   ): Seq[U] =
     runWithLocalOutput(sc => fn(sc.parallelize(data1), sc.parallelize(data2)))._2
@@ -114,7 +114,7 @@ trait PipelineTestUtils {
    * @return
    *   output data
    */
-  def runWithData[T1: Coder, T2: Coder, T3: Coder, U: Coder](
+  def runWithData[T1: Coder, T2: Coder, T3: Coder, U](
     data1: Iterable[T1],
     data2: Iterable[T2],
     data3: Iterable[T3]
@@ -143,7 +143,7 @@ trait PipelineTestUtils {
    * @return
    *   output data
    */
-  def runWithData[T1: Coder, T2: Coder, T3: Coder, T4: Coder, U: Coder](
+  def runWithData[T1: Coder, T2: Coder, T3: Coder, T4: Coder, U](
     data1: Iterable[T1],
     data2: Iterable[T2],
     data3: Iterable[T3],

--- a/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
+++ b/scio-test/src/main/scala/com/spotify/scio/testing/SCollectionMatchers.scala
@@ -34,7 +34,6 @@ import org.hamcrest.Matchers
 import org.hamcrest.MatcherAssert.assertThat
 
 import scala.jdk.CollectionConverters._
-import scala.reflect.ClassTag
 import com.twitter.chill.ClosureCleaner
 import cats.kernel.Eq
 import org.apache.beam.sdk.testing.SerializableMatchers
@@ -129,30 +128,30 @@ private object ScioMatchers {
       }
     }
 
-  def assertThatFn[T: Eq: Coder](
+  def assertThatFn[T: Eq](
     mm: h.Matcher[JIterable[TestWrapper[T]]]
   ): SerializableFunction[JIterable[T], Void] =
     makeFn[T](in => assertThat(TestWrapper.wrap(in), mm))
 
-  def assertThatNotFn[T: Eq: Coder](
+  def assertThatNotFn[T: Eq](
     mm: h.Matcher[JIterable[TestWrapper[T]]]
   ): SerializableFunction[JIterable[T], Void] =
     makeFn[T](in => assertThat(TestWrapper.wrap(in), Matchers.not(mm)))
 
-  def assert[T: Eq: Coder](
+  def assert[T: Eq](
     p: Iterable[TestWrapper[T]] => Boolean
   ): SerializableFunction[JIterable[T], Void] =
     makeFn[T](in => Predef.assert(p(TestWrapper.wrap(in).asScala)))
 
-  def assertSingle[T: Eq: Coder](p: TestWrapper[T] => Boolean): SerializableFunction[T, Void] =
+  def assertSingle[T: Eq](p: TestWrapper[T] => Boolean): SerializableFunction[T, Void] =
     makeFnSingle[T](in => Predef.assert(p(TestWrapper(in))))
 
-  def assertNot[T: Eq: Coder](
+  def assertNot[T: Eq](
     p: Iterable[TestWrapper[T]] => Boolean
   ): SerializableFunction[JIterable[T], Void] =
     makeFn[T](in => Predef.assert(!p(TestWrapper.wrap(in).asScala)))
 
-  def assertNotSingle[T: Eq: Coder](p: TestWrapper[T] => Boolean): SerializableFunction[T, Void] =
+  def assertNotSingle[T: Eq](p: TestWrapper[T] => Boolean): SerializableFunction[T, Void] =
     makeFnSingle[T](in => Predef.assert(!p(TestWrapper(in))))
 
   def isEqualTo[T: Eq: Coder](context: ScioContext, t: T): SerializableFunction[T, Void] = {
@@ -251,7 +250,7 @@ trait SCollectionMatchers extends EqInstances {
    * SCollection assertion only applied to the specified window, running the checker only on the
    * on-time pane for each key.
    */
-  def inOnTimePane[T: ClassTag](window: BoundedWindow)(matcher: MatcherBuilder[T]): Matcher[T] =
+  def inOnTimePane[T](window: BoundedWindow)(matcher: MatcherBuilder[T]): Matcher[T] =
     matcher match {
       case value: SingleMatcher[T, _] =>
         value.matcher(_.inOnTimePane(window))
@@ -260,7 +259,7 @@ trait SCollectionMatchers extends EqInstances {
     }
 
   /** SCollection assertion only applied to the specified window. */
-  def inWindow[T: ClassTag, B: ClassTag](
+  def inWindow[T, B](
     window: BoundedWindow
   )(matcher: IterableMatcher[T, B]): Matcher[T] =
     matcher.matcher(_.inWindow(window))
@@ -269,7 +268,7 @@ trait SCollectionMatchers extends EqInstances {
    * SCollection assertion only applied to the specified window across all panes that were not
    * produced by the arrival of late data.
    */
-  def inCombinedNonLatePanes[T: ClassTag, B: ClassTag](
+  def inCombinedNonLatePanes[T, B](
     window: BoundedWindow
   )(matcher: IterableMatcher[T, B]): Matcher[T] =
     matcher.matcher(_.inCombinedNonLatePanes(window))
@@ -278,7 +277,7 @@ trait SCollectionMatchers extends EqInstances {
    * SCollection assertion only applied to the specified window, running the checker only on the
    * final pane for each key.
    */
-  def inFinalPane[T: ClassTag, B: ClassTag](
+  def inFinalPane[T, B](
     window: BoundedWindow
   )(matcher: MatcherBuilder[T]): Matcher[T] =
     matcher match {
@@ -292,7 +291,7 @@ trait SCollectionMatchers extends EqInstances {
    * SCollection assertion only applied to the specified window, running the checker only on the
    * late pane for each key.
    */
-  def inLatePane[T: ClassTag, B: ClassTag](
+  def inLatePane[T, B](
     window: BoundedWindow
   )(matcher: MatcherBuilder[T]): Matcher[T] =
     matcher match {
@@ -320,13 +319,13 @@ trait SCollectionMatchers extends EqInstances {
    * SCollection assertion only applied to the specified window. The assertion expect outputs to be
    * produced to the provided window exactly once.
    */
-  def inOnlyPane[T: ClassTag, B: ClassTag](
+  def inOnlyPane[T, B](
     window: BoundedWindow
   )(matcher: SingleMatcher[T, B]): Matcher[T] =
     matcher.matcher(_.inOnlyPane(window))
 
   /** SCollection assertion only applied to early timing global window. */
-  def inEarlyGlobalWindowPanes[T: ClassTag, B: ClassTag](
+  def inEarlyGlobalWindowPanes[T, B](
     matcher: IterableMatcher[T, B]
   ): Matcher[T] =
     matcher.matcher(_.inEarlyGlobalWindowPanes)

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -799,7 +799,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     import com.google.common.hash.{BloomFilter, Funnels}
 
     implicit val funnel = Funnels.stringFunnel(Charset.forName("UTF-8"))
-    val bloomFilter = BloomFilter.create(funnel, 5L)
+    val bloomFilter = BloomFilter.create[String](funnel, 5L)
 
     bloomFilter coderShould roundtrip() and
       beOfType[Beam[_]] and

--- a/scio-test/src/test/scala/com/spotify/scio/coders/instances/kryo/JTraversableSerializerTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/instances/kryo/JTraversableSerializerTest.scala
@@ -22,10 +22,8 @@ import com.twitter.chill.{Kryo, KryoSerializer}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.reflect.ClassTag
-
 class JTraversableSerializerTest extends AnyFlatSpec with Matchers {
-  private def testRoundTrip[T: ClassTag, C <: Iterable[T]](
+  private def testRoundTrip[T, C <: Iterable[T]](
     ser: JTraversableSerializer[T, C],
     elems: C
   ): Unit = {

--- a/scio-test/src/test/scala/com/spotify/scio/testing/CoderAssertionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/testing/CoderAssertionsTest.scala
@@ -25,7 +25,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.io.{InputStream, NotSerializableException, ObjectOutputStream, OutputStream}
-import scala.annotation.nowarn
 
 case class Foo(id: String)
 
@@ -44,7 +43,6 @@ class CoderAssertionsTest extends AnyFlatSpec with Matchers {
   // A coder that can't be serialized
   private def notSerializableCoder: Coder[Foo] =
     Coder.beam(new CustomCoder[Foo] {
-      @nowarn
       private def writeObject(oos: ObjectOutputStream): Unit =
         throw new NotSerializableException()
       override def encode(value: Foo, outStream: OutputStream): Unit = ???

--- a/scio-test/src/test/scala/com/spotify/scio/transforms/BatchDoFnTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/transforms/BatchDoFnTest.scala
@@ -116,8 +116,8 @@ class BatchDoFnTest extends AnyFlatSpec with Matchers {
   }
 
   it should "flush the biggest buffer when too many concurrent windows are opened" in {
-    val maxLiveWindows = 5
-    val batchFn = new BatchDoFn[Int](10, _.toLong, maxLiveWindows)
+    val maxLiveWindows = 5L
+    val batchFn = new BatchDoFn[Int](10, _.toLong, maxLiveWindows.toInt)
     batchFn.setup()
     val windows = (0L until maxLiveWindows)
       .map(Instant.ofEpochSecond)

--- a/scio-test/src/test/scala/com/spotify/scio/values/ClosureTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/ClosureTest.scala
@@ -134,7 +134,7 @@ class NotSerializableObj {
 
 class NestedClosuresNotSerializable {
   val irrelevantInt: Int = 1
-  @nowarn("msg=parameter value name in method closure is never used")
+  @nowarn("msg=parameter name in method closure is never used")
   def closure(name: String)(body: => Int => Int): Int => Int = body
   def getMapFn: Int => Int = closure("one") {
     @nowarn("msg=local method x in method getMapFn is never used")

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -323,7 +323,7 @@ class SCollectionTest extends PipelineSpec {
       val p = sc
         .parallelize(Seq(Seq(1, 2, 3, 4, 5))) // SCollection with 1 element to get a single bundle
         .flatten // flatten the elements in the bundle
-        .batchWeighted(2, identity[Int])
+        .batchWeighted(2, _.toLong)
         .map(_.size)
       p should containInAnyOrder(Seq(2, 1, 1, 1))
     }


### PR DESCRIPTION
Fix compiler warnings
- remove deprecated compiler option and accept non unit statements
- remove unused method parameters (breaking changes for v0.14)
- silence required unused parameter (eg `IsJavaBean` evidence)
- set explicit types on implicits
- fix implicit type conversion (mostly widening)
- add `@uncheked` annotations in pattern matching when required
- avoid usage of slow avro generic coder (provide schema)