### PR TITLE
Make macro print debug logs if `bigquery.types.debug` enabled

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -31,8 +31,7 @@ private[types] object ConverterProvider {
     import c.universe._
     val tpe = weakTypeOf[T]
     val r = fromAvroInternal(c)(tpe)
-    debug(s"ConverterProvider.fromAvroImpl[$tpe]:")
-    debug(r)
+    debug(c)(s"ConverterProvider.fromAvroImpl[$tpe]:", r)
     c.Expr[GenericRecord => T](r)
   }
 
@@ -40,8 +39,7 @@ private[types] object ConverterProvider {
     import c.universe._
     val tpe = weakTypeOf[T]
     val r = toAvroInternal(c)(tpe)
-    debug(s"ConverterProvider.toAvroInternal[$tpe]:")
-    debug(r)
+    debug(c)(s"ConverterProvider.toAvroInternal[$tpe]:", r)
     c.Expr[T => GenericRecord](r)
   }
 
@@ -49,8 +47,7 @@ private[types] object ConverterProvider {
     import c.universe._
     val tpe = weakTypeOf[T]
     val r = fromTableRowInternal(c)(tpe)
-    debug(s"ConverterProvider.fromTableRowImpl[$tpe]:")
-    debug(r)
+    debug(c)(s"ConverterProvider.fromTableRowImpl[$tpe]:", r)
     c.Expr[TableRow => T](r)
   }
 
@@ -58,8 +55,7 @@ private[types] object ConverterProvider {
     import c.universe._
     val tpe = weakTypeOf[T]
     val r = toTableRowInternal(c)(tpe)
-    debug(s"ConverterProvider.toTableRowImpl[$tpe]:")
-    debug(r)
+    debug(c)(s"ConverterProvider.toTableRowImpl[$tpe]:", r)
     c.Expr[T => TableRow](r)
   }
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/MacroUtil.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/MacroUtil.scala
@@ -18,14 +18,11 @@
 package com.spotify.scio.bigquery.types
 
 import com.spotify.scio.bigquery.BigQuerySysProps
-import org.slf4j.LoggerFactory
 
 import scala.reflect.macros._
 import scala.reflect.runtime.universe._
 
 private[types] object MacroUtil {
-  private[this] val logger = LoggerFactory.getLogger(this.getClass)
-
   // Case class helpers for runtime reflection
 
   def isCaseClass(t: Type): Boolean =
@@ -68,9 +65,9 @@ private[types] object MacroUtil {
 
   // Debugging
 
-  @inline def debug(msg: Any): Unit =
+  @inline def debug(c: blackbox.Context)(h: String, t: c.Tree): Unit =
     if (BigQuerySysProps.Debug.value("false").toBoolean) {
-      logger.info(msg.toString)
+      c.echo(c.enclosingPosition, s"$h: $t")
     }
 
   // Namespace helpers

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -46,10 +46,7 @@ private[types] object SchemaProvider {
           case t if isCaseClass(t) => toFields(t)
           case t                   => throw new RuntimeException(s"Unsupported type $t")
         }
-        val r = new TableSchema().setFields(fields.toList.asJava)
-        debug(s"SchemaProvider.schemaOf[${typeOf[T]}]:")
-        debug(r)
-        r
+        new TableSchema().setFields(fields.toList.asJava)
       }
     )
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -253,8 +253,7 @@ private[types] object TypeProvider {
 
         c.abort(c.enclosingPosition, error)
     }
-    debug(s"TypeProvider.toTableImpl:")
-    debug(r)
+    debug(c)(s"TypeProvider.toTableImpl", r)
 
     if (shouldDumpClassesForPlugin) {
       dumpCodeForScalaPlugin(c)(Seq.empty, caseClassTree, name)
@@ -366,8 +365,7 @@ private[types] object TypeProvider {
         )
       case t => c.abort(c.enclosingPosition, s"Invalid annotation $t")
     }
-    debug(s"TypeProvider.schemaToType[$schema]:")
-    debug(r)
+    debug(c)(s"TypeProvider.schemaToType[$schema]:", r)
 
     if (shouldDumpClassesForPlugin) {
       dumpCodeForScalaPlugin(c)(records, caseClassTree, name)


### PR DESCRIPTION
Right now, logging goes through `slf4j`, but there isn't any logger impl at compile time, giving
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementational 1s
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

use the macro front end to print debug statements