### PR TITLE
Make default FileOperations constructor public

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
@@ -74,7 +74,7 @@ public abstract class FileOperations<V> implements Serializable, HasDisplayData 
     diskBufferBytes.compareAndSet(null, diskBufferMb * 1024L * 1024L);
   }
 
-  protected FileOperations(Compression compression, String mimeType) {
+  public FileOperations(Compression compression, String mimeType) {
     this.compression = compression;
     this.mimeType = mimeType;
   }


### PR DESCRIPTION
FileOperations is a public abstract class without a public constructor; therefore, it cannot be extended by any class outside the package.