### PR TITLE
Move BQ typed from query to queryRaw

### DIFF
--- a/integration/src/test/scala/com/spotify/scio/bigquery/types/BigQueryTypeIT.scala
+++ b/integration/src/test/scala/com/spotify/scio/bigquery/types/BigQueryTypeIT.scala
@@ -106,7 +106,7 @@ class BigQueryTypeIT extends AnyFlatSpec with Matchers {
     val bqt = BigQueryType[LegacyT]
     bqt.isQuery shouldBe true
     bqt.isTable shouldBe false
-    bqt.query shouldBe Some(legacyQuery)
+    bqt.queryRaw shouldBe Some(legacyQuery)
     bqt.table shouldBe None
     val fields = bqt.schema.getFields.asScala
     fields.size shouldBe 2
@@ -119,7 +119,7 @@ class BigQueryTypeIT extends AnyFlatSpec with Matchers {
     val bqt = BigQueryType[SqlT]
     bqt.isQuery shouldBe true
     bqt.isTable shouldBe false
-    bqt.query shouldBe Some(sqlQuery)
+    bqt.queryRaw shouldBe Some(sqlQuery)
     bqt.table shouldBe None
     val fields = bqt.schema.getFields.asScala
     fields.size shouldBe 2
@@ -145,11 +145,11 @@ class BigQueryTypeIT extends AnyFlatSpec with Matchers {
   }
 
   it should "work with legacy syntax with $LATEST" in {
-    BigQueryType[LegacyLatestT].query shouldBe Some(legacyLatestQuery)
+    BigQueryType[LegacyLatestT].queryRaw shouldBe Some(legacyLatestQuery)
   }
 
   it should "work with SQL syntax with $LATEST" in {
-    BigQueryType[SqlLatestT].query shouldBe Some(sqlLatestQuery)
+    BigQueryType[SqlLatestT].queryRaw shouldBe Some(sqlLatestQuery)
   }
 
   it should "have query fn" in {
@@ -242,7 +242,7 @@ class BigQueryTypeIT extends AnyFlatSpec with Matchers {
     val bqt = BigQueryType[ToTableT]
     bqt.isQuery shouldBe false
     bqt.isTable shouldBe false
-    bqt.query shouldBe None
+    bqt.queryRaw shouldBe None
     bqt.table shouldBe None
     val fields = bqt.schema.getFields.asScala
     fields.size shouldBe 2

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -796,7 +796,7 @@ object BigQueryTyped {
         val table = STable.Spec(bqt.table.get)
         ScioIO.ro[T](Table[T](table))
       case None if bqt.isQuery =>
-        val query = Query(bqt.query.get)
+        val query = Query(bqt.queryRaw.get)
         Select[T](query)
       case Some(s: STable) =>
         ScioIO.ro(Table[T](s))

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
@@ -91,7 +91,7 @@ final class BigQuery private (val client: Client) {
       if (bqt.isTable) {
         tables.rows(STable.Spec(bqt.table.get))
       } else if (bqt.isQuery) {
-        query.rows(bqt.query.get)
+        query.rows(bqt.queryRaw.get)
       } else {
         throw new IllegalArgumentException("Missing table or query field in companion object")
       }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/ScioContextSyntax.scala
@@ -149,7 +149,7 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
   def typedBigQueryStorage[T <: HasAnnotation: TypeTag: Coder](): SCollection[T] = {
     val bqt = BigQueryType[T]
     if (bqt.isQuery) {
-      self.read(BigQueryTyped.StorageQuery[T](Query(bqt.query.get)))
+      self.read(BigQueryTyped.StorageQuery[T](Query(bqt.queryRaw.get)))
     } else {
       val table = Table.Spec(bqt.table.get)
       val rr = bqt.rowRestriction

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/taps.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/taps.scala
@@ -122,7 +122,7 @@ final case class BigQueryTaps(self: Taps) {
         case null if bqt.isTable =>
           bigQueryTable(bqt.table.get)
         case null if bqt.isQuery =>
-          bigQuerySelect(bqt.query.get)
+          bigQuerySelect(bqt.queryRaw.get)
         case null =>
           throw new IllegalArgumentException(s"Missing table or query field in companion object")
         case _ if table.isDefined =>

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/BigQueryType.scala
@@ -423,8 +423,13 @@ class BigQueryType[T: TypeTag] {
     Try(getField("rowRestriction").asInstanceOf[Option[String]]).toOption.flatten
 
   /** Query from the annotation. */
+  @deprecated("use queryRaw instead", "0.14.0")
   def query: Option[String] =
-    Try(getField("query").asInstanceOf[String]).toOption
+    Try(getField("queryRaw").asInstanceOf[String]).toOption
+
+  /** Query from the annotation. */
+  def queryRaw: Option[String] =
+    Try(getField("queryRaw").asInstanceOf[String]).toOption
 
   /** Table description from the annotation. */
   def tableDescription: Option[String] =


### PR DESCRIPTION
BQ typed API was still depending on the deprecated `query` field which has been removed in https://github.com/spotify/scio/pull/5134.

Setup consistent `queryRaw` API and deprecate `query`