### PR TITLE
Patch datum factory for specific data in IOs

### DIFF
--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroDatumFactory.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroDatumFactory.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.spotify.scio.avro
+
+import org.apache.avro.Schema
+import org.apache.avro.io.{DatumReader, DatumWriter}
+import org.apache.avro.reflect.{ReflectData, ReflectDatumReader, ReflectDatumWriter}
+import org.apache.beam.sdk.extensions.avro.io.AvroDatumFactory
+import org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils
+
+/**
+ * Custom AvroDatumFactory for avro AvroDatumFactory relying on avro reflect so that underlying
+ * CharSequence type is String
+ */
+private[scio] class SpecificRecordDatumFactory[T](recordType: Class[T])
+    extends AvroDatumFactory[T](recordType) {
+  override def apply(writer: Schema, reader: Schema): DatumReader[T] = {
+    val data = new ReflectData(recordType.getClassLoader)
+    AvroUtils.addLogicalTypeConversions(data)
+    new ReflectDatumReader[T](writer, reader, data)
+  }
+
+  override def apply(writer: Schema): DatumWriter[T] = {
+    val data = new ReflectData(recordType.getClassLoader)
+    AvroUtils.addLogicalTypeConversions(data)
+    new ReflectDatumWriter[T](writer, data)
+  }
+}

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
@@ -183,6 +183,7 @@ final case class SpecificRecordIO[T <: SpecificRecord: ClassTag: Coder](path: St
     val t = BAvroIO
       .read(cls)
       .from(filePattern)
+      .withDatumReaderFactory(new SpecificRecordDatumFactory[T](cls))
     sc
       .applyTransform(t)
       .setCoder(coder)
@@ -194,7 +195,9 @@ final case class SpecificRecordIO[T <: SpecificRecord: ClassTag: Coder](path: St
    */
   override protected def write(data: SCollection[T], params: WriteP): Tap[T] = {
     val cls = ScioUtil.classOf[T]
-    val t = BAvroIO.write(cls)
+    val t = BAvroIO
+      .write(cls)
+      .withDatumWriterFactory(new SpecificRecordDatumFactory[T](cls))
 
     data.applyInternal(
       avroOut(

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/AvroCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/AvroCoders.scala
@@ -149,23 +149,18 @@ trait AvroCoders {
       throw new RuntimeException(msg)
     }
 
+    // same as SpecificRecordDatumFactory in scio-avro
     val factory = new AvroDatumFactory(clazz) {
       override def apply(writer: Schema, reader: Schema): DatumReader[T] = {
-        // create the datum writer using the schema api
-        // class API might be unsafe. See schemaForClass
-        val datumReader = new ReflectDatumReader[T](writer, reader, new ReflectData())
-        // for backward compat, add logical type support by default
-        AvroUtils.addLogicalTypeConversions(datumReader.getData)
-        datumReader
+        val data = new ReflectData(clazz.getClassLoader)
+        AvroUtils.addLogicalTypeConversions(data)
+        new ReflectDatumReader[T](writer, reader, data)
       }
 
       override def apply(writer: Schema): DatumWriter[T] = {
-        // create the datum writer using the schema api
-        // class API might be unsafe. See schemaForClass
-        val datumWriter = new ReflectDatumWriter[T](writer, new ReflectData())
-        // for backward compat, add logical type support by default
-        AvroUtils.addLogicalTypeConversions(datumWriter.getData)
-        datumWriter
+        val data = new ReflectData(clazz.getClassLoader)
+        AvroUtils.addLogicalTypeConversions(data)
+        new ReflectDatumWriter[T](writer, data)
       }
     }
 


### PR DESCRIPTION
Quick patch for https://github.com/apache/beam/issues/28279

Unfortunately, contains some code duplication:
- avro coder still in scio-core
- SMB avro not in scio package + not streamlined with beam AvroIO