### PR TITLE
Don't overwrite Configured projection in scio-smb

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
@@ -173,7 +173,10 @@ public class ParquetAvroFileOperations<ValueT> extends FileOperations<ValueT> {
       final Schema schema = schemaSupplier.get();
       final Configuration configuration = conf.get();
       AvroReadSupport.setAvroReadSchema(configuration, schema);
-      AvroReadSupport.setRequestedProjection(configuration, schema);
+
+      if (configuration.get(AvroReadSupport.AVRO_REQUESTED_PROJECTION) == null) {
+        AvroReadSupport.setRequestedProjection(configuration, schema);
+      }
 
       ParquetReader.Builder<ValueT> builder =
           AvroParquetReader.<ValueT>builder(new ParquetInputFile(channel)).withConf(configuration);


### PR DESCRIPTION
Non-api-breaking workaround for #5082--in 0.14.0 we can add `Schema projection` to the `ParquetAvroSortedBucketIO` read builder?