### PR TITLE
fix: Execute SmbIO output assertions

### DIFF
--- a/scio-smb/src/main/scala/com/spotify/scio/smb/SortMergeTransform.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/SortMergeTransform.scala
@@ -133,7 +133,7 @@ object SortMergeTransform {
       transformFn: (KeyType, R, SortedBucketTransform.SerializableConsumer[W]) => Unit
     ): ClosedTap[W] = {
       val data = read.parDo(new ViaTransform(transformFn))
-      TestDataManager.getOutput(sc.testId.get)(SortedBucketIOUtil.testId(output))
+      TestDataManager.getOutput(sc.testId.get)(SortedBucketIOUtil.testId(output))(data)
       ClosedTap(TapOf[W].saveForTest(data))
     }
   }
@@ -222,7 +222,7 @@ object SortMergeTransform {
           .of(new ViaTransformWithSideOutput(transformFn))
           .withSideInputs(sides.map(_.view).asJava)
       )
-      TestDataManager.getOutput(sc.testId.get)(SortedBucketIOUtil.testId(output))
+      TestDataManager.getOutput(sc.testId.get)(SortedBucketIOUtil.testId(output))(data)
       ClosedTap(TapOf[W].saveForTest(data))
     }
   }

--- a/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketSCollectionSyntax.scala
+++ b/scio-smb/src/main/scala/com/spotify/scio/smb/syntax/SortMergeBucketSCollectionSyntax.scala
@@ -56,7 +56,7 @@ final class SortedBucketSCollection[T](private val self: SCollection[T]) {
     import self.coder
 
     if (self.context.isTest) {
-      TestDataManager.getOutput(self.context.testId.get)(SortedBucketIOUtil.testId(write))
+      TestDataManager.getOutput(self.context.testId.get)(SortedBucketIOUtil.testId(write))(self)
       ClosedTap(TapOf[T].saveForTest(self))
     } else {
       val writeResult = self.applyInternal(write)
@@ -91,8 +91,9 @@ final class SortedBucketPairSCollection[K, V](private val self: SCollection[KV[K
     implicit val valueCoder: Coder[V] = Coder.beam(beamValueCoder)
 
     if (self.context.isTest) {
-      TestDataManager.getOutput(self.context.testId.get)(SortedBucketIOUtil.testId(write))
-      ClosedTap(TapOf[V].saveForTest(self.map(_.getValue)))
+      val data = self.map(_.getValue)
+      TestDataManager.getOutput(self.context.testId.get)(SortedBucketIOUtil.testId(write))(data)
+      ClosedTap(TapOf[V].saveForTest(data))
     } else {
       val writeResult =
         self.applyInternal(write.onKeyedCollection(beamValueCoder, verifyKeyExtraction))

--- a/scio-smb/src/test/scala/com/spotify/scio/smb/SmbIOTest.scala
+++ b/scio-smb/src/test/scala/com/spotify/scio/smb/SmbIOTest.scala
@@ -166,6 +166,7 @@ class SmbIOTest extends PipelineSpec {
     }
 
   "SmbIO" should "be able to mock sortMergeTransform input and saveAsSortedBucket output" in {
+    // success
     JobTest[SmbJoinSaveJob.type]
       .args(
         "--users=gs://users",
@@ -183,9 +184,24 @@ class SmbIOTest extends PipelineSpec {
         )
       )
       .run()
+
+    // error
+    an[AssertionError] shouldBe thrownBy {
+      JobTest[SmbJoinSaveJob.type]
+        .args(
+          "--users=gs://users",
+          "--accounts=gs://accounts",
+          "--output=gs://output"
+        )
+        .input(SmbIO[Integer, User]("gs://users", _.getId), Seq(user))
+        .input(SmbIO[Integer, Account]("gs://accounts", _.getId), Seq(accountA, accountB))
+        .output(SmbIO[Integer, User]("gs://output", _.getId))(_ should beEmpty)
+        .run()
+    }
   }
 
   it should "be able to mock sortMergeCoGroup and saveAsSortedBucket" in {
+    // success
     JobTest[SmbCoGroupSavePreKeyedJob.type]
       .args(
         "--users=gs://users",
@@ -198,9 +214,24 @@ class SmbIOTest extends PipelineSpec {
         _ should containInAnyOrder(Seq(joinedUserAccounts))
       )
       .run()
+
+    // error
+    an[AssertionError] shouldBe thrownBy {
+      JobTest[SmbCoGroupSavePreKeyedJob.type]
+        .args(
+          "--users=gs://users",
+          "--accounts=gs://accounts",
+          "--output=gs://output"
+        )
+        .input(SmbIO[Integer, User]("gs://users", _.getId), Seq(user))
+        .input(SmbIO[Integer, Account]("gs://accounts", _.getId), Seq(accountA, accountB))
+        .output(SmbIO[Integer, User]("gs://output", _.getId))(_ should beEmpty)
+        .run()
+    }
   }
 
   it should "be able to mock sortMergeTransform" in {
+    // success
     JobTest[SmbTransformJob.type]
       .args(
         "--users=/users",
@@ -213,6 +244,20 @@ class SmbIOTest extends PipelineSpec {
         _ should containInAnyOrder(Seq(joinedUserAccounts))
       )
       .run()
+
+    // error
+    an[AssertionError] shouldBe thrownBy {
+      JobTest[SmbTransformJob.type]
+        .args(
+          "--users=/users",
+          "--accounts=/accounts",
+          "--output=/output"
+        )
+        .input(SmbIO[Integer, User]("/users", _.getId), Seq(user))
+        .input(SmbIO[Integer, Account]("/accounts", _.getId), Seq(accountA, accountB))
+        .output(SmbIO[Integer, User]("/output", _.getId))(_ should beEmpty)
+        .run()
+    }
   }
 
   it should "be able to mock sortMergeTransform with side inputs" in {


### PR DESCRIPTION
SmbIO assersions are not executed. We only retrieve them, so they're marked as consumed but the SCollection to validate was not passed.

Add error case unit-tests to make sure the failing case is checked