### PR TITLE
Broaden use cases to FixAvroCoder 

### DIFF
--- a/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder13.scala
+++ b/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder13.scala
@@ -1,0 +1,14 @@
+/*
+rule = FixAvroCoder
+ */
+package fix.v0_14_0
+
+import com.spotify.scio.ScioContext
+
+object FixAvroCoder13 {
+  val sc = ScioContext()
+
+  val a: A = ???
+
+  sc.parallelize(Seq(a))
+}

--- a/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder14.scala
+++ b/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder14.scala
@@ -1,0 +1,13 @@
+/*
+rule = FixAvroCoder
+ */
+package fix.v0_14_0
+
+import com.spotify.scio.ScioContext
+
+object FixAvroCoder14 {
+  val sc = ScioContext()
+
+  val elements = Seq(new A)
+  sc.parallelize(elements)
+}

--- a/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder15.scala
+++ b/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder15.scala
@@ -1,0 +1,17 @@
+/*
+rule = FixAvroCoder
+ */
+package fix.v0_14_0
+
+import org.apache.avro.specific.SpecificRecord
+import com.spotify.scio.ScioContext
+import com.spotify.scio.coders.Coder
+
+object FixAvroCoder15 {
+
+  def someMethod[T <: SpecificRecord : Coder](someParam: String, t: T): Unit = ???
+
+  val sc = ScioContext()
+
+  someMethod("foo", new A)
+}

--- a/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder13.scala
+++ b/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder13.scala
@@ -1,0 +1,12 @@
+package fix.v0_14_0
+
+import com.spotify.scio.ScioContext
+import com.spotify.scio.avro._
+
+object FixAvroCoder13 {
+  val sc = ScioContext()
+
+  val a: A = ???
+
+  sc.parallelize(Seq(a))
+}

--- a/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder14.scala
+++ b/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder14.scala
@@ -1,0 +1,11 @@
+package fix.v0_14_0
+
+import com.spotify.scio.ScioContext
+import com.spotify.scio.avro._
+
+object FixAvroCoder14 {
+  val sc = ScioContext()
+
+  val elements = Seq(new A)
+  sc.parallelize(elements)
+}

--- a/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder15.scala
+++ b/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder15.scala
@@ -1,0 +1,15 @@
+package fix.v0_14_0
+
+import org.apache.avro.specific.SpecificRecord
+import com.spotify.scio.ScioContext
+import com.spotify.scio.coders.Coder
+import com.spotify.scio.avro._
+
+object FixAvroCoder15 {
+
+  def someMethod[T <: SpecificRecord : Coder](someParam: String, t: T): Unit = ???
+
+  val sc = ScioContext()
+
+  someMethod("foo", new A)
+}

--- a/scalafix/rules/src/main/scala/fix/v0_14_0/FixAvroCoder.scala
+++ b/scalafix/rules/src/main/scala/fix/v0_14_0/FixAvroCoder.scala
@@ -147,17 +147,15 @@ object FixAvroCoder {
   def methodHasAvroCoderTypeBound(expr: Term)(implicit doc: SemanticDocument): Boolean =
     expr.symbol.info.map(_.signature) match {
       case Some(MethodSignature(_, parameterLists, _)) =>
-        parameterLists.flatten.exists { p =>
-          p.symbol.info.map(_.signature).exists {
-            case ValueSignature(TypeRef(_, symbol, List(TypeRef(_, coderT, _)))) if CoderMatcher.matches(symbol) =>
-              coderT.info.map(_.signature).exists {
-                case TypeSignature(_, _, TypeRef(_, maybeAvroType, _)) if AvroMatcher.matches(maybeAvroType) =>
-                  true
-                case _ =>
-                  false
-              }
-            case _ => false
-          }
+        parameterLists.flatten.flatMap(_.symbol.info.map(_.signature)).exists {
+          case ValueSignature(TypeRef(_, symbol, List(TypeRef(_, coderT, _)))) if CoderMatcher.matches(symbol) =>
+            coderT.info.map(_.signature).exists {
+              case TypeSignature(_, _, TypeRef(_, maybeAvroType, _)) if AvroMatcher.matches(maybeAvroType) =>
+                true
+              case _ =>
+                false
+            }
+          case _ => false
         }
       case _ => false
     }

--- a/scalafix/rules/src/main/scala/fix/v0_14_0/FixAvroCoder.scala
+++ b/scalafix/rules/src/main/scala/fix/v0_14_0/FixAvroCoder.scala
@@ -17,6 +17,7 @@ object FixAvroCoder {
   )
   val AvroMatcher: SymbolMatcher = SymbolMatcher.normalized(
     "org/apache/avro/specific/SpecificRecord",
+    "org/apache/avro/specific/SpecificRecordBase",
     "org/apache/avro/specific/SpecificFixed",
     "org/apache/avro/generic/GenericRecord"
   )


### PR DESCRIPTION
adds two more use cases for AvroCoder:

1. `sc.parallelize(elements)` where `elements` is a collection of Avro types
2. invocation of a parameterized method with bound `T <: SpecificRecord: Coder`