### PR TITLE
Use non-deprecated version of murmur3_32

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -222,7 +222,7 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
     MURMUR3_32 {
       @Override
       public HashFunction create() {
-        return Hashing.murmur3_32();
+        return Hashing.murmur3_32_fixed();
       }
     },
     MURMUR3_128 {


### PR DESCRIPTION
This doesn't have any impact on users relying on this since we don't leverage the affect hashing method.

https://github.com/google/guava/commit/a36f08fe312ec16ad86b9206290929f0686d3b02