### PR TITLE
BigQuery JSON column: encode as Jackson JsonNode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -962,6 +962,7 @@ lazy val `scio-google-cloud-platform` = project
     libraryDependencies ++= Seq(
       // compile
       "com.esotericsoftware" % "kryo-shaded" % kryoVersion,
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "com.google.api" % "gax" % gcpBom.key.value,
       "com.google.api" % "gax-grpc" % gcpBom.key.value,
       "com.google.api-client" % "google-api-client" % gcpBom.key.value,

--- a/build.sbt
+++ b/build.sbt
@@ -424,6 +424,10 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   ProblemFilters.exclude[DirectAbstractMethodProblem](
     "org.apache.beam.sdk.coders.Coder.getCoderArguments"
+  ),
+  // added BQ Json object
+  ProblemFilters.exclude[MissingTypesProblem](
+    "com.spotify.scio.bigquery.types.package$Json$"
   )
 )
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -17,7 +17,6 @@
 
 package com.spotify.scio.bigquery.types
 
-import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.google.api.services.bigquery.model.TableRow
 import com.google.protobuf.ByteString
 import com.spotify.scio.bigquery.types.MacroUtil._
@@ -413,8 +412,8 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[Geography] =>
           q"$tree.wkt"
         case t if t =:= typeOf[Json] =>
-          // for BigQuery, we need to provide parsed JSON to prevent escaping
-          q"_root_.com.spotify.scio.bigquery.types.ConverterUtil.readJsonTree($tree)"
+          // for TableRow/json, we need to provide parsed JSON to prevent escaping
+          q"_root_.com.spotify.scio.bigquery.types.Json.parse($tree)"
         case t if t =:= typeOf[BigNumeric] =>
           q"$tree.wkt"
 
