### PR TITLE
Allow tuple coder extraction from wrapped RecordCoder

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
@@ -19,7 +19,7 @@ package com.spotify.scio.coders
 
 import com.spotify.scio.coders.CoderMaterializer.CoderOptions
 import com.spotify.scio.values.SCollection
-import org.apache.beam.sdk.coders.{Coder => BCoder, NullableCoder, StructuredCoder}
+import org.apache.beam.sdk.coders.{Coder => BCoder, NullableCoder}
 import org.apache.beam.sdk.values.PCollection
 
 import scala.annotation.tailrec

--- a/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/BeamCoders.scala
@@ -49,8 +49,7 @@ private[scio] object BeamCoders {
     val options = CoderOptions(coll.context.options)
     val coder = coll.internal.getCoder
     Some(unwrap(options, coder))
-      .collect { case c: StructuredCoder[_] => c }
-      .map(_.getComponents.asScala.toList)
+      .map(_.getCoderArguments.asScala.toList)
       .collect { case (c1: BCoder[K]) :: (c2: BCoder[V]) :: Nil =>
         val k = Coder.beam(unwrap(options, c1))
         val v = Coder.beam(unwrap(options, c2))
@@ -67,8 +66,7 @@ private[scio] object BeamCoders {
     val options = CoderOptions(coll.context.options)
     val coder = coll.internal.getCoder
     Some(unwrap(options, coder))
-      .collect { case c: StructuredCoder[_] => c }
-      .map(_.getComponents.asScala.toList)
+      .map(_.getCoderArguments.asScala.toList)
       .collect { case (c1: BCoder[A]) :: (c2: BCoder[B]) :: (c3: BCoder[C]) :: Nil =>
         val a = Coder.beam(unwrap(options, c1))
         val b = Coder.beam(unwrap(options, c2))
@@ -88,8 +86,7 @@ private[scio] object BeamCoders {
     val options = CoderOptions(coll.context.options)
     val coder = coll.internal.getCoder
     Some(unwrap(options, coder))
-      .collect { case c: StructuredCoder[_] => c }
-      .map(_.getComponents.asScala.toList)
+      .map(_.getCoderArguments.asScala.toList)
       .collect {
         case (c1: BCoder[A]) :: (c2: BCoder[B]) :: (c3: BCoder[C]) :: (c4: BCoder[D]) :: Nil =>
           val a = Coder.beam(unwrap(options, c1))

--- a/scio-core/src/main/scala/com/spotify/scio/coders/CustomCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/CustomCoder.scala
@@ -19,10 +19,10 @@ package com.spotify.scio.coders
 
 import java.io.{InputStream, OutputStream}
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException
-import org.apache.beam.sdk.coders.{Coder => BCoder, CustomCoder}
+import org.apache.beam.sdk.coders.{Coder => BCoder, CustomCoder, StructuredCoder}
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver
 
-import java.util.Objects
+import java.util.{List => JList, Objects}
 import scala.jdk.CollectionConverters._
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -120,7 +120,9 @@ final private[scio] class RecordCoder[T](
   val cs: IndexedSeq[(String, BCoder[Any])],
   construct: Seq[Any] => T,
   destruct: T => IndexedSeq[Any]
-) extends CustomCoder[T] {
+) extends StructuredCoder[T] {
+
+  override def getCoderArguments: JList[_ <: BCoder[_]] = cs.map(_._2).asJava
 
   override def toString: String = {
     val body = cs.map { case (l, c) => s"$l -> $c" }.mkString(", ")

--- a/scio-core/src/main/scala/com/spotify/scio/coders/WrappedCoder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/WrappedCoder.scala
@@ -18,18 +18,23 @@
 package com.spotify.scio.coders
 
 import java.io.{InputStream, OutputStream}
-import org.apache.beam.sdk.coders.{Coder => BCoder, StructuredCoder}
+import org.apache.beam.sdk.coders.{Coder => BCoder, CustomCoder}
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver
 
-import java.util.{Collections, List => JList}
+import java.util.{List => JList}
 
-/*
- * */
-sealed abstract private[scio] class WrappedCoder[T] extends StructuredCoder[T] {
+sealed abstract private[scio] class WrappedCoder[T] extends CustomCoder[T] {
   def bcoder: BCoder[T]
 
+  override def equals(obj: Any): Boolean = obj match {
+    case that: WrappedCoder[_] => bcoder == that.bcoder
+    case _                     => false
+  }
+
+  override def hashCode(): Int = bcoder.hashCode
+
   override def getCoderArguments: JList[_ <: BCoder[_]] =
-    Collections.singletonList(bcoder)
+    bcoder.getCoderArguments
 
   override def encode(value: T, os: OutputStream): Unit =
     bcoder.encode(value, os)

--- a/scio-test/src/test/scala/com/spotify/scio/coders/BeamCodersTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/BeamCodersTest.scala
@@ -1,0 +1,88 @@
+package com.spotify.scio.coders
+
+import com.spotify.scio.ScioContext
+import org.apache.beam.sdk.coders.{BigEndianShortCoder, ByteCoder, StringUtf8Coder, VarIntCoder}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class BeamCodersTest extends AnyFlatSpec with Matchers with TableDrivenPropertyChecks {
+
+  "BeamCoders" should "get scio coder from SCollection" in {
+    val sc = ScioContext()
+    val coll = sc.empty[String]()
+    val coder = BeamCoders.getCoder(coll)
+    coder shouldBe a[Beam[_]]
+    val beamKeyCoder = coder.asInstanceOf[Beam[_]]
+    beamKeyCoder.beam shouldBe StringUtf8Coder.of()
+  }
+
+  it should "get scio coders from tupled2 SCollection" in {
+    val coders = Table[Coder[(String, Int)]](
+      "coder",
+      Coder.tuple2Coder,
+      Coder.gen
+    )
+
+    forAll(coders) { coder =>
+      val sc = ScioContext()
+      val coll = sc.empty()(coder)
+      val (keyCoder, valueCoder) = BeamCoders.getTupleCoders(coll)
+      keyCoder shouldBe a[Beam[_]]
+      val beamKeyCoder = keyCoder.asInstanceOf[Beam[_]]
+      beamKeyCoder.beam shouldBe StringUtf8Coder.of()
+      valueCoder shouldBe a[Beam[_]]
+      val beamValueCoder = valueCoder.asInstanceOf[Beam[_]]
+      beamValueCoder.beam shouldBe VarIntCoder.of()
+    }
+  }
+
+  it should "get scio coders from tupled3 SCollection" in {
+    val coders = Table[Coder[(String, Int, Short)]](
+      "coder",
+      Coder.tuple3Coder,
+      Coder.gen
+    )
+
+    forAll(coders) { coder =>
+      val sc = ScioContext()
+      val coll = sc.empty()(coder)
+      val (c1, c2, c3) = BeamCoders.getTuple3Coders(coll)
+      c1 shouldBe a[Beam[_]]
+      val beamCoder1 = c1.asInstanceOf[Beam[_]]
+      beamCoder1.beam shouldBe StringUtf8Coder.of()
+      c2 shouldBe a[Beam[_]]
+      val beamCoder2 = c2.asInstanceOf[Beam[_]]
+      beamCoder2.beam shouldBe VarIntCoder.of()
+      c3 shouldBe a[Beam[_]]
+      val beamCoder3 = c3.asInstanceOf[Beam[_]]
+      beamCoder3.beam shouldBe BigEndianShortCoder.of()
+    }
+  }
+
+  it should "get scio coders from tupled4 SCollection" in {
+    val coders = Table[Coder[(String, Int, Short, Byte)]](
+      "coder",
+      Coder.tuple4Coder,
+      Coder.gen
+    )
+
+    forAll(coders) { coder =>
+      val sc = ScioContext()
+      val coll = sc.empty()(coder)
+      val (c1, c2, c3, c4) = BeamCoders.getTuple4Coders(coll)
+      c1 shouldBe a[Beam[_]]
+      val beamCoder1 = c1.asInstanceOf[Beam[_]]
+      beamCoder1.beam shouldBe StringUtf8Coder.of()
+      c2 shouldBe a[Beam[_]]
+      val beamCoder2 = c2.asInstanceOf[Beam[_]]
+      beamCoder2.beam shouldBe VarIntCoder.of()
+      c3 shouldBe a[Beam[_]]
+      val beamCoder3 = c3.asInstanceOf[Beam[_]]
+      beamCoder3.beam shouldBe BigEndianShortCoder.of()
+      c4 shouldBe a[Beam[_]]
+      val beamCoder4 = c4.asInstanceOf[Beam[_]]
+      beamCoder4.beam shouldBe ByteCoder.of()
+    }
+  }
+}

--- a/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/PairSCollectionFunctionsTest.scala
@@ -17,6 +17,7 @@
 
 package com.spotify.scio.values
 
+import com.spotify.scio.ScioContext
 import com.spotify.scio.coders.{Beam, MaterializedCoder}
 import com.spotify.scio.testing.PipelineSpec
 import com.spotify.scio.util.random.RandomSamplerUtils
@@ -30,56 +31,54 @@ import scala.collection.mutable
 
 class PairSCollectionFunctionsTest extends PipelineSpec {
   "PairSCollection" should "propagates unwrapped coders" in {
-    runWithContext { sc =>
-      val coll = sc.empty[(String, Int)]()
-      // internal is wrapped
-      val internalCoder = coll.internal.getCoder
-      internalCoder shouldBe a[MaterializedCoder[_]]
-      val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
-      materializedCoder.bcoder shouldBe a[StructuredCoder[_]]
-      val tupleCoder = materializedCoder.bcoder.asInstanceOf[StructuredCoder[_]]
-      val keyCoder = tupleCoder.getComponents.get(0)
-      keyCoder shouldBe StringUtf8Coder.of()
-      val valueCoder = tupleCoder.getComponents.get(1)
-      valueCoder shouldBe VarIntCoder.of()
-      // implicit SCollection key and value coder aren't
-      coll.keyCoder shouldBe a[Beam[_]]
-      val beamKeyCoder = coll.keyCoder.asInstanceOf[Beam[_]]
-      beamKeyCoder.beam shouldBe StringUtf8Coder.of()
+    val sc = ScioContext()
+    val coll = sc.empty[(String, Int)]()
+    // internal is wrapped
+    val internalCoder = coll.internal.getCoder
+    internalCoder shouldBe a[MaterializedCoder[_]]
+    val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
+    materializedCoder.bcoder shouldBe a[StructuredCoder[_]]
+    val tupleCoder = materializedCoder.bcoder.asInstanceOf[StructuredCoder[_]]
+    val keyCoder = tupleCoder.getComponents.get(0)
+    keyCoder shouldBe StringUtf8Coder.of()
+    val valueCoder = tupleCoder.getComponents.get(1)
+    valueCoder shouldBe VarIntCoder.of()
+    // implicit SCollection key and value coder aren't
+    coll.keyCoder shouldBe a[Beam[_]]
+    val beamKeyCoder = coll.keyCoder.asInstanceOf[Beam[_]]
+    beamKeyCoder.beam shouldBe StringUtf8Coder.of()
 
-      coll.valueCoder shouldBe a[Beam[_]]
-      val beamValueCoder = coll.valueCoder.asInstanceOf[Beam[_]]
-      beamValueCoder.beam shouldBe VarIntCoder.of()
-    }
+    coll.valueCoder shouldBe a[Beam[_]]
+    val beamValueCoder = coll.valueCoder.asInstanceOf[Beam[_]]
+    beamValueCoder.beam shouldBe VarIntCoder.of()
   }
 
   it should "propagate unwrapped nullable coders" in {
-    runWithContext { sc =>
-      sc.optionsAs[ScioOptions].setNullableCoders(true)
+    val sc = ScioContext()
+    sc.optionsAs[ScioOptions].setNullableCoders(true)
 
-      val coll = sc.empty[(String, Int)]()
-      // internal is wrapped
-      val internalCoder = coll.internal.getCoder
-      internalCoder shouldBe a[MaterializedCoder[_]]
-      val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
-      materializedCoder.bcoder shouldBe a[NullableCoder[_]]
-      val nullableTupleCoder = materializedCoder.bcoder.asInstanceOf[NullableCoder[_]]
-      val tupleCoder = nullableTupleCoder.getValueCoder.asInstanceOf[StructuredCoder[_]]
-      val keyCoder = tupleCoder.getComponents.get(0)
-      keyCoder shouldBe a[NullableCoder[_]]
-      keyCoder.asInstanceOf[NullableCoder[_]].getValueCoder shouldBe StringUtf8Coder.of()
-      val valueCoder = tupleCoder.getComponents.get(1)
-      valueCoder shouldBe a[NullableCoder[_]]
-      valueCoder.asInstanceOf[NullableCoder[_]].getValueCoder shouldBe VarIntCoder.of()
-      // implicit SCollection key and value coder aren't
-      coll.keyCoder shouldBe a[Beam[_]]
-      val beamKeyCoder = coll.keyCoder.asInstanceOf[Beam[_]]
-      beamKeyCoder.beam shouldBe StringUtf8Coder.of()
+    val coll = sc.empty[(String, Int)]()
+    // internal is wrapped
+    val internalCoder = coll.internal.getCoder
+    internalCoder shouldBe a[MaterializedCoder[_]]
+    val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
+    materializedCoder.bcoder shouldBe a[NullableCoder[_]]
+    val nullableTupleCoder = materializedCoder.bcoder.asInstanceOf[NullableCoder[_]]
+    val tupleCoder = nullableTupleCoder.getValueCoder.asInstanceOf[StructuredCoder[_]]
+    val keyCoder = tupleCoder.getComponents.get(0)
+    keyCoder shouldBe a[NullableCoder[_]]
+    keyCoder.asInstanceOf[NullableCoder[_]].getValueCoder shouldBe StringUtf8Coder.of()
+    val valueCoder = tupleCoder.getComponents.get(1)
+    valueCoder shouldBe a[NullableCoder[_]]
+    valueCoder.asInstanceOf[NullableCoder[_]].getValueCoder shouldBe VarIntCoder.of()
+    // implicit SCollection key and value coder aren't
+    coll.keyCoder shouldBe a[Beam[_]]
+    val beamKeyCoder = coll.keyCoder.asInstanceOf[Beam[_]]
+    beamKeyCoder.beam shouldBe StringUtf8Coder.of()
 
-      coll.valueCoder shouldBe a[Beam[_]]
-      val beamValueCoder = coll.valueCoder.asInstanceOf[Beam[_]]
-      beamValueCoder.beam shouldBe VarIntCoder.of()
-    }
+    coll.valueCoder shouldBe a[Beam[_]]
+    val beamValueCoder = coll.valueCoder.asInstanceOf[Beam[_]]
+    beamValueCoder.beam shouldBe VarIntCoder.of()
   }
 
   it should "support cogroup()" in {

--- a/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/values/SCollectionTest.scala
@@ -55,39 +55,36 @@ class SCollectionTest extends PipelineSpec {
   import SCollectionTest._
 
   "SCollection" should "propagates unwrapped coders" in {
-    runWithContext { sc =>
-      val coll = sc.empty[String]()
-      // internal is wrapped
-      val internalCoder = coll.internal.getCoder
-      internalCoder shouldBe a[MaterializedCoder[_]]
-      val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
-      materializedCoder.bcoder shouldBe StringUtf8Coder.of()
-      // implicit SCollection coder is not
-      val scioCoder = coll.coder
-      scioCoder shouldBe a[Beam[_]]
-      val beamCoder = scioCoder.asInstanceOf[Beam[_]]
-      beamCoder.beam shouldBe StringUtf8Coder.of()
-    }
+    val sc = ScioContext()
+    val coll = sc.empty[String]()
+    // internal is wrapped
+    val internalCoder = coll.internal.getCoder
+    internalCoder shouldBe a[MaterializedCoder[_]]
+    val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
+    materializedCoder.bcoder shouldBe StringUtf8Coder.of()
+    // implicit SCollection coder is not
+    val scioCoder = coll.coder
+    scioCoder shouldBe a[Beam[_]]
+    val beamCoder = scioCoder.asInstanceOf[Beam[_]]
+    beamCoder.beam shouldBe StringUtf8Coder.of()
   }
 
   it should "propagates unwrapped nullable coders" in {
-    runWithContext { sc =>
-      sc.optionsAs[ScioOptions].setNullableCoders(true)
-
-      val coll = sc.empty[String]()
-      // internal is wrapped
-      val internalCoder = coll.internal.getCoder
-      internalCoder shouldBe a[MaterializedCoder[_]]
-      val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
-      materializedCoder.bcoder shouldBe a[NullableCoder[_]]
-      val nullableCoder = materializedCoder.bcoder.asInstanceOf[NullableCoder[_]]
-      nullableCoder.getValueCoder shouldBe StringUtf8Coder.of()
-      // implicit SCollection coder is not
-      val scioCoder = coll.coder
-      scioCoder shouldBe a[Beam[_]]
-      val beamCoder = scioCoder.asInstanceOf[Beam[_]]
-      beamCoder.beam shouldBe StringUtf8Coder.of()
-    }
+    val sc = ScioContext()
+    sc.optionsAs[ScioOptions].setNullableCoders(true)
+    val coll = sc.empty[String]()
+    // internal is wrapped
+    val internalCoder = coll.internal.getCoder
+    internalCoder shouldBe a[MaterializedCoder[_]]
+    val materializedCoder = internalCoder.asInstanceOf[MaterializedCoder[_]]
+    materializedCoder.bcoder shouldBe a[NullableCoder[_]]
+    val nullableCoder = materializedCoder.bcoder.asInstanceOf[NullableCoder[_]]
+    nullableCoder.getValueCoder shouldBe StringUtf8Coder.of()
+    // implicit SCollection coder is not
+    val scioCoder = coll.coder
+    scioCoder shouldBe a[Beam[_]]
+    val beamCoder = scioCoder.asInstanceOf[Beam[_]]
+    beamCoder.beam shouldBe StringUtf8Coder.of()
   }
 
   it should "support applyTransform()" in {


### PR DESCRIPTION
fix #4945 

`SCollection[(K, V)]` should work with both `Tuple2Coder` (prefered) and `RecordCoder`.

Unfortunately, when operations requiring to split the coder, the extraction failed for `RecordCoder` due to improper coder definitions:
- `WrappedCoder` should not mask the underlying coder arguments
- `RecordCoder` should be a `StructuredCoder` and return the list of components.

Modify the tuple unwrapping so that we access the underlying coder arguments and pattern macth on those.
This will work for tuple, record and potentially for user custom  coder if well defined.

This PR also adds more test for `BeamCoders`