### PR TITLE
Simplify BucketedInput serialization

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroFileOperations.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Map;
-import java.util.Objects;
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileStream;
@@ -109,25 +108,6 @@ public class AvroFileOperations<ValueT> extends FileOperations<ValueT> {
 
   Schema getSchema() {
     return schemaSupplier.get();
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(getSchema(), codec.getCodec(), metadata, datumFactory);
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public boolean equals(Object obj) {
-    if (!(obj instanceof AvroFileOperations)) {
-      return false;
-    }
-    final AvroFileOperations<ValueT> that = (AvroFileOperations<ValueT>) obj;
-    return that.getSchema().equals(this.getSchema())
-        && that.codec.getCodec().toString().equals(this.codec.getCodec().toString())
-        && ((that.metadata == null && this.metadata == null)
-            || (this.metadata.equals(that.metadata)))
-        && that.datumFactory.equals(this.datumFactory);
   }
 
   private static class SerializableSchemaString implements Serializable {

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/FileOperations.java
@@ -28,7 +28,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -140,18 +139,6 @@ public abstract class FileOperations<V> implements Serializable, HasDisplayData 
     builder.add(DisplayData.item("FileOperations", getClass()));
     builder.add(DisplayData.item("compression", compression.toString()));
     builder.add(DisplayData.item("mimeType", mimeType));
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(getClass().getName(), compression, mimeType);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    return obj.getClass() == getClass()
-        && this.compression == ((FileOperations<?>) obj).compression
-        && this.mimeType.equals(((FileOperations<?>) obj).mimeType);
   }
 
   /** Per-element file reader. */

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperations.java
@@ -20,11 +20,7 @@ package org.apache.beam.sdk.extensions.smb;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
@@ -127,37 +123,6 @@ public class ParquetAvroFileOperations<ValueT> extends FileOperations<ValueT> {
 
   Schema getSchema() {
     return schemaSupplier.get();
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        getSchema(),
-        compression,
-        conf.get(),
-        projectionSupplier != null ? projectionSupplier.get() : null,
-        predicate);
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public boolean equals(Object obj) {
-    if (!(obj instanceof ParquetAvroFileOperations)) {
-      return false;
-    }
-    final ParquetAvroFileOperations<ValueT> that = (ParquetAvroFileOperations<ValueT>) obj;
-
-    return that.getSchema().equals(this.getSchema())
-        && that.compression.name().equals(this.compression.name())
-        && ((that.projectionSupplier == null && this.projectionSupplier == null)
-            || (this.projectionSupplier.get().equals(that.projectionSupplier.get())))
-        && ((that.predicate == null && this.predicate == null)
-            || (that.predicate.equals(this.predicate)))
-        && StreamSupport.stream(that.conf.get().spliterator(), false)
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-            .equals(
-                StreamSupport.stream(this.conf.get().spliterator(), false)
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
   ////////////////////////////////////////

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketSource.java
@@ -43,17 +43,12 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.coders.MapCoder;
-import org.apache.beam.sdk.coders.SerializableCoder;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
-import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.extensions.smb.BucketMetadataUtil.SourceMetadata;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
-import org.apache.beam.sdk.io.fs.ResourceIdCoder;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -422,17 +417,8 @@ public abstract class SortedBucketSource<KeyType> extends BoundedSource<KV<KeyTy
     protected transient SourceMetadata<V> sourceMetadata = null; // lazy
 
     private transient Map<ResourceId, KV<String, FileOperations<V>>> inputs;
-    private final Map<Integer, KV<String, FileOperations>> fileOperationsEncoding;
+    private final Map<Integer, KV<String, FileOperations<V>>> fileOperationsEncoding;
     private final Map<ResourceId, Integer> directoriesEncoding;
-
-    // Used to efficiently serialize BucketedInput instances
-    private static Coder<Map<ResourceId, Integer>> directoriesEncodingCoder =
-        MapCoder.of(ResourceIdCoder.of(), VarIntCoder.of());
-
-    private static Coder<Map<Integer, KV<String, FileOperations>>> fileOperationsEncodingCoder =
-        MapCoder.of(
-            VarIntCoder.of(),
-            KvCoder.of(StringUtf8Coder.of(), SerializableCoder.of(FileOperations.class)));
 
     public static <V> BucketedInput<V> of(
         Keying keying,

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperations.scala
@@ -30,10 +30,7 @@ import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.hadoop.{ParquetReader, ParquetWriter}
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 
-import scala.jdk.CollectionConverters._
-
 import java.nio.channels.{ReadableByteChannel, WritableByteChannel}
-import java.util.Objects
 
 object ParquetTypeFileOperations {
 
@@ -94,23 +91,6 @@ case class ParquetTypeFileOperations[T](
   override protected def createSink(): FileIO.Sink[T] = ParquetTypeSink(compression, conf)
 
   override def getCoder: BCoder[T] = CoderMaterializer.beamWithDefault(coder)
-
-  override def hashCode(): Int = Objects.hash(compression.name(), conf.get(), predicate)
-
-  override def equals(obj: Any): Boolean = obj match {
-    case ParquetTypeFileOperations(compressionThat, confThat, predicateThat) =>
-      this.compression.name() == compressionThat.name() && this.predicate == predicateThat &&
-      conf
-        .get()
-        .iterator()
-        .asScala
-        .map(e => (e.getKey, e.getValue))
-        .toMap
-        .equals(
-          confThat.get().iterator().asScala.map(e => (e.getKey, e.getValue)).toMap
-        )
-    case _ => false
-  }
 }
 
 private case class ParquetTypeReader[T](

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroFileOperationsTest.java
@@ -45,7 +45,6 @@ import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.MimeTypes;
-import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -73,9 +72,6 @@ public class AvroFileOperationsTest {
         AvroFileOperations.of(GenericRecordDatumFactory$.INSTANCE, USER_SCHEMA)
             .withCodec(CodecFactory.snappyCodec())
             .withMetadata(TEST_METADATA);
-
-    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
-
     final ResourceId file =
         fromFolder(output).resolve("file.avro", StandardResolveOptions.RESOLVE_FILE);
 
@@ -89,7 +85,6 @@ public class AvroFileOperationsTest {
                         .build())
             .collect(Collectors.toList());
     final FileOperations.Writer<GenericRecord> writer = fileOperations.createWriter(file);
-
     for (GenericRecord record : records) {
       writer.write(record);
     }
@@ -110,9 +105,6 @@ public class AvroFileOperationsTest {
         AvroFileOperations.of(new SpecificRecordDatumFactory<>(AvroGeneratedUser.class), schema)
             .withCodec(CodecFactory.snappyCodec())
             .withMetadata(TEST_METADATA);
-
-    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
-
     final ResourceId file =
         fromFolder(output).resolve("file.avro", StandardResolveOptions.RESOLVE_FILE);
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonFileOperationsTest.java
@@ -30,7 +30,6 @@ import org.apache.beam.sdk.io.fs.ResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.MimeTypes;
-import org.apache.beam.sdk.util.SerializableUtils;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -53,8 +52,6 @@ public class JsonFileOperationsTest {
 
   private void test(Compression compression) throws Exception {
     final JsonFileOperations fileOperations = JsonFileOperations.of(compression);
-    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
-
     final ResourceId file =
         fromFolder(output).resolve("file.json", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
@@ -37,7 +37,6 @@ import org.apache.beam.sdk.io.fs.ResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.MimeTypes;
-import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
@@ -94,8 +93,6 @@ public class ParquetAvroFileOperationsTest {
     final ParquetAvroFileOperations<GenericRecord> fileOperations =
         ParquetAvroFileOperations.of(USER_SCHEMA);
 
-    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
-
     final List<GenericRecord> actual = new ArrayList<>();
     fileOperations.iterator(file).forEachRemaining(actual::add);
 
@@ -106,9 +103,6 @@ public class ParquetAvroFileOperationsTest {
   public void testSpecificRecord() throws Exception {
     final ParquetAvroFileOperations<AvroGeneratedUser> fileOperations =
         ParquetAvroFileOperations.of(AvroGeneratedUser.class);
-
-    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
-
     final ResourceId file =
         fromFolder(output)
             .resolve("file.parquet", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);
@@ -141,7 +135,6 @@ public class ParquetAvroFileOperationsTest {
 
     final ParquetAvroFileOperations<TestLogicalTypes> fileOperations =
         ParquetAvroFileOperations.of(TestLogicalTypes.class).withConfiguration(conf);
-
     final ResourceId file =
         fromFolder(output)
             .resolve("file.parquet", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);
@@ -186,8 +179,6 @@ public class ParquetAvroFileOperationsTest {
             .withCompression(CompressionCodecName.ZSTD)
             .withProjection(projection);
 
-    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
-
     final List<GenericRecord> expected =
         USER_RECORDS.stream()
             .map(r -> new GenericRecordBuilder(USER_SCHEMA).set("name", r.get("name")).build())
@@ -209,8 +200,6 @@ public class ParquetAvroFileOperationsTest {
 
     final ParquetAvroFileOperations<AvroGeneratedUser> fileOperations =
         ParquetAvroFileOperations.of(AvroGeneratedUser.class).withProjection(projection);
-
-    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
 
     final ResourceId file =
         fromFolder(output)
@@ -301,8 +290,6 @@ public class ParquetAvroFileOperationsTest {
     final ParquetAvroFileOperations<GenericRecord> fileOperations =
         ParquetAvroFileOperations.of(USER_SCHEMA).withFilterPredicate(predicate);
 
-    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
-
     final List<GenericRecord> expected =
         USER_RECORDS.stream().filter(r -> (int) r.get("age") <= 5).collect(Collectors.toList());
     final List<GenericRecord> actual = new ArrayList<>();
@@ -325,35 +312,6 @@ public class ParquetAvroFileOperationsTest {
     MatcherAssert.assertThat(
         displayData, hasDisplayItem("compressionCodecName", CompressionCodecName.ZSTD.name()));
     MatcherAssert.assertThat(displayData, hasDisplayItem("schema", USER_SCHEMA.getFullName()));
-  }
-
-  @Test
-  public void testConfigurationEquality() {
-    final Configuration configuration1 = new Configuration();
-    configuration1.set("foo", "bar");
-
-    final ParquetAvroFileOperations<GenericRecord> fileOperations1 =
-        ParquetAvroFileOperations.of(USER_SCHEMA).withConfiguration(configuration1);
-
-    // Copy of configuration with same keys
-    final Configuration configuration2 = new Configuration();
-    configuration2.set("foo", "bar");
-
-    final ParquetAvroFileOperations<GenericRecord> fileOperations2 =
-        ParquetAvroFileOperations.of(USER_SCHEMA).withConfiguration(configuration2);
-
-    // Assert that configuration equality check fails
-    Assert.assertEquals(fileOperations1, SerializableUtils.ensureSerializable(fileOperations2));
-
-    // Copy of configuration with different keys
-    final Configuration configuration3 = new Configuration();
-    configuration3.set("bar", "baz");
-
-    final ParquetAvroFileOperations<GenericRecord> fileOperations3 =
-        ParquetAvroFileOperations.of(USER_SCHEMA).withConfiguration(configuration3);
-
-    // Assert that configuration equality check fails
-    Assert.assertNotEquals(fileOperations1, SerializableUtils.ensureSerializable(fileOperations3));
   }
 
   private void writeFile(ResourceId file) throws IOException {

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/TensorFlowFileOperationsTest.java
@@ -30,7 +30,6 @@ import org.apache.beam.sdk.io.fs.ResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.MimeTypes;
-import org.apache.beam.sdk.util.SerializableUtils;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -59,8 +58,6 @@ public class TensorFlowFileOperationsTest {
 
   private void test(Compression compression) throws Exception {
     final TensorFlowFileOperations fileOperations = TensorFlowFileOperations.of(compression);
-    Assert.assertEquals(fileOperations, SerializableUtils.ensureSerializable(fileOperations));
-
     final ResourceId file =
         fromFolder(output)
             .resolve("file.tfrecord", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);

--- a/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperationsTest.scala
+++ b/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeFileOperationsTest.scala
@@ -23,8 +23,6 @@ import com.spotify.scio.CoreSysProps
 import org.apache.beam.sdk.io.LocalResources
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions
 import org.apache.beam.sdk.io.fs.ResourceId
-import org.apache.beam.sdk.util.SerializableUtils
-import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.filter2.predicate.FilterApi
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.scalatest.flatspec.AnyFlatSpec
@@ -52,8 +50,6 @@ class ParquetTypeFileOperationsTest extends AnyFlatSpec with Matchers {
     writeFile(file)
 
     val fileOps = ParquetTypeFileOperations[User]()
-    SerializableUtils.ensureSerializable(fileOps) should equal(fileOps)
-
     val actual = fileOps.iterator(file).asScala.toSeq
 
     actual shouldBe users
@@ -68,7 +64,6 @@ class ParquetTypeFileOperationsTest extends AnyFlatSpec with Matchers {
     writeFile(file)
 
     val fileOps = ParquetTypeFileOperations[Username]()
-    SerializableUtils.ensureSerializable(fileOps) should equal(fileOps)
     val actual = fileOps.iterator(file).asScala.toSeq
 
     actual shouldBe users.map(u => Username(u.name))
@@ -84,31 +79,10 @@ class ParquetTypeFileOperationsTest extends AnyFlatSpec with Matchers {
 
     val predicate = FilterApi.ltEq(FilterApi.intColumn("age"), java.lang.Integer.valueOf(5))
     val fileOps = ParquetTypeFileOperations[User](predicate)
-    SerializableUtils.ensureSerializable(fileOps) should equal(fileOps)
     val actual = fileOps.iterator(file).asScala.toSeq
 
     actual shouldBe users.filter(_.age <= 5)
     tmpDir.delete()
-  }
-
-  it should "compare Configuration values in equals() check" in {
-    val conf1 = new Configuration()
-    conf1.set("foo", "bar")
-    val fileOps1 = ParquetTypeFileOperations[User](CompressionCodecName.UNCOMPRESSED, conf1)
-
-    val conf2 = new Configuration()
-    conf2.set("foo", "bar")
-    val fileOps2 = ParquetTypeFileOperations[User](CompressionCodecName.UNCOMPRESSED, conf2)
-
-    // FileOperations with equal Configuration maps should be equal
-    SerializableUtils.ensureSerializable(fileOps2) should equal(fileOps1)
-
-    val conf3 = new Configuration()
-    conf3.set("bar", "baz")
-    val fileOps3 = ParquetTypeFileOperations[User](CompressionCodecName.UNCOMPRESSED, conf3)
-
-    // FileOperations with different Configuration maps should not be equal
-    SerializableUtils.ensureSerializable(fileOps3) shouldNot equal(fileOps1)
   }
 
   private def writeFile(file: ResourceId): Unit = {


### PR DESCRIPTION
Removes overrides of readObject/writeObject by simply making all class members serializable/