@@ -476,9 +475,6 @@ private[types] object ConverterProvider {
 }
 
 object ConverterUtil {
-  private val mapper = new ObjectMapper()
-  def readJsonTree(json: Json): JsonNode = mapper.readTree(json.wkt)
-
   @inline final def notNull[@specialized(Boolean, Int, Long, Float, Double) T](x: T): Boolean =
     x != null
 }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -171,13 +171,14 @@ private[types] object ConverterProvider {
       val provider: OverrideTypeProvider =
         OverrideTypeProviderFinder.getProvider
       tpe match {
-        case t if provider.shouldOverrideType(c)(t) => q"$tree.toString"
-        case t if t =:= typeOf[Boolean]             => tree
-        case t if t =:= typeOf[Int]                 => q"$tree.toLong"
-        case t if t =:= typeOf[Long]                => tree
-        case t if t =:= typeOf[Float]               => q"$tree.toDouble"
-        case t if t =:= typeOf[Double]              => tree
-        case t if t =:= typeOf[String]              => tree
+        case t if provider.shouldOverrideType(c)(t)                     => q"$tree.toString"
+        case t if t =:= typeOf[Boolean]                                 => tree
+        case t if t =:= typeOf[Int]                                     => q"$tree.toLong"
+        case t if t =:= typeOf[Long]                                    => tree
+        case t if t =:= typeOf[Float]                                   => q"$tree.toDouble"
+        case t if t =:= typeOf[Double]                                  => tree
+        case t if t =:= typeOf[String]                                  => tree
+        case t if t =:= typeOf[com.fasterxml.jackson.databind.JsonNode] => tree
 
         case t if t =:= typeOf[BigDecimal] =>
           q"_root_.com.spotify.scio.bigquery.Numeric($tree).toString"
@@ -198,7 +199,7 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[Geography] =>
           q"$tree.wkt"
         case t if t =:= typeOf[Json] =>
-          q"$tree.wkt"
+          q"$tree.asJackson"
         case t if t =:= typeOf[BigNumeric] =>
           q"_root_.com.spotify.scio.bigquery.types.BigNumeric($tree.wkt).toString"
 
@@ -276,12 +277,13 @@ private[types] object ConverterProvider {
       tpe match {
         case t if provider.shouldOverrideType(c)(t) =>
           provider.createInstance(c)(t, q"$tree")
-        case t if t =:= typeOf[Boolean] => q"$s.toBoolean"
-        case t if t =:= typeOf[Int]     => q"$s.toInt"
-        case t if t =:= typeOf[Long]    => q"$s.toLong"
-        case t if t =:= typeOf[Float]   => q"$s.toFloat"
-        case t if t =:= typeOf[Double]  => q"$s.toDouble"
-        case t if t =:= typeOf[String]  => q"$s"
+        case t if t =:= typeOf[Boolean]                                 => q"$s.toBoolean"
+        case t if t =:= typeOf[Int]                                     => q"$s.toInt"
+        case t if t =:= typeOf[Long]                                    => q"$s.toLong"
+        case t if t =:= typeOf[Float]                                   => q"$s.toFloat"
+        case t if t =:= typeOf[Double]                                  => q"$s.toDouble"
+        case t if t =:= typeOf[String]                                  => q"$s"
+        case t if t =:= typeOf[com.fasterxml.jackson.databind.JsonNode] => q"$s"
         case t if t =:= typeOf[BigDecimal] =>
           q"_root_.com.spotify.scio.bigquery.Numeric($s)"
 
@@ -412,7 +414,7 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[Geography] =>
           q"$tree.wkt"
         case t if t =:= typeOf[Json] =>
-          q"$tree.wkt"
+          q"$tree.asJackson"
         case t if t =:= typeOf[BigNumeric] =>
           q"$tree.wkt"
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -412,10 +412,11 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[Geography] =>
           q"$tree.wkt"
         case t if t =:= typeOf[Json] =>
-          // for TableRow/json, we need to provide parsed JSON to prevent escaping
+          // for TableRow/json, use JSON to prevent escaping
           q"_root_.com.spotify.scio.bigquery.types.Json.parse($tree)"
         case t if t =:= typeOf[BigNumeric] =>
-          q"$tree.wkt"
+          // for TableRow/json, use string to avoid precision loss (like numeric)
+          q"$tree.wkt.toString"
 
         case t if isCaseClass(c)(t) => // nested records
           val fn = TermName("r" + t.typeSymbol.name)

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -17,6 +17,7 @@
 
 package com.spotify.scio.bigquery.types
 
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.google.api.services.bigquery.model.TableRow
 import com.google.protobuf.ByteString
 import com.spotify.scio.bigquery.types.MacroUtil._
@@ -171,14 +172,13 @@ private[types] object ConverterProvider {
       val provider: OverrideTypeProvider =
         OverrideTypeProviderFinder.getProvider
       tpe match {
-        case t if provider.shouldOverrideType(c)(t)                     => q"$tree.toString"
-        case t if t =:= typeOf[Boolean]                                 => tree
-        case t if t =:= typeOf[Int]                                     => q"$tree.toLong"
-        case t if t =:= typeOf[Long]                                    => tree
-        case t if t =:= typeOf[Float]                                   => q"$tree.toDouble"
-        case t if t =:= typeOf[Double]                                  => tree
-        case t if t =:= typeOf[String]                                  => tree
-        case t if t =:= typeOf[com.fasterxml.jackson.databind.JsonNode] => tree
+        case t if provider.shouldOverrideType(c)(t) => q"$tree.toString"
+        case t if t =:= typeOf[Boolean]             => tree
+        case t if t =:= typeOf[Int]                 => q"$tree.toLong"
+        case t if t =:= typeOf[Long]                => tree
+        case t if t =:= typeOf[Float]               => q"$tree.toDouble"
+        case t if t =:= typeOf[Double]              => tree
+        case t if t =:= typeOf[String]              => tree
 
         case t if t =:= typeOf[BigDecimal] =>
           q"_root_.com.spotify.scio.bigquery.Numeric($tree).toString"
@@ -199,7 +199,7 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[Geography] =>
           q"$tree.wkt"
         case t if t =:= typeOf[Json] =>
-          q"$tree.asJackson"
+          q"$tree.wkt"
         case t if t =:= typeOf[BigNumeric] =>
           q"_root_.com.spotify.scio.bigquery.types.BigNumeric($tree.wkt).toString"
 
@@ -277,13 +277,12 @@ private[types] object ConverterProvider {
       tpe match {
         case t if provider.shouldOverrideType(c)(t) =>
           provider.createInstance(c)(t, q"$tree")
-        case t if t =:= typeOf[Boolean]                                 => q"$s.toBoolean"
-        case t if t =:= typeOf[Int]                                     => q"$s.toInt"
-        case t if t =:= typeOf[Long]                                    => q"$s.toLong"
-        case t if t =:= typeOf[Float]                                   => q"$s.toFloat"
-        case t if t =:= typeOf[Double]                                  => q"$s.toDouble"
-        case t if t =:= typeOf[String]                                  => q"$s"
-        case t if t =:= typeOf[com.fasterxml.jackson.databind.JsonNode] => q"$s"
+        case t if t =:= typeOf[Boolean] => q"$s.toBoolean"
+        case t if t =:= typeOf[Int]     => q"$s.toInt"
+        case t if t =:= typeOf[Long]    => q"$s.toLong"
+        case t if t =:= typeOf[Float]   => q"$s.toFloat"
+        case t if t =:= typeOf[Double]  => q"$s.toDouble"
+        case t if t =:= typeOf[String]  => q"$s"
         case t if t =:= typeOf[BigDecimal] =>
           q"_root_.com.spotify.scio.bigquery.Numeric($s)"
 
@@ -414,7 +413,8 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[Geography] =>
           q"$tree.wkt"
         case t if t =:= typeOf[Json] =>
-          q"$tree.asJackson"
+          // for BigQuery, we need to provide parsed JSON to prevent escaping
+          q"_root_.com.spotify.scio.bigquery.types.ConverterUtil.readJsonTree($tree)"
         case t if t =:= typeOf[BigNumeric] =>
           q"$tree.wkt"
 
@@ -476,6 +476,9 @@ private[types] object ConverterProvider {
 }
 
 object ConverterUtil {
+  private val mapper = new ObjectMapper()
+  def readJsonTree(json: Json): JsonNode = mapper.readTree(json.wkt)
+
   @inline final def notNull[@specialized(Boolean, Int, Long, Float, Double) T](x: T): Boolean =
     x != null
 }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -90,7 +90,6 @@ private[types] object SchemaProvider {
       case t if t =:= typeOf[LocalDateTime] => ("DATETIME", Iterable.empty)
       case t if t =:= typeOf[Geography]     => ("GEOGRAPHY", Iterable.empty)
       case t if t =:= typeOf[Json]          => ("JSON", Iterable.empty)
-      case t if t =:= typeOf[com.fasterxml.jackson.databind.JsonNode] => ("JSON", Iterable.empty)
 
       case t if isCaseClass(t) => ("RECORD", toFields(t))
       case _                   => throw new RuntimeException(s"Unsupported type: $tpe")

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -90,6 +90,7 @@ private[types] object SchemaProvider {
       case t if t =:= typeOf[LocalDateTime] => ("DATETIME", Iterable.empty)
       case t if t =:= typeOf[Geography]     => ("GEOGRAPHY", Iterable.empty)
       case t if t =:= typeOf[Json]          => ("JSON", Iterable.empty)
+      case t if t =:= typeOf[com.fasterxml.jackson.databind.JsonNode] => ("JSON", Iterable.empty)
 
       case t if isCaseClass(t) => ("RECORD", toFields(t))
       case _                   => throw new RuntimeException(s"Unsupported type: $tpe")

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -17,6 +17,7 @@
 
 package com.spotify.scio.bigquery
 
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.spotify.scio.coders.Coder
 import org.apache.avro.Conversions.DecimalConversion
 import org.apache.avro.LogicalTypes
@@ -61,6 +62,12 @@ package object types {
    *   Well Known Text formatted string that BigQuery displays for Json
    */
   case class Json(wkt: String)
+  object Json {
+    private lazy val mapper = new ObjectMapper()
+
+    def apply(node: JsonNode): Json = Json(mapper.writeValueAsString(node))
+    def parse(json: Json): JsonNode = mapper.readTree(json.wkt)
+  }
 
   /**
    * Case class to serve as BigNumeric type to distinguish them from Numeric.

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -17,6 +17,7 @@
 
 package com.spotify.scio.bigquery
 
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.spotify.scio.coders.Coder
 import org.apache.avro.Conversions.DecimalConversion
 import org.apache.avro.LogicalTypes
@@ -53,14 +54,20 @@ package object types {
   case class Geography(wkt: String)
 
   /**
-   * Case class to serve as raw type for Json instances to distinguish them from Strings.
+   * Case class to serve as raw type for Json instances. On write, they will be transformed into
+   * Jackson JsonNode.
    *
    * See also https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#json_type
    *
    * @param wkt
    *   Well Known Text formatted string that BigQuery displays for Json
    */
-  case class Json(wkt: String)
+  case class Json(wkt: String) {
+    def asJackson: JsonNode = Json.mapper.readTree(wkt)
+  }
+  object Json {
+    private val mapper = new ObjectMapper()
+  }
 
   /**
    * Case class to serve as BigNumeric type to distinguish them from Numeric.

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -17,7 +17,6 @@
 
 package com.spotify.scio.bigquery
 
-import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.spotify.scio.coders.Coder
 import org.apache.avro.Conversions.DecimalConversion
 import org.apache.avro.LogicalTypes
@@ -54,20 +53,14 @@ package object types {
   case class Geography(wkt: String)
 
   /**
-   * Case class to serve as raw type for Json instances. On write, they will be transformed into
-   * Jackson JsonNode.
+   * Case class to serve as raw type for Json instances.
    *
    * See also https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#json_type
    *
    * @param wkt
    *   Well Known Text formatted string that BigQuery displays for Json
    */
-  case class Json(wkt: String) {
-    def asJackson: JsonNode = Json.mapper.readTree(wkt)
-  }
-  object Json {
-    private val mapper = new ObjectMapper()
-  }
+  case class Json(wkt: String)
 
   /**
    * Case class to serve as BigNumeric type to distinguish them from Numeric.

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
@@ -51,6 +51,12 @@ final class ConverterProviderSpec
       .retryUntil(_.precision <= Numeric.MaxNumericPrecision)
       .map(Numeric.apply)
   }
+  implicit val arbJson: Arbitrary[Json] = Arbitrary(
+    for {
+      key <- Gen.alphaStr
+      value <- Gen.alphaStr
+    } yield Json("{\"" + key + "\":\"" + value + "\"}")
+  )
   implicit val eqByteArrays: Eq[Array[Byte]] = Eq.instance[Array[Byte]](_.toList == _.toList)
   implicit val eqByteString: Eq[ByteString] = Eq.instance[ByteString](_ == _)
   implicit val eqInstant: Eq[Instant] = Eq.instance[Instant](_ == _)

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
@@ -55,7 +55,7 @@ final class ConverterProviderSpec
     for {
       key <- Gen.alphaStr
       value <- Gen.alphaStr
-    } yield Json("{\"" + key + "\":\"" + value + "\"}")
+    } yield Json(s"""{"$key":"$value"}""")
   )
   implicit val eqByteArrays: Eq[Array[Byte]] = Eq.instance[Array[Byte]](_.toList == _.toList)
   implicit val eqByteString: Eq[ByteString] = Eq.instance[ByteString](_ == _)

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -62,8 +62,12 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
   it should "handle required big numeric type" in {
     val bigNumeric = "12.34567890123456789012345678901234567890"
     val wkt = BigDecimal(bigNumeric)
-    RequiredBigNumeric.fromTableRow(TableRow("a" -> bigNumeric)) shouldBe RequiredBigNumeric(BigNumeric(wkt))
-    BigQueryType.toTableRow(RequiredBigNumeric(BigNumeric(wkt))) shouldBe TableRow("a" -> bigNumeric)
+    RequiredBigNumeric.fromTableRow(TableRow("a" -> bigNumeric)) shouldBe RequiredBigNumeric(
+      BigNumeric(wkt)
+    )
+    BigQueryType.toTableRow(RequiredBigNumeric(BigNumeric(wkt))) shouldBe TableRow(
+      "a" -> bigNumeric
+    )
   }
 
   it should "handle case classes with methods" in {

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -17,6 +17,7 @@
 
 package com.spotify.scio.bigquery.types
 
+import com.fasterxml.jackson.databind.node.{JsonNodeFactory, ObjectNode}
 import com.spotify.scio.bigquery._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
@@ -48,8 +49,14 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
 
   it should "handle required json type" in {
     val wkt = "{\"name\": \"Alice\", \"age\": 30}"
+    val jsNodeFactory = new JsonNodeFactory(false)
+    val jackson = jsNodeFactory
+      .objectNode()
+      .set[ObjectNode]("name", jsNodeFactory.textNode("Alice"))
+      .set[ObjectNode]("age", jsNodeFactory.numberNode(30))
+
     RequiredJson.fromTableRow(TableRow("a" -> wkt)) shouldBe RequiredJson(Json(wkt))
-    BigQueryType.toTableRow[RequiredJson](RequiredJson(Json(wkt))) shouldBe TableRow("a" -> wkt)
+    BigQueryType.toTableRow[RequiredJson](RequiredJson(Json(wkt))) shouldBe TableRow("a" -> jackson)
   }
 
   it should "handle case classes with methods" in {

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -59,6 +59,13 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
     BigQueryType.toTableRow[RequiredJson](RequiredJson(Json(wkt))) shouldBe TableRow("a" -> jackson)
   }
 
+  it should "handle required big numeric type" in {
+    val bigNumeric = "12.34567890123456789012345678901234567890"
+    val wkt = BigDecimal(bigNumeric)
+    RequiredBigNumeric.fromTableRow(TableRow("a" -> bigNumeric)) shouldBe RequiredBigNumeric(BigNumeric(wkt))
+    BigQueryType.toTableRow(RequiredBigNumeric(BigNumeric(wkt))) shouldBe TableRow("a" -> bigNumeric)
+  }
+
   it should "handle case classes with methods" in {
     RequiredWithMethod.fromTableRow(TableRow("a" -> "")) shouldBe RequiredWithMethod("")
     BigQueryType.toTableRow[RequiredWithMethod](RequiredWithMethod("")) shouldBe TableRow("a" -> "")
@@ -72,6 +79,9 @@ object ConverterProviderTest {
 
   @BigQueryType.toTable
   case class RequiredJson(a: Json)
+
+  @BigQueryType.toTable
+  case class RequiredBigNumeric(a: BigNumeric)
 
   @BigQueryType.toTable
   case class Required(a: String)

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -48,14 +48,14 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
   }
 
   it should "handle required json type" in {
-    val wkt = "{\"name\": \"Alice\", \"age\": 30}"
+    val wkt = """{"name":"Alice","age":30}"""
     val jsNodeFactory = new JsonNodeFactory(false)
     val jackson = jsNodeFactory
       .objectNode()
       .set[ObjectNode]("name", jsNodeFactory.textNode("Alice"))
       .set[ObjectNode]("age", jsNodeFactory.numberNode(30))
 
-    RequiredJson.fromTableRow(TableRow("a" -> wkt)) shouldBe RequiredJson(Json(wkt))
+    RequiredJson.fromTableRow(TableRow("a" -> jackson)) shouldBe RequiredJson(Json(wkt))
     BigQueryType.toTableRow[RequiredJson](RequiredJson(Json(wkt))) shouldBe TableRow("a" -> jackson)
   }
 


### PR DESCRIPTION
On write, BigQuery JSON columns must not be provided as `String`, as it will be escaped. Apache Beam warns:

`Make sure the TableRow value is a parsed JSON to ensure the read as a JSON type. Otherwise it will read as a raw (escaped) string.`

Reverse-eng. shows that is means "as a `JsonNode` from Jackson".