### PR TITLE
Deprecate annoy

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/annoy/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/annoy/package.scala
@@ -147,6 +147,7 @@ package object annoy {
      * @param dim
      *   Number of dimensions in vectors used to build the Annoy index
      */
+    @deprecated("Use voyager instead", "0.14.11")
     @experimental
     def annoySideInput(path: String, metric: AnnoyMetric, dim: Int): SideInput[AnnoyReader] = {
       val uri = AnnoyUri(path, self.options)
@@ -175,6 +176,7 @@ package object annoy {
      * @return
      *   A singleton SCollection containing the [[AnnoyUri]] of the saved files
      */
+    @deprecated("Use voyager instead", "0.14.11")
     @experimental
     def asAnnoy(path: String, metric: AnnoyMetric, dim: Int, nTrees: Int): SCollection[AnnoyUri] = {
       val uri = AnnoyUri(path, self.context.options)
@@ -217,6 +219,7 @@ package object annoy {
      * @return
      *   A singleton SCollection containing the [[AnnoyUri]] of the saved files
      */
+    @deprecated("Use voyager instead", "0.14.11")
     @experimental
     def asAnnoy(metric: AnnoyMetric, dim: Int, nTrees: Int): SCollection[AnnoyUri] = {
       val uuid = UUID.randomUUID()
@@ -242,6 +245,7 @@ package object annoy {
      * @return
      *   SideInput[AnnoyReader]
      */
+    @deprecated("Use voyager instead", "0.14.11")
     @experimental
     def asAnnoySideInput(metric: AnnoyMetric, dim: Int, nTrees: Int): SideInput[AnnoyReader] =
       self.asAnnoy(metric, dim, nTrees).asAnnoySideInput(metric, dim)
@@ -261,6 +265,7 @@ package object annoy {
      * @return
      *   SideInput[AnnoyReader]
      */
+    @deprecated("Use voyager instead", "0.14.11")
     @experimental
     def asAnnoySideInput(metric: AnnoyMetric, dim: Int): SideInput[AnnoyReader] = {
       val view = self.applyInternal(View.asSingleton())

--- a/site/src/main/paradox/extras/Annoy.md
+++ b/site/src/main/paradox/extras/Annoy.md
@@ -1,5 +1,7 @@
 # Annoy
 
+** Deprecated since Scio 0.14.11 **
+
 Scio integrates with Spotify's [Annoy](https://github.com/spotify/annoy), an approximate nearest neighbors library, via [annoy-java](https://github.com/spotify/annoy-java) and [annoy4s](https://github.com/annoy4s/annoy4s).
 
 ## Write


### PR DESCRIPTION
0.14.11 is used as `since` on the premise that we may do another patch before 0.15.0 and remove in 0.15.0. Otherwise we should just remove annoy outright IMO