### PR TITLE
Make sure Coder.gen produces informative error

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -228,8 +228,8 @@ object Coder
 }
 
 trait LowPriorityCoders { self: CoderDerivation with JavaBeanCoders =>
-  implicit override def javaBeanCoder[T: IsJavaBean: ClassTag]: Coder[T] = JavaCoders.javaBeanCoder
-  implicit override def gen[T]: Coder[T] = macro MagnoliaMacros.genWithoutAnnotations[T]
+  implicit def javaBeanCoderImplicit[T: IsJavaBean: ClassTag]: Coder[T] = javaBeanCoder
+  implicit def genImplicit[T]: Coder[T] = macro MagnoliaMacros.genWithoutAnnotations[T]
 }
 
 private[coders] object CoderStackTrace {

--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -21,7 +21,6 @@ import com.spotify.scio.{IsJavaBean, MagnoliaMacros}
 import com.spotify.scio.coders.instances._
 import org.apache.beam.sdk.coders.{Coder => BCoder}
 import org.apache.beam.sdk.values.KV
-import org.typelevel.scalaccompat.annotation.unused
 
 import scala.annotation.implicitNotFound
 import scala.reflect.ClassTag
@@ -222,14 +221,11 @@ object Coder
     with LowPriorityCoders {
   @inline final def apply[T](implicit c: Coder[T]): Coder[T] = c
 
-  @deprecated("Use Coder.kryo[T] instead", "0.14.0")
-  def fallback[T](@unused lp: shapeless.LowPriority): Coder[T] =
-    macro CoderMacros.issueFallbackWarning[T]
 }
 
 trait LowPriorityCoders { self: CoderDerivation with JavaBeanCoders =>
-  implicit def javaBeanCoderImplicit[T: IsJavaBean: ClassTag]: Coder[T] = javaBeanCoder
-  implicit def genImplicit[T]: Coder[T] = macro MagnoliaMacros.genWithoutAnnotations[T]
+  implicit override def javaBeanCoder[T: IsJavaBean: ClassTag]: Coder[T] = JavaCoders.javaBeanCoder
+  implicit override def gen[T]: Coder[T] = macro MagnoliaMacros.genWithoutAnnotations[T]
 }
 
 private[coders] object CoderStackTrace {

--- a/scio-core/src/main/scala/com/spotify/scio/coders/CoderDerivation.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/CoderDerivation.scala
@@ -23,7 +23,7 @@ import magnolia1._
 
 import scala.reflect.ClassTag
 
-private object CoderDerivation {
+private[coders] object CoderDerivation extends CoderDerivation {
 
   private object ProductIndexedSeqLike {
     def apply(p: Product): ProductIndexedSeqLike = new ProductIndexedSeqLike(p)

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -693,8 +693,7 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     val ok = SampleField("foo", RecordType(List(SampleField("bar", IntegerType))))
     val nok = SampleField("foo", RecordType(List(SampleField(null, IntegerType))))
 
-    // recursive type need to use the implicit derivation
-    implicit lazy val c: Coder[SampleField] = Coder.genImplicit[SampleField]
+    implicit lazy val c: Coder[SampleField] = Coder.gen[SampleField]
     ok coderShould roundtrip()
     val caught = intercept[beam.CoderException] {
       nok coderShould roundtrip()

--- a/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -33,8 +33,10 @@ import org.apache.beam.sdk.extensions.protobuf.ByteStringCoder
 import org.apache.beam.sdk.schemas.SchemaCoder
 import org.apache.commons.io.output.NullOutputStream
 import org.scalatest.Assertion
+import org.scalatest.exceptions.TestFailedException
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.typelevel.scalaccompat.annotation.nowarn
 
 import scala.collection.{mutable => mut}
 import java.io.{ByteArrayInputStream, ObjectOutputStream, ObjectStreamClass}
@@ -370,6 +372,19 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     (123, "hello", ta, tb, List(("bar", 1, "foo"))) coderShould notFallback()
   }
 
+  it should "give informative error when derivation fails" in {
+    // scalatest does not give the compiler error message with 'shouldNot compile'
+    // invert the test and get the message from the thrown exception
+    try {
+      "Coder.gen[NotDerivableClass]" should compile: @nowarn
+    } catch {
+      case e: TestFailedException =>
+        e.getMessage should include(
+          "in parameter 't' of product type com.spotify.scio.coders.NotDerivableClass"
+        )
+    }
+  }
+
   // FIXME: TableRowJsonCoder cannot be tested in scio-test because of circular dependency on scio-google-cloud-platform
   it should "support all the already supported types" in {
     import java.math.{BigInteger, BigDecimal => jBigDecimal}
@@ -678,7 +693,8 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     val ok = SampleField("foo", RecordType(List(SampleField("bar", IntegerType))))
     val nok = SampleField("foo", RecordType(List(SampleField(null, IntegerType))))
 
-    implicit lazy val c: Coder[SampleField] = Coder.gen[SampleField]
+    // recursive type need to use the implicit derivation
+    implicit lazy val c: Coder[SampleField] = Coder.genImplicit[SampleField]
     ok coderShould roundtrip()
     val caught = intercept[beam.CoderException] {
       nok coderShould roundtrip()
@@ -926,6 +942,10 @@ object PrivateClass {
   def apply(l: Long): PrivateClass = new PrivateClass(l)
 }
 case class UsesPrivateClass(privateClass: PrivateClass)
+
+// non derivable
+trait NotDerivableTrait
+case class NotDerivableClass(s: String, t: NotDerivableTrait)
 
 // avro
 object Avro {


### PR DESCRIPTION
After scio 0.14 release, we've noticed that when `Coder.gen[T]` fails to derive the coder, the compilation error is

```
too few argument lists for macro invocation
```
`Magnolia` is suppose to give informative error to help user finding what prevents the typeclass derivation.
~It turns out this only happens when the derivation method is  declared with `implicit`~

~Change the definition so `gen` is not implicit and add `genImplicit` for automatic derivation.~

~There is a corner case for recursive types: User **MUST** use the implicit API~

The real issue comes from the `fallback` override with an implicit parameter (this is a reserved method from magnolia). this explains the original error