### PR TITLE
Allow String key type to transform SMB sources with CharSequence key

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadata.java
@@ -134,12 +134,13 @@ public class AvroBucketMetadata<K1, K2, V extends IndexedRecord> extends BucketM
 
   @Override
   int hashPrimaryKeyMetadata() {
-    return Objects.hash(keyField, getKeyClass());
+    return Objects.hash(keyField, AvroUtils.castToComparableStringClass(getKeyClass()));
   }
 
   @Override
   int hashSecondaryKeyMetadata() {
-    return Objects.hash(keyFieldSecondary, getKeyClassSecondary());
+    return Objects.hash(
+        keyFieldSecondary, AvroUtils.castToComparableStringClass(getKeyClassSecondary()));
   }
 
   @Override
@@ -194,19 +195,15 @@ public class AvroBucketMetadata<K1, K2, V extends IndexedRecord> extends BucketM
 
   @Override
   <OtherKeyType> boolean keyClassMatches(Class<OtherKeyType> requestedReadType) {
-    if (requestedReadType == String.class && getKeyClass() == CharSequence.class) {
-      return true;
-    } else {
-      return super.keyClassMatches(requestedReadType);
-    }
+    return super.keyClassMatches(requestedReadType)
+        || AvroUtils.castToComparableStringClass(getKeyClass()) == requestedReadType
+        || AvroUtils.castToComparableStringClass(requestedReadType) == getKeyClass();
   }
 
   @Override
   <OtherKeyType> boolean keyClassSecondaryMatches(Class<OtherKeyType> requestedReadType) {
-    if (requestedReadType == String.class && getKeyClassSecondary() == CharSequence.class) {
-      return true;
-    } else {
-      return super.keyClassSecondaryMatches(requestedReadType);
-    }
+    return super.keyClassSecondaryMatches(requestedReadType)
+        || AvroUtils.castToComparableStringClass(getKeyClassSecondary()) == requestedReadType
+        || AvroUtils.castToComparableStringClass(requestedReadType) == getKeyClassSecondary();
   }
 }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroUtils.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroUtils.java
@@ -166,6 +166,14 @@ class AvroUtils {
         CharSequence.class, CharSequenceCoder.of());
   }
 
