### PR TITLE
Add SortedBucketTransform counter for records written

### DIFF
--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
@@ -323,7 +323,8 @@ public class SortedBucketTransformTest {
     SortedBucketSourceTest.verifyMetrics(
         result,
         ImmutableMap.of(
-            "SortedBucketTransform-KeyGroupSize", DistributionResult.create(9, 7, 1, 2)));
+            "SortedBucketTransform-KeyGroupSize", DistributionResult.create(9, 7, 1, 2)),
+        ImmutableMap.of("SortedBucketTransform-RecordsWritten", 2L));
   }
 
   private static KV<TestBucketMetadata, Map<BucketShardId, List<String>>> readAllFrom(


### PR DESCRIPTION
tested on SortMergeBucketExample:

<img width="1020" alt="Screenshot 2024-01-31 at 2 33 46 PM" src="https://github.com/spotify/scio/assets/1360529/c15a691c-baa8-480c-a71c-a6d1cd9de288">
