### PR TITLE
Support projection in ParquetAvroSortedBucketIO

### DIFF
--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
@@ -175,7 +175,9 @@ public class ParquetAvroFileOperationsTest {
             .endRecord();
 
     final ParquetAvroFileOperations<GenericRecord> fileOperations =
-        ParquetAvroFileOperations.of(USER_SCHEMA).withProjection(projection);
+        ParquetAvroFileOperations.of(USER_SCHEMA)
+            .withCompression(CompressionCodecName.ZSTD)
+            .withProjection(projection);
 
     final List<GenericRecord> expected =
         USER_RECORDS.stream()

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
@@ -98,7 +98,7 @@ public class ParquetAvroFileOperationsTest {
   @Test
   public void testSpecificRecord() throws Exception {
     final ParquetAvroFileOperations<AvroGeneratedUser> fileOperations =
-        ParquetAvroFileOperations.of(AvroGeneratedUser.getClassSchema());
+        ParquetAvroFileOperations.of(AvroGeneratedUser.class);
     final ResourceId file =
         fromFolder(output)
             .resolve("file.parquet", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);
@@ -134,8 +134,7 @@ public class ParquetAvroFileOperationsTest {
         AvroReadSupport.AVRO_DATA_SUPPLIER, AvroLogicalTypeSupplier.class, AvroDataSupplier.class);
 
     final ParquetAvroFileOperations<TestLogicalTypes> fileOperations =
-        ParquetAvroFileOperations.of(
-            TestLogicalTypes.getClassSchema(), CompressionCodecName.UNCOMPRESSED, conf);
+        ParquetAvroFileOperations.of(TestLogicalTypes.class).withConfiguration(conf);
     final ResourceId file =
         fromFolder(output)
             .resolve("file.parquet", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);
@@ -175,11 +174,8 @@ public class ParquetAvroFileOperationsTest {
             .requiredString("name")
             .endRecord();
 
-    final Configuration configuration = new Configuration();
-    AvroReadSupport.setRequestedProjection(configuration, projection);
-
     final ParquetAvroFileOperations<GenericRecord> fileOperations =
-        ParquetAvroFileOperations.of(USER_SCHEMA, CompressionCodecName.ZSTD, configuration);
+        ParquetAvroFileOperations.of(USER_SCHEMA).withProjection(projection);
 
     final List<GenericRecord> expected =
         USER_RECORDS.stream()
@@ -200,12 +196,8 @@ public class ParquetAvroFileOperationsTest {
             .requiredString("name")
             .endRecord();
 
-    final Configuration configuration = new Configuration();
-    AvroReadSupport.setRequestedProjection(configuration, projection);
-
     final ParquetAvroFileOperations<AvroGeneratedUser> fileOperations =
-        ParquetAvroFileOperations.of(
-            AvroGeneratedUser.class, CompressionCodecName.UNCOMPRESSED, configuration);
+        ParquetAvroFileOperations.of(AvroGeneratedUser.class).withProjection(projection);
 
     final ResourceId file =
         fromFolder(output)
@@ -253,7 +245,7 @@ public class ParquetAvroFileOperationsTest {
     final FilterPredicate predicate = FilterApi.ltEq(FilterApi.intColumn("age"), 5);
 
     final ParquetAvroFileOperations<GenericRecord> fileOperations =
-        ParquetAvroFileOperations.of(USER_SCHEMA, predicate);
+        ParquetAvroFileOperations.of(USER_SCHEMA).withFilterPredicate(predicate);
 
     final List<GenericRecord> expected =
         USER_RECORDS.stream().filter(r -> (int) r.get("age") <= 5).collect(Collectors.toList());
@@ -281,7 +273,7 @@ public class ParquetAvroFileOperationsTest {
 
   private void writeFile(ResourceId file) throws IOException {
     final ParquetAvroFileOperations<GenericRecord> fileOperations =
-        ParquetAvroFileOperations.of(USER_SCHEMA, CompressionCodecName.ZSTD);
+        ParquetAvroFileOperations.of(USER_SCHEMA).withCompression(CompressionCodecName.ZSTD);
     final FileOperations.Writer<GenericRecord> writer = fileOperations.createWriter(file);
     for (GenericRecord record : USER_RECORDS) {
       writer.write(record);

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroSortedBucketIOTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroSortedBucketIOTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.beam.sdk.extensions.smb;
 
+import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.Pipeline;
@@ -26,7 +27,6 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.parquet.avro.AvroReadSupport;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -39,8 +39,8 @@ public class ParquetAvroSortedBucketIOTest {
   @Test
   public void testReadSerializable() {
     final Configuration conf = new Configuration();
-    AvroReadSupport.setRequestedProjection(
-        conf, SchemaBuilder.record("Record").fields().requiredString("name").endRecord());
+    final Schema projection =
+        SchemaBuilder.record("Record").fields().requiredString("name").endRecord();
 
     SerializableUtils.ensureSerializable(
         SortedBucketIO.read(String.class)
@@ -48,7 +48,8 @@ public class ParquetAvroSortedBucketIOTest {
                 ParquetAvroSortedBucketIO.read(new TupleTag<>("input"), AvroGeneratedUser.class)
                     .from(folder.toString())
                     .withConfiguration(conf)
-                    .withFilterPredicate(FilterApi.lt(FilterApi.intColumn("test"), 5))));
+                    .withFilterPredicate(FilterApi.lt(FilterApi.intColumn("test"), 5))
+                    .withProjection(projection)));
 
     SerializableUtils.ensureSerializable(
         SortedBucketIO.read(String.class)
@@ -57,7 +58,8 @@ public class ParquetAvroSortedBucketIOTest {
                         new TupleTag<>("input"), AvroGeneratedUser.getClassSchema())
                     .from(folder.toString())
                     .withConfiguration(conf)
-                    .withFilterPredicate(FilterApi.lt(FilterApi.intColumn("test"), 5))));
+                    .withFilterPredicate(FilterApi.lt(FilterApi.intColumn("test"), 5))
+                    .withProjection(projection)));
   }
 
   @Test


### PR DESCRIPTION
Support a `Schema` projection as a builder arg to `ParquetAvroSortedBucketIO.Read`.

Adding a new constructor arg to `ParquetAvroFileOperations` made the constructor overloading too complex, so I reworked it into a simple Builder pattern. I tried out AutoValue, but it's a pretty heavyweight solution... if anyone has a strong opinion on the Builder style i'm very open to it :) 