### PR TITLE
Stable TableRow converted from BQ types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -975,6 +975,8 @@ lazy val `scio-google-cloud-platform` = project
       // compile
       "com.esotericsoftware" % "kryo-shaded" % kryoVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion,
+      "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
       "com.google.api" % "gax" % gcpBom.key.value,
       "com.google.api" % "gax-grpc" % gcpBom.key.value,
       "com.google.api-client" % "google-api-client" % gcpBom.key.value,
@@ -1727,7 +1729,6 @@ lazy val integration = project
     unusedCompileDependenciesTest := unusedCompileDependenciesTestSkipped.value,
     libraryDependencies ++= Seq(
       // compile
-      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "com.google.api-client" % "google-api-client" % gcpBom.key.value,
       "com.google.apis" % "google-api-services-bigquery" % googleApiServicesBigQueryVersion,
       "com.google.guava" % "guava" % guavaVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -408,19 +408,10 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   // added SortedMapCoder
   ProblemFilters.exclude[DirectMissingMethodProblem](
-    "com.spotify.scio.coders.instances.MutableMapCoder.encode"
+    "com.spotify.scio.coders.instances.MutableMapCoder.*"
   ),
   ProblemFilters.exclude[DirectAbstractMethodProblem](
     "org.apache.beam.sdk.coders.Coder.verifyDeterministic"
-  ),
-  ProblemFilters.exclude[DirectMissingMethodProblem](
-    "com.spotify.scio.coders.instances.MutableMapCoder.structuralValue"
-  ),
-  ProblemFilters.exclude[DirectMissingMethodProblem](
-    "com.spotify.scio.coders.instances.MutableMapCoder.isRegisterByteSizeObserverCheap"
-  ),
-  ProblemFilters.exclude[DirectMissingMethodProblem](
-    "com.spotify.scio.coders.instances.MutableMapCoder.registerByteSizeObserver"
   ),
   ProblemFilters.exclude[DirectAbstractMethodProblem](
     "org.apache.beam.sdk.coders.Coder.getCoderArguments"
@@ -436,6 +427,24 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   // relax type hierarchy for batch stream
   ProblemFilters.exclude[IncompatibleMethTypeProblem](
     "com.spotify.scio.grpc.GrpcBatchDoFn.asyncLookup"
+  ),
+  // added TableRow syntax
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "com.spotify.scio.bigquery.syntax.TableRowOps.*"
+  ),
+  // narrow return type from Map to TableRow
+  ProblemFilters.exclude[IncompatibleResultTypeProblem](
+    "com.spotify.scio.bigquery.syntax.TableRowOps.getRecord$extension"
+  ),
+  ProblemFilters.exclude[IncompatibleResultTypeProblem](
+    "com.spotify.scio.bigquery.syntax.TableRowOps.getRecord"
+  ),
+  // narrow return type from Seq to List
+  ProblemFilters.exclude[IncompatibleResultTypeProblem](
+    "com.spotify.scio.bigquery.syntax.TableRowOps.getRepeated$extension"
+  ),
+  ProblemFilters.exclude[IncompatibleResultTypeProblem](
+    "com.spotify.scio.bigquery.syntax.TableRowOps.getRepeated"
   )
 )
 

--- a/scio-examples/src/test/scala/com/spotify/scio/examples/complete/TopWikipediaSessionsTest.scala
+++ b/scio-examples/src/test/scala/com/spotify/scio/examples/complete/TopWikipediaSessionsTest.scala
@@ -17,7 +17,7 @@
 
 package com.spotify.scio.examples.complete
 
