### PR TITLE
Fix byte[] equality issue for MockByteArraySparkeyReader

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyIO.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyIO.scala
@@ -33,7 +33,7 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 /** Special version of [[com.spotify.scio.io.ScioIO]] for use with sparkey methods. */
-case class SparkeyTestIO[T] private (path: String) extends TestIO[T] {
+private[sparkey] case class SparkeyTestIO[T](path: String) extends TestIO[T] {
   override val tapT: TapT.Aux[T, T] = TapOf[T]
 }
 

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/instances/MockSparkeyReader.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/instances/MockSparkeyReader.scala
@@ -21,6 +21,7 @@ import com.spotify.sparkey.SparkeyReader.Entry
 import com.spotify.sparkey.{IndexHeader, LogHeader, SparkeyReader}
 
 import java.io.InputStream
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import scala.jdk.CollectionConverters._
 
@@ -74,7 +75,10 @@ case class MockByteArrayEntry(k: Array[Byte], v: Array[Byte])
 
 case class MockByteArraySparkeyReader(data: Map[Array[Byte], Array[Byte]])
     extends MockSparkeyReader {
-  override def getAsByteArray(key: Array[Byte]): Array[Byte] = data(key)
+  private lazy val internal = data.map { case (k, v) => (ByteBuffer.wrap(k), v) }
+
+  override def getAsByteArray(key: Array[Byte]): Array[Byte] =
+    internal.getOrElse(ByteBuffer.wrap(key), null)
   override def iterator(): java.util.Iterator[Entry] = data.iterator
     .map[Entry] { case (k, v) => MockByteArrayEntry(k, v) }
     .asJava

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/instances/MockSparkeyReader.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/instances/MockSparkeyReader.scala
@@ -59,7 +59,7 @@ case class MockStringEntry(k: String, v: String) extends MockEntry[String, Strin
 }
 
 case class MockStringSparkeyReader(data: Map[String, String]) extends MockSparkeyReader {
-  override def getAsString(key: String): String = data(key)
+  override def getAsString(key: String): String = data.getOrElse(key, null)
   override def iterator(): java.util.Iterator[Entry] = data.iterator
     .map[Entry] { case (k, v) => MockStringEntry(k, v) }
     .asJava

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/instances/MockSparkeyReader.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/instances/MockSparkeyReader.scala
@@ -21,7 +21,6 @@ import com.spotify.sparkey.SparkeyReader.Entry
 import com.spotify.sparkey.{IndexHeader, LogHeader, SparkeyReader}
 
 import java.io.InputStream
-import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import scala.jdk.CollectionConverters._
 
@@ -75,10 +74,10 @@ case class MockByteArrayEntry(k: Array[Byte], v: Array[Byte])
 
 case class MockByteArraySparkeyReader(data: Map[Array[Byte], Array[Byte]])
     extends MockSparkeyReader {
-  private lazy val internal = data.map { case (k, v) => (ByteBuffer.wrap(k), v) }
+  private lazy val internal = data.map { case (k, v) => (k.toVector, v) }
 
   override def getAsByteArray(key: Array[Byte]): Array[Byte] =
-    internal.getOrElse(ByteBuffer.wrap(key), null)
+    internal.getOrElse(key.toVector, null)
   override def iterator(): java.util.Iterator[Entry] = data.iterator
     .map[Entry] { case (k, v) => MockByteArrayEntry(k, v) }
     .asJava

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/SparkeyTest.scala
@@ -19,7 +19,8 @@ package com.spotify.scio.extra.sparkey
 
 import com.github.benmanes.caffeine.cache.{Cache => CCache, Caffeine}
 import com.spotify.scio._
-import com.spotify.scio.extra.sparkey.instances.MockStringSparkeyReader
+import com.spotify.scio.extra.sparkey.instances._
+import com.spotify.scio.io.TextIO
 import com.spotify.scio.testing._
 import com.spotify.scio.util._
 import com.spotify.scio.values.SCollection
@@ -102,13 +103,31 @@ class SparkeyTest extends PipelineSpec {
   val bigSideData: IndexedSeq[(String, String)] =
     (0 until 100).map(i => (('a' + i).toString, i.toString))
 
-  "JobTest" should "support mocking sparkey" in {
+  "JobTest" should "support mocking String-keyed Sparkey" in {
     val input = Map("a" -> "b", "c" -> "d")
     JobTest[SparkeyJob.type]
       .args("--input=foo", "--output1=bar", "--output2=baz")
       .input(SparkeyIO("foo"), Seq(MockStringSparkeyReader(input)))
       .output(SparkeyIO.output[String, String]("bar"))(_ should containInAnyOrder(input))
       .output(SparkeyIO.output[String, String]("baz"))(_ should containInAnyOrder(input))
+      .run()
+  }
+
+  it should "support mocking byte[]-keyed Sparkey" in {
+    val input = Map("foo" -> "bar", "bar" -> "baz").map { case (k, v) => (k.getBytes, v.getBytes) }
+
+    JobTest { sc =>
+      val si = sc.sparkeySideInput("input")
+      sc
+        .parallelize(List("foo", "bar"))
+        .withSideInputs(si)
+        .map { case (input, ctx) => new String(ctx(si).getAsByteArray(input.getBytes)) }
+        .toSCollection
+        .saveAsTextFile("output")
+    }
+      .args("--input=input", "--output=bar")
+      .input(SparkeyIO("input"), Seq(MockByteArraySparkeyReader(input)))
+      .output(TextIO("output"))(_ should containInAnyOrder(Seq("bar", "baz")))
       .run()
   }
 


### PR DESCRIPTION
MockByteArraySparkeyReader was not working properly since two `Array[Byte]`s containing the same bytes produce a different hashCode every time they're deserialized -- thus, the `Map#get` operation was throwing a `NoSuchElementException` even if it contained an Array[Byte] key matching the requested key bytes.

This solution wraps map keys in a ByteBuffer, which is safe to use as a Map key. It also returns `null` if the key doesn't exist in the map rather than throwing a `NoSuchElementException`, which matches the prior Sparkey behavior