### PR TITLE
Fix incompatible jackson libs pulled by beam-sdks-java-io-google-cloud-platform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ val beamVersion = "2.56.0"
 
 // check version used by beam
 // https://github.com/apache/beam/blob/v2.56.0/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+val arrowVersion = "15.0.1"
 val autoServiceVersion = "1.0.1"
 val autoValueVersion = "1.9"
 val bigdataossVersion = "2.2.16"
@@ -883,6 +884,11 @@ lazy val `scio-google-cloud-platform` = project
   .settings(beamRunnerSettings)
   .settings(
     description := "Scio add-on for Google Cloud Platform",
+    unusedCompileDependenciesFilter -= Seq(
+      // required for patching jackson version pulled by arrow
+      moduleFilter("org.apache.arrow", "arrow-vector"),
+      moduleFilter("com.fasterxml.jackson.datatype", "jackson-datatype-jsr310")
+    ).reduce(_ | _),
     libraryDependencies ++= Seq(
       // compile
       "com.esotericsoftware" % "kryo-shaded" % kryoVersion,
@@ -921,11 +927,12 @@ lazy val `scio-google-cloud-platform` = project
       "org.apache.avro" % "avro" % avroVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-extensions-google-cloud-platform-core" % beamVersion,
-      "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion excludeAll (Exclude.jacksons: _*),
+      "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion,
       "org.apache.beam" % "beam-vendor-guava-32_1_2-jre" % beamVendorVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
-      // runtime
-      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion % Runtime, // replace excluded
+      // patch jackson versions
+      "org.apache.arrow" % "arrow-vector" % arrowVersion excludeAll (Exclude.jacksons: _*),
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
       // test
       "com.google.cloud" % "google-cloud-storage" % googleCloudStorageVersion % Test,
       "com.spotify" %% "magnolify-cats" % magnolifyVersion % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -921,9 +921,11 @@ lazy val `scio-google-cloud-platform` = project
       "org.apache.avro" % "avro" % avroVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-extensions-google-cloud-platform-core" % beamVersion,
-      "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion,
+      "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion excludeAll (Exclude.jacksons: _*),
       "org.apache.beam" % "beam-vendor-guava-32_1_2-jre" % beamVendorVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
+      // runtime
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion % Runtime, // replace excluded
       // test
       "com.google.cloud" % "google-cloud-storage" % googleCloudStorageVersion % Test,
       "com.spotify" %% "magnolify-cats" % magnolifyVersion % Test,
@@ -1789,6 +1791,7 @@ ThisBuild / dependencyOverrides ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
   "com.github.luben" % "zstd-jni" % zstdJniVersion,
   "com.google.api" % "api-common" % googleApiCommonVersion,

--- a/project/Exclude.scala
+++ b/project/Exclude.scala
@@ -2,14 +2,20 @@ import sbt._
 
 object Exclude {
   // do not pull newer avro version
-  val avro = "org.apache.avro" % "avro"
-  val gcsio = "com.google.cloud.bigdataoss" % "gcsio"
+  val avro: ExclusionRule = "org.apache.avro" % "avro"
+  val gcsio: ExclusionRule = "com.google.cloud.bigdataoss" % "gcsio"
+  // do not pull newer jackson version
+  val jacksons: Seq[ExclusionRule] = Seq(
+    ExclusionRule("com.fasterxml.jackson.core"),
+    ExclusionRule("com.fasterxml.jackson.datatype"),
+    ExclusionRule("com.fasterxml.jackson.module")
+  )
   // replaced by io.dropwizard.metrics metrics-core
-  val metricsCore = "com.codahale.metrics" % "metrics-core"
+  val metricsCore: ExclusionRule = "com.codahale.metrics" % "metrics-core"
   // kafka isn't exposed in scio and pulling too many things
-  val beamKafka = "org.apache.beam" % "beam-sdks-java-io-kafka"
+  val beamKafka: ExclusionRule = "org.apache.beam" % "beam-sdks-java-io-kafka"
   // logger implementation must be given by the runner lib
-  val loggerImplementations = Seq(
+  val loggerImplementations: Seq[ExclusionRule] = Seq(
     "ch.qos.logback" % "logback-classic",
     "ch.qos.logback" % "logback-core",
     "ch.qos.reload4j" % "reload4j",


### PR DESCRIPTION
beam `beam-sdks-java-io-google-cloud-platform` has updated arrow to 15.0.1.
This version transitively pulls jackson 2.16 which conflicts with default beam jackson 2.14.1

```
com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.14.1 requires Jackson Databind version >= 2.14.0 and < 2.15.0 - Found jackson-databind version 2.16.0
```