-import com.spotify.scio.bigquery.TableRow
+import com.spotify.scio.bigquery._
 import com.spotify.scio.testing._
 
 class TopWikipediaSessionsTest extends PipelineSpec {

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/TableRowSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/TableRowSyntax.scala
@@ -17,85 +17,242 @@
 
 package com.spotify.scio.bigquery.syntax
 
-// import com.google.api.services.bigquery.model.{TableRow => GTableRow}
-import com.spotify.scio.bigquery.{Date, DateTime, TableRow, Time, Timestamp}
+import com.google.common.io.BaseEncoding
+import com.spotify.scio.bigquery._
+import com.spotify.scio.bigquery.types._
 import org.joda.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 
 import scala.jdk.CollectionConverters._
-
-import scala.util.Try
+import scala.util.chaining._
 
 /** Enhanced version of [[TableRow]] with typed getters. */
+object TableRowOps {
+  def boolean(value: AnyRef): Boolean = value match {
+    case x: java.lang.Boolean => Boolean.unbox(x)
+    case x: String            => x.toBoolean
+    case _ => throw new UnsupportedOperationException("Cannot convert to boolean: " + value)
+  }
+
+  def int(value: AnyRef): Int = value match {
+    case x: java.lang.Integer => Int.unbox(x)
+    case x: String            => x.toInt
+    case _ =>
+      throw new UnsupportedOperationException("Cannot convert to integer: " + value)
+  }
+
+  def long(value: AnyRef): Long = value match {
+    case x: java.lang.Long    => Long.unbox(x)
+    case x: java.lang.Integer => Int.unbox(x).toLong
+    case x: String            => x.toLong
+    case _ => throw new UnsupportedOperationException("Cannot convert to long: " + value)
+  }
+
+  def float(value: AnyRef): Float = value match {
+    case x: java.lang.Float  => Float.unbox(x)
+    case x: java.lang.Double => Double.unbox(x).toFloat
+    case x: String           => x.toFloat
+    case _ => throw new UnsupportedOperationException("Cannot convert to float: " + value)
+  }
+
+  def double(value: AnyRef): Double = value match {
+    case x: java.lang.Double => Double.unbox(x)
+    case x: String           => x.toDouble
+    case _ =>
+      throw new UnsupportedOperationException("Cannot convert to double: " + value)
+  }
+
+  def string(value: AnyRef): String = value match {
+    case x: java.lang.String => x
+    case _ =>
+      throw new UnsupportedOperationException("Cannot convert to string: " + value)
+  }
+
+  def numeric(value: AnyRef): BigDecimal = value match {
+    case x: scala.math.BigDecimal => Numeric(x)
+    case x: java.lang.Double      => Numeric(BigDecimal(x))
+    case x: String                => Numeric(x)
+    case _ =>
+      throw new UnsupportedOperationException("Cannot convert to numeric: " + value)
+  }
+
+  def bytes(value: AnyRef): Array[Byte] = value match {
+    case x: Array[Byte] => x
+    case x: String      => BaseEncoding.base64().decode(x)
+    case _ => throw new UnsupportedOperationException("Cannot convert to bytes: " + value)
+  }
+
+  def timestamp(value: AnyRef): Instant = value match {
+    case x: Instant          => x
+    case x: java.lang.String => Timestamp.parse(x)
+    case _ =>
+      throw new UnsupportedOperationException("Cannot convert to timestamp: " + value)
+  }
+
+  def date(value: AnyRef): LocalDate = value match {
+    case x: LocalDate => x
+    case x: String    => Date.parse(x)
+    case _            => throw new UnsupportedOperationException("Cannot convert to date: " + value)
+  }
+
+  def time(value: AnyRef): LocalTime = value match {
+    case x: LocalTime => x
+    case x: String    => Time.parse(x)
+    case _            => throw new UnsupportedOperationException("Cannot convert to time: " + value)
+  }
+
+  def datetime(value: AnyRef): LocalDateTime = value match {
+    case x: LocalDateTime => x
+    case x: String        => DateTime.parse(x)
+    case _ =>
+      throw new UnsupportedOperationException("Cannot convert to datetime: " + value)
+  }
+
+  def geography(value: AnyRef): Geography = value match {
+    case x: Geography => x
+    case x: String    => Geography(x)
+    case _ =>
+      throw new UnsupportedOperationException("Cannot convert to geography: " + value)
+  }
+
+  def json(value: AnyRef): Json = value match {
+    case x: Json     => x
+    case x: TableRow => Json(x)
+    case x: String   => Json(x)
+    case _           => throw new UnsupportedOperationException("Cannot convert to json: " + value)
+  }
+
+  def bignumeric(value: AnyRef): BigNumeric = value match {
+    case x: BigNumeric       => x
+    case x: java.lang.Double => BigNumeric(BigDecimal(x))
+    case x: String           => BigNumeric(x)
+    case _ =>
+      throw new UnsupportedOperationException("Cannot convert to bigNumeric: " + value)
+  }
+
+  def record(value: AnyRef): TableRow = value match {
+    case x: java.util.Map[String @unchecked, AnyRef @unchecked] =>
+      x.asScala.foldLeft(new TableRow()) { case (tr, (name, value)) =>
+        tr.set(name, value)
+      }
+    case _ =>
+      throw new UnsupportedOperationException("Cannot convert to record: " + value)
+  }
+
+  def cast[T](name: AnyRef, fn: AnyRef => T)(value: AnyRef): T = try {
+    fn(value)
+  } catch {
+    case e: UnsupportedOperationException =>
+      throw new UnsupportedOperationException("Field cannot be converted: " + name, e)
+  }
+
+  def required(name: AnyRef)(r: TableRow): AnyRef = {
+    val x = r.get(name)
+    if (x == null) throw new NoSuchElementException("Field not found: " + name)
+    x
+  }
+
+  def nullable(name: AnyRef)(r: TableRow): Option[AnyRef] = Option(r.get(name))
+
+  def repeated(name: AnyRef)(r: TableRow): List[AnyRef] = required(name)(r) match {
+    case l: java.util.List[AnyRef @unchecked] => l.iterator().asScala.toList
+    case _ => throw new UnsupportedOperationException("Field is not repeated: " + name)
+  }
+}
+
 final class TableRowOps(private val r: TableRow) extends AnyVal {
-  def getBoolean(name: AnyRef): Boolean =
-    this.getValue(name, _.toString.toBoolean, false)
+  import TableRowOps._
 
-  def getBooleanOpt(name: AnyRef): Option[Boolean] =
-    this.getValueOpt(name, _.toString.toBoolean)
+  def getRequired(name: AnyRef): AnyRef = required(name)(r)
+  def getNullable(name: AnyRef): Option[AnyRef] = nullable(name)(r)
+  def getRepeated(name: AnyRef): List[AnyRef] = repeated(name)(r)
 
-  def getLong(name: AnyRef): Long = this.getValue(name, _.toString.toLong, 0L)
+  /////////////////////////////////////////////////////////////////////////////
+  def getBoolean(name: AnyRef): Boolean = getRequired(name).pipe(cast(name, boolean))
+  def getBooleanOpt(name: AnyRef): Option[Boolean] = getNullable(name).map(cast(name, boolean))
+  def getBooleanList(name: AnyRef): List[Boolean] = getRepeated(name).map(cast(name, boolean))
 
-  def getLongOpt(name: AnyRef): Option[Long] =
-    this.getValueOpt(name, _.toString.toLong)
+  /////////////////////////////////////////////////////////////////////////////
+  def getInt(name: AnyRef): Int = getRequired(name).pipe(cast(name, int))
+  def getIntOpt(name: AnyRef): Option[Int] = getNullable(name).map(cast(name, int))
+  def getIntList(name: AnyRef): List[Int] = getRepeated(name).map(cast(name, int))
 
-  def getDouble(name: AnyRef): Double =
-    this.getValue(name, _.toString.toDouble, 0.0)
+  /////////////////////////////////////////////////////////////////////////////
+  def getLong(name: AnyRef): Long = getRequired(name).pipe(cast(name, long))
+  def getLongOpt(name: AnyRef): Option[Long] = getNullable(name).map(cast(name, long))
+  def getLongList(name: AnyRef): List[Long] = getRepeated(name).map(cast(name, long))
 
-  def getDoubleOpt(name: AnyRef): Option[Double] =
-    this.getValueOpt(name, _.toString.toDouble)
+  /////////////////////////////////////////////////////////////////////////////
+  def getFloat(name: AnyRef): Float = getRequired(name).pipe(cast(name, float))
+  def getFloatOpt(name: AnyRef): Option[Float] = getNullable(name).map(cast(name, float))
+  def getFloatList(name: AnyRef): List[Float] = getRepeated(name).map(cast(name, float))
 
-  def getString(name: AnyRef): String = this.getValue(name, _.toString, null)
+  /////////////////////////////////////////////////////////////////////////////
+  def getDouble(name: AnyRef): Double = getRequired(name).pipe(cast(name, double))
+  def getDoubleOpt(name: AnyRef): Option[Double] = getNullable(name).map(cast(name, double))
+  def getDoubleList(name: AnyRef): List[Double] = getRepeated(name).map(cast(name, double))
 
-  def getStringOpt(name: AnyRef): Option[String] =
-    this.getValueOpt(name, _.toString)
+  /////////////////////////////////////////////////////////////////////////////
+  def getString(name: AnyRef): String = getRequired(name).pipe(cast(name, string))
+  def getStringOpt(name: AnyRef): Option[String] = getNullable(name).map(cast(name, string))
+  def getStringList(name: AnyRef): List[String] = getRepeated(name).map(cast(name, string))
 
-  def getTimestamp(name: AnyRef): Instant =
-    this.getValue(name, v => Timestamp.parse(v.toString), null)
+  /////////////////////////////////////////////////////////////////////////////
+  def getNumeric(name: AnyRef): BigDecimal = getRequired(name).pipe(cast(name, numeric))
+  def getNumericOpt(name: AnyRef): Option[BigDecimal] = getNullable(name).map(cast(name, numeric))
+  def getNumericList(name: AnyRef): List[BigDecimal] = getRepeated(name).map(cast(name, numeric))
 
-  def getTimestampOpt(name: AnyRef): Option[Instant] =
-    this.getValueOpt(name, v => Timestamp.parse(v.toString))
+  /////////////////////////////////////////////////////////////////////////////
+  def getBytes(name: AnyRef): Array[Byte] = getRequired(name).pipe(cast(name, bytes))
+  def getBytesOpt(name: AnyRef): Option[Array[Byte]] = getNullable(name).map(cast(name, bytes))
+  def getBytesList(name: AnyRef): List[Array[Byte]] = getRepeated(name).map(cast(name, bytes))
 
-  def getDate(name: AnyRef): LocalDate =
-    this.getValue(name, v => Date.parse(v.toString), null)
+  /////////////////////////////////////////////////////////////////////////////
+  def getTimestamp(name: AnyRef): Instant = getRequired(name).pipe(cast(name, timestamp))
+  def getTimestampOpt(name: AnyRef): Option[Instant] = getNullable(name).map(cast(name, timestamp))
+  def getTimestampList(name: AnyRef): List[Instant] = getRepeated(name).map(cast(name, timestamp))
 
-  def getDateOpt(name: AnyRef): Option[LocalDate] =
-    this.getValueOpt(name, v => Date.parse(v.toString))
+  /////////////////////////////////////////////////////////////////////////////
+  def getDate(name: AnyRef): LocalDate = getRequired(name).pipe(cast(name, date))
+  def getDateOpt(name: AnyRef): Option[LocalDate] = getNullable(name).map(cast(name, date))
+  def getDateList(name: AnyRef): List[LocalDate] = getRepeated(name).map(cast(name, date))
 
-  def getTime(name: AnyRef): LocalTime =
-    this.getValue(name, v => Time.parse(v.toString), null)
+  /////////////////////////////////////////////////////////////////////////////
+  def getTime(name: AnyRef): LocalTime = getRequired(name).pipe(cast(name, time))
+  def getTimeOpt(name: AnyRef): Option[LocalTime] = getNullable(name).map(cast(name, time))
+  def getTimeList(name: AnyRef): List[LocalTime] = getRepeated(name).map(cast(name, time))
 
-  def getTimeOpt(name: AnyRef): Option[LocalTime] =
-    this.getValueOpt(name, v => Time.parse(v.toString))
-
-  def getDateTime(name: AnyRef): LocalDateTime =
-    this.getValue(name, v => DateTime.parse(v.toString), null)
-
+  /////////////////////////////////////////////////////////////////////////////
+  def getDateTime(name: AnyRef): LocalDateTime = getRequired(name).pipe(cast(name, datetime))
   def getDateTimeOpt(name: AnyRef): Option[LocalDateTime] =
-    this.getValueOpt(name, v => DateTime.parse(v.toString))
+    getNullable(name).map(cast(name, datetime))
+  def getDateTimeList(name: AnyRef): List[LocalDateTime] =
+    getRepeated(name).map(cast(name, datetime))
 
-  def getRepeated(name: AnyRef): Seq[AnyRef] =
-    this.getValue(name, x => x.asInstanceOf[java.util.List[AnyRef]].iterator().asScala.toSeq, null)
+  /////////////////////////////////////////////////////////////////////////////
+  def getGeography(name: AnyRef): Geography =
+    getRequired(name).pipe(cast(name, geography))
+  def getGeographyOpt(name: AnyRef): Option[Geography] =
+    getNullable(name).map(cast(name, geography))
+  def getGeographyList(name: AnyRef): List[Geography] =
+    getRepeated(name).map(cast(name, geography))
 
-  def getRecord(name: AnyRef): Map[String, AnyRef] =
-    this.getValue(name, x => x.asInstanceOf[java.util.Map[String, AnyRef]].asScala.toMap, null)
+  /////////////////////////////////////////////////////////////////////////////
+  def getJson(name: AnyRef): Json = getRequired(name).pipe(cast(name, json))
+  def getJsonOpt(name: AnyRef): Option[Json] = getNullable(name).map(cast(name, json))
+  def getJsonList(name: AnyRef): List[Json] = getRepeated(name).map(cast(name, json))
 
-  private def getValue[T](name: AnyRef, fn: AnyRef => T, default: T): T = {
-    val o = r.get(name)
-    if (o == null) {
-      default
-    } else {
-      fn(o)
-    }
-  }
+  /////////////////////////////////////////////////////////////////////////////
+  def getBigNumeric(name: AnyRef): BigNumeric =
+    getRequired(name).pipe(cast(name, bignumeric))
+  def getBigNumericOpt(name: AnyRef): Option[BigNumeric] =
+    getNullable(name).map(cast(name, bignumeric))
+  def getBigNumericList(name: AnyRef): List[BigNumeric] =
+    getRepeated(name).map(cast(name, bignumeric))
 
-  private def getValueOpt[T](name: AnyRef, fn: AnyRef => T): Option[T] = {
-    val o = r.get(name)
-    if (o == null) {
-      None
-    } else {
-      Try(fn(o)).toOption
-    }
-  }
+  /////////////////////////////////////////////////////////////////////////////
+  def getRecord(name: AnyRef): TableRow = getRequired(name).pipe(cast(name, record))
+  def getRecordOpt(name: AnyRef): Option[TableRow] = getNullable(name).map(cast(name, record))
+  def getRecordList(name: AnyRef): List[TableRow] = getRepeated(name).map(cast(name, record))
 }
 
 trait TableRowSyntax {

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/TableRowSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/TableRowSyntax.scala
@@ -25,8 +25,15 @@ import org.joda.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 import scala.jdk.CollectionConverters._
 import scala.util.chaining._
 
-/** Enhanced version of [[TableRow]] with typed getters. */
+/**
+ * Enhanced version of [[TableRow]] with typed getters.
+ *
+ * Maximize compatibility by allowing
+ *   - boxed java type
+ *   - string values
+ */
 object TableRowOps {
+
   def boolean(value: AnyRef): Boolean = value match {
     case x: java.lang.Boolean => Boolean.unbox(x)
     case x: String            => x.toBoolean
@@ -34,28 +41,26 @@ object TableRowOps {
   }
 
   def int(value: AnyRef): Int = value match {
-    case x: java.lang.Integer => Int.unbox(x)
-    case x: String            => x.toInt
+    case x: java.lang.Number => x.intValue()
+    case x: String           => x.toInt
     case _ =>
       throw new UnsupportedOperationException("Cannot convert to integer: " + value)
   }
 
   def long(value: AnyRef): Long = value match {
-    case x: java.lang.Long    => Long.unbox(x)
-    case x: java.lang.Integer => Int.unbox(x).toLong
-    case x: String            => x.toLong
+    case x: java.lang.Number => x.longValue()
+    case x: String           => x.toLong
     case _ => throw new UnsupportedOperationException("Cannot convert to long: " + value)
   }
 
   def float(value: AnyRef): Float = value match {
-    case x: java.lang.Float  => Float.unbox(x)
-    case x: java.lang.Double => Double.unbox(x).toFloat
+    case x: java.lang.Number => x.floatValue()
     case x: String           => x.toFloat
     case _ => throw new UnsupportedOperationException("Cannot convert to float: " + value)
   }
 
   def double(value: AnyRef): Double = value match {
-    case x: java.lang.Double => Double.unbox(x)
+    case x: java.lang.Number => x.doubleValue()
     case x: String           => x.toDouble
     case _ =>
       throw new UnsupportedOperationException("Cannot convert to double: " + value)
@@ -69,7 +74,8 @@ object TableRowOps {
 
   def numeric(value: AnyRef): BigDecimal = value match {
     case x: scala.math.BigDecimal => Numeric(x)
-    case x: java.lang.Double      => Numeric(BigDecimal(x))
+    case x: java.math.BigDecimal  => Numeric(BigDecimal(x))
+    case x: java.lang.Number      => Numeric(x.toString)
     case x: String                => Numeric(x)
     case _ =>
       throw new UnsupportedOperationException("Cannot convert to numeric: " + value)
@@ -122,9 +128,10 @@ object TableRowOps {
   }
 
   def bignumeric(value: AnyRef): BigNumeric = value match {
-    case x: BigNumeric       => x
-    case x: java.lang.Double => BigNumeric(BigDecimal(x))
-    case x: String           => BigNumeric(x)
+    case x: BigNumeric           => x
+    case x: java.math.BigDecimal => BigNumeric(x)
+    case x: java.lang.Number     => BigNumeric(x.toString)
+    case x: String               => BigNumeric(x)
     case _ =>
       throw new UnsupportedOperationException("Cannot convert to bigNumeric: " + value)
   }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -270,7 +270,7 @@ private[types] object ConverterProvider {
     // Converter helpers
     // =======================================================================
     def cast(tree: Tree, tpe: Type): Tree = {
-      val msg = Constant(s"Cannot convert to ${tpe.typeSymbol.name}: ")
+      val msg = s"Cannot convert to ${tpe.typeSymbol.name}: "
       val fail = q"""throw new _root_.java.lang.IllegalArgumentException($msg + $tree)"""
 
       def readBase64(term: TermName) =
@@ -418,7 +418,7 @@ private[types] object ConverterProvider {
 
       val tree = q"$fn.get($name)"
       def nonNullTree(fType: String) = {
-        val msg = Constant(s"$fType field '$name' is null")
+        val msg = s"""$fType field "$name" is null"""
         q"""{
           val v = $fn.get($name)
           if (v == null) {

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -387,10 +387,10 @@ private[types] object ConverterProvider {
         case t if provider.shouldOverrideType(c)(t) => q"$tree.toString"
         case t if t =:= typeOf[Boolean]             => tree
         case t if t =:= typeOf[Int]                 => tree
-        case t if t =:= typeOf[Long]                => tree
-        case t if t =:= typeOf[Float]               => tree
-        case t if t =:= typeOf[Double]              => tree
-        case t if t =:= typeOf[String]              => tree
+        case t if t =:= typeOf[Long]   => q"$tree.toString" // json doesn't support long
+        case t if t =:= typeOf[Float]  => q"$tree.toDouble" // json doesn't support float
+        case t if t =:= typeOf[Double] => tree
+        case t if t =:= typeOf[String] => tree
 
         case t if t =:= typeOf[BigDecimal] =>
           q"_root_.com.spotify.scio.bigquery.Numeric($tree).toString"
@@ -412,7 +412,7 @@ private[types] object ConverterProvider {
         case t if t =:= typeOf[Geography] =>
           q"$tree.wkt"
         case t if t =:= typeOf[Json] =>
-          // for TableRow/json, use JSON to prevent escaping
+          // for TableRow/json, use parsed JSON to prevent escaping
           q"_root_.com.spotify.scio.bigquery.types.Json.parse($tree)"
         case t if t =:= typeOf[BigNumeric] =>
           // for TableRow/json, use string to avoid precision loss (like numeric)

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/package.scala
@@ -17,10 +17,10 @@
 
 package com.spotify.scio.bigquery
 
-import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.spotify.scio.coders.Coder
 import org.apache.avro.Conversions.DecimalConversion
 import org.apache.avro.LogicalTypes
+import org.apache.beam.sdk.extensions.gcp.util.Transport
 import org.typelevel.scalaccompat.annotation.nowarn
 
 import java.math.MathContext
@@ -63,10 +63,11 @@ package object types {
    */
   case class Json(wkt: String)
   object Json {
-    private lazy val mapper = new ObjectMapper()
+    @transient
+    private lazy val jsonFactory = Transport.getJsonFactory
 
-    def apply(node: JsonNode): Json = Json(mapper.writeValueAsString(node))
-    def parse(json: Json): JsonNode = mapper.readTree(json.wkt)
+    def apply(row: TableRow): Json = Json(jsonFactory.toString(row))
+    def parse(json: Json): TableRow = jsonFactory.fromString(json.wkt, classOf[TableRow])
   }
 
   /**

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/TableRowSyntaxTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/TableRowSyntaxTest.scala
@@ -17,21 +17,379 @@
 
 package com.spotify.scio.bigquery
 
-import org.scalatest.matchers.should.Matchers
+import com.google.common.io.BaseEncoding
+import com.spotify.scio.bigquery.types.{Geography, Json}
+import com.spotify.scio.coders.{Coder, CoderMaterializer}
+import org.apache.beam.sdk.util.CoderUtils
+import org.joda.time.{Instant, LocalDate, LocalDateTime, LocalTime}
+import org.scalactic.Equality
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.charset.StandardCharsets
+import scala.jdk.CollectionConverters._
 
 class TableRowSyntaxTest extends AnyFlatSpec with Matchers {
-  "TableRowOps" should "#2673: not throw on get record" in {
-    val json = """{"record":{"foo":"bar"}}"""
-    val row = com.spotify.scio.util.ScioUtil.jsonFactory.fromString(json, classOf[TableRow])
-    val expected = Map("foo" -> "bar")
-    row.getRecord("record") shouldBe expected
+
+  private val bCoder = CoderMaterializer.beamWithDefault(Coder[TableRow])
+  def serialize(tableRow: TableRow): TableRow = CoderUtils.clone(bCoder, tableRow)
+
+  "TableRowOps" should "handle boolean" in {
+    val row = serialize(
+      new TableRow()
+        .set("value", true)
+        .set("other", "false")
+        .set("list", List(true, false).asJava)
+        .set("invalid", -1)
+    )
+
+    row.getBoolean("value") shouldBe true
+    row.getBoolean("other") shouldBe false
+
+    row.getBooleanOpt("value") shouldBe Some(true)
+    row.getBooleanOpt("missing") shouldBe None
+
+    row.getBooleanList("list") shouldBe List(true, false)
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getBoolean("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to boolean: -1"
   }
 
-  it should "#3378: not throw an NPE on a non-existent subrecord" in {
-    val dummy = List(("a", 1), ("b", 2))
-    val row = TableRow(dummy: _*)
-    val result = row.getRecord("c")
-    result shouldBe null
+  it should "handle integer" in {
+    val row = serialize(
+      new TableRow()
+        .set("value", 0)
+        .set("other", "1")
+        .set("list", List(0, 1).asJava)
+        .set("invalid", true)
+    )
+
+    row.getInt("value") shouldBe 0
+    row.getInt("other") shouldBe 1
+
+    row.getIntOpt("value") shouldBe Some(0)
+    row.getIntOpt("missing") shouldBe None
+
+    row.getIntList("list") shouldBe List(0, 1)
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getInt("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to integer: true"
+  }
+
+  it should "handle long" in {
+    val row = serialize(
+      new TableRow()
+        .set("value", 0L)
+        .set("other", "1")
+        .set("list", List(0L, 1L).asJava)
+        .set("invalid", true)
+    )
+
+    row.getLong("value") shouldBe 0L
+    row.getLong("other") shouldBe 1L
+
+    row.getLongOpt("value") shouldBe Some(0L)
+    row.getLongOpt("missing") shouldBe None
+
+    row.getLongList("list") shouldBe List(0L, 1L)
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getLong("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to long: true"
+  }
+
+  it should "handle float" in {
+    val row = serialize(
+      new TableRow()
+        .set("value", 0.0f)
+        .set("other", "1.1")
+        .set("list", List(0.0f, 1.1f).asJava)
+        .set("invalid", true)
+    )
+
+    row.getFloat("value") shouldBe 0.0f
+    row.getFloat("other") shouldBe 1.1f
+
+    row.getFloatOpt("value") shouldBe Some(0.0f)
+    row.getFloatOpt("missing") shouldBe None
+
+    row.getFloatList("list") shouldBe List(0.0f, 1.1f)
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getFloat("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to float: true"
+  }
+
+  it should "handle double" in {
+    val row = serialize(
+      new TableRow()
+        .set("value", 0.0)
+        .set("other", "1.1")
+        .set("list", List(0.0, 1.1).asJava)
+        .set("invalid", true)
+    )
+
+    row.getDouble("value") shouldBe 0.0
+    row.getDouble("other") shouldBe 1.1
+
+    row.getDoubleOpt("value") shouldBe Some(0.0)
+    row.getDoubleOpt("missing") shouldBe None
+
+    row.getDoubleList("list") shouldBe List(0.0, 1.1)
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getDouble("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to double: true"
+  }
+
+  it should "handle string" in {
+    val row = serialize(
+      new TableRow()
+        .set("value", "x")
+        .set("list", List("x", "").asJava)
+        .set("invalid", true)
+    )
+
+    row.getString("value") shouldBe "x"
+
+    row.getStringOpt("value") shouldBe Some("x")
+    row.getStringOpt("missing") shouldBe None
+
+    row.getStringList("list") shouldBe List("x", "")
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getString("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to string: true"
+  }
+
+  it should "handle numeric" in {
+    val bd1 = BigDecimal("1.23")
+    val bd2 = BigDecimal("45.6")
+    val row = serialize(
+      new TableRow()
+        .set("value", bd1.bigDecimal)
+        .set("other", bd2.toString())
+        .set("list", List(bd1.bigDecimal, bd2.bigDecimal).asJava)
+        .set("invalid", true)
+    )
+
+    row.getNumeric("value") shouldBe bd1
+    row.getNumeric("other") shouldBe bd2
+
+    row.getNumericOpt("value") shouldBe Some(bd1)
+    row.getNumericOpt("missing") shouldBe None
+
+    row.getNumericList("list") shouldBe List(bd1, bd2)
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getNumeric("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to numeric: true"
+  }
+
+  it should "handle bytes" in {
+    val helloWorldBytes = "hello world!".getBytes(StandardCharsets.UTF_8)
+    val helloBytes = "hello".getBytes(StandardCharsets.UTF_8)
+    val worldBytes = "world".getBytes(StandardCharsets.UTF_8)
+    val row = serialize(
+      new TableRow()
+        .set("value", BaseEncoding.base64().encode(helloWorldBytes))
+        .set(
+          "list",
+          List(
+            BaseEncoding.base64().encode(helloBytes),
+            BaseEncoding.base64().encode(worldBytes)
+          ).asJava
+        )
+        .set("invalid", true)
+    )
+
+    implicit val eqArray: Equality[Array[Byte]] =
+      (a: Array[Byte], b: Any) =>
+        (a, b) match {
+          case (abs, bbs: Array[Byte]) => abs.sameElements(bbs)
+          case _                       => false
+        }
+    implicit val eqOpt: Equality[Option[Array[Byte]]] =
+      (a: Option[Array[Byte]], b: Any) =>
+        (a, b) match {
+          case (None, None)                        => true
+          case (Some(abs), Some(bbs: Array[Byte])) => abs === bbs
+          case _                                   => false
+        }
+
+    implicit val listEq: Equality[List[Array[Byte]]] =
+      (a: List[Array[Byte]], b: Any) =>
+        (a, b) match {
+          case (a, b: List[Array[Byte]]) if a.size == b.size =>
+            a.zip(b).forall { case (abs, bbs) => abs === bbs }
+          case _ => false
+        }
+
+    row.getBytes("value") should ===(helloWorldBytes)
+
+    row.getBytesOpt("value") should ===(Some(helloWorldBytes))
+    row.getBytesOpt("missing") should ===(None)
+
+    row.getBytesList("list") should ===(List(helloBytes, worldBytes))
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getBytes("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to bytes: true"
+  }
+
+  it should "handle timestamp" in {
+    val now = Instant.now()
+    val future = now.plus(1000)
+    val row = serialize(
+      new TableRow()
+        .set("value", now)
+        .set("list", List(now, future).asJava)
+        .set("invalid", true)
+    )
+
+    row.getTimestamp("value") shouldBe now
+
+    row.getTimestampOpt("value") shouldBe Some(now)
+    row.getTimestampOpt("missing") shouldBe None
+
+    row.getTimestampList("list") shouldBe List(now, future)
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getTimestamp("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to timestamp: true"
+  }
+
+  it should "handle date" in {
+    val today = LocalDate.now()
+    val tomorrow = today.plusDays(1)
+    val row = serialize(
+      new TableRow()
+        .set("value", today)
+        .set("list", List(today, tomorrow).asJava)
+        .set("invalid", true)
+    )
+
+    row.getDate("value") shouldBe today
+
+    row.getDateOpt("value") shouldBe Some(today)
+    row.getDateOpt("missing") shouldBe None
+
+    row.getDateList("list") shouldBe List(today, tomorrow)
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getDate("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to date: true"
+  }
+
+  it should "handle time" in {
+    val now = LocalTime.now()
+    val future = now.plusHours(1)
+    val row = serialize(
+      new TableRow()
+        .set("value", now)
+        .set("list", List(now, future).asJava)
+        .set("invalid", true)
+    )
+
+    row.getTime("value") shouldBe now
+
+    row.getTimeOpt("value") shouldBe Some(now)
+    row.getTimeOpt("missing") shouldBe None
+
+    row.getTimeList("list") shouldBe List(now, future)
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getTime("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to time: true"
+  }
+
+  it should "handle datetime" in {
+    val now = LocalDateTime.now()
+    val future = now.plusMinutes(1)
+    val row = serialize(
+      new TableRow()
+        .set("value", now)
+        .set("list", List(now, future).asJava)
+        .set("invalid", true)
+    )
+
+    row.getDateTime("value") shouldBe now
+
+    row.getDateTimeOpt("value") shouldBe Some(now)
+    row.getDateTimeOpt("missing") shouldBe None
+
+    row.getDateTimeList("list") shouldBe List(now, future)
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getDateTime("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to datetime: true"
+  }
+
+  it should "handle geography" in {
+    val point = "POINT(1 1)"
+    val line = "LINESTRING(1 1, 2 1)"
+    val row = serialize(
+      new TableRow()
+        .set("value", point)
+        .set("list", List(point, line).asJava)
+        .set("invalid", true)
+    )
+
+    row.getGeography("value") shouldBe Geography(point)
+
+    row.getGeographyOpt("value") shouldBe Some(Geography(point))
+    row.getGeographyOpt("missing") shouldBe None
+
+    row.getGeographyList("list") shouldBe List(Geography(point), Geography(line))
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getGeography("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to geography: true"
+  }
+
+  it should "handle json" in {
+    val kv = """{"key": "value"}"""
+    val empty = "{}"
+    val row = serialize(
+      new TableRow()
+        .set("value", kv)
+        .set("list", List(kv, empty).asJava)
+        .set("invalid", true)
+    )
+
+    row.getJson("value") shouldBe Json(kv)
+
+    row.getJsonOpt("value") shouldBe Some(Json(kv))
+    row.getJsonOpt("missing") shouldBe None
+
+    row.getJsonList("list") shouldBe List(Json(kv), Json(empty))
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getJson("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to json: true"
+  }
+
+  it should "handle record" in {
+    val kv = new TableRow().set("key", "value")
+    val empty = new TableRow()
+    val row = serialize(
+      new TableRow()
+        .set("value", kv)
+        .set("list", List(kv, empty).asJava)
+        .set("invalid", true)
+    )
+
+    row.getRecord("value") shouldBe kv
+
+    row.getRecordOpt("value") shouldBe Some(kv)
+    row.getRecordOpt("missing") shouldBe None
+
+    row.getRecordList("list") shouldBe List(kv, empty)
+
+    val e = the[UnsupportedOperationException] thrownBy (row.getRecord("invalid"))
+    e.getMessage shouldBe "Field cannot be converted: invalid"
+    e.getCause.getMessage shouldBe "Cannot convert to record: true"
   }
 }

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
@@ -53,7 +53,9 @@ final class ConverterProviderSpec
   }
   implicit val arbJson: Arbitrary[Json] = Arbitrary(
     for {
-      key <- Gen.alphaStr
+      // f is a field from TableRow.
+      // Jackson ObjectMapper will fail with such key
+      key <- Gen.alphaStr.retryUntil(_ != "f")
       value <- Gen.alphaStr
     } yield Json(s"""{"$key":"$value"}""")
   )

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderSpec.scala
@@ -53,8 +53,8 @@ final class ConverterProviderSpec
   }
   implicit val arbJson: Arbitrary[Json] = Arbitrary(
     for {
-      // f is a field from TableRow.
-      // Jackson ObjectMapper will fail with such key
+      // f is a key field from TableRow. It cannot be used as column name
+      // see https://github.com/apache/beam/issues/33531
       key <- Gen.alphaStr.retryUntil(_ != "f")
       value <- Gen.alphaStr
     } yield Json(s"""{"$key":"$value"}""")

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -26,20 +26,20 @@ import org.scalatest.flatspec.AnyFlatSpec
 class ConverterProviderTest extends AnyFlatSpec with Matchers {
   import ConverterProviderTest._
 
-  "ConverterProvider" should "throw NPE with meaningful message for null in REQUIRED field" in {
-    the[NullPointerException] thrownBy {
+  "ConverterProvider" should "throw NoSuchElementException with meaningful message for missing REQUIRED field" in {
+    the[NoSuchElementException] thrownBy {
       Required.fromTableRow(TableRow())
-    } should have message """REQUIRED field "a" is null"""
+    } should have message "Field not found: a"
   }
 
   it should "handle null in NULLABLE field" in {
     Nullable.fromTableRow(TableRow()) shouldBe Nullable(None)
   }
 
-  it should "throw NPE with meaningful message for null in REPEATED field" in {
-    the[NullPointerException] thrownBy {
+  it should "throw NoSuchElementException with meaningful message for missing in REPEATED field" in {
+    the[NoSuchElementException] thrownBy {
       Repeated.fromTableRow(TableRow())
-    } should have message """REPEATED field "a" is null"""
+    } should have message "Field not found: a"
   }
 
   it should "handle required geography type" in {

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -29,7 +29,7 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
   "ConverterProvider" should "throw NPE with meaningful message for null in REQUIRED field" in {
     the[NullPointerException] thrownBy {
       Required.fromTableRow(TableRow())
-    } should have message "REQUIRED field 'a' is null"
+    } should have message """REQUIRED field "a" is null"""
   }
 
   it should "handle null in NULLABLE field" in {
@@ -39,7 +39,7 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
   it should "throw NPE with meaningful message for null in REPEATED field" in {
     the[NullPointerException] thrownBy {
       Repeated.fromTableRow(TableRow())
-    } should have message "REPEATED field 'a' is null"
+    } should have message """REPEATED field "a" is null"""
   }
 
   it should "handle required geography type" in {

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -17,7 +17,6 @@
 
 package com.spotify.scio.bigquery.types
 
-import com.fasterxml.jackson.databind.node.{JsonNodeFactory, ObjectNode}
 import com.google.protobuf.ByteString
 import com.spotify.scio.bigquery._
 import org.joda.time.{Instant, LocalDate, LocalDateTime, LocalTime}
@@ -30,7 +29,7 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
   "ConverterProvider" should "throw NPE with meaningful message for null in REQUIRED field" in {
     the[NullPointerException] thrownBy {
       Required.fromTableRow(TableRow())
-    } should have message """REQUIRED field "a" is null"""
+    } should have message "REQUIRED field 'a' is null"
   }
 
   it should "handle null in NULLABLE field" in {
@@ -40,7 +39,7 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
   it should "throw NPE with meaningful message for null in REPEATED field" in {
     the[NullPointerException] thrownBy {
       Repeated.fromTableRow(TableRow())
-    } should have message """REPEATED field "a" is null"""
+    } should have message "REPEATED field 'a' is null"
   }
 
   it should "handle required geography type" in {
@@ -51,14 +50,12 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
 
   it should "handle required json type" in {
     val wkt = """{"name":"Alice","age":30}"""
-    val jsNodeFactory = new JsonNodeFactory(false)
-    val jackson = jsNodeFactory
-      .objectNode()
-      .set[ObjectNode]("name", jsNodeFactory.textNode("Alice"))
-      .set[ObjectNode]("age", jsNodeFactory.numberNode(30))
+    val parsed = new TableRow()
+      .set("name", "Alice")
+      .set("age", 30)
 
-    RequiredJson.fromTableRow(TableRow("a" -> jackson)) shouldBe RequiredJson(Json(wkt))
-    BigQueryType.toTableRow[RequiredJson](RequiredJson(Json(wkt))) shouldBe TableRow("a" -> jackson)
+    RequiredJson.fromTableRow(TableRow("a" -> parsed)) shouldBe RequiredJson(Json(wkt))
+    BigQueryType.toTableRow[RequiredJson](RequiredJson(Json(wkt))) shouldBe TableRow("a" -> parsed)
   }
 
   it should "handle required big numeric type" in {


### PR DESCRIPTION
Coder[TableRow] is destructive (it is a dummy JSON serializer), we should make sure that the TableRow object converted from a BQ model is stable after serialization.

We currently have an issue with
- long that are serialized as string to avoid overflow
- float that are read back as double
- json that is read as nested TableRow

As side effect, I needed to avoid `toString` conversion when converting back a BQ typed model from a `TableRow`