### PR TITLE
[gcp] Fix BQ BIGNUMERIC type support

### DIFF
--- a/integration/src/main/scala/com/spotify/scio/bigquery/PopulateTestData.scala
+++ b/integration/src/main/scala/com/spotify/scio/bigquery/PopulateTestData.scala
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.services.bigquery.model.{Dataset, DatasetReference}
 import com.google.protobuf.ByteString
 import com.spotify.scio.bigquery.client.BigQuery
-import com.spotify.scio.bigquery.types.{Geography, Json}
+import com.spotify.scio.bigquery.types.{BigNumeric, Geography, Json}
 import org.joda.time._
 import org.joda.time.format.DateTimeFormat
 import org.slf4j.LoggerFactory
@@ -53,7 +53,8 @@ object PopulateTestData {
     time: LocalTime,
     datetime: LocalDateTime,
     geography: Geography,
-    json: Json
+    json: Json,
+    bigNumeric: BigNumeric
   )
 
   @BigQueryType.toTable
@@ -69,7 +70,8 @@ object PopulateTestData {
     time: Option[LocalTime],
     datetime: Option[LocalDateTime],
     geography: Option[Geography],
-    json: Option[Json]
+    json: Option[Json],
+    bigNumeric: Option[BigNumeric]
   )
 
   @BigQueryType.toTable
@@ -85,7 +87,8 @@ object PopulateTestData {
     time: List[LocalTime],
     datetime: List[LocalDateTime],
     geography: List[Geography],
-    json: List[Json]
+    json: List[Json],
+    bigNumeric: List[BigNumeric]
   )
 
   case class Record(int: Long, string: String)
@@ -209,7 +212,8 @@ object PopulateTestData {
       dt.toLocalTime.plusMillis(i),
       dt.toLocalDateTime.plusMillis(i),
       Geography(s"POINT($i $i)"),
-      Json(s"""{"value": $i}""")
+      Json(s"""{"value": $i}"""),
+      BigNumeric(BigDecimal(i))
     )
   }
 
@@ -228,7 +232,8 @@ object PopulateTestData {
       Some(dt.toLocalTime.plusMillis(i)),
       Some(dt.toLocalDateTime.plusMillis(i)),
       Some(Geography(s"POINT($i $i)")),
-      Some(Json(s"""{"value": $i}"""))
+      Some(Json(s"""{"value": $i}""")),
+      Some(BigNumeric(BigDecimal(i)))
     )
   }
 
@@ -247,7 +252,8 @@ object PopulateTestData {
       List(dt.toLocalTime.plusMillis(i)),
       List(dt.toLocalDateTime.plusMillis(i)),
       List(Geography(s"POINT($i $i)")),
-      List(Json(s"""{"value": $i}"""))
+      List(Json(s"""{"value": $i}""")),
+      List(BigNumeric(BigDecimal(i)))
     )
   }
 }

