### PR TITLE
Fix Scalafix rule for Avro package import

### DIFF
--- a/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder10.scala
+++ b/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder10.scala
@@ -1,0 +1,19 @@
+/*
+rule = FixAvroCoder
+ */
+package fix.v0_14_0
+
+import com.spotify.scio.avro._
+import com.spotify.scio.io.TextIO
+import com.spotify.scio.testing.PipelineSpec
+
+object FixAvroCoder10 extends PipelineSpec {
+  object SomeScioJob {
+    def main(args: Array[String]): Unit = ???
+  }
+
+  JobTest[SomeScioJob.type]
+    .input(TextIO("a"), Seq())
+    .input(AvroIO[A]("b"), Seq())
+    .input(TextIO("c"), Seq())
+}

--- a/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder10.scala
+++ b/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder10.scala
@@ -1,0 +1,16 @@
+package fix.v0_14_0
+
+import com.spotify.scio.avro._
+import com.spotify.scio.io.TextIO
+import com.spotify.scio.testing.PipelineSpec
+
+object FixAvroCoder10 extends PipelineSpec {
+  object SomeScioJob {
+    def main(args: Array[String]): Unit = ???
+  }
+
+  JobTest[SomeScioJob.type]
+    .input(TextIO("a"), Seq())
+    .input(AvroIO[A]("b"), Seq())
+    .input(TextIO("c"), Seq())
+}

--- a/scalafix/rules/src/main/scala/fix/v0_14_0/FixAvroCoder.scala
+++ b/scalafix/rules/src/main/scala/fix/v0_14_0/FixAvroCoder.scala
@@ -159,7 +159,12 @@ class FixAvroCoder extends SemanticRule("FixAvroCoder") {
             Patch.removeImportee(i) + Patch.addGlobalImport(avroImport)
         }.asPatch
       case importer"com.spotify.scio.avro.{..$imps}" =>
-        imps.map(i => Patch.removeImportee(i) + Patch.addGlobalImport(avroImport)).asPatch
+        imps
+          .filterNot {
+            case importee"_" => true
+            case _ => false
+          }
+          .map(i => Patch.removeImportee(i) + Patch.addGlobalImport(avroImport)).asPatch
       case t @ q"$obj.$fn" if AvroCoderMatcher.matches(fn.symbol) =>
         // fix direct usage of Coder.avro*
         Patch.replaceTree(t, q"$fn".syntax) + Patch.addGlobalImport(avroImport)


### PR DESCRIPTION
Existing `com.spotify.scio.avro._` imports were being removed.