### PR TITLE
Snowflake write: escape backslash in CSV files

### DIFF
--- a/scio-snowflake/src/main/scala/com/spotify/scio/snowflake/SnowflakeIO.scala
+++ b/scio-snowflake/src/main/scala/com/spotify/scio/snowflake/SnowflakeIO.scala
@@ -124,7 +124,8 @@ object SnowflakeIO {
   }
 
   private[snowflake] def userDataMapper[T: RowEncoder]: UserDataMapper[T] = { (element: T) =>
-    RowEncoder[T].encode(element).toArray
+    // Snowflake COPY uses backslash as escape char
+    RowEncoder[T].encode(element).toArray.map(_.replace("\\", "\\\\"))
   }
 }
 


### PR DESCRIPTION
Unsure it is the right way to do that — can't find how to properly configure escapes chars with kantan.