### PR TITLE
Make checkVersion more dynamic

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
@@ -92,11 +92,12 @@ private[scio] object VersionUtil {
     sys.props.get("scio.ignoreVersionWarning").exists(_.trim == "true")
 
   private def migrationMessage(latest: SemVer): Option[String] = {
-    val SemVer(major, minor, rev, _) = latest
+    val SemVer(major, minor, _, _) = latest
     val shortVersion = s"$major.$minor"
-    val fullVersion = s"v$major.$minor.$rev"
+    val fullVersion = s"v$major.$minor.0"
 
-    val url = s"https://spotify.github.io/scio/releases/migrations/$fullVersion-Migration-Guide.html"
+    val url =
+      s"https://spotify.github.io/scio/releases/migrations/$fullVersion-Migration-Guide.html"
     Try(requestFactory.buildGetRequest(new GenericUrl(url)).execute())
       .filter(_.getStatusCode == 200)
       .map(_ => MessagePattern(shortVersion, url))

--- a/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
@@ -125,7 +125,7 @@ private[scio] object VersionUtil {
           if (
             latestVersion.copy(rev = 0, suffix = "") > currentVersion.copy(rev = 0, suffix = "")
           ) {
-            migrationMessage(latestVersion).foreach(buffer.append)
+            migrationMessage(latestVersion).foreach(buffer.append(_))
           }
         }
       }

--- a/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/VersionUtil.scala
@@ -53,22 +53,22 @@ private[scio] object VersionUtil {
        | $YELLOW>$BOLD Scio $version introduced some breaking changes in the API.$RESET
        | $YELLOW>$RESET Follow the migration guide to upgrade: $url.
        | $YELLOW>$RESET Scio provides automatic migration rules (See migration guide).
-      """.stripMargin
+       |""".stripMargin
   private[this] val NewerVersionPattern: (String, String) => String = (current, v) => s"""
       | $YELLOW>$BOLD A newer version of Scio is available: $current -> $v$RESET
-      | $YELLOW>$RESET Use `-Dscio.ignoreVersionWarning=true` to disable this check.$RESET
+      | $YELLOW>$RESET Use `-Dscio.ignoreVersionWarning=true` to disable this check.
       |""".stripMargin
 
+  private lazy val requestFactory = new NetHttpTransport()
+    .createRequestFactory { (request: HttpRequest) =>
+      request.setConnectTimeout(Timeout)
+      request.setReadTimeout(Timeout)
+    }
+
   private lazy val latest: Option[String] = Try {
-    val transport = new NetHttpTransport()
-    val response = transport
-      .createRequestFactory { (request: HttpRequest) =>
-        request.setConnectTimeout(Timeout)
-        request.setReadTimeout(Timeout)
-        request.setParser(new JsonObjectParser(GsonFactory.getDefaultInstance))
-        ()
-      }
+    val response = requestFactory
       .buildGetRequest(new GenericUrl(Url))
+      .setParser(new JsonObjectParser(GsonFactory.getDefaultInstance))
       .execute()
       .parseAs(classOf[java.util.List[java.util.Map[String, AnyRef]]])
     response.asScala
@@ -91,28 +91,16 @@ private[scio] object VersionUtil {
   private[scio] def ignoreVersionCheck: Boolean =
     sys.props.get("scio.ignoreVersionWarning").exists(_.trim == "true")
 
-  private def messages(current: SemVer, latest: SemVer): Option[String] = (current, latest) match {
-    case (SemVer(0, minor, _, _), SemVer(0, 7, _, _)) if minor < 7 =>
-      Some(
-        MessagePattern("0.7", "https://spotify.github.io/scio/migrations/v0.7.0-Migration-Guide")
-      )
-    case (SemVer(0, minor, _, _), SemVer(0, 8, _, _)) if minor < 8 =>
-      Some(
-        MessagePattern("0.8", "https://spotify.github.io/scio/migrations/v0.8.0-Migration-Guide")
-      )
-    case (SemVer(0, minor, _, _), SemVer(0, 9, _, _)) if minor < 9 =>
-      Some(
-        MessagePattern("0.9", "https://spotify.github.io/scio/migrations/v0.9.0-Migration-Guide")
-      )
-    case (SemVer(0, minor, _, _), SemVer(0, 10, _, _)) if minor < 10 =>
-      Some(
-        MessagePattern("0.10", "https://spotify.github.io/scio/migrations/v0.10.0-Migration-Guide")
-      )
-    case (SemVer(0, minor, _, _), SemVer(0, 12, _, _)) if minor < 12 =>
-      Some(
-        MessagePattern("0.12", "https://spotify.github.io/scio/migrations/v0.12.0-Migration-Guide")
-      )
-    case _ => None
+  private def migrationMessage(latest: SemVer): Option[String] = {
+    val SemVer(major, minor, rev, _) = latest
+    val shortVersion = s"$major.$minor"
+    val fullVersion = s"v$major.$minor.$rev"
+
+    val url = s"https://spotify.github.io/scio/releases/migrations/$fullVersion-Migration-Guide.html"
+    Try(requestFactory.buildGetRequest(new GenericUrl(url)).execute())
+      .filter(_.getStatusCode == 200)
+      .map(_ => MessagePattern(shortVersion, url))
+      .toOption
   }
 
   def checkVersion(
@@ -124,15 +112,20 @@ private[scio] object VersionUtil {
       Nil
     } else {
       val buffer = mutable.Buffer.empty[String]
-      val v1 = parseVersion(current)
-      if (v1.suffix.contains("SNAPSHOT")) {
+      val currentVersion = parseVersion(current)
+      if (currentVersion.suffix.contains("SNAPSHOT")) {
         buffer.append(s"Using a SNAPSHOT version of Scio: $current")
       }
       latestOverride.orElse(latest).foreach { v =>
-        val v2 = parseVersion(v)
-        if (v2 > v1) {
+        val latestVersion = parseVersion(v)
+        if (latestVersion > currentVersion) {
           buffer.append(NewerVersionPattern(current, v))
-          messages(v1, v2).foreach(buffer.append(_))
+          // breaking upgrade
+          if (
+            latestVersion.copy(rev = 0, suffix = "") > currentVersion.copy(rev = 0, suffix = "")
+          ) {
+            migrationMessage(latestVersion).foreach(buffer.append)
+          }
         }
       }
       buffer.toSeq

--- a/scio-test/src/test/scala/com/spotify/scio/VersionUtilTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/VersionUtilTest.scala
@@ -76,7 +76,7 @@ class VersionUtilTest extends AnyFlatSpec with Matchers {
     // checks the migration page is up for 0.14.0
     val current = "0.13.6"
     val latest = "0.14.1"
-    VersionUtil.checkVersion(current, Some(latest)) shouldBe Seq(
+    VersionUtil.checkVersion(current, Some(latest), ignore = false) shouldBe Seq(
       s"""
          | $YELLOW>$BOLD A newer version of Scio is available: $current -> $latest$RESET
          | $YELLOW>$RESET Use `-Dscio.ignoreVersionWarning=true` to disable this check.

--- a/scio-test/src/test/scala/com/spotify/scio/VersionUtilTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/VersionUtilTest.scala
@@ -40,7 +40,7 @@ class VersionUtilTest extends AnyFlatSpec with Matchers {
       "Using a SNAPSHOT version of Scio: 0.1.0-SNAPSHOT",
       s"""
        | $YELLOW>$BOLD A newer version of Scio is available: 0.1.0-SNAPSHOT -> 0.1.0$RESET
-       | $YELLOW>$RESET Use `-Dscio.ignoreVersionWarning=true` to disable this check.$RESET
+       | $YELLOW>$RESET Use `-Dscio.ignoreVersionWarning=true` to disable this check.
        |""".stripMargin
     )
   }
@@ -49,7 +49,7 @@ class VersionUtilTest extends AnyFlatSpec with Matchers {
     VersionUtil.checkVersion(oldVer, Some(newVer), ignore = false) shouldBe Seq(
       s"""
         | $YELLOW>$BOLD A newer version of Scio is available: $oldVer -> $newVer$RESET
-        | $YELLOW>$RESET Use `-Dscio.ignoreVersionWarning=true` to disable this check.$RESET
+        | $YELLOW>$RESET Use `-Dscio.ignoreVersionWarning=true` to disable this check.
         |""".stripMargin
     )
 
@@ -70,5 +70,22 @@ class VersionUtilTest extends AnyFlatSpec with Matchers {
         verifyNewVersion(versions(i), versions(j))
       }
     }
+  }
+
+  it should "point to migration guide when there are breaking changes" in {
+    // checks the migration page is up for 0.14.0
+    val current = "0.13.6"
+    val latest = "0.14.0"
+    VersionUtil.checkVersion(current, Some(latest)) shouldBe Seq(
+      s"""
+         | $YELLOW>$BOLD A newer version of Scio is available: $current -> $latest$RESET
+         | $YELLOW>$RESET Use `-Dscio.ignoreVersionWarning=true` to disable this check.
+         |""".stripMargin,
+      s"""
+         | $YELLOW>$BOLD Scio 0.14 introduced some breaking changes in the API.$RESET
+         | $YELLOW>$RESET Follow the migration guide to upgrade: https://spotify.github.io/scio/releases/migrations/v0.14.0-Migration-Guide.html.
+         | $YELLOW>$RESET Scio provides automatic migration rules (See migration guide).
+         |""".stripMargin
+    )
   }
 }

--- a/scio-test/src/test/scala/com/spotify/scio/VersionUtilTest.scala
+++ b/scio-test/src/test/scala/com/spotify/scio/VersionUtilTest.scala
@@ -75,7 +75,7 @@ class VersionUtilTest extends AnyFlatSpec with Matchers {
   it should "point to migration guide when there are breaking changes" in {
     // checks the migration page is up for 0.14.0
     val current = "0.13.6"
-    val latest = "0.14.0"
+    val latest = "0.14.1"
     VersionUtil.checkVersion(current, Some(latest)) shouldBe Seq(
       s"""
          | $YELLOW>$BOLD A newer version of Scio is available: $current -> $latest$RESET


### PR DESCRIPTION
Scio is not able to link to future migration resources.

Make `checkVersion` more dynamic by testing if a migration page exists in case of breaking version upgrade