### PR TITLE
Remove duplicated scalac option

### DIFF
--- a/project/ScalacOptions.scala
+++ b/project/ScalacOptions.scala
@@ -78,7 +78,6 @@ object ScalacOptions {
       .tokensForVersion(ScalaVersion(major, minor, patch), proposedScalacOptions)
   }
 
-  private val cpuParallelism = math.min(java.lang.Runtime.getRuntime.availableProcessors(), 16)
   def defaults(scalaVersion: String): Seq[String] = tokensForVersion(
     scalaVersion,
     Set(
@@ -86,7 +85,6 @@ object ScalacOptions {
       macroAnnotationsOption,
       macroShowCoderFallback(true),
       maxClassfileName(100),
-      privateBackendParallelism(cpuParallelism),
       privateWarnMacrosOption,
       warnMacrosOption,
       warnConfOption


### PR DESCRIPTION
scalac backend parallelism option is already handled by the `sbt-typelevel` plugin [here](https://github.com/typelevel/sbt-typelevel/blob/18e9bf9eb4ddad718a7553bc13044cce19a8931c/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala#L182).

Remove from build to avoid duplicate option