### PR TITLE
Allow manual release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: release
 on:
-  push:
-    branches: [main]
-    tags: ["*"]
+  - workflow_dispatch
+  - push:
+      branches: [main]
+      tags: ["*"]
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Allow manual release on GHA, so SNAPSHOTS can be published from any branch.

This will reduce temptation of creating a a tag like `0.14.0-dev1` ending in the [release repository](https://repo1.maven.org/maven2/com/spotify/scio-core_2.12/0.14.0-dev1/)