### PR TITLE
Support a transform() API for ScioContext

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -700,6 +700,24 @@ class ScioContext private[scio] (
   ): SCollection[U] =
     applyTransform(Option(name), root)
 
+  def transform[U](f: ScioContext => SCollection[U]): SCollection[U] = transform(this.tfName)(f)
+
+  def transform[U](name: String)(f: ScioContext => SCollection[U]): SCollection[U] =
+    wrap(transform_(name)(f(_).internal))
+
+  private[scio] def transform_[U <: POutput](f: ScioContext => U): U =
+    transform_(tfName)(f)
+
+  private[scio] def transform_[U <: POutput](name: String)(f: ScioContext => U): U = {
+    val sc: ScioContext = this
+    applyInternal(
+      name,
+      new PTransform[PBegin, U]() {
+        override def expand(pBegin: PBegin): U = f(sc)
+      }
+    )
+  }
+
   /**
    * Get an SCollection for a text file.
    * @group input


### PR DESCRIPTION
The `SCollection#transform` exists to wrap multiple SColl-to-SColl transforms into a single, named composite transform, but we don't have an equivalent for root-level transforms invoked on `ScioContext`.