### PR TITLE
Convert SortMergeBucketExample to Parquet + update tests

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
@@ -78,6 +78,12 @@ object SortMergeBucketWriteExample {
   implicit val coder: Coder[GenericRecord] =
     avroGenericRecordCoder(SortMergeBucketExample.UserDataSchema)
 
+  def pipeline(cmdLineArgs: Array[String]): ScioContext = {
+    val (sc, args) = ContextAndArgs(cmdLineArgs)
+    pipeline(sc, args)
+    sc
+  }
+
   def pipeline(sc: ScioContext, args: Args): (ClosedTap[GenericRecord], ClosedTap[Account]) = {
     val userWriteTap = sc
       .parallelize(0 until 500)
@@ -147,8 +153,7 @@ object SortMergeBucketWriteExample {
   }
 
   def main(cmdLineArgs: Array[String]): Unit = {
-    val (sc, args) = ContextAndArgs(cmdLineArgs)
-    pipeline(sc, args)
+    val sc = pipeline(cmdLineArgs)
     sc.run().waitUntilDone()
     ()
   }
@@ -161,6 +166,12 @@ object SortMergeBucketJoinExample {
     avroGenericRecordCoder(SortMergeBucketExample.UserDataSchema)
 
   case class AccountProjection(id: Int, amount: Double)
+
+  def pipeline(cmdLineArgs: Array[String]): ScioContext = {
+    val (sc, args) = ContextAndArgs(cmdLineArgs)
+    pipeline(sc, args)
+    sc
+  }
 
   def pipeline(sc: ScioContext, args: Args): ClosedTap[String] = {
     // #SortMergeBucketExample_join
@@ -196,8 +207,7 @@ object SortMergeBucketJoinExample {
   }
 
   def main(cmdLineArgs: Array[String]): Unit = {
-    val (sc, args) = ContextAndArgs(cmdLineArgs)
-    pipeline(sc, args)
+    val sc = pipeline(cmdLineArgs)
     sc.run().waitUntilDone()
     ()
   }
@@ -209,6 +219,12 @@ object SortMergeBucketTransformExample {
   // ParquetTypeSortedBucketIO supports case class projections for reading and writing
   case class AccountProjection(id: Int, amount: Double)
   case class CombinedAccount(id: Int, age: Int, totalValue: Double)
+
+  def pipeline(cmdLineArgs: Array[String]): ScioContext = {
+    val (sc, args) = ContextAndArgs(cmdLineArgs)
+    pipeline(sc, args)
+    sc
+  }
 
   def pipeline(sc: ScioContext, args: Args): ClosedTap[CombinedAccount] = {
     implicit val coder: Coder[GenericRecord] = avroGenericRecordCoder(
@@ -259,8 +275,7 @@ object SortMergeBucketTransformExample {
   }
 
   def main(cmdLineArgs: Array[String]): Unit = {
-    val (sc, args) = ContextAndArgs(cmdLineArgs)
-    pipeline(sc, args)
+    val sc = pipeline(cmdLineArgs)
     sc.run().waitUntilDone()
     ()
   }

--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/SortMergeBucketExample.scala
@@ -19,23 +19,30 @@
 // Usage:
 
 // `sbt runMain "com.spotify.scio.examples.extra.SortMergeBucketWriteExample
-// --outputL=[OUTPUT]--outputR=[OUTPUT]"`
+// --users=[OUTPUT] --accounts=[OUTPUT]"`
 // `sbt runMain "com.spotify.scio.examples.extra.SortMergeBucketJoinExample
-// --inputL=[INPUT]--inputR=[INPUT] --output=[OUTPUT]"`
+// --users=[INPUT] --accounts=[INPUT] --output=[OUTPUT]"`
 // `sbt runMain "com.spotify.scio.examples.extra.SortMergeBucketTransformExample
-// --inputL=[INPUT]--inputR=[INPUT] --output=[OUTPUT]"`
+// --users=[INPUT] --accounts=[INPUT] --output=[OUTPUT]"`
 package com.spotify.scio.examples.extra
 
 import com.spotify.scio.{Args, ContextAndArgs, ScioContext}
 import com.spotify.scio.avro._
 import com.spotify.scio.coders.Coder
+import com.spotify.scio.io.ClosedTap
+import com.spotify.scio.parquet.ParquetConfiguration
 import com.spotify.scio.values.SCollection
-import org.apache.avro.Schema
-import org.apache.avro.file.CodecFactory
+import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType
-import org.apache.beam.sdk.extensions.smb.{AvroSortedBucketIO, TargetParallelism}
+import org.apache.beam.sdk.extensions.smb.{
+  ParquetAvroSortedBucketIO,
+  ParquetTypeSortedBucketIO,
+  TargetParallelism
+}
 import org.apache.beam.sdk.values.TupleTag
+import org.apache.parquet.filter2.predicate.FilterApi
+import org.apache.parquet.hadoop.ParquetOutputFormat
 
 import scala.util.Random
 
@@ -49,7 +56,7 @@ object SortMergeBucketExample {
       |    "fields": [
       |        {
       |            "name": "userId",
-      |            "type": ["null", {"type": "string", "avro.java.string": "String"}]
+      |            "type": "int"
       |        },
       |        {
       |          "name": "age", "type": "int"
@@ -58,10 +65,11 @@ object SortMergeBucketExample {
       |""".stripMargin
   )
 
-  def user(id: String, age: Int): GenericRecord = new GenericRecordBuilder(UserDataSchema)
-    .set("userId", id)
-    .set("age", age)
-    .build()
+  def user(id: Int, age: Int): GenericRecord =
+    new GenericRecordBuilder(UserDataSchema)
+      .set("userId", id)
+      .set("age", age)
+      .build()
 }
 
 object SortMergeBucketWriteExample {
@@ -70,17 +78,15 @@ object SortMergeBucketWriteExample {
   implicit val coder: Coder[GenericRecord] =
     avroGenericRecordCoder(SortMergeBucketExample.UserDataSchema)
 
-  def pipeline(cmdLineArgs: Array[String]): ScioContext = {
-    val (sc, args) = ContextAndArgs(cmdLineArgs)
-
-    sc.parallelize(0 until 500)
-      .map(i => SortMergeBucketExample.user(i.toString, i % 100))
+  def pipeline(sc: ScioContext, args: Args): (ClosedTap[GenericRecord], ClosedTap[Account]) = {
+    val userWriteTap = sc
+      .parallelize(0 until 500)
+      .map(i => SortMergeBucketExample.user(i % 100, i % 100))
       .saveAsSortedBucket(
-        AvroSortedBucketIO
-          .write(classOf[String], "userId", SortMergeBucketExample.UserDataSchema)
+        ParquetAvroSortedBucketIO
+          .write(classOf[Integer], "userId", SortMergeBucketExample.UserDataSchema)
           .to(args("users"))
           .withTempDirectory(sc.options.getTempLocation)
-          .withCodec(CodecFactory.snappyCodec())
           .withHashType(HashType.MURMUR3_32)
           .withFilenamePrefix("example-prefix")
           .withNumBuckets(2)
@@ -88,30 +94,34 @@ object SortMergeBucketWriteExample {
       )
 
     // #SortMergeBucketExample_sink
-    sc.parallelize(250 until 750)
+    val accountWriteTap = sc
+      .parallelize(250 until 750)
       .map { i =>
         Account
           .newBuilder()
-          .setId(i)
-          .setName(i.toString)
+          .setId(i % 100)
+          .setName(s"name$i")
           .setType(s"type${i % 5}")
           .setAmount(Random.nextDouble() * 1000)
           .build()
       }
       .saveAsSortedBucket(
-        AvroSortedBucketIO
-          .write[String, Account](classOf[String], "name", classOf[Account])
+        ParquetAvroSortedBucketIO
+          .write[Integer, Account](classOf[Integer], "id", classOf[Account])
           .to(args("accounts"))
           .withSorterMemoryMb(128)
           .withTempDirectory(sc.options.getTempLocation)
-          .withCodec(CodecFactory.snappyCodec())
+          .withConfiguration(
+            ParquetConfiguration.of(ParquetOutputFormat.BLOCK_SIZE -> 512 * 1024 * 1024)
+          )
           .withHashType(HashType.MURMUR3_32)
           .withFilenamePrefix("part") // Default is "bucket"
           .withNumBuckets(1)
           .withNumShards(1)
       )
     // #SortMergeBucketExample_sink
-    sc
+
+    (userWriteTap, accountWriteTap)
   }
 
   def secondaryKeyExample(
@@ -121,11 +131,11 @@ object SortMergeBucketWriteExample {
     in
       // #SortMergeBucketExample_sink_secondary
       .saveAsSortedBucket(
-        AvroSortedBucketIO
-          .write[String, String, Account](
+        ParquetAvroSortedBucketIO
+          .write[Integer, String, Account](
             // primary key class and field
-            classOf[String],
-            "name",
+            classOf[Integer],
+            "id",
             // secondary key class and field
             classOf[String],
             "type",
@@ -137,8 +147,10 @@ object SortMergeBucketWriteExample {
   }
 
   def main(cmdLineArgs: Array[String]): Unit = {
-    val sc = pipeline(cmdLineArgs)
+    val (sc, args) = ContextAndArgs(cmdLineArgs)
+    pipeline(sc, args)
     sc.run().waitUntilDone()
+    ()
   }
 }
 
@@ -148,40 +160,42 @@ object SortMergeBucketJoinExample {
   implicit val coder: Coder[GenericRecord] =
     avroGenericRecordCoder(SortMergeBucketExample.UserDataSchema)
 
-  case class UserAccountData(userId: String, age: Int, balance: Double) {
-    override def toString: String = s"$userId\t$age\t$balance"
-  }
+  case class AccountProjection(id: Int, amount: Double)
 
-  def pipeline(cmdLineArgs: Array[String]): ScioContext = {
-    val (sc, args) = ContextAndArgs(cmdLineArgs)
-
-    val mapFn: ((String, (GenericRecord, Account))) => UserAccountData = {
-      case (userId, (userData, account)) =>
-        UserAccountData(userId, userData.get("age").toString.toInt, account.getAmount)
-    }
-
+  def pipeline(sc: ScioContext, args: Args): ClosedTap[String] = {
     // #SortMergeBucketExample_join
     sc.sortMergeJoin(
-      classOf[String],
-      AvroSortedBucketIO
-        .read(new TupleTag[GenericRecord]("lhs"), SortMergeBucketExample.UserDataSchema)
-        // 1. Only 1 user per user ID
-        // 2. Out of key intersection 250-499, only 100 (300-349, 400-499) with age < 50
-        .withPredicate((xs, x) => xs.size() == 0 && x.get("age").asInstanceOf[Int] < 50)
+      classOf[Integer],
+      ParquetAvroSortedBucketIO
+        .read(new TupleTag[GenericRecord](), SortMergeBucketExample.UserDataSchema)
+        .withProjection(
+          SchemaBuilder
+            .record("UserProjection")
+            .fields
+            .requiredInt("userId")
+            .requiredInt("age")
+            .endRecord
+        )
+        // Filter at the Parquet IO level to users under 50
+        .withFilterPredicate(FilterApi.lt(FilterApi.intColumn("age"), Int.box(50)))
+        // Filter at the SMB Cogrouping level to a single record per uesr
+        .withPredicate((xs, _) => xs.size() == 0)
         .from(args("users")),
-      AvroSortedBucketIO
-        .read(new TupleTag[Account]("rhs"), classOf[Account])
+      ParquetTypeSortedBucketIO
+        .read(new TupleTag[AccountProjection]())
         .from(args("accounts")),
       TargetParallelism.max()
-    ).map(mapFn) // Apply mapping function
+    ).map { case (_, (userData, account)) =>
+      (userData.get("age").asInstanceOf[Int], account.amount)
+    }.groupByKey
+      .mapValues(amounts => amounts.sum / amounts.size)
       .saveAsTextFile(args("output"))
     // #SortMergeBucketExample_join
-
-    sc
   }
 
   def main(cmdLineArgs: Array[String]): Unit = {
-    val sc = pipeline(cmdLineArgs)
+    val (sc, args) = ContextAndArgs(cmdLineArgs)
+    pipeline(sc, args)
     sc.run().waitUntilDone()
     ()
   }
@@ -190,48 +204,38 @@ object SortMergeBucketJoinExample {
 object SortMergeBucketTransformExample {
   import com.spotify.scio.smb._
 
-  def pipeline(cmdLineArgs: Array[String]): ScioContext = {
-    val (sc, args) = ContextAndArgs(cmdLineArgs)
+  case class AccountProjection(id: Int, amount: Double)
+  case class CombinedAccount(id: Int, age: Int, totalValue: Double)
 
-    implicit val coderUserData: Coder[GenericRecord] =
-      avroGenericRecordCoder(SortMergeBucketExample.UserDataSchema)
-    implicit val coderAccount: Coder[Account] =
-      avroSpecificRecordCoder
-
-    // #SortMergeBucketExample_transform
-    val (readLhs, readRhs) = (
-      AvroSortedBucketIO
-        .read(new TupleTag[GenericRecord]("lhs"), SortMergeBucketExample.UserDataSchema)
-        .from(args("users")),
-      AvroSortedBucketIO
-        .read(new TupleTag[Account]("rhs"), classOf[Account])
-        .from(args("accounts"))
+  def pipeline(sc: ScioContext, args: Args): ClosedTap[CombinedAccount] = {
+    implicit val coder: Coder[GenericRecord] = avroGenericRecordCoder(
+      SortMergeBucketExample.UserDataSchema
     )
 
+    // #SortMergeBucketExample_transform
     sc.sortMergeTransform(
-      classOf[String],
-      readLhs,
-      readRhs,
+      classOf[Integer],
+      ParquetAvroSortedBucketIO
+        .read(new TupleTag[GenericRecord](), SortMergeBucketExample.UserDataSchema)
+        .withFilterPredicate(FilterApi.lt(FilterApi.intColumn("age"), Int.box(50)))
+        .from(args("users")),
+      ParquetTypeSortedBucketIO
+        .read(new TupleTag[AccountProjection]())
+        .from(args("accounts")),
       TargetParallelism.auto()
     ).to(
-      AvroSortedBucketIO
-        .transformOutput(classOf[String], "name", classOf[Account])
+      ParquetTypeSortedBucketIO
+        .transformOutput[Integer, CombinedAccount]("id")
         .to(args("output"))
     ).via { case (key, (users, accounts), outputCollector) =>
-      users.foreach { _ =>
+      val sum = accounts.map(_.amount).sum
+      users.foreach { user =>
         outputCollector.accept(
-          Account
-            .newBuilder()
-            .setId(key.toInt)
-            .setName(key)
-            .setType("combinedAmount")
-            .setAmount(accounts.foldLeft(0.0)(_ + _.getAmount))
-            .build()
+          CombinedAccount(key, user.get("age").asInstanceOf[Integer], sum)
         )
       }
     }
     // #SortMergeBucketExample_transform
-    sc
   }
 
   def secondaryReadExample(cmdLineArgs: Array[String]): Unit = {
@@ -241,7 +245,7 @@ object SortMergeBucketTransformExample {
     sc.sortMergeGroupByKey(
       classOf[String], // primary key class
       classOf[String], // secondary key class
-      AvroSortedBucketIO
+      ParquetAvroSortedBucketIO
         .read(new TupleTag[Account]("account"), classOf[Account])
         .from(args("accounts"))
     ).map { case ((primaryKey, secondaryKey), elements) =>
@@ -251,7 +255,8 @@ object SortMergeBucketTransformExample {
   }
 
   def main(cmdLineArgs: Array[String]): Unit = {
-    val sc = pipeline(cmdLineArgs)
+    val (sc, args) = ContextAndArgs(cmdLineArgs)
+    pipeline(sc, args)
     sc.run().waitUntilDone()
     ()
   }

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/SortMergeBucketExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/SortMergeBucketExampleTest.scala
@@ -21,7 +21,8 @@ import com.spotify.scio.ContextAndArgs
 
 import java.io.File
 import java.nio.file.Files
-import com.spotify.scio.avro.Account
+import com.spotify.scio.avro._
+import com.spotify.scio.coders.Coder
 import com.spotify.scio.examples.extra.SortMergeBucketJoinExample.AccountProjection
 import com.spotify.scio.examples.extra.SortMergeBucketTransformExample.CombinedAccount
 import com.spotify.scio.io.TextIO
@@ -87,6 +88,9 @@ class SortMergeBucketExampleTest extends PipelineSpec {
   }
 
   "SortMergeBucketJoinExample" should "work with JobTest" in {
+    implicit val coder: Coder[GenericRecord] =
+      avroGenericRecordCoder(SortMergeBucketExample.UserDataSchema)
+
     val userInput = (0 until 200)
       .map(i => SortMergeBucketExample.user(i, i % 100))
     val accountInput = (25 until 225)
@@ -140,6 +144,9 @@ class SortMergeBucketExampleTest extends PipelineSpec {
   }
 
   "SortMergeBucketTransformExample" should "work with JobTest" in {
+    implicit val coder: Coder[GenericRecord] =
+      avroGenericRecordCoder(SortMergeBucketExample.UserDataSchema)
+
     val userInput = (0 until 100)
       .map(i => SortMergeBucketExample.user(i, i % 100))
     val accountInput = (100 until 300)

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/SortMergeBucketExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/SortMergeBucketExampleTest.scala
@@ -31,7 +31,7 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.beam.sdk.extensions.smb.BucketMetadata
 import org.apache.beam.sdk.io.fs.ResourceId
 import org.apache.beam.sdk.io.{FileSystems, LocalResources}
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Supplier
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Supplier
 
 import java.nio.channels.Channels
 import java.util.UUID
@@ -77,6 +77,7 @@ class SortMergeBucketExampleTest extends PipelineSpec {
     // Inspect metadata on real written files
     def getMetadataPath(smbDir: File): ResourceId =
       LocalResources.fromFile(smbDir.toPath.resolve("metadata.json").toFile, false)
+
     BucketMetadata
       .from(Channels.newInputStream(FileSystems.open(getMetadataPath(userDir))))
       .getNumBuckets shouldBe 2

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/extra/SortMergeBucketExampleTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/extra/SortMergeBucketExampleTest.scala
@@ -17,82 +17,182 @@
 
 package com.spotify.scio.examples.extra
 
+import com.spotify.scio.ContextAndArgs
+
 import java.io.File
 import java.nio.file.Files
-import com.spotify.scio.avro.{Account, AvroIO, GenericRecordTap, SpecificRecordTap}
-import com.spotify.scio.io.{TextIO, TextTap}
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.flatspec.AnyFlatSpec
+import com.spotify.scio.avro.Account
+import com.spotify.scio.examples.extra.SortMergeBucketJoinExample.AccountProjection
+import com.spotify.scio.examples.extra.SortMergeBucketTransformExample.CombinedAccount
+import com.spotify.scio.io.TextIO
+import com.spotify.scio.smb.SmbIO
+import com.spotify.scio.testing.PipelineSpec
+import org.apache.avro.generic.GenericRecord
+import org.apache.beam.sdk.extensions.smb.BucketMetadata
+import org.apache.beam.sdk.io.fs.ResourceId
+import org.apache.beam.sdk.io.{FileSystems, LocalResources}
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Supplier
 
-class SortMergeBucketExampleTest extends AnyFlatSpec with Matchers {
-  def withTempFolders(testCode: (File, File, File) => Unit): Unit = {
+import java.nio.channels.Channels
+import java.util.UUID
+
+class SortMergeBucketExampleTest extends PipelineSpec {
+  private def withTempFolders(testCode: Supplier[File] => Unit): Unit = {
     val tempFolder = Files.createTempDirectory("smb")
     tempFolder.toFile.deleteOnExit()
 
-    testCode(
-      tempFolder.resolve("userData").toFile,
-      tempFolder.resolve("accountData").toFile,
-      tempFolder.resolve("joinOutput").toFile
+    testCode(() => tempFolder.resolve(UUID.randomUUID().toString).toFile)
+  }
+
+  "SortMergeBucketWriteExample" should "work with JobTest" in {
+    JobTest[SortMergeBucketWriteExample.type]
+      .args("--users=gs://users", "--accounts=gs://accounts")
+      .output(SmbIO[Int, GenericRecord]("gs://users", _.get("userId").asInstanceOf[Int]))(
+        _ should haveSize(500)
+      )
+      .output(SmbIO[Int, AccountProjection]("gs://accounts", _.id))(_ should haveSize(500))
+      .run()
+  }
+
+  it should "work with Taps" in withTempFolders { tmpDirSupplier =>
+    val (userDir, accountDir) = (tmpDirSupplier.get(), tmpDirSupplier.get())
+
+    val (sc, args) = ContextAndArgs(Array(s"--users=$userDir", s"--accounts=$accountDir"))
+    val (userTap, accountTap) = SortMergeBucketWriteExample.pipeline(sc, args)
+    val writeResult = sc.run().waitUntilDone()
+
+    // Open Taps and assert on Iterator output
+    userTap
+      .get(writeResult)
+      .value
+      .map(_.get("userId").asInstanceOf[Integer])
+      .toSeq should contain theSameElementsAs (0 until 500).map(i => i % 100)
+
+    accountTap
+      .get(writeResult)
+      .value
+      .map(_.getId)
+      .toSeq should contain theSameElementsAs (250 until 750).map(i => i % 100)
+
+    // Inspect metadata on real written files
+    def getMetadataPath(smbDir: File): ResourceId =
+      LocalResources.fromFile(smbDir.toPath.resolve("metadata.json").toFile, false)
+    BucketMetadata
+      .from(Channels.newInputStream(FileSystems.open(getMetadataPath(userDir))))
+      .getNumBuckets shouldBe 2
+    BucketMetadata
+      .from(Channels.newInputStream(FileSystems.open(getMetadataPath(accountDir))))
+      .getNumBuckets shouldBe 1
+  }
+
+  "SortMergeBucketJoinExample" should "work with JobTest" in {
+    val userInput = (0 until 200)
+      .map(i => SortMergeBucketExample.user(i, i % 100))
+    val accountInput = (25 until 225)
+      .map(i => AccountProjection(i, i * 10.0d))
+
+    val expectedOutput = (0 until 200)
+      .flatMap { userId =>
+        for {
+          user <- userInput.filter(_.get("userId").asInstanceOf[Int] == userId)
+          account <- accountInput.filter(_.id == userId)
+        } yield (user.get("age").asInstanceOf[Integer], account.amount)
+      }
+      .groupBy(_._1)
+      .map { case (age, grped) =>
+        val amounts = grped.map(_._2)
+        (age, amounts.sum / amounts.size) // Compute average account value per age
+      }
+
+    JobTest[SortMergeBucketJoinExample.type]
+      .args("--users=gs://users", "--accounts=gs://accounts", "--output=gs://output")
+      .input(
+        SmbIO[Integer, GenericRecord]("gs://users", _.get("userId").asInstanceOf[Integer]),
+        userInput
+      )
+      .input(SmbIO[Int, AccountProjection]("gs://accounts", _.id), accountInput)
+      .output(TextIO("gs://output"))(_ should containInAnyOrder(expectedOutput.map(_.toString)))
+      .run()
+  }
+
+  it should "work with Taps" in withTempFolders { tmpDirSupplier =>
+    val (userDir, accountDir) = (tmpDirSupplier.get(), tmpDirSupplier.get())
+
+    // Write local data
+    {
+      val (writeSc, writeArgs) =
+        ContextAndArgs(Array(s"--users=$userDir", s"--accounts=$accountDir"))
+      SortMergeBucketWriteExample.pipeline(writeSc, writeArgs)
+      writeSc.run().waitUntilDone()
+    }
+
+    // Run SortMergeBucketJoinExample and assert on tapped output
+    val joinOutput = tmpDirSupplier.get()
+
+    val (sc, args) =
+      ContextAndArgs(Array(s"--users=$userDir", s"--accounts=$accountDir", s"--output=$joinOutput"))
+    val tap = SortMergeBucketJoinExample.pipeline(sc, args)
+    val result = sc.run().waitUntilDone()
+
+    val joinedSmbData = tap.get(result).value
+    joinedSmbData should have size 50
+  }
+
+  "SortMergeBucketTransformExample" should "work with JobTest" in {
+    val userInput = (0 until 100)
+      .map(i => SortMergeBucketExample.user(i, i % 100))
+    val accountInput = (100 until 300)
+      .map(i => AccountProjection(i, i * 10.0d))
+
+    val expectedOutput = (0 until 200)
+      .flatMap { userId =>
+        for {
+          user <- userInput.filter(_.get("userId").asInstanceOf[Integer] == userId)
+          account <- accountInput.filter(_.id == userId)
+        } yield (
+          (userId.asInstanceOf[Integer], user.get("age").asInstanceOf[Integer]),
+          account.amount
+        )
+      }
+      .groupBy(_._1)
+      .map { case ((userId, age), grped) => CombinedAccount(userId, age, grped.map(_._2).sum) }
+
+    JobTest[SortMergeBucketTransformExample.type]
+      .args("--users=gs://users", "--accounts=gs://accounts", "--output=gs://output")
+      .input(
+        SmbIO[Integer, GenericRecord]("gs://users", _.get("userId").asInstanceOf[Integer]),
+        userInput
+      )
+      .input(SmbIO[Integer, AccountProjection]("gs://accounts", _.id), accountInput)
+      .output(SmbIO[Integer, SortMergeBucketTransformExample.CombinedAccount]("gs://output", _.id))(
+        _ should containInAnyOrder(expectedOutput)
+      )
+      .run()
+  }
+
+  it should "work with Taps" in withTempFolders { tmpDirSupplier =>
+    val (userDir, accountDir) = (tmpDirSupplier.get(), tmpDirSupplier.get())
+
+    // Write local data
+    {
+      val (writeSc, writeArgs) =
+        ContextAndArgs(Array(s"--users=$userDir", s"--accounts=$accountDir"))
+      SortMergeBucketWriteExample.pipeline(writeSc, writeArgs)
+      writeSc.run().waitUntilDone()
+    }
+
+    // Run SortMergeBucketTransformExample and assert on tapped output
+    val transformOutput = tmpDirSupplier.get()
+
+    val (sc, args) = ContextAndArgs(
+      Array(s"--users=$userDir", s"--accounts=$accountDir", s"--output=${transformOutput}")
     )
-  }
+    val tap = SortMergeBucketTransformExample.pipeline(sc, args)
+    val result = sc.run().waitUntilDone()
 
-  "SortMergeBucketExample" should "join user and account data" in withTempFolders {
-    (userDir, accountDir, joinOutputDir) =>
-      SortMergeBucketWriteExample.main(
-        Array(
-          s"--users=$userDir",
-          s"--accounts=$accountDir"
-        )
-      )
-
-      GenericRecordTap(
-        path = userDir.getAbsolutePath,
-        schema = SortMergeBucketExample.UserDataSchema,
-        params = AvroIO.ReadParam(".avro")
-      ).value.size shouldBe 500
-
-      SpecificRecordTap[Account](
-        path = accountDir.getAbsolutePath,
-        params = AvroIO.ReadParam(".avro")
-      ).value.size shouldBe 500
-
-      SortMergeBucketJoinExample.main(
-        Array(
-          s"--users=$userDir",
-          s"--accounts=$accountDir",
-          s"--output=$joinOutputDir"
-        )
-      )
-
-      TextTap(
-        path = joinOutputDir.getAbsolutePath,
-        params = TextIO.ReadParam(suffix = ".txt")
-      ).value.size shouldBe 100
-  }
-
-  it should "transform user and account data" in withTempFolders {
-    (userDir, accountDir, joinOutputDir) =>
-      SortMergeBucketWriteExample.main(
-        Array(
-          s"--users=$userDir",
-          s"--accounts=$accountDir"
-        )
-      )
-
-      SortMergeBucketTransformExample.main(
-        Array(
-          s"--users=$userDir",
-          s"--accounts=$accountDir",
-          s"--output=$joinOutputDir"
-        )
-      )
-
-      SpecificRecordTap[Account](
-        joinOutputDir.getAbsolutePath,
-        AvroIO.ReadParam(".avro")
-      ).value
-        .map(account => (account.getId, account.getType.toString))
-        .toList should contain theSameElementsAs (0 until 500).map((_, "combinedAmount"))
-      ()
+    val transformedSmbData = tap.get(result).value
+    transformedSmbData should have size 250
+    // Assert that Parquet FilterPredicate was applied
+    assert(transformedSmbData.forall(r => r.age < 50))
   }
 }

--- a/site/src/main/paradox/extras/Sort-Merge-Bucket.md
+++ b/site/src/main/paradox/extras/Sort-Merge-Bucket.md
@@ -355,7 +355,7 @@ class SmbJobTest extends PipelineSpec {
         val smbInput: Seq[Account] = ???
         
         JobTest[SmbJob.type]
-              .args("--input=gs://input", "--output=gs://output", "--transformInput=gs://tfxInput")
+              .args("--input=gs://input", "--output=gs://output")
              
               // Mock .sortMergeGroupByKey
               .input(SmbIO[Int, Account]("gs://input", _.getId), smbInput)
@@ -371,7 +371,7 @@ class SmbJobTest extends PipelineSpec {
 
 SMB Transforms can be mocked by combing input and output `SmbIO`s:
 
-```scala mdoc compile:only
+```scala mdoc:compile-only
 // Scio job
 object SmbTransformJob {
     def main(cmdLineArgs: Array[String]): Unit = {

--- a/site/src/main/paradox/extras/Sort-Merge-Bucket.md
+++ b/site/src/main/paradox/extras/Sort-Merge-Bucket.md
@@ -333,7 +333,7 @@ object SmbJob {
         
         // Write
         val writeData: SCollection[Account] = ???
-        val write = writeData.saveAsSortedBucket(
+        writeData.saveAsSortedBucket(
             ParquetAvroSortedBucketIO
               .write(classOf[Integer], "id", classOf[Account])
               .to(args("output"))
@@ -369,7 +369,7 @@ class SmbJobTest extends PipelineSpec {
 }
 ```
 
-SMB Transforms can be mocked by combing input and output `SmbIO`s:
+SMB Transforms can be mocked by combining input and output `SmbIO`s:
 
 ```scala mdoc:compile-only
 // Scio job

--- a/site/src/main/paradox/extras/Sort-Merge-Bucket.md
+++ b/site/src/main/paradox/extras/Sort-Merge-Bucket.md
@@ -459,7 +459,8 @@ class SmbLocalFilesTest extends PipelineSpec {
         val dir = Files.createTempDirectory("smb").toString
         
         // Test write
-        runWithContext { sc =>
+        {
+            val sc = ScioContext()
             val tap = SmbRealFilesJob.write(sc, dir)
             val scioResult = sc.run().waitUntilDone()
         
@@ -471,7 +472,8 @@ class SmbLocalFilesTest extends PipelineSpec {
         }
         
         // Test read in separate ScioContext
-        runWithContext { sc =>
+        {
+            val sc = ScioContext()
             val tap = SmbRealFilesJob.read(sc, dir).materialize
             val scioResult = sc.run().waitUntilDone()
         


### PR DESCRIPTION
Updates SortMergeBucketExample to use Parquet writes (both typed and Avro) and demonstrate features like FilterPredicates, Projections, and Configurations. Also updates the unit tests to demonstrate the new `SmbIO` functionality as well as the smb-write Tap functionality.

Todo:

- [ ] Update documentation to explain new testing methods and when to use JobTest vs SMB taps.