### PR TITLE
Fix memory leak in avro SlowGenericRecordCoder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -483,6 +483,10 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   // dropped custom BigQueryAvroUtilsWrapper
   ProblemFilters.exclude[MissingClassProblem](
     "org.apache.beam.sdk.io.gcp.bigquery.BigQueryAvroUtilsWrapper"
+  ),
+  // Changes in avro SlowGenericRecordCoder
+  ProblemFilters.exclude[Problem](
+    "com.spotify.scio.coders.avro.SlowGenericRecordCoder*"
   )
 )
 

--- a/integration/src/test/scala/com/spotify/scio/bigquery/BigQueryIOIT.scala
+++ b/integration/src/test/scala/com/spotify/scio/bigquery/BigQueryIOIT.scala
@@ -60,7 +60,7 @@ class BigQueryIOIT extends PipelineSpec {
     r.get("corpus").asInstanceOf[String]
 
   def extractCorpus(r: GenericRecord): String =
-    r.get("corpus").asInstanceOf[String]
+    r.get("corpus").asInstanceOf[CharSequence].toString
 
   def extractWordCount(r: TableRow): (String, Long) = {
     val word = r.get("word").asInstanceOf[String]
@@ -69,8 +69,8 @@ class BigQueryIOIT extends PipelineSpec {
   }
 
   def extractWordCount(r: GenericRecord): (String, Long) = {
-    val word = r.get("word").asInstanceOf[String]
-    val count = r.get("word_count").asInstanceOf[String].toLong
+    val word = r.get("word").asInstanceOf[CharSequence].toString
+    val count = r.get("word_count").asInstanceOf[Long]
     word -> count
   }
 

--- a/scio-avro/src/main/scala/com/spotify/scio/coders/avro/AvroCoders.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/coders/avro/AvroCoders.scala
@@ -39,7 +39,12 @@ final private class SlowGenericRecordCoder extends CustomCoder[GenericRecord] {
   // Use String for 1.8 compat
   private val sc = StringUtf8Coder.of()
 
-  // Reuse parsed schemas because avro uses caching
+  /**
+   * Reuse parsed schemas because GenericDatumReader caches decoders based on schema reference
+   * equality.
+   * @see
+   *   [[org.apache.avro.generic.GenericDatumReader.getResolver]].
+   */
   @transient private lazy val schemaCache = new TrieMap[String, Schema]()
 
   private val encoder = new EmptyOnDeserializationThreadLocal[BinaryEncoder]()

--- a/scio-avro/src/main/scala/com/spotify/scio/coders/avro/AvroCoders.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/coders/avro/AvroCoders.scala
@@ -22,35 +22,47 @@ import com.spotify.scio.coders.{Coder, CoderGrammar}
 import com.spotify.scio.util.ScioUtil
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericRecord, IndexedRecord}
+import org.apache.avro.io.{BinaryDecoder, BinaryEncoder, DecoderFactory, EncoderFactory}
 import org.apache.avro.specific.{SpecificData, SpecificFixed, SpecificRecord}
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException
-import org.apache.beam.sdk.coders.{AtomicCoder, Coder => BCoder, CustomCoder, StringUtf8Coder}
+import org.apache.beam.sdk.coders.{CustomCoder, StringUtf8Coder}
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder
 import org.apache.beam.sdk.extensions.avro.io.AvroDatumFactory
-import org.apache.beam.sdk.util.common.ElementByteSizeObserver
+import org.apache.beam.sdk.util.EmptyOnDeserializationThreadLocal
 
 import java.io.{InputStream, OutputStream}
+import scala.collection.concurrent.TrieMap
 import scala.reflect.ClassTag
 
-final private class SlowGenericRecordCoder extends AtomicCoder[GenericRecord] {
-  // TODO: can we find something more efficient than String ?
+final private class SlowGenericRecordCoder extends CustomCoder[GenericRecord] {
+  // Schema is serializable on avro 1.9+
+  // Use String for 1.8 compat
   private val sc = StringUtf8Coder.of()
 
-  private def genericCoder(schema: Schema): BCoder[GenericRecord] =
-    AvroCoder.of(GenericRecordDatumFactory, schema)
+  // Reuse parsed schemas because avro uses caching
+  @transient private lazy val parser = new Schema.Parser()
+  @transient private lazy val schemaCache = new TrieMap[String, Schema]()
+
+  private val encoder = new EmptyOnDeserializationThreadLocal[BinaryEncoder]();
+  private val decoder = new EmptyOnDeserializationThreadLocal[BinaryDecoder]();
 
   override def encode(value: GenericRecord, os: OutputStream): Unit = {
+    val enc = EncoderFactory.get().directBinaryEncoder(os, encoder.get())
+    encoder.set(enc)
     val schema = value.getSchema
-    val coder = genericCoder(schema)
-    sc.encode(schema.toString, os)
-    coder.encode(value, os)
+    val schemaString = schema.toString
+    sc.encode(schemaString, os)
+    val writer = AvroDatumFactory.generic()(schema)
+    writer.write(value, enc)
   }
 
   override def decode(is: InputStream): GenericRecord = {
-    val schemaStr = sc.decode(is)
-    val schema = new Schema.Parser().parse(schemaStr)
-    val coder = genericCoder(schema)
-    coder.decode(is)
+    val dec = DecoderFactory.get().directBinaryDecoder(is, decoder.get())
+    decoder.set(dec)
+    val schemaString = sc.decode(is)
+    val schema = schemaCache.getOrElseUpdate(schemaString, parser.parse(schemaString))
+    val reader = AvroDatumFactory.generic()(schema, schema)
+    reader.read(null, dec)
   }
 
   // delegate methods for determinism and equality checks
@@ -59,18 +71,6 @@ final private class SlowGenericRecordCoder extends AtomicCoder[GenericRecord] {
       this,
       "Coder[GenericRecord] without schema is non-deterministic"
     )
-  override def consistentWithEquals(): Boolean = false
-  override def structuralValue(value: GenericRecord): AnyRef =
-    genericCoder(value.getSchema).structuralValue(value)
-
-  // delegate methods for byte size estimation
-  override def isRegisterByteSizeObserverCheap(value: GenericRecord): Boolean =
-    genericCoder(value.getSchema).isRegisterByteSizeObserverCheap(value)
-  override def registerByteSizeObserver(
-    value: GenericRecord,
-    observer: ElementByteSizeObserver
-  ): Unit =
-    genericCoder(value.getSchema).registerByteSizeObserver(value, observer)
 }
 
 /**

--- a/scio-avro/src/main/scala/com/spotify/scio/coders/avro/AvroCoders.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/coders/avro/AvroCoders.scala
@@ -40,11 +40,10 @@ final private class SlowGenericRecordCoder extends CustomCoder[GenericRecord] {
   private val sc = StringUtf8Coder.of()
 
   // Reuse parsed schemas because avro uses caching
-  @transient private lazy val parser = new Schema.Parser()
   @transient private lazy val schemaCache = new TrieMap[String, Schema]()
 
-  private val encoder = new EmptyOnDeserializationThreadLocal[BinaryEncoder]();
-  private val decoder = new EmptyOnDeserializationThreadLocal[BinaryDecoder]();
+  private val encoder = new EmptyOnDeserializationThreadLocal[BinaryEncoder]()
+  private val decoder = new EmptyOnDeserializationThreadLocal[BinaryDecoder]()
 
   override def encode(value: GenericRecord, os: OutputStream): Unit = {
     val enc = EncoderFactory.get().directBinaryEncoder(os, encoder.get())
@@ -60,7 +59,7 @@ final private class SlowGenericRecordCoder extends CustomCoder[GenericRecord] {
     val dec = DecoderFactory.get().directBinaryDecoder(is, decoder.get())
     decoder.set(dec)
     val schemaString = sc.decode(is)
-    val schema = schemaCache.getOrElseUpdate(schemaString, parser.parse(schemaString))
+    val schema = schemaCache.getOrElseUpdate(schemaString, new Schema.Parser().parse(schemaString))
     val reader = AvroDatumFactory.generic()(schema, schema)
     reader.read(null, dec)
   }


### PR DESCRIPTION
- `AvroCoder` should not be created on every elements as it uses  ThreadLocal variables that do not get unregistered.
- avro `GenericDatumReader` uses a thread local `RESOLVER_CACHE` with schema keys to reuse decoders. Reuse parsed schemas to avoid growing the cache