### PR TITLE
Fix sending empty request when batch is empty

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/BaseAsyncBatchLookupDoFn.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/BaseAsyncBatchLookupDoFn.java
@@ -197,8 +197,9 @@ public abstract class BaseAsyncBatchLookupDoFn<
 
     // send remaining
     try {
-      /** @todo handle exception properly * */
-      createRequest();
+      if (!batch.isEmpty()) {
+        createRequest();
+      }
       if (!futures.isEmpty()) {
         // Block until all pending futures are complete
         waitForFutures(futures.values());


### PR DESCRIPTION
# Description

When `finishBundle` is called a call to `createRequest` to send any remaining elements in the bundle in a single gRPC request. In some corner cases we can end up sending empty batch requests (with no elements) like in the following: 
* In the case where all the bundle can be satisfied from the cache 
* in the case when the bundle size == batch size

Basically any time we reach the `finishBundle` and the batch queue is empty we send an empty batch request as we are not checking in `createRequest` if there are elements or not. 

# Changes

Only call `createRequest` in `finishBundle` if there are still element in the batch queue.