### PR TITLE
Fixes a minor formatting issue in the FAQs

### DIFF
--- a/site/src/main/paradox/FAQ.md
+++ b/site/src/main/paradox/FAQ.md
@@ -608,7 +608,8 @@ Your Scio applications should define a `main` method instead of extending `scala
 
 #### How to inspect the content of an `SCollection`?
 
-There is multiple options here:
+There are multiple options here:
+
 - Use `debug()` method on an `SCollection` to print its content as the data flows through the DAG during the execution (after the `run` or `runAndCollect`)
 - Use a debugger and setup break points - make sure to break inside of your functions to stop control at the execution not the pipeline construction time
 - In [[Scio-REPL]], use `runAndCollect()` to execute the pipeline and materialize the contents of an `SCollection`


### PR DESCRIPTION
<img width="864" alt="before" src="https://github.com/user-attachments/assets/b8ffe84a-6143-4905-873a-450c922c657e">

As you can see, the bullets are broken. I hope the spacing will fix them.