### PR TITLE
(fix #5147) Fix Materialize for elements that match compression encoding signature

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
@@ -91,7 +91,7 @@ final private[scio] class MaterializeTap[T: Coder] private (path: String, coder:
     if (storage.isDone()) {
       val filePattern = ScioUtil.filePattern(path, BinaryIO.ReadParam.DefaultSuffix)
       BinaryIO
-        .openInputStreamsFor(filePattern)
+        .openInputStreamsFor(filePattern, tryDecompress = false)
         .flatMap { is =>
           new Iterator[T] {
             private val reader = MaterializeTap.MaterializeReader

--- a/scio-test/src/test/scala/com/spotify/scio/io/TapTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/TapTest.scala
@@ -280,6 +280,7 @@ class TapTest extends TapSpec {
     ) shouldBe CompressorStreamFactory.DEFLATE
 
     // Assert that we can still materialize it in a tap
-    runWithLocalOutput(_.parallelize(Seq(element))) should contain only element
+    val (_, tapped) = runWithLocalOutput(_.parallelize(Seq(element)))
+    tapped should contain only element
   }
 }

--- a/scio-test/src/test/scala/com/spotify/scio/io/TapTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/io/TapTest.scala
@@ -280,9 +280,6 @@ class TapTest extends TapSpec {
     ) shouldBe CompressorStreamFactory.DEFLATE
 
     // Assert that we can still materialize it in a tap
-    val sc = ScioContext()
-    val f = sc.parallelize(Seq(element)).materialize
-    val scioResult = sc.run().waitUntilDone()
-    scioResult.tap(f).value.toSet shouldBe Set(element)
+    runWithLocalOutput(_.parallelize(Seq(element))) should contain only element
   }
 }


### PR DESCRIPTION
See detailed explanation in #5147.