### PR TITLE
Fix redis examples

### DIFF
--- a/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
+++ b/scio-examples/src/main/scala/com/spotify/scio/examples/extra/RedisExamples.scala
@@ -27,6 +27,8 @@ import org.apache.beam.examples.common.ExampleUtils
 import org.apache.beam.sdk.options.{PipelineOptions, StreamingOptions}
 import scala.concurrent.{ExecutionContext, Future}
 
+// Example: Redis Examples
+
 // ## Redis Read Strings example
 // Read strings from Redis by a key pattern
 
@@ -135,7 +137,7 @@ object RedisWriteStreamingExample {
 // `sbt "runMain com.spotify.scio.examples.extra.RedisLookUpStringsExample
 // --project=[PROJECT] --runner=DataflowRunner --region=[REGION NAME]
 // --redisHost=[REDIS_HOST]
-// --redisPort=[REDIS_PORT]
+// --redisPort=[REDIS_PORT]`
 object RedisLookUpStringsExample {
 
   def main(cmdlineArgs: Array[String]): Unit = {
@@ -146,7 +148,6 @@ object RedisLookUpStringsExample {
     val connectionOptions = RedisConnectionOptions(redisHost, redisPort)
 
     sc.parallelize(Seq("key1", "key2", "unknownKey"))
-      // #RedisLookup_example
       .parDo(
         new RedisDoFn[String, (String, Option[String])](connectionOptions, 1000) {
           override def request(value: String, client: Client)(implicit
@@ -157,7 +158,6 @@ object RedisLookUpStringsExample {
               .map { case r: List[String @unchecked] => (value, r.headOption) }
         }
       )
-      // #RedisLookup_example
       .debug()
 
     sc.run()


### PR DESCRIPTION
Adds missing `Example:` prefix needed to make redis example show up on the examples page, fixes usage formatting, moves documentation example into markdown to avoid it rendering as a header, removes scio-private `parDo` usage