### PR TITLE
Add layer for low priority coder conflict

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/Coder.scala
@@ -223,9 +223,12 @@ object Coder
 
 }
 
-trait LowPriorityCoders { self: CoderDerivation with JavaBeanCoders =>
-  implicit override def javaBeanCoder[T: IsJavaBean: ClassTag]: Coder[T] = JavaCoders.javaBeanCoder
+trait LowPriorityCoders extends LowPriorityCoders1 { self: CoderDerivation with JavaBeanCoders =>
   implicit override def gen[T]: Coder[T] = macro MagnoliaMacros.genWithoutAnnotations[T]
+}
+
+trait LowPriorityCoders1 { self: JavaBeanCoders =>
+  implicit override def javaBeanCoder[T: IsJavaBean: ClassTag]: Coder[T] = JavaCoders.javaBeanCoder
 }
 
 private[coders] object CoderStackTrace {


### PR DESCRIPTION
Relates to #5243

This change is not strictly required, but is a nice to have for IntelliJ linter.

In practice, `gen` and `javaBeanCoder` do not conflict but due to some limitation of IntelliJ, it shows the following 

![image](https://github.com/spotify/scio/assets/2845540/e37ceacd-ae7a-4827-83b4-735499b69ade)

Prevent implicit conflict by layering
