### PR TITLE
(chore) Update to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,9 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' coverage test coverageAggregate
 
       - name: Upload coverage report
-        run: 'bash <(curl -s https://codecov.io/bash)'
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   it-test:
     name: Integration Test

--- a/build.sbt
+++ b/build.sbt
@@ -302,8 +302,9 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
           List("coverage", "test", "coverageAggregate"),
           name = Some("Test coverage")
         ),
-        WorkflowStep.Run(
-          List("bash <(curl -s https://codecov.io/bash)"),
+        WorkflowStep.Use(
+          UseRef.Public("codecov", "codecov-action", "v4"),
+          Map("token" -> "${{ secrets.CODECOV_TOKEN }}"),
           name = Some("Upload coverage report")
         )
       ),


### PR DESCRIPTION
Codecov coverage report changed to a github action.

See https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/