### PR TITLE
Support writing extra metadata in scio-parquet

### DIFF
--- a/scio-parquet/src/main/java/com/spotify/scio/parquet/WriterUtils.java
+++ b/scio-parquet/src/main/java/com/spotify/scio/parquet/WriterUtils.java
@@ -29,7 +29,10 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 public class WriterUtils {
   public static <T, SELF extends ParquetWriter.Builder<T, SELF>> ParquetWriter<T> build(
-      ParquetWriter.Builder<T, SELF> builder, Configuration conf, CompressionCodecName compression)
+      ParquetWriter.Builder<T, SELF> builder,
+      Configuration conf,
+      CompressionCodecName compression,
+      Map<String, String> extraMetadata)
       throws IOException {
     // https://github.com/apache/parquet-mr/tree/master/parquet-hadoop#class-parquetoutputformat
     long rowGroupSize =
@@ -51,6 +54,10 @@ public class WriterUtils {
         getColumnarConfig(conf, ParquetOutputFormat.BLOOM_FILTER_EXPECTED_NDV, Long::parseLong)
             .entrySet()) {
       builder = builder.withBloomFilterNDV(entry.getKey(), entry.getValue());
+    }
+
+    if (extraMetadata != null) {
+      builder = builder.withExtraMetaData(extraMetadata);
     }
 
     return builder

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/syntax/SCollectionSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/avro/syntax/SCollectionSyntax.scala
@@ -64,7 +64,8 @@ class SCollectionOps[T <: IndexedRecord](private val self: SCollection[T]) exten
     shardNameTemplate: String = WriteParam.DefaultShardNameTemplate,
     tempDirectory: String = WriteParam.DefaultTempDirectory,
     filenamePolicySupplier: FilenamePolicySupplier = WriteParam.DefaultFilenamePolicySupplier,
-    prefix: String = WriteParam.DefaultPrefix
+    prefix: String = WriteParam.DefaultPrefix,
+    metadata: Map[String, String] = WriteParam.DefaultMetadata
   )(implicit ct: ClassTag[T], coder: Coder[T]): ClosedTap[T] = {
     val param = WriteParam(
       schema = schema,
@@ -75,7 +76,8 @@ class SCollectionOps[T <: IndexedRecord](private val self: SCollection[T]) exten
       filenamePolicySupplier = filenamePolicySupplier,
       prefix = prefix,
       shardNameTemplate = shardNameTemplate,
-      tempDirectory = tempDirectory
+      tempDirectory = tempDirectory,
+      metadata = metadata
     )
     self.write(ParquetAvroIO[T](path))(param)
   }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/ParquetExampleIO.scala
@@ -159,7 +159,8 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
     shardNameTemplate: String,
     isWindowed: Boolean,
     tempDirectory: ResourceId,
-    isLocalRunner: Boolean
+    isLocalRunner: Boolean,
+    metadata: Map[String, String]
   ) = {
     require(tempDirectory != null, "tempDirectory must not be null")
     val fp = FilenamePolicySupplier.resolve(
@@ -177,7 +178,8 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
       dynamicDestinations,
       schema,
       job.getConfiguration,
-      compression
+      compression,
+      metadata.asJava
     )
     val transform = WriteFiles.to(sink).withNumShards(numShards)
     if (!isWindowed) transform else transform.withWindowedWrites()
@@ -197,7 +199,8 @@ final case class ParquetExampleIO(path: String) extends ScioIO[Example] {
         params.shardNameTemplate,
         ScioUtil.isWindowed(data),
         ScioUtil.tempDirOrDefault(params.tempDirectory, data.context),
-        ScioUtil.isLocalRunner(data.context.options.getRunner)
+        ScioUtil.isLocalRunner(data.context.options.getRunner),
+        params.metadata
       )
     )
     tap(ParquetExampleIO.ReadParam(params))
@@ -237,6 +240,7 @@ object ParquetExampleIO {
     val DefaultPrefix: String = null
     val DefaultShardNameTemplate: String = null
     val DefaultTempDirectory: String = null
+    val DefaultMetadata: Map[String, String] = null
   }
 
   final case class WriteParam private (
@@ -248,7 +252,8 @@ object ParquetExampleIO {
     filenamePolicySupplier: FilenamePolicySupplier = WriteParam.DefaultFilenamePolicySupplier,
     prefix: String = WriteParam.DefaultPrefix,
     shardNameTemplate: String = WriteParam.DefaultShardNameTemplate,
-    tempDirectory: String = WriteParam.DefaultTempDirectory
+    tempDirectory: String = WriteParam.DefaultTempDirectory,
+    metadata: Map[String, String] = WriteParam.DefaultMetadata
   )
 }
 

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/dynamic/ParquetExampleSink.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/dynamic/ParquetExampleSink.scala
@@ -26,11 +26,13 @@ import org.tensorflow.proto.example.Example
 import org.tensorflow.metadata.v0.Schema
 
 import java.nio.channels.WritableByteChannel
