### PR TITLE
10 minute timeout for futures by default to split the difference between Inf and 1

### DIFF
--- a/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
+++ b/scio-core/src/main/java/com/spotify/scio/transforms/FutureHandlers.java
@@ -42,7 +42,7 @@ public class FutureHandlers {
   public interface Base<F, V> {
 
     default Duration getTimeout() {
-      return Duration.ofMinutes(1);
+      return Duration.ofMinutes(10);
     }
 
     void waitForFutures(Iterable<F> futures)


### PR DESCRIPTION
We've had several internal reports of "previously working" pipelines repeatedly failing due to timeout