### PR TITLE
Fix multi-line DML statement detection

### DIFF
--- a/integration/src/test/scala/com/spotify/scio/bigquery/BigQueryClientIT.scala
+++ b/integration/src/test/scala/com/spotify/scio/bigquery/BigQueryClientIT.scala
@@ -56,7 +56,8 @@ class BigQueryClientIT extends AnyFlatSpec with Matchers {
     val table = bq.tables.createTemporary(location = "EU").getTableReference
     val tableRef = bq.load.json(sources, table.asTableSpec, schema = Some(schema))
     tableRef.map { ref =>
-      val insertQuery = s"insert into `${ref.asTableSpec}` values (1603, 'alien', 9000, 'alien')"
+      val insertQuery = s"""insert into `${ref.asTableSpec}`
+                           |values (1603, 'alien', 9000, 'alien')""".stripMargin
       bq.query.run(
         insertQuery,
         createDisposition = null,

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/client/BigQuery.scala
@@ -166,7 +166,7 @@ final class BigQuery private (val client: Client) {
 /** Companion object for [[BigQuery]]. */
 object BigQuery {
   private[scio] def isDML(sqlQuery: String): Boolean =
-    sqlQuery.toUpperCase().matches("(UPDATE|MERGE|INSERT|DELETE).*")
+    sqlQuery.toUpperCase().matches("(?s)(UPDATE|MERGE|INSERT|DELETE).*")
 
   private lazy val instance: BigQuery =
     BigQuerySysProps.Project.valueOption.map(BigQuery(_)).getOrElse {


### PR DESCRIPTION
Use [DOTALL](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#DOTALL) mode to match multi-line DML statement

Fix #5136 