+import scala.jdk.CollectionConverters._
 
 class ParquetExampleSink(
   val schema: Schema,
   val compression: CompressionCodecName,
-  val conf: SerializableConfiguration
+  val conf: SerializableConfiguration,
+  val metadata: Map[String, String]
 ) extends FileIO.Sink[Example] {
 
   private var writer: ParquetWriter[Example] = _
@@ -38,7 +40,7 @@ class ParquetExampleSink(
   override def open(channel: WritableByteChannel): Unit = {
     val outputFile = BeamOutputFile.of(channel)
     val builder = TensorflowExampleParquetWriter.builder(outputFile).withSchema(schema)
-    writer = WriterUtils.build(builder, conf.get, compression)
+    writer = WriterUtils.build(builder, conf.get, compression, metadata.asJava)
   }
 
   override def write(element: Example): Unit = writer.write(element)

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/dynamic/syntax/SCollectionSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/dynamic/syntax/SCollectionSyntax.scala
@@ -44,7 +44,8 @@ final class DynamicParquetExampleSCollectionOps(
     compression: CompressionCodecName = ParquetExampleIO.WriteParam.DefaultCompression,
     conf: Configuration = ParquetExampleIO.WriteParam.DefaultConfiguration,
     tempDirectory: String = ParquetExampleIO.WriteParam.DefaultTempDirectory,
-    prefix: String = ParquetExampleIO.WriteParam.DefaultPrefix
+    prefix: String = ParquetExampleIO.WriteParam.DefaultPrefix,
+    metadata: Map[String, String] = ParquetExampleIO.WriteParam.DefaultMetadata
   )(
     destinationFn: Example => String
   ): ClosedTap[Nothing] = {
@@ -56,7 +57,8 @@ final class DynamicParquetExampleSCollectionOps(
       val sink = new ParquetExampleSink(
         schema,
         compression,
-        new SerializableConfiguration(ParquetConfiguration.ofNullable(conf))
+        new SerializableConfiguration(ParquetConfiguration.ofNullable(conf)),
+        metadata
       )
       val write = writeDynamic(
         path = path,

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/syntax/SCollectionSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/tensorflow/syntax/SCollectionSyntax.scala
@@ -41,7 +41,8 @@ final class SCollectionOps(private val self: SCollection[Example]) extends AnyVa
     shardNameTemplate: String = WriteParam.DefaultShardNameTemplate,
     tempDirectory: String = WriteParam.DefaultTempDirectory,
     filenamePolicySupplier: FilenamePolicySupplier = WriteParam.DefaultFilenamePolicySupplier,
-    prefix: String = WriteParam.DefaultPrefix
+    prefix: String = WriteParam.DefaultPrefix,
+    metadata: Map[String, String] = WriteParam.DefaultMetadata
   ): ClosedTap[Example] =
     self.write(ParquetExampleIO(path))(
       WriteParam(
@@ -53,7 +54,8 @@ final class SCollectionOps(private val self: SCollection[Example]) extends AnyVa
         filenamePolicySupplier,
         prefix,
         shardNameTemplate,
-        tempDirectory
+        tempDirectory,
+        metadata
       )
     )
 }

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/ParquetTypeIO.scala
@@ -133,7 +133,8 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
     shardNameTemplate: String,
     isWindowed: Boolean,
     tempDirectory: ResourceId,
-    isLocalRunner: Boolean
+    isLocalRunner: Boolean,
+    metadata: Map[String, String]
   ) = {
     require(tempDirectory != null, "tempDirectory must not be null")
     val fp = FilenamePolicySupplier.resolve(
@@ -151,7 +152,8 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
       dynamicDestinations,
       tpe,
       job.getConfiguration,
-      compression
+      compression,
+      metadata.asJava
     )
     val transform = WriteFiles.to(sink).withNumShards(numShards)
     if (!isWindowed) transform else transform.withWindowedWrites()
@@ -170,7 +172,8 @@ final case class ParquetTypeIO[T: ClassTag: Coder: ParquetType](
         params.shardNameTemplate,
         ScioUtil.isWindowed(data),
         ScioUtil.tempDirOrDefault(params.tempDirectory, data.context),
-        ScioUtil.isLocalRunner(data.context.options.getRunner)
+        ScioUtil.isLocalRunner(data.context.options.getRunner),
+        params.metadata
       )
     )
     tap(ParquetTypeIO.ReadParam(params))
@@ -208,6 +211,7 @@ object ParquetTypeIO {
     val DefaultPrefix: String = null
     val DefaultShardNameTemplate: String = null
     val DefaultTempDirectory: String = null
+    val DefaultMetadata: Map[String, String] = null
   }
 
   final case class WriteParam private (
@@ -218,7 +222,8 @@ object ParquetTypeIO {
     filenamePolicySupplier: FilenamePolicySupplier = WriteParam.DefaultFilenamePolicySupplier,
     prefix: String = WriteParam.DefaultPrefix,
     shardNameTemplate: String = WriteParam.DefaultShardNameTemplate,
-    tempDirectory: String = WriteParam.DefaultTempDirectory
+    tempDirectory: String = WriteParam.DefaultTempDirectory,
+    metadata: Map[String, String] = WriteParam.DefaultMetadata
   )
 }
 

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/syntax/SCollectionSyntax.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/types/syntax/SCollectionSyntax.scala
@@ -42,7 +42,8 @@ final class SCollectionOps[T](private val self: SCollection[T]) extends AnyVal {
     shardNameTemplate: String = WriteParam.DefaultShardNameTemplate,
     tempDirectory: String = WriteParam.DefaultTempDirectory,
     filenamePolicySupplier: FilenamePolicySupplier = WriteParam.DefaultFilenamePolicySupplier,
-    prefix: String = WriteParam.DefaultPrefix
+    prefix: String = WriteParam.DefaultPrefix,
+    metadata: Map[String, String] = WriteParam.DefaultMetadata
   )(implicit ct: ClassTag[T], coder: Coder[T], pt: ParquetType[T]): ClosedTap[T] =
     self.write(ParquetTypeIO[T](path))(
       WriteParam(
@@ -53,7 +54,8 @@ final class SCollectionOps[T](private val self: SCollection[T]) extends AnyVal {
         filenamePolicySupplier,
         prefix,
         shardNameTemplate,
-        tempDirectory
+        tempDirectory,
+        metadata
       )
     )
 }

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
@@ -22,7 +22,7 @@ import com.spotify.scio._
 import com.spotify.scio.avro._
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.io.{ClosedTap, FileNamePolicySpec, ScioIOTest, TapSpec, TextIO}
-import com.spotify.scio.parquet.ParquetConfiguration
+import com.spotify.scio.parquet.{BeamInputFile, ParquetConfiguration}
 import com.spotify.scio.parquet.read.ParquetReadConfiguration
 import com.spotify.scio.testing._
 import com.spotify.scio.util.FilenamePolicySupplier
@@ -43,7 +43,9 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory
 import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, IntervalWindow, PaneInfo}
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.HadoopReadOptions
 import org.apache.parquet.avro.{AvroDataSupplier, AvroReadSupport, AvroWriteSupport}
+import org.apache.parquet.hadoop.ParquetFileReader
 import org.joda.time.{DateTimeFieldType, Duration, Instant}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.prop.TableDrivenPropertyChecks.{forAll => forAllCases, Table}
@@ -352,6 +354,27 @@ class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
       data should containInAnyOrder(genericRecords)
       sc2.run()
     }
