### PR TITLE
fix FixQuery scalafix rule for macro-generated classes

### DIFF
--- a/scalafix/rules/src/main/scala/fix/v0_14_0/FixQuery.scala
+++ b/scalafix/rules/src/main/scala/fix/v0_14_0/FixQuery.scala
@@ -12,9 +12,17 @@ class FixQuery extends SemanticRule("FixQuery") {
 
   import FixQuery._
 
+  private def isQuery(term: Tree)(implicit doc: SemanticDocument): Boolean = {
+    term.symbol.info.exists { info =>
+      info.overriddenSymbols.exists(HasQueryMatcher.matches)
+    }
+  }
+
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
       case t @ q"$qual.$fn" if HasQueryMatcher.matches(fn) =>
+        Patch.replaceTree(t, q"$qual.queryRaw".syntax)
+      case t @ q"$qual.query" if isQuery(t) =>
         Patch.replaceTree(t, q"$qual.queryRaw".syntax)
     }.asPatch
   }

--- a/scalafix/rules/src/main/scala/fix/v0_14_0/FixQuery.scala
+++ b/scalafix/rules/src/main/scala/fix/v0_14_0/FixQuery.scala
@@ -12,11 +12,8 @@ class FixQuery extends SemanticRule("FixQuery") {
 
   import FixQuery._
 
-  private def isQuery(term: Tree)(implicit doc: SemanticDocument): Boolean = {
-    term.symbol.info.exists { info =>
-      info.overriddenSymbols.exists(HasQueryMatcher.matches)
-    }
-  }
+  private def isQuery(term: Tree)(implicit doc: SemanticDocument): Boolean =
+    term.symbol.info.exists(_.overriddenSymbols.exists(HasQueryMatcher.matches))
 
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {


### PR DESCRIPTION
This new case works for `#query` usage invoked from a class generated via `BigQueryType.fromQuery`. I didn't add a test since I didn't want to add mix BQ authentication/billing with the Scalafix project 😅 tested ad-hoc on local projects.