### PR TITLE
Fix REPL assembly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1668,6 +1668,9 @@ lazy val `scio-repl` = project
         case PathList("commonMain", _*) =>
           // drop conflicting squareup linkdata
           MergeStrategy.discard
+        case PathList("mozilla", "public-suffix-list.txt") =>
+          // drop conflicting suffix lists from beam-vendor-grpc, httpclient
+          MergeStrategy.discard
         case PathList("META-INF", "io.netty.versions.properties") =>
           // merge conflicting netty property files
           MergeStrategy.filterDistinctLines


### PR DESCRIPTION
after upgrading Beam to 2.63.0, (#2390), `scio-repl` was failing with:

```
[error] 1 error(s) were encountered during the merge:
[error] java.lang.RuntimeException: 
[error] Deduplicate found different file contents in the following:
[error]   Jar name = beam-vendor-grpc-1_69_0-0.1.jar, jar org = org.apache.beam, entry target = mozilla/public-suffix-list.txt
[error]   Jar name = httpclient-4.5.13.jar, jar org = org.apache.httpcomponents, entry target = mozilla/public-suffix-list.txt
```