### PR TITLE
Set outputStrategy for run scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -259,6 +259,7 @@ val commonSettings = formatSettings ++
     ),
     resolvers ++= Resolver.sonatypeOssRepos("public"),
     fork := true,
+    run / outputStrategy := Some(OutputStrategy.StdoutOutput),
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     Test / javaOptions ++= Seq(
       "-Xms512m",


### PR DESCRIPTION
As we fork the JVM, set the `outputStrategy` to `StdoutOutput` for run scope so we can get the repl working and stacktraces in `runMain`