--- a/integration/src/test/scala/com/spotify/scio/bigquery/types/BigQueryStorageIT.scala
+++ b/integration/src/test/scala/com/spotify/scio/bigquery/types/BigQueryStorageIT.scala
@@ -50,8 +50,9 @@ class BigQueryStorageIT extends AnyFlatSpec with Matchers {
         dt.toLocalDate.plusDays(i),
         dt.toLocalTime.plusMillis(i),
         dt.toLocalDateTime.plusMillis(i),
-        s"POINT($i $i)", // geography is not an avro logical type
-        s"""{"value":$i}""" // json is not an avro logical type
+        Geography(s"POINT($i $i)"),
+        Json(s"""{"value":$i}"""),
+        BigNumeric(BigDecimal(i))
       )
     }.asJava
     val (sc, _) = ContextAndArgs(
@@ -77,8 +78,9 @@ class BigQueryStorageIT extends AnyFlatSpec with Matchers {
         Some(dt.toLocalDate.plusDays(i)),
         Some(dt.toLocalTime.plusMillis(i)),
         Some(dt.toLocalDateTime.plusMillis(i)),
-        Some(s"POINT($i $i)"), // geography is not an avro logical type
-        Some(s"""{"value":$i}""") // json is not an avro logical type
+        Some(Geography(s"POINT($i $i)")),
+        Some(Json(s"""{"value":$i}""")),
+        Some(BigNumeric(BigDecimal(i)))
       )
     }.asJava
     val (sc, _) = ContextAndArgs(
@@ -104,8 +106,9 @@ class BigQueryStorageIT extends AnyFlatSpec with Matchers {
         List(dt.toLocalDate.plusDays(i)),
         List(dt.toLocalTime.plusMillis(i)),
         List(dt.toLocalDateTime.plusMillis(i)),
-        List(s"POINT($i $i)"), // geography is not an avro logical type
-        List(s"""{"value":$i}""") // json is not an avro logical type
+        List(Geography(s"POINT($i $i)")),
+        List(Json(s"""{"value":$i}""")),
+        List(BigNumeric(BigDecimal(i)))
       )
     }.asJava
     val (sc, _) = ContextAndArgs(
@@ -192,7 +195,8 @@ class BigQueryStorageIT extends AnyFlatSpec with Matchers {
         Some(dt.toLocalTime.plusMillis(i)),
         Some(dt.toLocalDateTime.plusMillis(i)),
         Some(Geography(s"POINT($i $i)")),
-        Some(Json(s"""{"value":$i}"""))
+        Some(Json(s"""{"value":$i}""")),
+        Some(BigNumeric(BigDecimal(i)))
       )
     }.asJava
     val (sc, _) = ContextAndArgs(
@@ -221,7 +225,8 @@ class BigQueryStorageIT extends AnyFlatSpec with Matchers {
         dt.toLocalTime.plusMillis(i),
         dt.toLocalDateTime.plusMillis(i),
         Geography(s"POINT($i $i)"),
-        Json(s"""{"value":$i}""")
+        Json(s"""{"value":$i}"""),
+        BigNumeric(BigDecimal(i))
       )
     }.asJava
     val (sc, _) = ContextAndArgs(
@@ -260,7 +265,8 @@ class BigQueryStorageIT extends AnyFlatSpec with Matchers {
         Some(dt.toLocalTime.plusMillis(i)),
         Some(dt.toLocalDateTime.plusMillis(i)),
         Some(Geography(s"POINT($i $i)")),
-        Some(Json(s"""{"value":$i}"""))
+        Some(Json(s"""{"value":$i}""")),
+        Some(BigNumeric(BigDecimal(i)))
       )
     }.asJava
     val (sc, _) = ContextAndArgs(

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryTypes.scala
@@ -300,13 +300,12 @@ object Numeric {
   val MaxNumericPrecision = 38
   val MaxNumericScale = 9
 
-  private[this] val DecimalConverter = new DecimalConversion
-  private[this] val DecimalLogicalType = LogicalTypes.decimal(MaxNumericPrecision, MaxNumericScale)
+  private val DecimalConverter = new DecimalConversion
+  private val DecimalLogicalType = LogicalTypes.decimal(MaxNumericPrecision, MaxNumericScale)
 
   def apply(value: String): BigDecimal = apply(BigDecimal(value))
 
   def apply(value: BigDecimal): BigDecimal = {
-    // NUMERIC's max scale is 9, precision is 38
     val scaled = if (value.scale > MaxNumericScale) {
       value.setScale(MaxNumericScale, scala.math.BigDecimal.RoundingMode.HALF_UP)
     } else {

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/StorageUtil.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/StorageUtil.scala
@@ -99,17 +99,13 @@ object StorageUtil {
         }
       case Type.STRING =>
         // FIXME: schema.getLogicalType == null in this case, BigQuery service side bug?
-        if (schema.getProp("logicalType") == "datetime") {
-          "DATETIME"
-        } else {
-          schema.getLogicalType match {
-            case null                          => "STRING"
-            case t if t.getName == "datetime"  => "DATETIME"
-            case t if t.getName == "geography" => "GEOGRAPHY"
-            case t if t.getName == "json"      => "JSON"
-            case t =>
-              throw new IllegalStateException(s"Unsupported logical type: $t")
-          }
+        val logicalType = schema.getProp("logicalType")
+        val sqlType = schema.getProp("sqlType")
+        (logicalType, sqlType) match {
+          case ("datetime", _)  => "DATETIME"
+          case (_, "GEOGRAPHY") => "GEOGRAPHY"
+          case (_, "JSON")      => "JSON"
+          case _                => "STRING"
         }
       case Type.RECORD =>
         tableField.setFields(getFieldSchemas(schema).asJava)

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/BigQueryTag.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/BigQueryTag.scala
@@ -17,4 +17,6 @@
 
 package com.spotify.scio.bigquery.types
 
-class BigQueryTag extends scala.annotation.StaticAnnotation with Serializable
+import scala.annotation.StaticAnnotation
+
+class BigQueryTag extends StaticAnnotation with Serializable

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -79,6 +79,7 @@ private[types] object SchemaProvider {
       case t if t =:= typeOf[Double]     => ("FLOAT", Iterable.empty)
       case t if t =:= typeOf[String]     => ("STRING", Iterable.empty)
       case t if t =:= typeOf[BigDecimal] => ("NUMERIC", Iterable.empty)
+      case t if t =:= typeOf[BigNumeric] => ("BIGNUMERIC", Iterable.empty)
 
       case t if t =:= typeOf[ByteString]  => ("BYTES", Iterable.empty)
       case t if t =:= typeOf[Array[Byte]] => ("BYTES", Iterable.empty)

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/TypeProvider.scala
@@ -271,7 +271,6 @@ private[types] object TypeProvider {
         case "FLOAT" | "FLOAT64"                   => (tq"_root_.scala.Double", Nil)
         case "STRING"                              => (tq"_root_.java.lang.String", Nil)
         case "NUMERIC"                             => (tq"_root_.scala.BigDecimal", Nil)
-        case "BIGNUMERIC"                          => (tq"_root_.scala.BigDecimal", Nil)
         case "BYTES"                               => (tq"_root_.com.google.protobuf.ByteString", Nil)
         case "TIMESTAMP"                           => (tq"_root_.org.joda.time.Instant", Nil)
         case "DATE"                                => (tq"_root_.org.joda.time.LocalDate", Nil)
@@ -279,6 +278,7 @@ private[types] object TypeProvider {
         case "DATETIME"                            => (tq"_root_.org.joda.time.LocalDateTime", Nil)
         case "GEOGRAPHY"                           => (tq"_root_.com.spotify.scio.bigquery.types.Geography", Nil)
         case "JSON"                                => (tq"_root_.com.spotify.scio.bigquery.types.Json", Nil)
+        case "BIGNUMERIC"                          => (tq"_root_.com.spotify.scio.bigquery.types.BigNumeric", Nil)
         case "RECORD" | "STRUCT" =>
           val name = NameProvider.getUniqueName(tfs.getName)
           val (fields, records) = toFields(tfs.getFields)

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -17,8 +17,13 @@
 
 package com.spotify.scio.bigquery
 
+import com.spotify.scio.coders.Coder
+import org.apache.avro.Conversions.DecimalConversion
+import org.apache.avro.LogicalTypes
 import org.typelevel.scalaccompat.annotation.nowarn
 
+import java.math.MathContext
+import java.nio.ByteBuffer
 import scala.annotation.StaticAnnotation
 package object types {
 
@@ -39,7 +44,8 @@ package object types {
   /**
    * Case class to serve as raw type for Geography instances to distinguish them from Strings.
    *
-   * See also https://cloud.google.com/bigquery/docs/gis-data
+   * See also
+   * https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#geography_type
    *
    * @param wkt
    *   Well Known Text formatted string that BigQuery displays for Geography
@@ -49,10 +55,53 @@ package object types {
   /**
    * Case class to serve as raw type for Json instances to distinguish them from Strings.
    *
-   * See also https://cloud.google.com/bigquery/docs/json-data
+   * See also https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#json_type
    *
    * @param wkt
    *   Well Known Text formatted string that BigQuery displays for Json
    */
   case class Json(wkt: String)
+
+  /**
+   * Case class to serve as BigNumeric type to distinguish them from Numeric.
+   *
+   * See also https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric_types
+   *
+   * @param wkt
+   *   Well Known big numeric
+   */
+  case class BigNumeric private (wkt: BigDecimal)
+  object BigNumeric {
+    implicit val bigNumericCoder: Coder[BigNumeric] =
+      Coder.xmap(Coder[BigDecimal])(new BigNumeric(_), _.wkt)
+
+    val MaxNumericPrecision = 77
+    val MaxNumericScale = 38
+
+    private val DecimalConverter = new DecimalConversion
+    private val DecimalLogicalType = LogicalTypes.decimal(MaxNumericPrecision, MaxNumericScale)
+
+    def apply(value: String): BigNumeric = apply(BigDecimal(value))
+
+    def apply(value: BigDecimal): BigNumeric = {
+      val scaled = if (value.scale > MaxNumericScale) {
+        value.setScale(MaxNumericScale, scala.math.BigDecimal.RoundingMode.HALF_UP)
+      } else {
+        value
+      }
+      require(
+        scaled.precision <= MaxNumericPrecision,
+        s"max allowed precision is $MaxNumericPrecision"
+      )
+
+      val wkt = scaled.round(new MathContext(MaxNumericPrecision))
+      new BigNumeric(wkt)
+    }
+
+    // For BigQueryType macros only, do not use directly
+    def parse(value: Any): BigNumeric = value match {
+      case b: ByteBuffer => new BigNumeric(DecimalConverter.fromBytes(b, null, DecimalLogicalType))
+      case _             => apply(value.toString)
+    }
+  }
 }

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/TypeProviderTest.scala
@@ -125,7 +125,9 @@ class TypeProviderTest extends AnyFlatSpec with Matchers {
   it should "infer types for Numerics" in {
     BigQueryType[RecordWithNumerics].avroSchema shouldBe RecordWithNumerics.avroSchema
 
-    compileErrors("new RecordWithNumerics(BigDecimal.apply(42), BigDecimal.apply(43))") shouldBe ""
+    compileErrors(
+      "new RecordWithNumerics(BigDecimal(42), BigNumeric(BigDecimal(43)))"
+    ) shouldBe empty
     val error = compileErrors("new RecordWithNumerics(true, false)").replace(" ", "")
     error should include("found:Boolean(true)")
     error should include("required:BigDecimal")
@@ -442,6 +444,54 @@ class TypeProviderTest extends AnyFlatSpec with Matchers {
       .map(_.getName) should not contain "tupled"
   }
 
+  @BigQueryType.fromSchema("""
+                             |{
+                             |  "fields": [ {"mode": "REQUIRED", "name": "f1", "type": "INTEGER"} ]
+                             |}
+    """.stripMargin)
+  class Artisanal1FieldWithBody {
+    object InnerObject {
+      def innerObjectInnerMethod: String = "so artisanal"
+    }
+    val bar: Long = 42L
+    def foo: String = "foo"
+  }
+
+  it should "support user defined body in fromSchema" in {
+    Artisanal1Field.getClass.getMethods
+      .map(_.getName) should not contain "tupled"
+    RecordWithRequiredPrimitives.schema should not be null
+    (classOf[TableRow => RecordWithRequiredPrimitives]
+      isAssignableFrom RecordWithRequiredPrimitives.fromTableRow.getClass) shouldBe true
+    (classOf[ToTable => RecordWithRequiredPrimitives]
+      isAssignableFrom RecordWithRequiredPrimitives.toTableRow.getClass) shouldBe true
+    Artisanal1FieldWithBody(3).bar shouldBe 42L
+    Artisanal1FieldWithBody(3).foo shouldBe "foo"
+    Artisanal1FieldWithBody(3).InnerObject.innerObjectInnerMethod shouldBe "so artisanal"
+  }
+
+  @Annotation1
+  @BigQueryType.fromSchema("""
+                             |{"fields": [ {"mode": "REQUIRED", "name": "f1", "type": "DATE"} ]}
+                             |""".stripMargin)
+  @Annotation2
+  class SchemaWithSurroundingAnnotations
+
+  it should "preserve surrounding user defined annotations" in {
+    containsAllAnnotTypes[SchemaWithSurroundingAnnotations]
+  }
+
+  @BigQueryType.fromSchema("""
+                             |{"fields": [ {"mode": "REQUIRED", "name": "f1", "type": "DATE"} ]}
+                             |""".stripMargin)
+  @Annotation1
+  @Annotation2
+  class SchemaWithSequentialAnnotations
+
+  it should "preserve sequential user defined annotations" in {
+    containsAllAnnotTypes[SchemaWithSequentialAnnotations]
+  }
+
   @BigQueryType.toTable
   case class TwentyThree(
     a1: Int,
@@ -504,32 +554,6 @@ class TypeProviderTest extends AnyFlatSpec with Matchers {
     DescriptionTbl.tableDescription shouldBe "Foo bar table description"
   }
 
-  @BigQueryType.fromSchema("""
-      |{
-      |  "fields": [ {"mode": "REQUIRED", "name": "f1", "type": "INTEGER"} ]
-      |}
-    """.stripMargin)
-  class Artisanal1FieldWithBody {
-    object InnerObject {
-      def innerObjectInnerMethod: String = "so artisanal"
-    }
-    val bar: Long = 42L
-    def foo: String = "foo"
-  }
-
-  it should "support user defined body in fromSchema" in {
-    Artisanal1Field.getClass.getMethods
-      .map(_.getName) should not contain "tupled"
-    RecordWithRequiredPrimitives.schema should not be null
-    (classOf[TableRow => RecordWithRequiredPrimitives]
-      isAssignableFrom RecordWithRequiredPrimitives.fromTableRow.getClass) shouldBe true
-    (classOf[ToTable => RecordWithRequiredPrimitives]
-      isAssignableFrom RecordWithRequiredPrimitives.toTableRow.getClass) shouldBe true
-    Artisanal1FieldWithBody(3).bar shouldBe 42L
-    Artisanal1FieldWithBody(3).foo shouldBe "foo"
-    Artisanal1FieldWithBody(3).InnerObject.innerObjectInnerMethod shouldBe "so artisanal"
-  }
-
   @BigQueryType.toTable
   case class Artisanal1ToTableWithBody(a1: Int) {
     object InnerObject {
@@ -579,28 +603,6 @@ class TypeProviderTest extends AnyFlatSpec with Matchers {
     containsAllAnnotTypes[RecordWithSequentialAnnotations]
   }
 
-  @Annotation1
-  @BigQueryType.fromSchema("""
-      |{"fields": [ {"mode": "REQUIRED", "name": "f1", "type": "DATE"} ]}
-      |""".stripMargin)
-  @Annotation2
-  class SchemaWithSurroundingAnnotations
-
-  "BigQueryType.fromSchema" should "preserve surrounding user defined annotations" in {
-    containsAllAnnotTypes[SchemaWithSurroundingAnnotations]
-  }
-
-  @BigQueryType.fromSchema("""
-      |{"fields": [ {"mode": "REQUIRED", "name": "f1", "type": "DATE"} ]}
-      |""".stripMargin)
-  @Annotation1
-  @Annotation2
-  class SchemaWithSequentialAnnotations
-
-  it should "preserve sequential user defined annotations" in {
-    containsAllAnnotTypes[SchemaWithSequentialAnnotations]
-  }
-
   "BigQueryType" should " #1414: not fail on refined types" in {
     noException should be thrownBy
       BigQueryType[TypeProviderTest.RefinedClass with BigQueryType.HasAnnotation]
@@ -633,5 +635,20 @@ class TypeProviderTest extends AnyFlatSpec with Matchers {
     val cc = JsonRecordFrom(Json(wkt))
     cc.f1 shouldBe Json(wkt)
     JsonRecordTo(Json(wkt))
+  }
+
+  @BigQueryType.fromSchema("""
+      |{"fields": [{"mode": "REQUIRED", "name": "f1", "type": "BIGNUMERIC"}]}
+    """.stripMargin)
+  class BigNumericRecordFrom
+
+  @BigQueryType.toTable
+  case class BigNumericRecordTo(f1: BigNumeric)
+
+  it should "support BIGNUMERIC type" in {
+    val wkt = BigDecimal(30.31)
+    val cc = BigNumericRecordFrom(BigNumeric(wkt))
+    cc.f1 shouldBe BigNumeric(wkt)
+    BigNumericRecordTo(BigNumeric(wkt))
   }
 }


### PR DESCRIPTION
`BIGNUMERIC` is currently not properly supported.
- `toTable` cannot infer a schema of type `BIGNUMERIC`
- reading from a `BIGNUMERIC` table returns badly converted `BigDecimal` (using wrong scale/precision)

Introduce new type `BigNumeric` to solve this issue