### PR TITLE
Propagate ParquetOutputFormat options to ParquetWriter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1365,6 +1365,7 @@ lazy val `scio-smb`: Project = project
       "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion % Provided,
       "org.apache.avro" % "avro" % avroVersion % Provided,
       "org.apache.hadoop" % "hadoop-common" % hadoopVersion % Provided,
+      "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % Provided,
       "org.apache.parquet" % "parquet-avro" % parquetVersion % Provided excludeAll ("org.apache.avro" % "avro"),
       "org.apache.parquet" % "parquet-column" % parquetVersion % Provided,
       "org.apache.parquet" % "parquet-common" % parquetVersion % Provided,

--- a/build.sbt
+++ b/build.sbt
@@ -1365,7 +1365,7 @@ lazy val `scio-smb`: Project = project
       "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion % Provided,
       "org.apache.avro" % "avro" % avroVersion % Provided,
       "org.apache.hadoop" % "hadoop-common" % hadoopVersion % Provided,
-      "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % Provided,
+      "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % Test,
       "org.apache.parquet" % "parquet-avro" % parquetVersion % Provided excludeAll ("org.apache.avro" % "avro"),
       "org.apache.parquet" % "parquet-column" % parquetVersion % Provided,
       "org.apache.parquet" % "parquet-common" % parquetVersion % Provided,

