### PR TITLE
[scio-avro] fix: allow conversions field in record

### DIFF
--- a/scio-avro/src/test/avro/scio-avro-test.avsc
+++ b/scio-avro/src/test/avro/scio-avro-test.avsc
@@ -1,7 +1,65 @@
-{
-  "type": "record",
-  "name": "Test",
-  "fields": [
-    {"name": "test", "type": "int"}
-  ]
-}
+[
+  {
+    "type": "record",
+    "name": "Test",
+    "namespace": "com.spotify.scio.avro",
+    "fields": [
+      {
+        "name": "test",
+        "type": "int"
+      }
+    ]
+  },
+  {
+    "name": "LogicalTypesTest",
+    "namespace": "com.spotify.scio.avro",
+    "doc": "Record for testing logical types",
+    "type": "record",
+    "fields": [
+      {
+        "name": "timestamp",
+        "type": {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      },
+      {
+        "name": "local_date_time",
+        "type": {
+          "name": "LocalDateTimeTest",
+          "type": "record",
+          "fields": [
+            {
+              "name": "date",
+              "type": {
+                "type": "int",
+                "logicalType": "date"
+              }
+            },
+            {
+              "name": "time",
+              "type": {
+                "type": "int",
+                "logicalType": "time-millis"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "record",
+    "name": "NameConflict",
+    "namespace": "com.spotify.scio.avro",
+    "fields": [
+      {
+        "name": "conversions",
+        "type": {
+          "type": "array",
+          "items": "int"
+        }
+      }
+    ]
+  }
+]

--- a/scio-avro/src/test/scala/com/spotify/scio/avro/AvroDatumFactoryTest.scala
+++ b/scio-avro/src/test/scala/com/spotify/scio/avro/AvroDatumFactoryTest.scala
@@ -32,20 +32,26 @@ class AvroDatumFactoryTest extends AnyFlatSpec with Matchers {
       val writer = factory(schema)
       val data = writer.asInstanceOf[SpecificDatumWriter[LogicalTypesTest]].getData
       // top-level
-      data.getConversionFor(LogicalTypes.timestampMillis()) shouldBe a[TimeConversions.TimestampConversion]
+      val timestamp = data.getConversionFor(LogicalTypes.timestampMillis())
+      timestamp shouldBe a[TimeConversions.TimestampConversion]
       // nested-level
-      data.getConversionFor(LogicalTypes.date()) shouldBe a[TimeConversions.DateConversion]
-      data.getConversionFor(LogicalTypes.timeMillis()) shouldBe a[TimeConversions.TimeConversion]
+      val date = data.getConversionFor(LogicalTypes.date())
+      date shouldBe a[TimeConversions.DateConversion]
+      val time = data.getConversionFor(LogicalTypes.timeMillis())
+      time shouldBe a[TimeConversions.TimeConversion]
     }
 
     {
       val reader = factory(schema, schema)
       val data = reader.asInstanceOf[SpecificDatumReader[LogicalTypesTest]].getData
       // top-level
-      data.getConversionFor(LogicalTypes.timestampMillis()) shouldBe a[TimeConversions.TimestampConversion]
+      val timestamp = data.getConversionFor(LogicalTypes.timestampMillis())
+      timestamp shouldBe a[TimeConversions.TimestampConversion]
       // nested-level
-      data.getConversionFor(LogicalTypes.date()) shouldBe a[TimeConversions.DateConversion]
-      data.getConversionFor(LogicalTypes.timeMillis()) shouldBe a[TimeConversions.TimeConversion]
+      val date = data.getConversionFor(LogicalTypes.date())
+      date shouldBe a[TimeConversions.DateConversion]
+      val time = data.getConversionFor(LogicalTypes.timeMillis())
+      time shouldBe a[TimeConversions.TimeConversion]
     }
   }
 

--- a/scio-avro/src/test/scala/com/spotify/scio/avro/AvroDatumFactoryTest.scala
+++ b/scio-avro/src/test/scala/com/spotify/scio/avro/AvroDatumFactoryTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.spotify.scio.avro
 
 import org.apache.avro.LogicalTypes

--- a/scio-avro/src/test/scala/com/spotify/scio/avro/AvroDatumFactoryTest.scala
+++ b/scio-avro/src/test/scala/com/spotify/scio/avro/AvroDatumFactoryTest.scala
@@ -1,0 +1,43 @@
+package com.spotify.scio.avro
+
+import org.apache.avro.LogicalTypes
+import org.apache.avro.data.TimeConversions
+import org.apache.avro.specific.{SpecificDatumReader, SpecificDatumWriter}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AvroDatumFactoryTest extends AnyFlatSpec with Matchers {
+
+  "SpecificRecordDatumFactory" should "patch 1.8 model with conversions" in {
+    val factory = new SpecificRecordDatumFactory(classOf[LogicalTypesTest])
+    val schema = LogicalTypesTest.getClassSchema
+
+    {
+      val writer = factory(schema)
+      val data = writer.asInstanceOf[SpecificDatumWriter[LogicalTypesTest]].getData
+      // top-level
+      data.getConversionFor(LogicalTypes.timestampMillis()) shouldBe a[TimeConversions.TimestampConversion]
+      // nested-level
+      data.getConversionFor(LogicalTypes.date()) shouldBe a[TimeConversions.DateConversion]
+      data.getConversionFor(LogicalTypes.timeMillis()) shouldBe a[TimeConversions.TimeConversion]
+    }
+
+    {
+      val reader = factory(schema, schema)
+      val data = reader.asInstanceOf[SpecificDatumReader[LogicalTypesTest]].getData
+      // top-level
+      data.getConversionFor(LogicalTypes.timestampMillis()) shouldBe a[TimeConversions.TimestampConversion]
+      // nested-level
+      data.getConversionFor(LogicalTypes.date()) shouldBe a[TimeConversions.DateConversion]
+      data.getConversionFor(LogicalTypes.timeMillis()) shouldBe a[TimeConversions.TimeConversion]
+    }
+  }
+
+  it should "allow classes with 'conversions' field" in {
+    val f = new SpecificRecordDatumFactory(classOf[NameConflict])
+    val schema = LogicalTypesTest.getClassSchema
+    noException shouldBe thrownBy(f(schema))
+    noException shouldBe thrownBy(f(schema, schema))
+  }
+
+}


### PR DESCRIPTION
We relied on 'conversions' being a reserved field in avro. However, when records do not contain logical types, 'conversions' can be a valid field name.

Make avro 1.8 logical-type patching more lenient