### PR TITLE
Restrict implicit dynamic extensions for generic avro SCollection

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/io/dynamic/syntax/SCollectionSyntax.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/dynamic/syntax/SCollectionSyntax.scala
@@ -107,7 +107,7 @@ final class DynamicSpecificRecordSCollectionOps[T <: SpecificRecord](
  * Enhanced version of [[com.spotify.scio.values.SCollection SCollection]] with dynamic destinations
  * methods.
  */
-final class DynamicGenericRecordSCollectionOps[T <: GenericRecord](private val self: SCollection[T])
+final class DynamicGenericRecordSCollectionOps(private val self: SCollection[GenericRecord])
     extends AnyVal {
   import DynamicSCollectionOps.writeDynamic
 
@@ -122,7 +122,7 @@ final class DynamicGenericRecordSCollectionOps[T <: GenericRecord](private val s
     tempDirectory: String = null,
     prefix: String = null
   )(
-    destinationFn: T => String
+    destinationFn: GenericRecord => String
   ): ClosedTap[Nothing] = {
     if (self.context.isTest) {
       throw new NotImplementedError(
@@ -132,10 +132,7 @@ final class DynamicGenericRecordSCollectionOps[T <: GenericRecord](private val s
       val nm = new JHashMap[String, AnyRef]()
       nm.putAll(metadata.asJava)
       val sink = BAvroIO
-        .sinkViaGenericRecords(
-          schema,
-          (element: T, _: Schema) => element
-        )
+        .sink[GenericRecord](schema)
         .withCodec(codec)
         .withMetadata(nm)
       val write =
@@ -257,9 +254,9 @@ trait SCollectionSyntax {
   ): DynamicSpecificRecordSCollectionOps[T] =
     new DynamicSpecificRecordSCollectionOps(sc)
 
-  implicit def dynamicGenericRecordSCollectionOps[T <: GenericRecord](
-    sc: SCollection[T]
-  ): DynamicGenericRecordSCollectionOps[T] =
+  implicit def dynamicGenericRecordSCollectionOps(
+    sc: SCollection[GenericRecord]
+  ): DynamicGenericRecordSCollectionOps =
     new DynamicGenericRecordSCollectionOps(sc)
 
   implicit def dynamicSCollectionOps[T](sc: SCollection[T]): DynamicSCollectionOps[T] =

--- a/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/dynamic/DynamicFileTest.scala
@@ -128,7 +128,7 @@ class DynamicFileTest extends PipelineSpec with TapSpec {
     sc1
       .parallelize(1 to 10)
       .map(newGenericRecord)
-      .saveAsDynamicAvroFile(dir.getAbsolutePath, schema = schema) { r =>
+      .saveAsDynamicAvroFile(path = dir.getAbsolutePath, schema = schema) { r =>
         partitionIntegers(r.get("int_field").asInstanceOf[Int])
       }
     sc1.run()
@@ -148,7 +148,7 @@ class DynamicFileTest extends PipelineSpec with TapSpec {
     sc1
       .parallelize(1 to 10)
       .map(newSpecificRecord)
-      .saveAsDynamicAvroFile(dir.getAbsolutePath)(r => partitionIntegers(r.getIntField))
+      .saveAsDynamicAvroFile(path = dir.getAbsolutePath)(r => partitionIntegers(r.getIntField))
     sc1.run()
     verifyOutput(dir, "even", "odd")
 


### PR DESCRIPTION
When using named parameter on `saveAsDynamicAvroFile`, implicit resolution fails with

```
[error] Note that implicit conversions are not applicable because they are ambiguous:
[error]  both method dynamicSpecificRecordSCollectionOps in trait SCollectionSyntax of type [T <: org.apache.avro.specific.SpecificRecord](sc: com.spotify.scio.values.SCollection[T])com.spotify.scio.io.dynamic.syntax.DynamicSpecificRecordSCollectionOps[T]
[error]  and method dynamicGenericRecordSCollectionOps in trait SCollectionSyntax of type [T <: org.apache.avro.generic.GenericRecord](sc: com.spotify.scio.values.SCollection[T])com.spotify.scio.io.dynamic.syntax.DynamicGenericRecordSCollectionOps[T]
[error]  are possible conversion functions from com.spotify.scio.values.SCollection[com.spotify.scio.avro.TestRecord] to ?{def saveAsDynamicAvroFile: ?}
[error]       .map(newSpecificRecord)
[error]
```

Restrict the implicit creation for generic avro on `SCollection[GenericRecord]`