### PR TITLE
fix: use fully qualified types in macros

### DIFF
--- a/scio-core/src/test/scala/com/spotify/scio/coders/CoderTest.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/coders/CoderTest.scala
@@ -545,6 +545,12 @@ final class CoderTest extends AnyFlatSpec with Matchers {
     )
   }
 
+  it should "derive when protobuf Any is in scope" in {
+    """import com.google.protobuf.Any
+      |Coder.gen[DummyCC]
+      |""".stripMargin should compile
+  }
+
   it should "support classes with private constructors" in {
     import com.spotify.scio.coders.kryo.{fallback => f}
     PrivateClass(42L) coderShould fallback() and materializeTo[KryoAtomicCoder[_]]

--- a/scio-macros/src/main/scala/com/spotify/scio/MagnoliaMacros.scala
+++ b/scio-macros/src/main/scala/com/spotify/scio/MagnoliaMacros.scala
@@ -40,15 +40,16 @@ private[scio] object MagnoliaMacros {
     // format: off
     // Remove annotations from magnolia since they are
     // not serializable and we don't use them anyway
+    val empty = q"_root_.scala.Array.empty[_root_.scala.Any]"
     val removeAnnotations: PartialFunction[Tree, Tree] = {
       case q"$caseClass($typeName, $isObject, $isValueClass, $parametersArray, $_, $_, $_)" if caseClass.symbol.name == TypeName("CaseClass") =>
-        q"$caseClass($typeName, $isObject, $isValueClass, $parametersArray, Array.empty[Any], Array.empty[Any], Array.empty[Any])"
+        q"$caseClass($typeName, $isObject, $isValueClass, $parametersArray, $empty, $empty, $empty)"
       case q"Param.apply[$tpTC, $tpT, $tpP]($name, $typeNameParam, $idx, $isRepeated, $typeclassParam, $defaultVal, $_, $_, $_)" =>
-        q"_root_.magnolia1.Param[$tpTC, $tpT, $tpP]($name, $typeNameParam, $idx, $isRepeated, $typeclassParam, $defaultVal, Array.empty[Any], Array.empty[Any], Array.empty[Any])"
+        q"_root_.magnolia1.Param[$tpTC, $tpT, $tpP]($name, $typeNameParam, $idx, $isRepeated, $typeclassParam, $defaultVal, $empty, $empty, $empty)"
       case q"new SealedTrait($typeName, $subtypesArray, $_, $_, $_)" =>
-        q"new _root_.magnolia1.SealedTrait($typeName, $subtypesArray, Array.empty[Any], Array.empty[Any], Array.empty[Any])"
+        q"new _root_.magnolia1.SealedTrait($typeName, $subtypesArray, $empty, $empty, $empty)"
       case q"Subtype[$tpTC, $tpT, $tpS]($name, $idx, $_, $_, $_, $tc, $isType, $asType)" =>
-        q"_root_.magnolia1.Subtype[$tpTC, $tpT, $tpS]($name, $idx, Array.empty[Any], Array.empty[Any], Array.empty[Any], $tc, $isType, $asType)"
+        q"_root_.magnolia1.Subtype[$tpTC, $tpT, $tpS]($name, $idx, $empty, $empty, $empty, $tc, $isType, $asType)"
     }
 
     // remove all outer references used in rawConstruct


### PR DESCRIPTION
Use fully qualified types in scio coder macros to avoid conflicts with user's imports

Fix #5410