### PR TITLE
Fix bq Avro format issue for nested records

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1050,6 +1050,7 @@ lazy val `scio-google-cloud-platform` = project
       moduleFilter("org.apache.arrow", "arrow-vector"),
       moduleFilter("com.fasterxml.jackson.datatype", "jackson-datatype-jsr310")
     ).reduce(_ | _),
+    Test / javaOptions += "-Doverride.type.provider=com.spotify.scio.bigquery.validation.SampleOverrideTypeProvider",
     libraryDependencies ++= Seq(
       // compile
       "com.esotericsoftware" % "kryo-shaded" % kryoVersion,

--- a/integration/src/test/scala/com/spotify/scio/bigquery/TypedBigQueryIT.scala
+++ b/integration/src/test/scala/com/spotify/scio/bigquery/TypedBigQueryIT.scala
@@ -21,11 +21,14 @@ import com.google.protobuf.ByteString
 import com.spotify.scio.avro._
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.bigquery.BigQueryTypedTable.Format
+import com.spotify.scio.bigquery.BigQueryTypedTable.Format.GenericRecordWithLogicalTypes
 import com.spotify.scio.bigquery.client.BigQuery
 import com.spotify.scio.bigquery.types.{BigNumeric, Geography, Json}
 import com.spotify.scio.testing._
 import magnolify.scalacheck.auto._
+import org.apache.avro.UnresolvedUnionException
 import org.apache.avro.generic.GenericRecord
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.{Method => WriteMethod}
 import org.apache.beam.sdk.options.PipelineOptionsFactory
 import org.joda.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 import org.joda.time.format.DateTimeFormat
@@ -35,6 +38,8 @@ import org.scalatest.BeforeAndAfterAll
 import scala.util.{Random, Try}
 
 object TypedBigQueryIT {
+  case class Nested(int: Int)
+
   @BigQueryType.toTable
   case class Record(
     bool: Boolean,
@@ -53,6 +58,27 @@ object TypedBigQueryIT {
     // - BQ load uses 'long(local-timestamp-micros)'
     // BigQueryType avroSchema favors read with string type
     // datetime: LocalDateTime,
+    geography: Geography,
+    json: Json,
+    bigNumeric: BigNumeric,
+    nestedRequired: Nested,
+    nestedOptional: Option[Nested]
+  )
+
+  // A record with no nested record types
+  @BigQueryType.toTable
+  case class FlatRecord(
+    bool: Boolean,
+    int: Int,
+    long: Long,
+    float: Float,
+    double: Double,
+    numeric: BigDecimal,
+    string: String,
+    byteString: ByteString,
+    timestamp: Instant,
+    date: LocalDate,
+    time: LocalTime,
     geography: Geography,
     json: Json,
     bigNumeric: BigNumeric
@@ -115,9 +141,11 @@ object TypedBigQueryIT {
       s"data-integration-test:bigquery_avro_it.$name${now}_${Random.nextInt(Int.MaxValue)}"
     Table.Spec(spec)
   }
-  private val typedTable = table("records")
+  private val typedTableFileLoads = table("records_fileloads")
+  private val typedTableStorage = table("records_storage")
   private val tableRowTable = table("records_tablerow")
   private val avroTable = table("records_avro")
+  private val avroFlatTable = table("records_avro_flat")
 
   private val records = Gen.listOfN(5, recordGen).sample.get
   private val options = PipelineOptionsFactory
@@ -135,24 +163,30 @@ class TypedBigQueryIT extends PipelineSpec with BeforeAndAfterAll {
 
   override protected def afterAll(): Unit = {
     // best effort cleanup
-    Try(bq.tables.delete(typedTable.ref))
+    Try(bq.tables.delete(typedTableFileLoads.ref))
+    Try(bq.tables.delete(typedTableStorage.ref))
     Try(bq.tables.delete(tableRowTable.ref))
     Try(bq.tables.delete(avroTable.ref))
+    Try(bq.tables.delete(avroFlatTable.ref))
   }
 
-  "TypedBigQuery" should "handle records as TableRow" in {
+  "TypedBigQuery" should "write case classes using FileLoads API" in {
     runWithRealContext(options) { sc =>
       sc.parallelize(records)
-        .saveAsTypedBigQueryTable(typedTable, createDisposition = CREATE_IF_NEEDED)
+        .saveAsTypedBigQueryTable(
+          typedTableFileLoads,
+          createDisposition = CREATE_IF_NEEDED,
+          method = WriteMethod.FILE_LOADS
+        )
     }.waitUntilFinish()
 
     runWithRealContext(options) { sc =>
-      val data = sc.typedBigQuery[Record](typedTable)
+      val data = sc.typedBigQuery[Record](typedTableFileLoads)
       data should containInAnyOrder(records)
     }
   }
 
-  "BigQueryTypedTable" should "handle records as TableRow format" in {
+  it should "write case classes manually converted to TableRows using FileLoads API" in {
     runWithRealContext(options) { sc =>
       sc.parallelize(records)
         .map(Record.toTableRow)
@@ -177,7 +211,7 @@ class TypedBigQueryIT extends PipelineSpec with BeforeAndAfterAll {
     }
   }
 
-  it should "handle records as avro format" in {
+  it should "write case classes manually converted to GenericRecords using FileLoads API" in {
     implicit val coder: Coder[GenericRecord] = avroGenericRecordCoder(Record.avroSchema)
 
     runWithRealContext(options) { sc =>
@@ -191,9 +225,41 @@ class TypedBigQueryIT extends PipelineSpec with BeforeAndAfterAll {
     }.waitUntilFinish()
 
     runWithRealContext(options) { sc =>
+      sc.typedBigQuery[Record](avroTable) should containInAnyOrder(records)
+    }
+
+    // Due to Beam bug with automatic schema detection, can't parse nested record types as GenericRecords yet
+    // Todo remove assertThrows after fixing in Beam
+    assertThrows[UnresolvedUnionException] {
+      runWithRealContext(options) { sc =>
+        val data =
+          sc.bigQueryTable(avroTable, format = GenericRecordWithLogicalTypes)
+            .map(Record.fromAvro)
+        data should containInAnyOrder(records)
+      }
+    }
+  }
+
+  it should "read BigQuery rows into GenericRecords and convert them to case classes for records without nested types" in {
+    implicit val coder: Coder[GenericRecord] = avroGenericRecordCoder(FlatRecord.avroSchema)
+
+    val flatRecords = Gen.listOfN(5, implicitly[Arbitrary[FlatRecord]].arbitrary).sample.get
+
+    runWithRealContext(options) { sc =>
+      sc.parallelize(flatRecords)
+        .map(FlatRecord.toAvro)
+        .saveAsBigQueryTable(
+          avroFlatTable,
+          schema = FlatRecord.schema,
+          createDisposition = CREATE_IF_NEEDED
+        )
+    }.waitUntilFinish()
+
+    runWithRealContext(options) { sc =>
       val data =
-        sc.bigQueryTable(avroTable, Format.GenericRecordWithLogicalTypes).map(Record.fromAvro)
-      data should containInAnyOrder(records)
+        sc.bigQueryTable(avroFlatTable, Format.GenericRecordWithLogicalTypes)
+          .map(FlatRecord.fromAvro)
+      data should containInAnyOrder(flatRecords)
     }
   }
 }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/MacroUtil.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/MacroUtil.scala
@@ -74,6 +74,7 @@ private[types] object MacroUtil {
   // Namespace helpers
 
   val SBQ = "_root_.com.spotify.scio.bigquery"
+  val BeamAvroConverterNamespace = "org.apache.beam.sdk.io.gcp.bigquery"
   val GModel = "_root_.com.google.api.services.bigquery.model"
   val GBQIO = "_root_.org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO"
   val SType: String = s"$SBQ.types.BigQueryType"

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -19,11 +19,12 @@ package com.spotify.scio.bigquery.types
 
 import com.google.protobuf.ByteString
 import com.spotify.scio.bigquery._
-import org.apache.avro.generic.GenericRecordBuilder
+import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.avro.Schema
 import org.joda.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
+
 import scala.jdk.CollectionConverters._
 
 class ConverterProviderTest extends AnyFlatSpec with Matchers {
@@ -118,37 +119,100 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
          |            "name": "repeatedField",
          |            "doc": "Translated Avro Schema for repeatedField",
          |            "fields": [{"name": "a", "type": "string"}]
-         |          }}}]}
+         |          }}
+         |      },
+         |      {
+         |        "name": "doubleNestedField",
+         |        "type": {
+         |          "type": "record",
+         |          "name": "doubleNestedField",
+         |          "doc": "Translated Avro Schema for doubleNestedField",
+         |          "fields":[
+         |            {"name": "requiredNestedField",
+         |             "type":{
+         |               "type": "record",
+         |               "name": "requiredNestedField",
+         |               "doc": "Translated Avro Schema for requiredNestedField",
+         |               "fields": [{"name":"a","type":"string"}]}}
+         |           ]}}
+         |   ]}
          |""".stripMargin)
 
     SchemaProvider.avroSchemaOf[CaseClassWithNested] shouldBe expectedSchema
 
-    val cc1 = CaseClassWithNested(Required("foo"), Some(Required("bar")), List(Required("baz")))
-    val avro1 = new GenericRecordBuilder(expectedSchema)
-      .set(
-        "requiredField",
-        new GenericRecordBuilder(expectedSchema.getField("requiredField").schema())
-          .set("a", "foo")
-          .build()
-      )
-      .set(
-        "optionalField",
-        new GenericRecordBuilder(expectedSchema.getField("optionalField").schema().getTypes.get(1))
-          .set("a", "bar")
-          .build()
-      )
-      .set(
-        "repeatedField",
-        List(
-          new GenericRecordBuilder(expectedSchema.getField("repeatedField").schema().getElementType)
-            .set("a", "baz")
+    def toAvro(
+      required: String,
+      optional: Option[String],
+      list: List[String],
+      doubleNested: String
+    ): GenericRecord = {
+      new GenericRecordBuilder(expectedSchema)
+        .set(
+          "requiredField",
+          new GenericRecordBuilder(expectedSchema.getField("requiredField").schema())
+            .set("a", required)
             .build()
-        ).asJava
-      )
-      .build()
+        )
+        .set(
+          "doubleNestedField",
+          new GenericRecordBuilder(expectedSchema.getField("doubleNestedField").schema())
+            .set(
+              "requiredNestedField",
+              new GenericRecordBuilder(
+                expectedSchema
+                  .getField("doubleNestedField")
+                  .schema()
+                  .getField("requiredNestedField")
+                  .schema()
+              )
+                .set("a", doubleNested)
+                .build()
+            )
+            .build()
+        )
+        .set(
+          "optionalField",
+          optional
+            .map(o =>
+              new GenericRecordBuilder(
+                expectedSchema.getField("optionalField").schema().getTypes.get(1)
+              )
+                .set("a", o)
+                .build()
+            )
+            .orNull
+        )
+        .set(
+          "repeatedField",
+          list
+            .map(element =>
+              new GenericRecordBuilder(
+                expectedSchema.getField("repeatedField").schema().getElementType
+              )
+                .set("a", element)
+                .build()
+            )
+            .asJava
+        )
+        .build()
+    }
 
+    // Test with populated lists/optionals
+    val cc1 = CaseClassWithNested(
+      Required("foo"),
+      Some(Required("bar")),
+      List(Required("baz")),
+      DoubleNested(Required("barbaz"))
+    )
+    val avro1 = toAvro("foo", Some("bar"), List("baz"), "barbaz")
     bqt.toAvro(cc1) shouldBe avro1
     bqt.fromAvro(avro1) shouldBe cc1
+
+    // Test with empty lists/optionals
+    val cc2 = CaseClassWithNested(Required("foo"), None, List(), DoubleNested(Required("barbaz")))
+    val avro2 = toAvro("foo", None, List(), "barbaz")
+    bqt.toAvro(cc2) shouldBe avro2
+    bqt.fromAvro(avro2) shouldBe cc2
   }
 }
 
@@ -198,10 +262,13 @@ object ConverterProviderTest {
     bigNumeric: BigNumeric = BigNumeric(BigDecimal(11))
   )
 
-  @BigQueryType.toTable()
+  case class DoubleNested(requiredNestedField: Required)
+
+  @BigQueryType.toTable
   case class CaseClassWithNested(
     requiredField: Required,
     optionalField: Option[Required],
-    repeatedField: List[Required]
+    repeatedField: List[Required],
+    doubleNestedField: DoubleNested
   )
 }


### PR DESCRIPTION
A proper fix for https://github.com/spotify/scio/issues/5597.

tl;dr for Avro-formatted BQ loads, an Avro schema should always set the _type_ of a nested record type to match its _field name_, since BQ schemas do not support naming nested schemas. The behavior of Beam's `BigQueryUtils.toGenericAvroSchema` utility is correct in this regard (minus inconsistent namespace assignment); we just needed to properly set the right field names in the BigQueryType macro.