### PR TITLE
(fix #5067) Drop Java 8 Targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Scio 0.3.0 and future versions depend on Apache Beam (`org.apache.beam`) while e
 
 # Quick Start
 
-Download and install the [Java Development Kit (JDK)](https://adoptopenjdk.net/index.html) version 8.
+Download and install the Java Development Kit (JDK) version 11 or higher,
+eg. [adoptium](https://adoptium.net/index.html) or [corretto](https://aws.amazon.com/corretto/).
 
 Install [sbt](https://www.scala-sbt.org/1.x/docs/Setup.html).
 

--- a/build.sbt
+++ b/build.sbt
@@ -221,7 +221,7 @@ val scala212 = "2.12.18"
 val scalaDefault = scala213
 
 // compiler settings
-ThisBuild / tlJdkRelease := Some(8)
+ThisBuild / tlJdkRelease := Some(11)
 ThisBuild / tlFatalWarnings := false
 ThisBuild / scalaVersion := scalaDefault
 ThisBuild / crossScalaVersions := Seq(scalaDefault, scala212)

--- a/site/src/main/paradox/FAQ.md
+++ b/site/src/main/paradox/FAQ.md
@@ -484,7 +484,7 @@ If you encounter an SBT error with message "Initial heap size set to a larger va
 
 You might get an error message like `java.io.IOException: Unable to create parent directories of /Applications/IntelliJ IDEA CE.app/Contents/bin/.bigquery/012345abcdef.schema.json`. This usually happens to people who run IntelliJ IDEA with its bundled JVM. There are two solutions.
 
-- Install JDK from [java.com](https://www.java.com/) and switch to it by following the "All platforms: switch between installed runtimes" section in this [page](https://intellij-support.jetbrains.com/hc/en-us/articles/206544879-Selecting-the-JDK-version-the-IDE-will-run-under).
+- Install JDK from a vendor like [adoptium](https://adoptium.net/index.html) or [corretto](https://aws.amazon.com/corretto/) and switch to it by following the "All platforms: switch between installed runtimes" section in this [page](https://intellij-support.jetbrains.com/hc/en-us/articles/206544879-Selecting-the-JDK-version-the-IDE-will-run-under).
 - Override the bigquery `.cache` directory as a JVM compiler parameter. On the bottom right of the IntelliJ window, click the icon that looks like a clock, and then "Configure...". Then, edit the JVM parameters to include the line `-Dbigquery.cache.directory=</path/to/repository>/.bigquery`. Then, restart the compile server by clicking on the clock icon -> Stop, and then Start.
 
 #### How to make IntelliJ IDEA work with type safe BigQuery classes?


### PR DESCRIPTION
Fix #5067

Testing: Checked javac/scalacOptions

```sbt
% sbt "show javacOptions"
...
[info] 	List(-deprecation, -encoding, UTF-8, -feature, -unchecked, -Wextra-implicit, -Wnumeric-widen, -Wunused, -Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit, -Wconf:cat=scala3-migration:s, -Ybackend-parallelism, 10, -language:_, -release, 11, -Ydelambdafy:inline, -Wconf:cat=deprecation&origin=scala\..*&since>2.12.99:s,cat=unused-imports&origin=scala\.collection\.compat\..*:s,cat=unused-imports&origin=kantan\.codecs\.compat\..*:s,cat=unused-imports&origin=com\.spotify\.scio\.repl\.compat\..*:s,cat=unused:e, -Wmacros:after, -Ymacro-annotations, -Xmacro-settings:show-coder-fallback=true)


% sbt "show scalacOptions"
[info] javacOptions
...
[info] 	List(-encoding, utf8, --release, 11)
```