### PR TITLE
Sort Path IDs in SmbIO

### DIFF
--- a/scio-smb/src/main/scala/com/spotify/scio/smb/SmbIO.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/SmbIO.scala
@@ -41,7 +41,7 @@ object SmbIO {
     new SmbIO[K, T](path, keyBy)
 
   def testId(paths: String*): String = {
-    val normalizedPaths = paths.map(p => ScioUtil.strippedPath(p) + "/").mkString(",")
+    val normalizedPaths = paths.map(p => ScioUtil.strippedPath(p) + "/").sorted.mkString(",")
     s"SmbIO($normalizedPaths)"
   }
 


### PR DESCRIPTION
when a partitioned SMB input's paths are read using `args.list(..)`, they don't always result in a deterministic SmbIO name