+  static Class castToComparableStringClass(Class cls) {
+    if (cls == String.class) {
+      return CharSequence.class;
+    } else {
+      return cls;
+    }
+  }
+
   private static class ByteBufferCoder extends AtomicCoder<ByteBuffer> {
     private static final ByteBufferCoder INSTANCE = new ByteBufferCoder();
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -403,11 +403,9 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
     final Class<? extends BucketMetadata> otherClass = other.getClass();
     final Set<Class<? extends BucketMetadata>> compatibleTypes = compatibleMetadataTypes();
 
-    if (compatibleTypes.isEmpty() && other.getClass() != this.getClass()) {
-      return false;
-    } else if (!this.keyClassMatches(other.getKeyClass())
-        && !(compatibleTypes.contains(otherClass)
-            && (other.compatibleMetadataTypes().contains(this.getClass())))) {
+    if ((other.getClass() != this.getClass())
+        && (!compatibleTypes.contains(otherClass)
+            || !other.compatibleMetadataTypes().contains(this.getClass()))) {
       return false;
     }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -405,7 +405,7 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
 
     if (compatibleTypes.isEmpty() && other.getClass() != this.getClass()) {
       return false;
-    } else if (this.getKeyClass() != other.getKeyClass()
+    } else if (!this.keyClassMatches(other.getKeyClass())
         && !(compatibleTypes.contains(otherClass)
             && (other.compatibleMetadataTypes().contains(this.getClass())))) {
       return false;

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/BucketMetadata.java
@@ -404,8 +404,8 @@ public abstract class BucketMetadata<K1, K2, V> implements Serializable, HasDisp
     final Set<Class<? extends BucketMetadata>> compatibleTypes = compatibleMetadataTypes();
 
     if ((other.getClass() != this.getClass())
-        && (!compatibleTypes.contains(otherClass)
-            || !other.compatibleMetadataTypes().contains(this.getClass()))) {
+        && !(compatibleTypes.contains(otherClass)
+            || other.compatibleMetadataTypes().contains(this.getClass()))) {
       return false;
     }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetBucketMetadata.java
@@ -149,12 +149,13 @@ public class ParquetBucketMetadata<K1, K2, V> extends BucketMetadata<K1, K2, V> 
 
   @Override
   int hashPrimaryKeyMetadata() {
-    return Objects.hash(keyField, getKeyClass());
+    return Objects.hash(keyField, AvroUtils.castToComparableStringClass(getKeyClass()));
   }
 
   @Override
   int hashSecondaryKeyMetadata() {
-    return Objects.hash(keyFieldSecondary, getKeyClassSecondary());
+    return Objects.hash(
+        keyFieldSecondary, AvroUtils.castToComparableStringClass(getKeyClassSecondary()));
   }
 
   @Override
@@ -230,20 +231,16 @@ public class ParquetBucketMetadata<K1, K2, V> extends BucketMetadata<K1, K2, V> 
 
   @Override
   <OtherKeyType> boolean keyClassMatches(Class<OtherKeyType> requestedReadType) {
-    if (requestedReadType == String.class && getKeyClass() == CharSequence.class) {
-      return true;
-    } else {
-      return super.keyClassMatches(requestedReadType);
-    }
+    return super.keyClassMatches(requestedReadType)
+        || AvroUtils.castToComparableStringClass(getKeyClass()) == requestedReadType
+        || AvroUtils.castToComparableStringClass(requestedReadType) == getKeyClass();
   }
 
   @Override
   <OtherKeyType> boolean keyClassSecondaryMatches(Class<OtherKeyType> requestedReadType) {
-    if (requestedReadType == String.class && getKeyClassSecondary() == CharSequence.class) {
-      return true;
-    } else {
-      return super.keyClassSecondaryMatches(requestedReadType);
-    }
+    return super.keyClassSecondaryMatches(requestedReadType)
+        || AvroUtils.castToComparableStringClass(getKeyClassSecondary()) == requestedReadType
+        || AvroUtils.castToComparableStringClass(requestedReadType) == getKeyClassSecondary();
   }
 
   ////////////////////////////////////////////////////////////////////////////////

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -436,7 +436,7 @@ public class SortedBucketIO {
       Optional<Coder<K1>> c =
           inputs.stream()
               .flatMap(i -> i.getSourceMetadata().mapping.values().stream())
-              .filter(sm -> sm.metadata.getKeyClass() == keyClassPrimary)
+              .filter(sm -> sm.metadata.keyClassMatches(keyClassPrimary))
               .findFirst()
               .map(sm -> (Coder<K1>) sm.metadata.getKeyCoder());
       if (!c.isPresent())

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -388,7 +388,7 @@ public class SortedBucketIO {
       Optional<Coder<K1>> c =
           inputs.stream()
               .flatMap(i -> i.getSourceMetadata().mapping.values().stream())
-              .filter(sm -> sm.metadata.getKeyClass() == keyClassPrimary)
+              .filter(sm -> sm.metadata.keyClassMatches(keyClassPrimary))
               .findFirst()
               .map(sm -> (Coder<K1>) sm.metadata.getKeyCoder());
       if (!c.isPresent())
@@ -454,7 +454,7 @@ public class SortedBucketIO {
               .filter(
                   sm ->
                       sm.metadata.getKeyClassSecondary() != null
-                          && sm.metadata.getKeyClassSecondary() == keyClassSecondary
+                          && sm.metadata.keyClassSecondaryMatches(keyClassSecondary)
                           && sm.metadata.getKeyCoderSecondary() != null)
               .findFirst()
               .map(sm -> (Coder<K2>) sm.metadata.getKeyCoderSecondary());

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/AvroBucketMetadataTest.java
@@ -364,6 +364,51 @@ public class AvroBucketMetadataTest {
   }
 
   @Test
+  public void testParquetMetadataCompatibility() throws Exception {
+    final AvroBucketMetadata<String, Integer, GenericRecord> metadata1 =
+        new AvroBucketMetadata<>(
+            2,
+            1,
+            String.class,
+            "name",
+            Integer.class,
+            "favorite_number",
+            HashType.MURMUR3_32,
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+            AvroGeneratedUser.SCHEMA$);
+
+    final ParquetBucketMetadata<String, Integer, GenericRecord> metadata2 =
+        new ParquetBucketMetadata<>(
+            2,
+            1,
+            String.class,
+            "favorite_color",
+            Integer.class,
+            "favorite_number",
+            HashType.MURMUR3_32,
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+            AvroGeneratedUser.SCHEMA$);
+
+    final ParquetBucketMetadata<String, Integer, GenericRecord> metadata3 =
+        new ParquetBucketMetadata<>(
+            4,
+            1,
+            String.class,
+            "favorite_color",
+            Integer.class,
+            "favorite_number",
+            HashType.MURMUR3_32,
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX,
+            AvroGeneratedUser.SCHEMA$);
+
+    Assert.assertFalse(metadata1.isPartitionCompatibleForPrimaryKey(metadata2));
+    Assert.assertFalse(metadata1.isPartitionCompatibleForPrimaryAndSecondaryKey(metadata2));
+
+    Assert.assertTrue(metadata2.isPartitionCompatibleForPrimaryKey(metadata3));
+    Assert.assertTrue(metadata2.isPartitionCompatibleForPrimaryAndSecondaryKey(metadata3));
+  }
+
+  @Test
   public void testKeyTypeCheckingBytes()
       throws CannotProvideCoderException, NonDeterministicException {
     new AvroBucketMetadata<>(

--- a/scio-smb/src/test/scala/com/spotify/scio/smb/SmbVersionParityTest.scala
+++ b/scio-smb/src/test/scala/com/spotify/scio/smb/SmbVersionParityTest.scala
@@ -30,7 +30,7 @@ import org.apache.beam.sdk.values.TupleTag
 import java.nio.file.Files
 
 class SmbVersionParityTest extends PipelineSpec {
-  private def testRoundtrip(
+  private def testReadRoundtrip(
     write: SortedBucketIO.Write[CharSequence, _, Account],
     read: SortedBucketIO.Read[Account]
   ): Unit = {
@@ -64,11 +64,49 @@ class SmbVersionParityTest extends PipelineSpec {
       .toSeq should contain theSameElementsAs accounts
   }
 
+  private def testTransformRoundtrip(
+    write: SortedBucketIO.Write[CharSequence, Void, Account],
+    read: SortedBucketIO.Read[Account],
+    transform: SortedBucketIO.TransformOutput[String, Void, Account]
+  ): Unit = {
+    val accounts = (1 to 10).map { i =>
+      Account
+        .newBuilder()
+        .setId(i)
+        .setName(i.toString)
+        .setAmount(i.toDouble)
+        .setType(s"type$i")
+        .setAccountStatus(AccountStatus.Active)
+        .build()
+    }
+
+    {
+      val sc = ScioContext()
+      sc.parallelize(accounts)
+        .saveAsSortedBucket(write)
+      sc.run()
+    }
+
+    // Read data
+    val sc = ScioContext()
+    val tap = sc
+      .sortMergeTransform(classOf[String], read)
+      .to(transform)
+      .via { case (_, records, outputCollector) =>
+        records.foreach(outputCollector.accept(_))
+      }
+
+    tap
+      .get(sc.run().waitUntilDone())
+      .value
+      .toSeq should contain theSameElementsAs accounts
+  }
+
   "SortedBucketSource" should "be able to read CharSequence-keyed Avro sources written before 0.14" in {
     val output = Files.createTempDirectory("smb-version-test-avro").toFile
     output.deleteOnExit()
 
-    testRoundtrip(
+    testReadRoundtrip(
       AvroSortedBucketIO
         .write(classOf[CharSequence], "name", classOf[Account])
         .to(output.getAbsolutePath)
@@ -80,11 +118,33 @@ class SmbVersionParityTest extends PipelineSpec {
     )
   }
 
+  it should "be able to transform CharSequence-keyed Avro sources written before 0.14" in {
+    val tmpDir = Files.createTempDirectory("smb-version-test-avro-tfx").toFile
+    tmpDir.deleteOnExit()
+
+    val writeOutput = tmpDir.toPath.resolve("write")
+    val tfxOutput = tmpDir.toPath.resolve("tfx")
+
+    testTransformRoundtrip(
+      AvroSortedBucketIO
+        .write(classOf[CharSequence], "name", classOf[Account])
+        .to(writeOutput.toString)
+        .withNumBuckets(1)
+        .withNumShards(1),
+      AvroSortedBucketIO
+        .read(new TupleTag[Account], classOf[Account])
+        .from(writeOutput.toString),
+      AvroSortedBucketIO
+        .transformOutput(classOf[String], "name", classOf[Account])
+        .to(tfxOutput.toString)
+    )
+  }
+
   it should "be able to read CharSequence-keyed Parquet sources written before 0.14" in {
     val output = Files.createTempDirectory("smb-version-test-parquet").toFile
     output.deleteOnExit()
 
-    testRoundtrip(
+    testReadRoundtrip(
       ParquetAvroSortedBucketIO
         .write(classOf[CharSequence], "name", classOf[Account])
         .to(output.getAbsolutePath)
@@ -93,6 +153,28 @@ class SmbVersionParityTest extends PipelineSpec {
       ParquetAvroSortedBucketIO
         .read(new TupleTag[Account], classOf[Account])
         .from(output.getAbsolutePath)
+    )
+  }
+
+  it should "be able to transform CharSequence-keyed Parquet sources written before 0.14" in {
+    val tmpDir = Files.createTempDirectory("smb-version-test-parquet-tfx").toFile
+    tmpDir.deleteOnExit()
+
+    val writeOutput = tmpDir.toPath.resolve("write")
+    val tfxOutput = tmpDir.toPath.resolve("tfx")
+
+    testTransformRoundtrip(
+      ParquetAvroSortedBucketIO
+        .write(classOf[CharSequence], "name", classOf[Account])
+        .to(writeOutput.toString)
+        .withNumBuckets(1)
+        .withNumShards(1),
+      ParquetAvroSortedBucketIO
+        .read(new TupleTag[Account], classOf[Account])
+        .from(writeOutput.toString),
+      ParquetAvroSortedBucketIO
+        .transformOutput(classOf[String], "name", classOf[Account])
+        .to(tfxOutput.toString)
     )
   }
 }


### PR DESCRIPTION
extension of #5291 for transforms.

\+ adds support for sources with multiple partitions, where some partitions have CharSequence key and some have String key

( 🤦‍♀️ )