### PR TITLE
Increase BQ read timeout for integration test

### DIFF
--- a/.github/workflows/it-tests.yml
+++ b/.github/workflows/it-tests.yml
@@ -25,6 +25,7 @@ jobs:
       - name: set JVM opts
         run: scripts/gha_setup.sh
         env:
+          BQ_READ_TIMEOUT: 30000
           CLOUDSQL_SQLSERVER_PASSWORD: ${{ secrets.CLOUDSQL_SQLSERVER_PASSWORD }}
       - run: sbt IntegrationTest/test
 
@@ -48,5 +49,7 @@ jobs:
           java-version: 11
       - name: Setup project
         run: scripts/gha_setup.sh
+        env:
+          BQ_READ_TIMEOUT: 30000
       - name: Build documentation
         run: sbt site/makeSite

--- a/scripts/gha_setup.sh
+++ b/scripts/gha_setup.sh
@@ -6,4 +6,6 @@ set -e
 [[ -z "${BEAM_RUNNERS}" ]]                   || echo "-DbeamRunners=$BEAM_RUNNERS"                                >> .sbtopts
 [[ -z "${GOOGLE_CLOUD_PROJECT}" ]]           || echo "-Dbigquery.project=$GOOGLE_CLOUD_PROJECT"                   >> .sbtopts
 [[ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]] || echo "-Dbigquery.secret=$GOOGLE_APPLICATION_CREDENTIALS"          >> .sbtopts
+[[ -z "${BQ_CONNECT_TIMEOUT}" ]]             || echo "-Dbigquery.connect_timeout=$BQ_CONNECT_TIMEOUT"             >> .sbtopts
+[[ -z "${BQ_READ_TIMEOUT}" ]]                || echo "-Dbigquery.read_timeout=$BQ_READ_TIMEOUT"                   >> .sbtopts
 [[ -z "${CLOUDSQL_SQLSERVER_PASSWORD}" ]]    || echo "-Dcloudsql.sqlserver.password=$CLOUDSQL_SQLSERVER_PASSWORD" >> .sbtopts


### PR DESCRIPTION
Some tntegration test fail compilation due to BQ macro reaching timeout when generating case classes.
Increase timeout to pass the step on the CI