### PR TITLE
Relax versioning regex

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
@@ -31,9 +31,12 @@ import scala.collection.mutable
 import scala.util.Try
 
 private[scio] object VersionUtil {
+
+  private val oderSemVer: Ordering[SemVer] =
+    Ordering.by(v => (v.major, v.minor, v.rev, v.suffix.toUpperCase()))
+
   case class SemVer(major: Int, minor: Int, rev: Int, suffix: String) extends Ordered[SemVer] {
-    def compare(that: SemVer): Int =
-      Ordering[(Int, Int, Int, String)].compare(SemVer.unapply(this).get, SemVer.unapply(that).get)
+    def compare(that: SemVer): Int = oderSemVer.compare(this, that)
   }
 
   private[this] val Timeout = 3000
@@ -122,7 +125,7 @@ private[scio] object VersionUtil {
     } else {
       val buffer = mutable.Buffer.empty[String]
       val v1 = parseVersion(current)
-      if (v1.suffix.contains("-SNAPSHOT")) {
+      if (v1.suffix.contains("SNAPSHOT")) {
         buffer.append(s"Using a SNAPSHOT version of Scio: $current")
       }
       latestOverride.orElse(latest).foreach { v =>


### PR DESCRIPTION
Since we use `sbt-typelevel` plugin to compute the project version, we can use the `tlBaseVersion` setting to tell the current minor version.

If no artifact for this minor has been published, the plugin uses a pre-release version, omitting the tiny: `0.14-93b3df1-SNAPSHOT`

Relax regex in `VersionUtils` so we don't get some exception running integration tests