--- a/build.sbt
+++ b/build.sbt
@@ -1336,6 +1336,10 @@ lazy val `scio-smb`: Project = project
   .settings(beamRunnerSettings)
   .settings(
     description := "Sort Merge Bucket source/sink implementations for Apache Beam",
+    unusedCompileDependenciesFilter -= Seq(
+      // ParquetUtils calls functions defined in parent class from hadoop-mapreduce-client-core
+      moduleFilter("org.apache.hadoop", "hadoop-mapreduce-client-core")
+    ).reduce(_ | _),
     libraryDependencies ++= Seq(
       // compile
       "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
@@ -1365,7 +1369,7 @@ lazy val `scio-smb`: Project = project
       "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion % Provided,
       "org.apache.avro" % "avro" % avroVersion % Provided,
       "org.apache.hadoop" % "hadoop-common" % hadoopVersion % Provided,
-      "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % Test,
+      "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % Provided,
       "org.apache.parquet" % "parquet-avro" % parquetVersion % Provided excludeAll ("org.apache.avro" % "avro"),
       "org.apache.parquet" % "parquet-column" % parquetVersion % Provided,
       "org.apache.parquet" % "parquet-common" % parquetVersion % Provided,

--- a/scio-parquet/src/main/java/com/spotify/scio/parquet/WriterUtils.java
+++ b/scio-parquet/src/main/java/com/spotify/scio/parquet/WriterUtils.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -56,9 +57,11 @@ public class WriterUtils {
         .withConf(conf)
         .withCompressionCodec(compression)
         .withPageSize(ParquetOutputFormat.getPageSize(conf))
+        .withPageRowCountLimit(conf.getInt(ParquetOutputFormat.PAGE_ROW_COUNT_LIMIT, ParquetProperties.DEFAULT_PAGE_ROW_COUNT_LIMIT))
+        .withPageWriteChecksumEnabled(ParquetOutputFormat.getPageWriteChecksumEnabled(conf))
         .withWriterVersion(ParquetOutputFormat.getWriterVersion(conf))
-        .withDictionaryEncoding(ParquetOutputFormat.getEnableDictionary(conf))
         .withBloomFilterEnabled(ParquetOutputFormat.getBloomFilterEnabled(conf))
+        .withDictionaryEncoding(ParquetOutputFormat.getEnableDictionary(conf))
         .withDictionaryPageSize(ParquetOutputFormat.getDictionaryPageSize(conf))
         .withMaxRowCountForPageSizeCheck(ParquetOutputFormat.getMaxRowCountForPageSizeCheck(conf))
         .withMinRowCountForPageSizeCheck(ParquetOutputFormat.getMinRowCountForPageSizeCheck(conf))

--- a/scio-parquet/src/main/java/com/spotify/scio/parquet/WriterUtils.java
+++ b/scio-parquet/src/main/java/com/spotify/scio/parquet/WriterUtils.java
@@ -57,7 +57,10 @@ public class WriterUtils {
         .withConf(conf)
         .withCompressionCodec(compression)
         .withPageSize(ParquetOutputFormat.getPageSize(conf))
-        .withPageRowCountLimit(conf.getInt(ParquetOutputFormat.PAGE_ROW_COUNT_LIMIT, ParquetProperties.DEFAULT_PAGE_ROW_COUNT_LIMIT))
+        .withPageRowCountLimit(
+            conf.getInt(
+                ParquetOutputFormat.PAGE_ROW_COUNT_LIMIT,
+                ParquetProperties.DEFAULT_PAGE_ROW_COUNT_LIMIT))
         .withPageWriteChecksumEnabled(ParquetOutputFormat.getPageWriteChecksumEnabled(conf))
         .withWriterVersion(ParquetOutputFormat.getWriterVersion(conf))
         .withBloomFilterEnabled(ParquetOutputFormat.getBloomFilterEnabled(conf))

--- a/scio-parquet/src/main/java/com/spotify/scio/parquet/WriterUtils.java
+++ b/scio-parquet/src/main/java/com/spotify/scio/parquet/WriterUtils.java
@@ -18,6 +18,9 @@
 package com.spotify.scio.parquet;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -28,12 +31,47 @@ public class WriterUtils {
       ParquetWriter.Builder<T, SELF> builder, Configuration conf, CompressionCodecName compression)
       throws IOException {
     // https://github.com/apache/parquet-mr/tree/master/parquet-hadoop#class-parquetoutputformat
-    int rowGroupSize =
-        conf.getInt(ParquetOutputFormat.BLOCK_SIZE, ParquetWriter.DEFAULT_BLOCK_SIZE);
+    long rowGroupSize =
+        conf.getLong(ParquetOutputFormat.BLOCK_SIZE, ParquetWriter.DEFAULT_BLOCK_SIZE);
+
+    for (Map.Entry<String, Boolean> entry :
+        getColumnarConfig(conf, ParquetOutputFormat.BLOOM_FILTER_ENABLED, Boolean::parseBoolean)
+            .entrySet()) {
+      builder = builder.withBloomFilterEnabled(entry.getKey(), entry.getValue());
+    }
+
+    for (Map.Entry<String, Boolean> entry :
+        getColumnarConfig(conf, ParquetOutputFormat.ENABLE_DICTIONARY, Boolean::parseBoolean)
+            .entrySet()) {
+      builder = builder.withDictionaryEncoding(entry.getKey(), entry.getValue());
+    }
+
+    for (Map.Entry<String, Long> entry :
+        getColumnarConfig(conf, ParquetOutputFormat.BLOOM_FILTER_EXPECTED_NDV, Long::parseLong)
+            .entrySet()) {
+      builder = builder.withBloomFilterNDV(entry.getKey(), entry.getValue());
+    }
+
     return builder
         .withConf(conf)
         .withCompressionCodec(compression)
+        .withDictionaryEncoding(ParquetOutputFormat.getEnableDictionary(conf))
+        .withBloomFilterEnabled(ParquetOutputFormat.getBloomFilterEnabled(conf))
+        .withDictionaryPageSize(ParquetOutputFormat.getDictionaryPageSize(conf))
+        .withMaxRowCountForPageSizeCheck(ParquetOutputFormat.getMaxRowCountForPageSizeCheck(conf))
+        .withMinRowCountForPageSizeCheck(ParquetOutputFormat.getMinRowCountForPageSizeCheck(conf))
+        .withValidation(ParquetOutputFormat.getValidation(conf))
         .withRowGroupSize(rowGroupSize)
         .build();
+  }
+
+  private static <T> Map<String, T> getColumnarConfig(
+      Configuration conf, String key, Function<String, T> toT) {
+    final String keyPrefix = key + "#";
+    return conf.getPropsWithPrefix(keyPrefix).entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                entry -> entry.getKey().replaceFirst(keyPrefix, ""),
+                entry -> toT.apply(entry.getValue())));
   }
 }

--- a/scio-parquet/src/main/java/com/spotify/scio/parquet/WriterUtils.java
+++ b/scio-parquet/src/main/java/com/spotify/scio/parquet/WriterUtils.java
@@ -55,6 +55,8 @@ public class WriterUtils {
     return builder
         .withConf(conf)
         .withCompressionCodec(compression)
+        .withPageSize(ParquetOutputFormat.getPageSize(conf))
+        .withWriterVersion(ParquetOutputFormat.getWriterVersion(conf))
         .withDictionaryEncoding(ParquetOutputFormat.getEnableDictionary(conf))
         .withBloomFilterEnabled(ParquetOutputFormat.getBloomFilterEnabled(conf))
         .withDictionaryPageSize(ParquetOutputFormat.getDictionaryPageSize(conf))

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/TestWriterUtils.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/TestWriterUtils.scala
@@ -1,0 +1,116 @@
+package com.spotify.scio.parquet
+
+import com.spotify.scio._
+import com.spotify.scio.parquet.avro._
+import com.spotify.scio.avro.{Account, AccountStatus}
+import org.apache.commons.io.FileUtils
+import org.apache.parquet.HadoopReadOptions
+import org.apache.parquet.column.Encoding
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters._
+
+class TestWriterUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+  private lazy val testDir = Files.createTempDirectory("scio-parquet-writer-utils-test-").toFile
+
+  case class NestedRecord(fieldC: String)
+  case class Record(fieldA: Int, fieldB: NestedRecord)
+
+  override protected def afterAll(): Unit = FileUtils.deleteDirectory(testDir)
+
+  "WriterUtils" should "set configuration values correctly" in {
+    val path = testDir.toPath.resolve("avro-files")
+
+    val (sc, _) = ContextAndArgs(Array())
+    sc.parallelize(1 to 10)
+      .map { r =>
+        Account
+          .newBuilder()
+          .setId(r)
+          .setType("checking")
+          .setName(r.toString)
+          .setAmount(r.doubleValue)
+          .setAccountStatus(AccountStatus.Active)
+          .build()
+      }
+      .saveAsParquetAvroFile( // WriterUtils has too many protected classes to invoke directly; test via Scio write
+        path.toFile.getAbsolutePath,
+        numShards = 1,
+        conf = ParquetConfiguration.of(
+          "parquet.enable.dictionary" -> false,
+          "parquet.enable.dictionary#account_status" -> true,
+          "parquet.bloom.filter.enabled" -> true,
+          "parquet.bloom.filter.enabled#id" -> false
+        )
+      )
+
+    sc.run()
+
+    val columnEncodings = getColumnEncodings(path.resolve("part-00000-of-00001.parquet"))
+
+    assertColumn(
+      columnEncodings(0),
+      "id",
+      hasBloomFilter = false,
+      Seq(Encoding.BIT_PACKED, Encoding.PLAIN)
+    )
+    assertColumn(
+      columnEncodings(1),
+      "type",
+      hasBloomFilter = true,
+      Seq(Encoding.BIT_PACKED, Encoding.PLAIN)
+    )
+    assertColumn(
+      columnEncodings(2),
+      "name",
+      hasBloomFilter = true,
+      Seq(
+        Encoding.BIT_PACKED,
+        Encoding.RLE,
+        Encoding.PLAIN
+      ) // RLE encoding is used for optional fields
+    )
+    assertColumn(
+      columnEncodings(3),
+      "amount",
+      hasBloomFilter = true,
+      Seq(Encoding.BIT_PACKED, Encoding.PLAIN)
+    )
+    assertColumn(
+      columnEncodings(4),
+      "account_status",
+      hasBloomFilter = true,
+      Seq(Encoding.BIT_PACKED, Encoding.RLE, Encoding.PLAIN_DICTIONARY)
+    )
+  }
+
+  private def getColumnEncodings(path: Path): List[ColumnChunkMetaData] = {
+    val options = HadoopReadOptions.builder(ParquetConfiguration.empty()).build
+    val r = ParquetFileReader.open(BeamInputFile.of(path.toFile.getAbsolutePath), options)
+    assert(r.getRowGroups.size() == 1)
+
+    val columns = r.getRowGroups.get(0).getColumns.asScala.toList
+    r.close()
+    columns
+  }
+
+  private def assertColumn(
+    column: ColumnChunkMetaData,
+    name: String,
+    hasBloomFilter: Boolean,
+    encodings: Iterable[Encoding]
+  ): Unit = {
+    column.getPath.asScala should contain only name
+    column.getEncodings.asScala should contain theSameElementsAs encodings
+    if (hasBloomFilter) {
+      column.getBloomFilterOffset should be > -1L
+    } else {
+      column.getBloomFilterOffset shouldBe -1L
+    }
+  }
+}

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/TestWriterUtils.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/TestWriterUtils.scala
@@ -40,7 +40,7 @@ class TestWriterUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   "WriterUtils" should "set configuration values correctly" in {
     val path = testDir.toPath.resolve("avro-files")
 
-    val (sc, _) = ContextAndArgs(Array())
+    val sc = ScioContext()
     sc.parallelize(1 to 10)
       .map { r =>
         Account

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/TestWriterUtils.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/TestWriterUtils.scala
@@ -18,9 +18,6 @@ import scala.jdk.CollectionConverters._
 class TestWriterUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   private lazy val testDir = Files.createTempDirectory("scio-parquet-writer-utils-test-").toFile
 
-  case class NestedRecord(fieldC: String)
-  case class Record(fieldA: Int, fieldB: NestedRecord)
-
   override protected def afterAll(): Unit = FileUtils.deleteDirectory(testDir)
 
   "WriterUtils" should "set configuration values correctly" in {
@@ -71,9 +68,9 @@ class TestWriterUtils extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
       hasBloomFilter = true,
       Seq(
         Encoding.BIT_PACKED,
-        Encoding.RLE,
+        Encoding.RLE, // RLE encoding is used for optional fields
         Encoding.PLAIN
-      ) // RLE encoding is used for optional fields
+      )
     )
     assertColumn(
       columnEncodings(3),

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/TestWriterUtils.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/TestWriterUtils.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2023 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.scio.parquet
 
 import com.spotify.scio._

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
@@ -42,7 +42,6 @@ import org.apache.parquet.avro.AvroWriteSupport;
 import org.apache.parquet.avro.SpecificDataSupplier;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
-import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -227,14 +226,9 @@ public class ParquetAvroFileOperations<ValueT> extends FileOperations<ValueT> {
       // https://github.com/apache/parquet-mr/tree/master/parquet-hadoop#class-parquetoutputformat
       final Configuration configuration = conf.get();
 
-      int rowGroupSize =
-          configuration.getInt(ParquetOutputFormat.BLOCK_SIZE, ParquetWriter.DEFAULT_BLOCK_SIZE);
       AvroParquetWriter.Builder<ValueT> builder =
           AvroParquetWriter.<ValueT>builder(new ParquetOutputFile(channel))
-              .withSchema(schemaSupplier.get())
-              .withCompressionCodec(compression)
-              .withConf(configuration)
-              .withRowGroupSize(rowGroupSize);
+              .withSchema(schemaSupplier.get());
 
       // Workaround for PARQUET-2265
       if (configuration.getClass(AvroWriteSupport.AVRO_DATA_SUPPLIER, null) != null) {
@@ -248,7 +242,7 @@ public class ParquetAvroFileOperations<ValueT> extends FileOperations<ValueT> {
                 ReflectionUtils.newInstance(dataModelSupplier, configuration).get());
       }
 
-      writer = builder.build();
+      writer = ParquetUtils.buildWriter(builder, configuration, compression);
     }
 
     @Override

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetUtils.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.beam.sdk.extensions.smb;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.ParquetOutputFormat;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+
+class ParquetUtils {
+  static <T, SELF extends ParquetWriter.Builder<T, SELF>> ParquetWriter<T> buildWriter(
+      ParquetWriter.Builder<T, SELF> builder, Configuration conf, CompressionCodecName compression)
+      throws IOException {
+    // https://github.com/apache/parquet-mr/tree/master/parquet-hadoop#class-parquetoutputformat
+    long rowGroupSize =
+        conf.getLong(ParquetOutputFormat.BLOCK_SIZE, ParquetWriter.DEFAULT_BLOCK_SIZE);
+
+    for (Map.Entry<String, Boolean> entry :
+        getColumnarConfig(conf, ParquetOutputFormat.BLOOM_FILTER_ENABLED, Boolean::parseBoolean)
+            .entrySet()) {
+      builder = builder.withBloomFilterEnabled(entry.getKey(), entry.getValue());
+    }
+
+    for (Map.Entry<String, Boolean> entry :
+        getColumnarConfig(conf, ParquetOutputFormat.ENABLE_DICTIONARY, Boolean::parseBoolean)
+            .entrySet()) {
+      builder = builder.withDictionaryEncoding(entry.getKey(), entry.getValue());
+    }
+
+    for (Map.Entry<String, Long> entry :
+        getColumnarConfig(conf, ParquetOutputFormat.BLOOM_FILTER_EXPECTED_NDV, Long::parseLong)
+            .entrySet()) {
+      builder = builder.withBloomFilterNDV(entry.getKey(), entry.getValue());
+    }
+
+    return builder
+        .withConf(conf)
+        .withCompressionCodec(compression)
+        .withDictionaryEncoding(ParquetOutputFormat.getEnableDictionary(conf))
+        .withBloomFilterEnabled(ParquetOutputFormat.getBloomFilterEnabled(conf))
+        .withDictionaryPageSize(ParquetOutputFormat.getDictionaryPageSize(conf))
+        .withMaxRowCountForPageSizeCheck(ParquetOutputFormat.getMaxRowCountForPageSizeCheck(conf))
+        .withMinRowCountForPageSizeCheck(ParquetOutputFormat.getMinRowCountForPageSizeCheck(conf))
+        .withValidation(ParquetOutputFormat.getValidation(conf))
+        .withRowGroupSize(rowGroupSize)
+        .build();
+  }
+
+  private static <T> Map<String, T> getColumnarConfig(
+      Configuration conf, String key, Function<String, T> toT) {
+    final String keyPrefix = key + "#";
+    return conf.getPropsWithPrefix(keyPrefix).entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                entry -> entry.getKey().replaceFirst(keyPrefix, ""),
+                entry -> toT.apply(entry.getValue())));
+  }
+}

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetUtils.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetUtils.java
@@ -57,7 +57,10 @@ class ParquetUtils {
         .withConf(conf)
         .withCompressionCodec(compression)
         .withPageSize(ParquetOutputFormat.getPageSize(conf))
-        .withPageRowCountLimit(conf.getInt(ParquetOutputFormat.PAGE_ROW_COUNT_LIMIT, ParquetProperties.DEFAULT_PAGE_ROW_COUNT_LIMIT))
+        .withPageRowCountLimit(
+            conf.getInt(
+                ParquetOutputFormat.PAGE_ROW_COUNT_LIMIT,
+                ParquetProperties.DEFAULT_PAGE_ROW_COUNT_LIMIT))
         .withPageWriteChecksumEnabled(ParquetOutputFormat.getPageWriteChecksumEnabled(conf))
         .withWriterVersion(ParquetOutputFormat.getWriterVersion(conf))
         .withBloomFilterEnabled(ParquetOutputFormat.getBloomFilterEnabled(conf))

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetUtils.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetUtils.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -56,13 +57,16 @@ class ParquetUtils {
         .withConf(conf)
         .withCompressionCodec(compression)
         .withPageSize(ParquetOutputFormat.getPageSize(conf))
+        .withPageRowCountLimit(conf.getInt(ParquetOutputFormat.PAGE_ROW_COUNT_LIMIT, ParquetProperties.DEFAULT_PAGE_ROW_COUNT_LIMIT))
+        .withPageWriteChecksumEnabled(ParquetOutputFormat.getPageWriteChecksumEnabled(conf))
         .withWriterVersion(ParquetOutputFormat.getWriterVersion(conf))
-        .withDictionaryEncoding(ParquetOutputFormat.getEnableDictionary(conf))
         .withBloomFilterEnabled(ParquetOutputFormat.getBloomFilterEnabled(conf))
+        .withDictionaryEncoding(ParquetOutputFormat.getEnableDictionary(conf))
         .withDictionaryPageSize(ParquetOutputFormat.getDictionaryPageSize(conf))
         .withMaxRowCountForPageSizeCheck(ParquetOutputFormat.getMaxRowCountForPageSizeCheck(conf))
         .withMinRowCountForPageSizeCheck(ParquetOutputFormat.getMinRowCountForPageSizeCheck(conf))
         .withValidation(ParquetOutputFormat.getValidation(conf))
+        .withRowGroupSize(rowGroupSize)
         .withRowGroupSize(rowGroupSize)
         .build();
   }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetUtils.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetUtils.java
@@ -55,6 +55,8 @@ class ParquetUtils {
     return builder
         .withConf(conf)
         .withCompressionCodec(compression)
+        .withPageSize(ParquetOutputFormat.getPageSize(conf))
+        .withWriterVersion(ParquetOutputFormat.getWriterVersion(conf))
         .withDictionaryEncoding(ParquetOutputFormat.getEnableDictionary(conf))
         .withBloomFilterEnabled(ParquetOutputFormat.getBloomFilterEnabled(conf))
         .withDictionaryPageSize(ParquetOutputFormat.getDictionaryPageSize(conf))

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
@@ -127,17 +127,13 @@ private case class ParquetTypeSink[T](
     extends FileIO.Sink[T] {
   @transient private var writer: ParquetWriter[T] = _
 
-  override def open(channel: WritableByteChannel): Unit = {
-    // https://github.com/apache/parquet-mr/tree/master/parquet-hadoop#class-parquetoutputformat
-    val rowGroupSize =
-      conf.get().getLong(ParquetOutputFormat.BLOCK_SIZE, ParquetWriter.DEFAULT_BLOCK_SIZE)
-    writer = pt
-      .writeBuilder(new ParquetOutputFile(channel))
-      .withCompressionCodec(compression)
-      .withConf(conf.get())
-      .withRowGroupSize(rowGroupSize)
-      .build()
-  }
+  override def open(channel: WritableByteChannel): Unit =
+    writer = ParquetUtils.buildWriter(
+      pt
+        .writeBuilder(new ParquetOutputFile(channel)),
+      conf.get(),
+      compression
+    )
 
   override def write(element: T): Unit = writer.write(element)
   override def flush(): Unit = writer.close()

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
@@ -27,7 +27,7 @@ import org.apache.beam.sdk.util.MimeTypes
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.filter2.compat.FilterCompat
 import org.apache.parquet.filter2.predicate.FilterPredicate
-import org.apache.parquet.hadoop.{ParquetOutputFormat, ParquetReader, ParquetWriter}
+import org.apache.parquet.hadoop.{ParquetReader, ParquetWriter}
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 
 import java.nio.channels.{ReadableByteChannel, WritableByteChannel}


### PR DESCRIPTION
We were not properly propagating all of the `ParquetOutputFormat` [options](https://github.com/apache/parquet-mr/blob/master/parquet-hadoop/README.md#properties) to `ParquetWriter`: as is shown in some of the parquet-mr [examples](https://github.com/apache/parquet-mr/blob/9b5a962df3007009a227ef421600197531f970a5/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectReadWrite.java#L143-L148), they are _not_ automatically parsed from the `Configuration`; the expectation is that these options are passed directly to `ParquetWriter`.
