### PR TITLE
Fix sparkey loading issue for unknown keys

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -411,6 +411,10 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   ProblemFilters.exclude[MissingClassProblem](
     "com.spotify.scio.coders.instances.kryo.BigtableRetriesExhaustedExceptionSerializer"
+  ),
+  // added new Cache.get method
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "com.spotify.scio.util.Cache.get"
   )
 )
 


### PR DESCRIPTION
Fix #5386 

Add new get method on cache that takes an optional default value.
Use it in sparkey to make sure this unknown keys from sparkey won't fail the loading cache step.