### PR TITLE
Use hash join when writing sparkey

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyIO.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyIO.scala
@@ -124,7 +124,7 @@ object SparkeyIO {
 
       // write files to temporary locations
       val tempShardUris = shards
-        .rightOuterJoin(allShards)
+        .hashFullOuterJoin(allShards)
         .map { case (shard, (xs, _)) =>
           // use a temp uri so that if a bundle fails retries will not fail
           val tempUri = SparkeyUri(s"$tempPath/${UUID.randomUUID}")


### PR DESCRIPTION
When writing to sparkey, `allShards` represents every expected shard even if there is no corresponding data in `shards` for that shard number.

`shards.rightOuterJoin(allShards)` (added in https://github.com/spotify/scio/pull/5208) fails when a shard contains large amounts of data, leading to the error described in https://github.com/spotify/scio/issues/5300: `java.lang.OutOfMemoryError: Required array length 2147483639 + 15534 is too large`. 

This PR replaces `rightOuterJoin` with `hashFullOuterJoin` (note that there is no `hashRightOuterJoin` implementation). A hash join is a good fit because the right-hand side contains very little data (only the keys of the shards) and it doesn't need to use an array to represent the large left-hand side's values. As a result, some failing workflows that succeeded in Scio 0.13.* will run successfully again.