### PR TITLE
(WIP) (#5296) Support Parquet predicates/projections in tests

### DIFF
--- a/scio-parquet/src/main/java/com/spotify/scio/parquet/BeamOutputFile.java
+++ b/scio-parquet/src/main/java/com/spotify/scio/parquet/BeamOutputFile.java
@@ -43,7 +43,7 @@ public class BeamOutputFile implements OutputFile {
     return of(FileSystems.matchNewResource(path, false));
   }
 
-  private BeamOutputFile(OutputStream outputStream) {
+  BeamOutputFile(OutputStream outputStream) {
     this.outputStream = outputStream;
   }
 

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/ParquetAvroIO.scala
@@ -22,7 +22,7 @@ import com.spotify.scio.ScioContext
 import com.spotify.scio.coders.{Coder, CoderMaterializer}
 import com.spotify.scio.io.{ScioIO, Tap, TapOf, TapT}
 import com.spotify.scio.parquet.read.{ParquetRead, ParquetReadConfiguration, ReadSupportFactory}
-import com.spotify.scio.parquet.{GcsConnectorUtil, ParquetConfiguration}
+import com.spotify.scio.parquet._
 import com.spotify.scio.testing.TestDataManager
 import com.spotify.scio.util.{FilenamePolicySupplier, Functions, ScioUtil}
 import com.spotify.scio.values.SCollection
@@ -43,6 +43,8 @@ import org.apache.hadoop.mapreduce.Job
 import org.apache.parquet.avro.{
   AvroDataSupplier,
   AvroParquetInputFormat,
+  AvroParquetReader,
+  AvroParquetWriter,
   AvroReadSupport,
   GenericDataSupplier
 }
@@ -50,6 +52,7 @@ import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.hadoop.ParquetInputFormat
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 
+import java.io.ByteArrayOutputStream
 import scala.reflect.{classTag, ClassTag}
 
 final case class ParquetAvroIO[T: ClassTag: Coder](path: String) extends ScioIO[T] {
@@ -66,11 +69,18 @@ final case class ParquetAvroIO[T: ClassTag: Coder](path: String) extends ScioIO[
 
   override protected def readTest(sc: ScioContext, params: ReadP): SCollection[T] = {
     type AvroType = params.avroClass.type
+
+    val cleanedProjectionFn = ClosureCleaner.clean(params.projectionFn.asInstanceOf[AvroType => T])
+
     // The projection function is not part of the test input, so it must be applied directly
     TestDataManager
       .getInput(sc.testId.get)(ParquetAvroIO[AvroType](path)(classTag, null))
       .toSCollection(sc)
-      .map(params.projectionFn.asInstanceOf[AvroType => T])
+      .flatMap(
+        params.testRoundtripFn
+          .asInstanceOf[AvroType => Option[AvroType]]
+          .andThen(_.map(cleanedProjectionFn))
+      )
   }
 
   private def parquetOut(
@@ -172,6 +182,33 @@ object ParquetAvroIO {
         readSplittableDoFn(sc, path)
       } else {
         readLegacy(sc, path)
+      }
+    }
+
+    private[avro] def testRoundtripFn: A => Option[A] = {
+      val configuration = {
+        setupConfig()
+        new SerializableConfiguration(confOrDefault)
+      }
+
+      record => {
+        val stream = new ByteArrayOutputStream()
+        val writer = AvroParquetWriter
+          .builder[A](inMemoryOutputFile(stream))
+          .withSchema(ReflectData.get().getSchema(record.getClass))
+          .build()
+
+        writer.write(record)
+        writer.close()
+
+        val reader = AvroParquetReader
+          .builder[A](inMemoryInputFile(stream.toByteArray))
+          .withConf(configuration.get())
+          .build()
+
+        val roundtripped = reader.read()
+        reader.close()
+        Option(roundtripped) // If record is filtered out, reader.read will return null
       }
     }
 

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/package.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/package.scala
@@ -17,9 +17,9 @@
 package com.spotify.scio
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.parquet.io.{OutputFile, PositionOutputStream}
+import org.apache.parquet.io._
 
-import java.io.OutputStream
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, OutputStream}
 import java.nio.channels.{Channels, WritableByteChannel}
 
 package object parquet {
@@ -73,5 +73,29 @@ package object parquet {
 
     private[parquet] def ofNullable(conf: Configuration): Configuration =
       Option(conf).getOrElse(empty())
+  }
+
+  private[parquet] def inMemoryOutputFile(baos: ByteArrayOutputStream): OutputFile =
+    new BeamOutputFile(baos)
+
+  private[parquet] def inMemoryInputFile(bytes: Array[Byte]): InputFile = new InputFile {
+    override def getLength: Long = bytes.length
+
+    override def newStream(): SeekableInputStream =
+      new DelegatingSeekableInputStream(new ByteArrayInputStream(bytes)) {
+        override def getPos: Long = bytes.length - getStream.available()
+        override def mark(readlimit: Int): Unit = {
+          if (readlimit != 0) {
+            throw new UnsupportedOperationException(
+              "In-memory seekable input stream is intended for testing only, can't mark past 0"
+            )
+          }
+          super.mark(readlimit)
+        }
+        override def seek(newPos: Long): Unit = {
+          getStream.reset()
+          getStream.skip(newPos)
+        }
+      }
   }
 }

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
@@ -495,12 +495,15 @@ class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
       e.getCause shouldBe a[NotImplementedError]
   }
 
-  it should "apply map functions to test input" in {
+  it should "apply map, projection, and predicate functions to test input" in {
     JobTest[ParquetTestJob.type]
       .args("--input=input", "--output=output")
       .input(
         ParquetAvroIO[Account]("input"),
-        List(Account.newBuilder().setId(1).setName("foo").setType("bar").setAmount(2.0).build())
+        List(
+          Account.newBuilder().setId(1).setName("foo").setType("bar").setAmount(2.0).build(),
+          Account.newBuilder().setId(1).setName("foo").setType("bar").setAmount(10.0).build()
+        )
       )
       .output(TextIO("output"))(_ should containSingleValue(("foo", 2.0).toString))
       .run()
@@ -513,7 +516,8 @@ object ParquetTestJob {
     sc
       .parquetAvroFile[Account](
         args("input"),
-        projection = Projection[Account](_.getName, _.getAmount)
+        projection = Projection[Account](_.getName, _.getAmount),
+        predicate = Predicate[Account](_.getAmount < 5.0)
       )
       .map(a => (a.getName.toString, a.getAmount))
       .saveAsTextFile(args("output"))


### PR DESCRIPTION
WIP of Parquet projection/predicate support in JobTest.

Alternately, we could provide custom assertions similar to `CoderAssertions`, i.e.:

```scala
val record: AvroType = ???
record withPredicate(FilterApi.and(...)) withProjection(...schema...) should eq(...)
```

but I think that's overall harder for users to work with.

The downside of this approach is that I'll have to implement separately for ParquetAvroIO, ParquetTypeIO, ParquetExampleIO, and SmbIO.

any feedback on the different possible approaches here is welcome!