### PR TITLE
Remove references to Spotify FOSS Slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Scio is developed and maintained by an infrastructure team at Spotify. It is the
 
 # Submitting issues
 
-Feel free to discuss issues in the #scio channel on Spotify FOSS Slack (get an invite [here](https://slackin.spotify.com/)) or [Google Group](https://groups.google.com/forum/#!forum/scio-users) first.
+Feel free to discuss issues in the [Google Group](https://groups.google.com/forum/#!forum/scio-users) first.
 
 Don't hesitate to create [GitHub issues](https://github.com/spotify/scio/issues) for bugs, feature requests, or questions. When reporting a bug, it would help to include a small, reproducible code snippet or unit test.
 

--- a/site/src/main/paradox/dev/How-to-Release.md
+++ b/site/src/main/paradox/dev/How-to-Release.md
@@ -52,5 +52,4 @@ git push origin vX.Y.Z
 - Clean the `mimaBinaryIssueFilters` in `build.sbt`
 - Run @github[scripts/bump_scio.sh](/scripts/bump_scio.sh) to update [homebrew formula](https://github.com/spotify/homebrew-public/blob/master/scio.rb) and `scioVersion` in downstream repos including [scio.g8](https://github.com/spotify/scio.g8), [featran](https://github.com/spotify/featran), etc.
 - Send external announcement to scio-users@googlegroups.com and user@beam.apache.org
-- Announce on public [Slack](https://slackin.spotify.com/)
 - Announce on Twitter

--- a/site/src/main/paradox/index.md
+++ b/site/src/main/paradox/index.md
@@ -14,7 +14,6 @@ Example Scio pipelines and tests can be found under @github[scio-examples](/scio
 See @scaladoc[Scio Scaladocs](com.spotify.scio.index)  for current API documentation.
 
 ## Getting help
-- `#scio` channel on Spotify FOSS Slack, get an invite [here](https://slackin.spotify.com/)
 - [![Google Group](https://img.shields.io/badge/Google%20Group-scio--users-blue.svg)](https://groups.google.com/forum/#!forum/scio-users)
 - [![Stack Overflow](https://img.shields.io/badge/Stack%20Overflow-spotify--scio-yellow.svg)](https://stackoverflow.com/questions/tagged/spotify-scio)
 


### PR DESCRIPTION
The FOSS Slack is being shut down. We will continue use GitHub issues, discussions, etc. for receiving feedback and bug reports.