### PR TITLE
Support null CharSequence keys

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -160,7 +160,7 @@ public class AvroBucketMetadata<K1, K2, V extends IndexedRecord> extends BucketM
     }
     Object keyObj = node.get(keyPath[keyPath.length - 1]);
     // Always convert CharSequence to String, in case reader and writer disagree
-    if (keyClazz == CharSequence.class || keyClazz == String.class) {
+    if (keyObj != null && (keyClazz == CharSequence.class || keyClazz == String.class)) {
       keyObj = keyObj.toString();
     }
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
If avro SMB string keys are null, instead of going to the special bucket as described in the [doc](https://spotify.github.io/scio/extras/Sort-Merge-Bucket.html#null-keys-in-smb-datasets), code throws a `NullPointerExeption` 