### PR TITLE
Support pubsub epoch timestamp attribute in test

### DIFF
--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/pubsub/PubsubIOTest.scala
@@ -121,9 +121,18 @@ class PubsubIOTest extends PipelineSpec with ScioIOSpec {
       .run()
   }
 
-  it should "pass correct PubsubIO with attributes" in {
+  it should "pass correct PubsubIO with attributes and ISO timestamp" in {
     testPubsubWithAttributesJob(
       Map(PubsubWithAttributesJob.timestampAttribute -> new Instant().toString),
+      "aX",
+      "bX",
+      "cX"
+    )
+  }
+
+  it should "pass correct PubsubIO with attributes and epoch timestamp" in {
+    testPubsubWithAttributesJob(
+      Map(PubsubWithAttributesJob.timestampAttribute -> new Instant().getMillis.toString),
       "aX",
       "bX",
       "cX"


### PR DESCRIPTION
See beam's  implementation [here](https://github.com/apache/beam/blob/17718a97eafe46796d0eaf0ac38f134a3adbe2bf/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClient.java#L85)