+  }
+
+  it should "write extra metadata" in withTempDir { dir =>
+    val sc = ScioContext()
+    val outDir = s"${dir.toPath.resolve("test-metadata").toFile.getAbsolutePath}"
+
+    sc
+      .parallelize(1 to 10)
+      .map(x => new Account(x, x.toString, x.toString, x.toDouble, AccountStatus.Active))
+      .saveAsParquetAvroFile(outDir, metadata = Map("foo" -> "bar", "bar" -> "baz"), numShards = 1)
+    sc.run()
+
+    val options = HadoopReadOptions.builder(ParquetConfiguration.empty()).build
+    val r =
+      ParquetFileReader.open(BeamInputFile.of(s"$outDir/part-00000-of-00001.parquet"), options)
+    val metadata = r.getFileMetaData.getKeyValueMetaData
+
+    metadata.get("foo") shouldBe "bar"
+    metadata.get("bar") shouldBe "baz"
+
+    r.close()
   }
 
   class TestRecordProjection(@unused str: String)


### PR DESCRIPTION
Parquet 0.14 supports setting extra file metadata via ParquetWriter: https://github.com/apache/parquet-java/pull/1241

I added a new `metadata` output param to the scio-parquet Avro/Magnolify/Tensorflow bindings, which matches the naming convention we use in the scio-avro write APIs.