### PR TITLE
(fix) Update SmbIO to support absolute path in test

### DIFF
--- a/scio-smb/src/main/scala/com/spotify/scio/smb/SmbIO.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/SmbIO.scala
@@ -41,7 +41,7 @@ object SmbIO {
     new SmbIO[K, T](path, keyBy)
 
   def testId(paths: String*): String = {
-    val normalizedPaths = paths.map(p => ScioUtil.strippedPath(p) + "/").sorted.mkString(",")
+    val normalizedPaths = paths.map(ScioUtil.strippedPath).sorted.mkString(",")
     s"SmbIO($normalizedPaths)"
   }
 

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/SortedBucketIOUtil.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/SortedBucketIOUtil.scala
@@ -29,9 +29,7 @@ object SortedBucketIOUtil {
         .getInputs
         .asScala
         .toSeq
-        .map { case (rId, _) =>
-          s"${rId.getCurrentDirectory}${Option(rId.getFilename).getOrElse("")}"
-        }: _*
+        .map { case (rId, _) => rId.toString }: _*
     )
 
   def testId(write: beam.SortedBucketIO.Write[_, _, _]): String =

--- a/scio-smb/src/test/scala/com/spotify/scio/smb/SmbIOTest.scala
+++ b/scio-smb/src/test/scala/com/spotify/scio/smb/SmbIOTest.scala
@@ -203,13 +203,13 @@ class SmbIOTest extends PipelineSpec {
   it should "be able to mock sortMergeTransform" in {
     JobTest[SmbTransformJob.type]
       .args(
-        "--users=gs://users",
-        "--accounts=gs://accounts",
-        "--output=gs://output"
+        "--users=/users",
+        "--accounts=/accounts",
+        "--output=/output"
       )
-      .input(SmbIO[Integer, User]("gs://users", _.getId), Seq(user))
-      .input(SmbIO[Integer, Account]("gs://accounts", _.getId), Seq(accountA, accountB))
-      .output(SmbIO[Integer, User]("gs://output", _.getId))(
+      .input(SmbIO[Integer, User]("/users", _.getId), Seq(user))
+      .input(SmbIO[Integer, Account]("/accounts", _.getId), Seq(accountA, accountB))
+      .output(SmbIO[Integer, User]("/output", _.getId))(
         _ should containInAnyOrder(Seq(joinedUserAccounts))
       )
       .run()
@@ -218,13 +218,13 @@ class SmbIOTest extends PipelineSpec {
   it should "be able to mock sortMergeTransform with side inputs" in {
     JobTest[SmbTransformWithSideInputsJob.type]
       .args(
-        "--users=gs://users",
-        "--accounts=gs://accounts",
-        "--output=gs://output"
+        "--users=/users",
+        "--accounts=/accounts",
+        "--output=/output"
       )
-      .input(SmbIO[Integer, User]("gs://users", _.getId), Seq(user))
-      .input(SmbIO[Integer, Account]("gs://accounts", _.getId), Seq(accountA, accountB))
-      .output(SmbIO[Integer, User]("gs://output", _.getId))(
+      .input(SmbIO[Integer, User]("/users", _.getId), Seq(user))
+      .input(SmbIO[Integer, Account]("/accounts", _.getId), Seq(accountA, accountB))
+      .output(SmbIO[Integer, User]("/output", _.getId))(
         _ should containInAnyOrder(
           Seq(User.newBuilder(user).setAccounts(List(accountA, accountB).asJava).setId(7).build())
         )


### PR DESCRIPTION
Using relative path in test is still not supported because creation of a bucketed input relies on the file system operation to create a resource.