### PR TITLE
Update FixAvroCoder to match transformed Avro SCollections

### DIFF
--- a/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder16.scala
+++ b/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder16.scala
@@ -1,0 +1,13 @@
+/*
+rule = FixAvroCoder
+ */
+package fix.v0_14_0
+
+import com.spotify.scio.values.SCollection
+
+object FixAvroCoder16 {
+
+  def someMethod(data: SCollection[A]): SCollection[A] = {
+    data.map(r => ("foo", r))
+  }
+}

--- a/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder16.scala
+++ b/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder16.scala
@@ -7,7 +7,7 @@ import com.spotify.scio.values.SCollection
 
 object FixAvroCoder16 {
 
-  def someMethod(data: SCollection[A]): SCollection[A] = {
+  def someMethod(data: SCollection[A]): SCollection[(String, A)] = {
     data.map(r => ("foo", r))
   }
 }

--- a/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder16.scala
+++ b/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixAvroCoder16.scala
@@ -1,0 +1,11 @@
+package fix.v0_14_0
+
+import com.spotify.scio.values.SCollection
+import com.spotify.scio.avro._
+
+object FixAvroCoder16 {
+
+  def someMethod(data: SCollection[A]): SCollection[(String, A)] = {
+    data.map(r => ("foo", r))
+  }
+}


### PR DESCRIPTION
Our Scalafix rule was missing utility-type classes that contain helper methods for SCollections, like:

```
  def someMethod(data: SCollection[A]): SCollection[(String, A)] = {
    data.map(r => ("foo", r))
  }
```

This updates the rule to check for method that returns `SCollection[T <: SpecificRecord]`. There's a tiny chance of a false positive if the method doesn't actually invoke any SCollection mapper functions but I don't think that usage is very common. I could update the method to inspect the function body for usage of functions with a Coder bound but I think that would be very error-prone