### PR TITLE
Improve accuracy of FixQuery rule

### DIFF
--- a/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixQuery.scala
+++ b/scalafix/input-0_14/src/main/scala/fix/v0_14_0/FixQuery.scala
@@ -3,13 +3,20 @@ rule = FixQuery
  */
 package fix.v0_14_0
 
-import com.spotify.scio.bigquery.types.BigQueryType.{HasQuery, Query}
+import com.spotify.scio.bigquery.types.BigQueryType.HasQuery
+
+// Workaround to get 0.14 code to compile (query method has been removed from HasQuery)
+trait HasQueryRaw {
+  def query: String = ???
+}
+
+object HasQueryType extends HasQuery with HasQueryRaw {
+  override def queryRaw: String = ???
+  override def query: String = ???
+}
 
 object FixQuery {
+  HasQueryType.query
 
-  val a: HasQuery = ???
-  val b: Query[_] = ???
-
-  a.query
-  b.query
+  HasQueryType.query.format("foo")
 }

--- a/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixQuery.scala
+++ b/scalafix/output-0_14/src/main/scala/fix/v0_14_0/FixQuery.scala
@@ -1,12 +1,19 @@
 package fix.v0_14_0
 
-import com.spotify.scio.bigquery.types.BigQueryType.{HasQuery, Query}
+import com.spotify.scio.bigquery.types.BigQueryType.HasQuery
+
+// Workaround to get 0.14 code to compile (query method has been removed from HasQuery)
+trait HasQueryRaw {
+  def query: String = ???
+}
+
+object HasQueryType extends HasQuery with HasQueryRaw {
+  override def queryRaw: String = ???
+  override def query: String = ???
+}
 
 object FixQuery {
+  HasQueryType.queryRaw
 
-  val a: HasQuery = ???
-  val b: Query[_] = ???
-
-  a.queryRaw
-  b.queryRaw
+  HasQueryType.queryRaw.format("foo")
 }

--- a/scalafix/rules/src/main/scala/fix/v0_14_0/FixQuery.scala
+++ b/scalafix/rules/src/main/scala/fix/v0_14_0/FixQuery.scala
@@ -6,17 +6,10 @@ import scala.meta._
 object FixQuery {
   val HasQueryMatcher: SymbolMatcher =
     SymbolMatcher.normalized("com/spotify/scio/bigquery/types/BigQueryType/HasQuery")
-
-  val HasQueryMethodMatcher: SymbolMatcher =
-    SymbolMatcher.normalized("com/spotify/scio/bigquery/types/BigQueryType/HasQuery#query")
 }
 
 class FixQuery extends SemanticRule("FixQuery") {
-
   import FixQuery._
-
-  private def isQuery(term: Tree)(implicit doc: SemanticDocument): Boolean =
-    term.symbol.info.exists(_.overriddenSymbols.exists(HasQueryMethodMatcher.matches))
 
   private def isQueryFormat(term: Tree)(implicit doc: SemanticDocument): Boolean =
     term.symbol.info.map(_.signature).exists {
@@ -30,12 +23,8 @@ class FixQuery extends SemanticRule("FixQuery") {
 
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
-      case t @ q"$qual.$fn" if HasQueryMethodMatcher.matches(fn) =>
+      case t @ q"$qual.query" if isQueryFormat(qual) =>
         Patch.replaceTree(t, q"$qual.queryRaw".syntax)
-      case t @ q"$qual.query" if isQuery(t) =>
-        Patch.replaceTree(t, q"$qual.queryRaw".syntax)
-      case t @ q"$qual.query.format" if isQueryFormat(qual) =>
-        Patch.replaceTree(t, q"$qual.queryRaw.format".syntax)
     }.asPatch
   }
 

--- a/scalafix/rules/src/main/scala/fix/v0_14_0/FixQuery.scala
+++ b/scalafix/rules/src/main/scala/fix/v0_14_0/FixQuery.scala
@@ -5,6 +5,9 @@ import scala.meta._
 
 object FixQuery {
   val HasQueryMatcher: SymbolMatcher =
+    SymbolMatcher.normalized("com/spotify/scio/bigquery/types/BigQueryType/HasQuery")
+
+  val HasQueryMethodMatcher: SymbolMatcher =
     SymbolMatcher.normalized("com/spotify/scio/bigquery/types/BigQueryType/HasQuery#query")
 }
 
@@ -13,14 +16,26 @@ class FixQuery extends SemanticRule("FixQuery") {
   import FixQuery._
 
   private def isQuery(term: Tree)(implicit doc: SemanticDocument): Boolean =
-    term.symbol.info.exists(_.overriddenSymbols.exists(HasQueryMatcher.matches))
+    term.symbol.info.exists(_.overriddenSymbols.exists(HasQueryMethodMatcher.matches))
+
+  private def isQueryFormat(term: Tree)(implicit doc: SemanticDocument): Boolean =
+    term.symbol.info.map(_.signature).exists {
+      case ClassSignature(_, parents, _, _) =>
+        parents.exists {
+          case TypeRef(_, symbol, _) if HasQueryMatcher.matches(symbol) => true
+          case _                                                        => false
+        }
+      case _ => false
+    }
 
   override def fix(implicit doc: SemanticDocument): Patch = {
     doc.tree.collect {
-      case t @ q"$qual.$fn" if HasQueryMatcher.matches(fn) =>
+      case t @ q"$qual.$fn" if HasQueryMethodMatcher.matches(fn) =>
         Patch.replaceTree(t, q"$qual.queryRaw".syntax)
       case t @ q"$qual.query" if isQuery(t) =>
         Patch.replaceTree(t, q"$qual.queryRaw".syntax)
+      case t @ q"$qual.query.format" if isQueryFormat(qual) =>
+        Patch.replaceTree(t, q"$qual.queryRaw.format".syntax)
     }.asPatch
   }
 


### PR DESCRIPTION
The accuracy of FixQuery was not good when used on `@BigQueryType.from` macros. By matching on the `<macro>.query.from` expression, we can pick up on the macro class's ClassSignature, which includes `HasQuery` as a parent.