### PR TITLE
Don't re-use ReflectData in AvroCoder

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/AvroCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/AvroCoders.scala
@@ -22,7 +22,7 @@ import com.spotify.scio.util.ScioUtil
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.io.{DatumReader, DatumWriter}
-import org.apache.avro.reflect.{ReflectDatumReader, ReflectDatumWriter}
+import org.apache.avro.reflect.{ReflectData, ReflectDatumReader, ReflectDatumWriter}
 import org.apache.avro.specific.{SpecificData, SpecificFixed, SpecificRecord}
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException
 import org.apache.beam.sdk.coders.{AtomicCoder, CustomCoder, StringUtf8Coder}
@@ -153,7 +153,8 @@ trait AvroCoders {
       override def apply(writer: Schema, reader: Schema): DatumReader[T] = {
         // create the datum writer using the schema api
         // class API might be unsafe. See schemaForClass
-        val datumReader = new ReflectDatumReader[T](schemaForClass(clazz).get);
+        val schema = schemaForClass(clazz).get
+        val datumReader = new ReflectDatumReader[T](schema, schema, new ReflectData())
         datumReader.setExpected(reader)
         datumReader.setSchema(writer)
         // for backward compat, add logical type support by default
@@ -164,7 +165,7 @@ trait AvroCoders {
       override def apply(writer: Schema): DatumWriter[T] = {
         // create the datum writer using the schema api
         // class API might be unsafe. See schemaForClass
-        val datumWriter = new ReflectDatumWriter[T](schemaForClass(clazz).get)
+        val datumWriter = new ReflectDatumWriter[T](schemaForClass(clazz).get, new ReflectData())
         datumWriter.setSchema(writer)
         // for backward compat, add logical type support by default
         AvroUtils.addLogicalTypeConversions(datumWriter.getData)

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/AvroCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/AvroCoders.scala
@@ -153,10 +153,7 @@ trait AvroCoders {
       override def apply(writer: Schema, reader: Schema): DatumReader[T] = {
         // create the datum writer using the schema api
         // class API might be unsafe. See schemaForClass
-        val schema = schemaForClass(clazz).get
-        val datumReader = new ReflectDatumReader[T](schema, schema, new ReflectData())
-        datumReader.setExpected(reader)
-        datumReader.setSchema(writer)
+        val datumReader = new ReflectDatumReader[T](writer, reader, new ReflectData())
         // for backward compat, add logical type support by default
         AvroUtils.addLogicalTypeConversions(datumReader.getData)
         datumReader
@@ -165,8 +162,7 @@ trait AvroCoders {
       override def apply(writer: Schema): DatumWriter[T] = {
         // create the datum writer using the schema api
         // class API might be unsafe. See schemaForClass
-        val datumWriter = new ReflectDatumWriter[T](schemaForClass(clazz).get, new ReflectData())
-        datumWriter.setSchema(writer)
+        val datumWriter = new ReflectDatumWriter[T](writer, new ReflectData())
         // for backward compat, add logical type support by default
         AvroUtils.addLogicalTypeConversions(datumWriter.getData)
         datumWriter


### PR DESCRIPTION
Addresses concurrency issue with encoding Avro records at scale -- we suspect the root cause is concurrent access of the shared ReflectData singleton.