### PR TITLE
Include more default jdkAddOpenModules for Java 17+

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/runners/dataflow/DataflowContext.scala
@@ -49,10 +49,18 @@ case object DataflowContext extends RunnerContext {
     if (JavaMajorVersion >= 17 && dataflowPipelineOpts.getJdkAddOpenModules == null) {
       dataflowPipelineOpts.setJdkAddOpenModules(
         List(
-          "java.base/java.util=ALL-UNNAMED",
-          "java.base/java.lang.invoke=ALL-UNNAMED",
+          "java.base/java.io=ALL-UNNAMED",
           "java.base/java.lang=ALL-UNNAMED",
-          "java.base/java.nio=ALL-UNNAMED"
+          "java.base/java.lang.invoke=ALL-UNNAMED",
+          "java.base/java.lang.reflect=ALL-UNNAMED",
+          "java.base/java.net=ALL-UNNAMED",
+          "java.base/java.nio=ALL-UNNAMED",
+          "java.base/java.text=ALL-UNNAMED",
+          "java.base/java.time=ALL-UNNAMED",
+          "java.base/java.util=ALL-UNNAMED",
+          "java.base/java.util.concurrent=ALL-UNNAMED",
+          "java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+          "java.base/java.util.concurrent.locks=ALL-UNNAMED"
         ).asJava
       )
     }


### PR DESCRIPTION
Open more modules, based off of Kryo-related errors we've seen, as well as the set of modules opened by [Flink](https://github.com/apache/flink/blob/release-1.20.0/flink-dist/src/main/resources/config.yaml#L24).