### PR TITLE
Remove TF model from the resource cache before closing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -199,7 +199,12 @@ def previousVersion(currentVersion: String): Option[String] = {
 }
 
 lazy val mimaSettings = Def.settings(
-  mimaBinaryIssueFilters := Seq.empty,
+  mimaBinaryIssueFilters := Seq(
+    // scio-tensorflow ConcurrentHashMap instead of ConcurrentMap (#5011)
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "com.spotify.scio.tensorflow.PredictDoFn.createResource"
+    )
+  ),
   mimaPreviousArtifacts := previousVersion(version.value)
     .filter(_ => publishArtifact.value)
     .map(organization.value % s"${normalizedName.value}_${scalaBinaryVersion.value}" % _)

--- a/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
+++ b/scio-tensorflow/src/main/scala/com/spotify/scio/tensorflow/TensorFlowDoFns.scala
@@ -18,8 +18,7 @@
 package com.spotify.scio.tensorflow
 
 import java.time.Duration
-import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
-import java.util.function.Function
+import java.util.concurrent.ConcurrentHashMap
 import com.spotify.zoltar.tf.{TensorFlowLoader, TensorFlowModel}
 import com.spotify.zoltar.Model
 import org.apache.beam.sdk.transforms.DoFn.{
@@ -40,15 +39,13 @@ import com.spotify.scio.transforms.DoFnWithResource
 import com.spotify.scio.transforms.DoFnWithResource.ResourceType
 import com.spotify.zoltar.Model.Id
 
-import java.util.concurrent.atomic.AtomicInteger
-
 sealed trait PredictDoFn[T, V, M <: Model[_]]
     extends DoFnWithResource[T, V, PredictDoFn.Resource[M]] {
   import PredictDoFn._
 
   def modelId: String
 
-  def loadModel: M
+  def loadModel(): M
 
   def model: M = getResource.get(modelId)._2
 
@@ -60,22 +57,20 @@ sealed trait PredictDoFn[T, V, M <: Model[_]]
 
   def outputTensorNames: Seq[String]
 
-  override def createResource(): Resource[M] = new ConcurrentHashMap[String, (AtomicInteger, M)]()
+  override def createResource(): Resource[M] = new ConcurrentHashMap[String, (Int, M)]()
 
   override def getResourceType: DoFnWithResource.ResourceType = ResourceType.PER_CLASS
 
   @Setup
   override def setup(): Unit = {
     super.setup()
-    val (a, _) = getResource.computeIfAbsent(
+    getResource.compute(
       modelId,
-      new Function[String, (AtomicInteger, M)] {
-        override def apply(v1: String): (AtomicInteger, M) =
-          new AtomicInteger(0) -> loadModel
+      {
+        case (_, null)              => 1 -> loadModel()
+        case (_, (refCount, model)) => (refCount + 1) -> model
       }
     )
-    a.incrementAndGet()
-    ()
   }
 
   /** Process an element asynchronously. */
@@ -111,21 +106,25 @@ sealed trait PredictDoFn[T, V, M <: Model[_]]
 
   @Teardown
   override def teardown(): Unit = {
-    Log.info(s"Tearing down predict DoFn $this")
-    Option(getResource.get(modelId)) match {
-      case Some((running, m)) =>
-        if (running.decrementAndGet() == 0) {
-          getResource.remove(modelId)
-          m.close()
-        }
-      case _ =>
-        Log.warn("No model to close while tearing down predict DoFn")
-    }
+    Log.info("Tearing down predict DoFn {}", this)
+    getResource.compute(
+      modelId,
+      {
+        case (_, null) =>
+          Log.warn("No model to close while tearing down predict DoFn")
+          null
+        case (_, (1, model)) =>
+          model.close()
+          null
+        case (_, (refCount, model)) =>
+          (refCount - 1) -> model
+      }
+    )
   }
 }
 
 object PredictDoFn {
-  type Resource[M <: Model[_]] = ConcurrentMap[String, (AtomicInteger, M)]
+  type Resource[M <: Model[_]] = ConcurrentHashMap[String, (Int, M)]
 
   private val Log = LoggerFactory.getLogger(this.getClass)
 }
@@ -138,7 +137,7 @@ abstract private[tensorflow] class SavedBundlePredictDoFn[T, V](
   override def modelId: String =
     s"tf:$uri:$signatureName:${options.tags.asScala.mkString(":")}"
 
-  override def loadModel: TensorFlowModel =
+  override def loadModel(): TensorFlowModel =
     TensorFlowLoader
       .create(Id.create(modelId), uri, options, signatureName)
       .get(Duration.ofDays(Integer.MAX_VALUE))


### PR DESCRIPTION
During `PredictDoFn` teardown, the model gets closed without being removed from the cache. This can create some illegal states if the PredictDoFn subclass gets used more than once. There are valid use cases to use the same prediction computation in different parts of the DAG. It is safer to remove the model from the cache before closing it.

This solution is still not perfect because there is a potential for race conditions if setup and teardown happens at the same time with two instances sharing a JVM. This is possible when running tests in parallel in a direct runner, for example.

TODO: I could not run tests locally because I have a M1, may need to rely on the github action to see what else needs to change