### PR TITLE
Report exception for unmatched batch request

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/UnmatchedRequestException.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/UnmatchedRequestException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.spotify.scio.transforms;
+
+public class UnmatchedRequestException extends RuntimeException {
+  public UnmatchedRequestException(String id) {
+    super("Unmatched batch request for ID: " + id);
+  }
+}

--- a/scio-core/src/main/java/com/spotify/scio/transforms/UnmatchedRequestException.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/UnmatchedRequestException.java
@@ -16,8 +16,30 @@
 
 package com.spotify.scio.transforms;
 
+import java.util.Objects;
+
 public class UnmatchedRequestException extends RuntimeException {
+
+  private final String id;
+
   public UnmatchedRequestException(String id) {
     super("Unmatched batch request for ID: " + id);
+    this.id = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    UnmatchedRequestException that = (UnmatchedRequestException) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
   }
 }


### PR DESCRIPTION
When getting an response for a batch request, return an UnmatchedRequestException for unmatched requests