### PR TITLE
Add location to BigQuery LoadOps

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/LoadOps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/LoadOps.scala
@@ -49,7 +49,8 @@ final private[client] class LoadOps(client: Client, jobService: JobOps) {
     skipLeadingRows: Int = 0,
     fieldDelimiter: Option[String] = None,
     ignoreUnknownValues: Boolean = false,
-    encoding: Option[String] = None
+    encoding: Option[String] = None,
+    location: Option[String] = None
   ): Try[TableReference] =
     execute(
       sources = sources,
@@ -66,7 +67,8 @@ final private[client] class LoadOps(client: Client, jobService: JobOps) {
       skipLeadingRows = Some(skipLeadingRows),
       fieldDelimiter = fieldDelimiter,
       ignoreUnknownValues = Some(ignoreUnknownValues),
-      encoding = encoding
+      encoding = encoding,
+      location = location
     )
 
   def json(
@@ -78,7 +80,8 @@ final private[client] class LoadOps(client: Client, jobService: JobOps) {
     autodetect: Boolean = false,
     maxBadRecords: Int = 0,
     ignoreUnknownValues: Boolean = false,
-    encoding: Option[String] = None
+    encoding: Option[String] = None,
+    location: Option[String] = None
   ): Try[TableReference] =
     execute(
       sources = sources,
@@ -90,7 +93,8 @@ final private[client] class LoadOps(client: Client, jobService: JobOps) {
       autodetect = Some(autodetect),
       maxBadRecords = maxBadRecords,
       ignoreUnknownValues = Some(ignoreUnknownValues),
-      encoding = encoding
+      encoding = encoding,
+      location = location
     )
 
   def avro(
@@ -100,7 +104,8 @@ final private[client] class LoadOps(client: Client, jobService: JobOps) {
     writeDisposition: WriteDisposition = WRITE_APPEND,
     schema: Option[TableSchema] = None,
     maxBadRecords: Int = 0,
-    encoding: Option[String] = None
+    encoding: Option[String] = None,
+    location: Option[String] = None
   ): Try[TableReference] =
     execute(
       sources = sources,
@@ -110,7 +115,8 @@ final private[client] class LoadOps(client: Client, jobService: JobOps) {
       writeDisposition = writeDisposition,
       schema = schema,
       maxBadRecords = maxBadRecords,
-      encoding = encoding
+      encoding = encoding,
+      location = location
     )
 
   @nowarn("msg=private default argument in class LoadOps is never used")
@@ -129,7 +135,8 @@ final private[client] class LoadOps(client: Client, jobService: JobOps) {
     skipLeadingRows: Option[Int] = None,
     fieldDelimiter: Option[String] = None,
     ignoreUnknownValues: Option[Boolean] = None,
-    encoding: Option[String] = None
+    encoding: Option[String] = None,
+    location: Option[String] = None
   ): Try[TableReference] = Try {
     val tableRef = bq.BigQueryHelpers.parseTableSpec(destinationTable)
 
@@ -155,7 +162,10 @@ final private[client] class LoadOps(client: Client, jobService: JobOps) {
       .setLoad(jobConfigLoad)
 
     val fullJobId = BigQueryUtil.generateJobId(client.project)
-    val jobReference = new JobReference().setProjectId(client.project).setJobId(fullJobId)
+    val jobReference = new JobReference()
+      .setProjectId(client.project)
+      .setJobId(fullJobId)
+      .setLocation(location.orNull)
     val job = new Job().setConfiguration(jobConfig).setJobReference(jobReference)
 
     Logger.info(s"Loading data into $destinationTable from ${sources.mkString(", ")}")


### PR DESCRIPTION
This PR adds the option to set the `location` for a BigQuery load job. This is needed that load works correctly when loading data to a table located in a single region (non EU/US). When for example loading data to a table in `me-central2`, the load itself works, but the `waitForJobs` never completes as BigQuery API always returns a 404 when querying the job infos: 
```
BigQuery request failed: id: <project>-2519647d-c737-4e12-acc2-d7cc6861f2b8, error: com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
GET https://bigquery.googleapis.com/bigquery/v2/projects/<project>/jobs/<project>-2519647d-c737-4e12-acc2-d7cc6861f2b8
{
  "code": 404,
  "errors": [
    {
      "domain": "global",
      "message": "Not found: Job <project><project>-2519647d-c737-4e12-acc2-d7cc6861f2b8",
      "reason": "notFound"
    }
  ],
  "message": "Not found: Job <project>:<project>-2519647d-c737-4e12-acc2-d7cc6861f2b8",
  "status": "NOT_FOUND"
}
```

When the location ist set correctly, `waitForJobs` will be able the get the infos approriately as the location will be set here: https://github.com/spotify/scio/blob/11e0012ef784851be82f0e96d857e89a6196ce30/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/JobOps.scala#L97