### PR TITLE
Implement hashCode() and equals() for FileOperations subclasses

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroFileOperations.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileStream;
@@ -108,6 +109,25 @@ public class AvroFileOperations<ValueT> extends FileOperations<ValueT> {
 
   Schema getSchema() {
     return schemaSupplier.get();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getSchema(), codec.getCodec(), metadata, datumFactory);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof AvroFileOperations)) {
+      return false;
+    }
+    final AvroFileOperations<ValueT> that = (AvroFileOperations<ValueT>) obj;
+    return that.getSchema().equals(this.getSchema())
+        && that.codec.getCodec().toString().equals(this.codec.getCodec().toString())
+        && ((that.metadata == null && this.metadata == null)
+            || (this.metadata.equals(that.metadata)))
+        && that.datumFactory.equals(this.datumFactory);
   }
 
   private static class SerializableSchemaString implements Serializable {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -139,6 +140,18 @@ public abstract class FileOperations<V> implements Serializable, HasDisplayData 
     builder.add(DisplayData.item("FileOperations", getClass()));
     builder.add(DisplayData.item("compression", compression.toString()));
     builder.add(DisplayData.item("mimeType", mimeType));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass().getName(), compression, mimeType);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj.getClass() == getClass()
+        && this.compression == ((FileOperations<?>) obj).compression
+        && this.mimeType.equals(((FileOperations<?>) obj).mimeType);
   }
 
   /** Per-element file reader. */

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
@@ -20,7 +20,11 @@ package org.apache.beam.sdk.extensions.smb;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
@@ -123,6 +127,37 @@ public class ParquetAvroFileOperations<ValueT> extends FileOperations<ValueT> {
 
   Schema getSchema() {
     return schemaSupplier.get();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        getSchema(),
+        compression,
+        conf.get(),
+        projectionSupplier != null ? projectionSupplier.get() : null,
+        predicate);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof ParquetAvroFileOperations)) {
+      return false;
+    }
+    final ParquetAvroFileOperations<ValueT> that = (ParquetAvroFileOperations<ValueT>) obj;
+
+    return that.getSchema().equals(this.getSchema())
+        && that.compression.name().equals(this.compression.name())
+        && ((that.projectionSupplier == null && this.projectionSupplier == null)
+            || (this.projectionSupplier.get().equals(that.projectionSupplier.get())))
+        && ((that.predicate == null && this.predicate == null)
+            || (that.predicate.equals(this.predicate)))
+        && StreamSupport.stream(that.conf.get().spliterator(), false)
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+            .equals(
+                StreamSupport.stream(this.conf.get().spliterator(), false)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
   ////////////////////////////////////////

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroFileOperationsTest.java
@@ -45,6 +45,7 @@ import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.MimeTypes;
+import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -72,6 +73,9 @@ public class AvroFileOperationsTest {
         AvroFileOperations.of(GenericRecordDatumFactory$.INSTANCE, USER_SCHEMA)
             .withCodec(CodecFactory.snappyCodec())
             .withMetadata(TEST_METADATA);
+
+    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
+
     final ResourceId file =
         fromFolder(output).resolve("file.avro", StandardResolveOptions.RESOLVE_FILE);
 
@@ -85,6 +89,7 @@ public class AvroFileOperationsTest {
                         .build())
             .collect(Collectors.toList());
     final FileOperations.Writer<GenericRecord> writer = fileOperations.createWriter(file);
+
     for (GenericRecord record : records) {
       writer.write(record);
     }
@@ -105,6 +110,9 @@ public class AvroFileOperationsTest {
         AvroFileOperations.of(new SpecificRecordDatumFactory<>(AvroGeneratedUser.class), schema)
             .withCodec(CodecFactory.snappyCodec())
             .withMetadata(TEST_METADATA);
+
+    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
+
     final ResourceId file =
         fromFolder(output).resolve("file.avro", StandardResolveOptions.RESOLVE_FILE);
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonFileOperationsTest.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.io.fs.ResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.MimeTypes;
+import org.apache.beam.sdk.util.SerializableUtils;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -52,6 +53,8 @@ public class JsonFileOperationsTest {
 
   private void test(Compression compression) throws Exception {
     final JsonFileOperations fileOperations = JsonFileOperations.of(compression);
+    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
+
     final ResourceId file =
         fromFolder(output).resolve("file.json", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
@@ -37,6 +37,7 @@ import org.apache.beam.sdk.io.fs.ResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.MimeTypes;
+import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
@@ -93,6 +94,8 @@ public class ParquetAvroFileOperationsTest {
     final ParquetAvroFileOperations<GenericRecord> fileOperations =
         ParquetAvroFileOperations.of(USER_SCHEMA);
 
+    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
+
     final List<GenericRecord> actual = new ArrayList<>();
     fileOperations.iterator(file).forEachRemaining(actual::add);
 
@@ -103,6 +106,9 @@ public class ParquetAvroFileOperationsTest {
   public void testSpecificRecord() throws Exception {
     final ParquetAvroFileOperations<AvroGeneratedUser> fileOperations =
         ParquetAvroFileOperations.of(AvroGeneratedUser.class);
+
+    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
+
     final ResourceId file =
         fromFolder(output)
             .resolve("file.parquet", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);
@@ -135,6 +141,7 @@ public class ParquetAvroFileOperationsTest {
 
     final ParquetAvroFileOperations<TestLogicalTypes> fileOperations =
         ParquetAvroFileOperations.of(TestLogicalTypes.class).withConfiguration(conf);
+
     final ResourceId file =
         fromFolder(output)
             .resolve("file.parquet", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);
@@ -179,6 +186,8 @@ public class ParquetAvroFileOperationsTest {
             .withCompression(CompressionCodecName.ZSTD)
             .withProjection(projection);
 
+    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
+
     final List<GenericRecord> expected =
         USER_RECORDS.stream()
             .map(r -> new GenericRecordBuilder(USER_SCHEMA).set("name", r.get("name")).build())
@@ -200,6 +209,8 @@ public class ParquetAvroFileOperationsTest {
 
     final ParquetAvroFileOperations<AvroGeneratedUser> fileOperations =
         ParquetAvroFileOperations.of(AvroGeneratedUser.class).withProjection(projection);
+
+    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
 
     final ResourceId file =
         fromFolder(output)
@@ -290,6 +301,8 @@ public class ParquetAvroFileOperationsTest {
     final ParquetAvroFileOperations<GenericRecord> fileOperations =
         ParquetAvroFileOperations.of(USER_SCHEMA).withFilterPredicate(predicate);
 
+    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
+
     final List<GenericRecord> expected =
         USER_RECORDS.stream().filter(r -> (int) r.get("age") <= 5).collect(Collectors.toList());
     final List<GenericRecord> actual = new ArrayList<>();
@@ -312,6 +325,35 @@ public class ParquetAvroFileOperationsTest {
     MatcherAssert.assertThat(
         displayData, hasDisplayItem("compressionCodecName", CompressionCodecName.ZSTD.name()));
     MatcherAssert.assertThat(displayData, hasDisplayItem("schema", USER_SCHEMA.getFullName()));
+  }
+
+  @Test
+  public void testConfigurationEquality() {
+    final Configuration configuration1 = new Configuration();
+    configuration1.set("foo", "bar");
+
+    final ParquetAvroFileOperations<GenericRecord> fileOperations1 =
+        ParquetAvroFileOperations.of(USER_SCHEMA).withConfiguration(configuration1);
+
+    // Copy of configuration with same keys
+    final Configuration configuration2 = new Configuration();
+    configuration2.set("foo", "bar");
+
+    final ParquetAvroFileOperations<GenericRecord> fileOperations2 =
+        ParquetAvroFileOperations.of(USER_SCHEMA).withConfiguration(configuration2);
+
+    // Assert that configuration equality check fails
+    Assert.assertEquals(fileOperations1, SerializableUtils.ensureSerializable(fileOperations2));
+
+    // Copy of configuration with different keys
+    final Configuration configuration3 = new Configuration();
+    configuration3.set("bar", "baz");
+
+    final ParquetAvroFileOperations<GenericRecord> fileOperations3 =
+        ParquetAvroFileOperations.of(USER_SCHEMA).withConfiguration(configuration3);
+
+    // Assert that configuration equality check fails
+    Assert.assertNotEquals(fileOperations1, SerializableUtils.ensureSerializable(fileOperations3));
   }
 
   private void writeFile(ResourceId file) throws IOException {

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowFileOperationsTest.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.io.fs.ResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.MimeTypes;
+import org.apache.beam.sdk.util.SerializableUtils;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -58,6 +59,8 @@ public class TensorFlowFileOperationsTest {
 
   private void test(Compression compression) throws Exception {
     final TensorFlowFileOperations fileOperations = TensorFlowFileOperations.of(compression);
+    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
+
     final ResourceId file =
         fromFolder(output)
             .resolve("file.tfrecord", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);

--- a/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperationsTest.scala
+++ b/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperationsTest.scala
@@ -23,6 +23,8 @@ import com.spotify.scio.CoreSysProps
 import org.apache.beam.sdk.io.LocalResources
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions
 import org.apache.beam.sdk.io.fs.ResourceId
+import org.apache.beam.sdk.util.SerializableUtils
+import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.filter2.predicate.FilterApi
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.scalatest.flatspec.AnyFlatSpec
@@ -50,6 +52,8 @@ class ParquetTypeFileOperationsTest extends AnyFlatSpec with Matchers {
     writeFile(file)
 
     val fileOps = ParquetTypeFileOperations[User]()
+    SerializableUtils.ensureSerializable(fileOps) should equal(fileOps)
+
     val actual = fileOps.iterator(file).asScala.toSeq
 
     actual shouldBe users
@@ -64,6 +68,7 @@ class ParquetTypeFileOperationsTest extends AnyFlatSpec with Matchers {
     writeFile(file)
 
     val fileOps = ParquetTypeFileOperations[Username]()
+    SerializableUtils.ensureSerializable(fileOps) should equal(fileOps)
     val actual = fileOps.iterator(file).asScala.toSeq
 
     actual shouldBe users.map(u => Username(u.name))
@@ -79,10 +84,31 @@ class ParquetTypeFileOperationsTest extends AnyFlatSpec with Matchers {
 
     val predicate = FilterApi.ltEq(FilterApi.intColumn("age"), java.lang.Integer.valueOf(5))
     val fileOps = ParquetTypeFileOperations[User](predicate)
+    SerializableUtils.ensureSerializable(fileOps) should equal(fileOps)
     val actual = fileOps.iterator(file).asScala.toSeq
 
     actual shouldBe users.filter(_.age <= 5)
     tmpDir.delete()
+  }
+
+  it should "compare Configuration values in equals() check" in {
+    val conf1 = new Configuration()
+    conf1.set("foo", "bar")
+    val fileOps1 = ParquetTypeFileOperations[User](CompressionCodecName.UNCOMPRESSED, conf1)
+
+    val conf2 = new Configuration()
+    conf2.set("foo", "bar")
+    val fileOps2 = ParquetTypeFileOperations[User](CompressionCodecName.UNCOMPRESSED, conf2)
+
+    // FileOperations with equal Configuration maps should be equal
+    SerializableUtils.ensureSerializable(fileOps2) should equal(fileOps1)
+
+    val conf3 = new Configuration()
+    conf3.set("bar", "baz")
+    val fileOps3 = ParquetTypeFileOperations[User](CompressionCodecName.UNCOMPRESSED, conf3)
+
+    // FileOperations with different Configuration maps should not be equal
+    SerializableUtils.ensureSerializable(fileOps3) shouldNot equal(fileOps1)
   }
 
   private def writeFile(file: ResourceId): Unit = {


### PR DESCRIPTION
Non-consistent equals() seems to be an issue for FlinkRunner.