### PR TITLE
Remove abstract getFileOperations from SortedBucketIO.Read

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
@@ -248,12 +248,10 @@ public class AvroSortedBucketIO {
     }
 
     @SuppressWarnings("unchecked")
-    @Override
     FileOperations<T> getFileOperations() {
       return getRecordClass() == null
-             ? (AvroFileOperations<T>) AvroFileOperations.of(getSchema())
-             : (AvroFileOperations<T>)
-                 AvroFileOperations.of((Class<SpecificRecord>) getRecordClass());
+          ? (AvroFileOperations<T>) AvroFileOperations.of(getSchema())
+          : (AvroFileOperations<T>) AvroFileOperations.of((Class<SpecificRecord>) getRecordClass());
     }
 
     @Override

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
@@ -156,7 +156,6 @@ public class JsonSortedBucketIO {
       return toBuilder().setPredicate(predicate).build();
     }
 
-    @Override
     FileOperations<TableRow> getFileOperations() {
       return JsonFileOperations.of(getCompression());
     }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
@@ -104,7 +104,8 @@ public class ParquetAvroFileOperations<ValueT> extends FileOperations<ValueT> {
 
   @Override
   protected Reader<ValueT> createReader() {
-    return new ParquetAvroReader<>(schemaSupplier, projectionSupplier, conf, predicate, recordClass);
+    return new ParquetAvroReader<>(
+        schemaSupplier, projectionSupplier, conf, predicate, recordClass);
   }
 
   @Override
@@ -163,10 +164,7 @@ public class ParquetAvroFileOperations<ValueT> extends FileOperations<ValueT> {
 
       if (recordClass == null && configuration.get(AvroReadSupport.AVRO_DATA_SUPPLIER) == null) {
         configuration.setClass(
-            AvroReadSupport.AVRO_DATA_SUPPLIER,
-            GenericDataSupplier.class,
-            AvroDataSupplier.class
-        );
+            AvroReadSupport.AVRO_DATA_SUPPLIER, GenericDataSupplier.class, AvroDataSupplier.class);
       }
 
       ParquetReader.Builder<ValueT> builder =

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroSortedBucketIO.java
@@ -286,15 +286,14 @@ public class ParquetAvroSortedBucketIO {
     @Override
     public BucketedInput<T> toBucketedInput(final SortedBucketSource.Keying keying) {
       return BucketedInput.of(
-        keying,
-        getTupleTag(),
-        getInputDirectories(),
-        getFilenameSuffix(),
-        getFileOperations(),
-        getPredicate());
+          keying,
+          getTupleTag(),
+          getInputDirectories(),
+          getFilenameSuffix(),
+          getFileOperations(),
+          getPredicate());
     }
 
-    @Override
     FileOperations<T> getFileOperations() {
       ParquetAvroFileOperations<T> fileOperations =
           getRecordClass() == null
@@ -302,9 +301,9 @@ public class ParquetAvroSortedBucketIO {
               : ParquetAvroFileOperations.of(getRecordClass());
 
       return fileOperations
-              .withFilterPredicate(getFilterPredicate())
-              .withProjection(getProjection())
-              .withConfiguration(getConfiguration());
+          .withFilterPredicate(getFilterPredicate())
+          .withProjection(getProjection())
+          .withConfiguration(getConfiguration());
     }
   }
 
@@ -564,9 +563,7 @@ public class ParquetAvroSortedBucketIO {
               ? (ParquetAvroFileOperations<T>) ParquetAvroFileOperations.of(getSchema())
               : ParquetAvroFileOperations.of(getRecordClass());
 
-      return fileOperations
-          .withConfiguration(getConfiguration())
-          .withCompression(getCompression());
+      return fileOperations.withConfiguration(getConfiguration()).withCompression(getCompression());
     }
 
     @Override

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -499,8 +499,6 @@ public class SortedBucketIO {
   public abstract static class Read<V> implements Serializable {
     public abstract TupleTag<V> getTupleTag();
 
-    abstract FileOperations<V> getFileOperations();    
-
     public abstract BucketedInput<V> toBucketedInput(SortedBucketSource.Keying keying);
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
@@ -169,12 +169,10 @@ public class TensorFlowBucketIO {
       return toBuilder().setPredicate(predicate).build();
     }
 
-    @Override
     FileOperations<Example> getFileOperations() {
       return TensorFlowFileOperations.of(getCompression());
     }
 
-    @Override
     public BucketedInput<Example> toBucketedInput(final SortedBucketSource.Keying keying) {
       return BucketedInput.of(
           keying,

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIO.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIO.scala
@@ -100,7 +100,7 @@ object ParquetTypeSortedBucketIO {
       )
     }
 
-    override def getFileOperations: FileOperations[T] =
+    def getFileOperations: FileOperations[T] =
       ParquetTypeFileOperations[T](filterPredicate, configuration)
   }
 


### PR DESCRIPTION
Fix refactoring mistake from https://github.com/spotify/scio/pull/5064 -- `getFileOperations` should not be specified as an abstract method in `SortedBucketIO.Read`, this breaks the ability of implementations to provide mixed file operations per input directory.