### PR TITLE
use noOp cache instead of null when instantiating typedSparkeySideInput

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -150,9 +150,17 @@ package object sparkey extends SparkeyReaderInstances with SparkeyCoders {
     def typedSparkeySideInput[T](
       basePath: String,
       decoder: Array[Byte] => T,
-      cache: Cache[String, T] = Cache.noOp[String, T]
+      cache: Cache[String, T] = null
     ): SideInput[TypedSparkeyReader[T]] =
-      sparkeySideInput(basePath, reader => new TypedSparkeyReader[T](reader, decoder, cache))
+      sparkeySideInput(
+        basePath,
+        reader =>
+          new TypedSparkeyReader[T](
+            reader,
+            decoder,
+            if (cache == null) Cache.noOp[String, T] else cache
+          )
+      )
 
     /**
      * Create a SideInput of `CachedStringSparkeyReader` from a [[SparkeyUri]] base path, to be used

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -158,7 +158,7 @@ package object sparkey extends SparkeyReaderInstances with SparkeyCoders {
           new TypedSparkeyReader[T](
             reader,
             decoder,
-            if (cache == null) Cache.noOp[String, T] else cache
+           Option(cache).getOrElse(Cache.noOp[String, T])
           )
       )
 

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -158,7 +158,7 @@ package object sparkey extends SparkeyReaderInstances with SparkeyCoders {
           new TypedSparkeyReader[T](
             reader,
             decoder,
-           Option(cache).getOrElse(Cache.noOp[String, T])
+            Option(cache).getOrElse(Cache.noOp[String, T])
           )
       )
 

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -150,7 +150,7 @@ package object sparkey extends SparkeyReaderInstances with SparkeyCoders {
     def typedSparkeySideInput[T](
       basePath: String,
       decoder: Array[Byte] => T,
-      cache: Cache[String, T] = null
+      cache: Cache[String, T] = Cache.noOp[String, T]
     ): SideInput[TypedSparkeyReader[T]] =
       sparkeySideInput(basePath, reader => new TypedSparkeyReader[T](reader, decoder, cache))
 


### PR DESCRIPTION
When attempting to access an element in a side input instantiated by `typedSparkeySideInput` where `cache` isn't specified, the following error is thrown since the cache is explicitly set to null:

```
Error message from worker: java.lang.NullPointerException: Cannot invoke "com.spotify.scio.util.Cache.get(Object, scala.Function0)" because the return value of "com.spotify.scio.extra.sparkey.instances.TypedSparkeyReader.cache()" is null
	com.spotify.scio.extra.sparkey.instances.TypedSparkeyReader.get(TypedSparkeyReader.scala:42)
	com.spotify.scio.extra.sparkey.instances.TypedSparkeyReader.get(TypedSparkeyReader.scala:31)
```