### PR TITLE
fix: set avro-dataum-factory in parameters

### DIFF
--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroIO.scala
@@ -26,12 +26,7 @@ import org.apache.avro.Schema
 import org.apache.avro.file.CodecFactory
 import org.apache.avro.generic.{GenericRecord, IndexedRecord}
 import org.apache.avro.specific.{SpecificData, SpecificRecord}
-import org.apache.beam.sdk.extensions.avro.io.{
-  AvroDatumFactory,
-  AvroIO => BAvroIO,
-  AvroSink,
-  AvroSource
-}
+import org.apache.beam.sdk.extensions.avro.io.{AvroDatumFactory, AvroIO => BAvroIO}
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/syntax/ScioContextSyntax.scala
@@ -108,8 +108,10 @@ final class ScioContextOps(private val self: ScioContext) extends AnyVal {
       GenericRecordParseIO.ReadParam.DefaultDatumFactory
   )(
     parseFn: GenericRecord => T
-  ): SCollection[T] =
-    self.read(GenericRecordParseIO[T](path, parseFn))(GenericRecordParseIO.ReadParam(suffix))
+  ): SCollection[T] = {
+    val param = GenericRecordParseIO.ReadParam(suffix, datumFactory)
+    self.read(GenericRecordParseIO[T](path, parseFn))(param)
+  }
 
   /**
    * Get an SCollection of type [[org.apache.avro.specific.SpecificRecord SpecificRecord]] for an


### PR DESCRIPTION
custom `datumFactory` was not propagated to the parameter class