### PR TITLE
Use Avro 1.8-compatible APIs in BigQueryType macro

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -255,7 +255,7 @@ private[types] object ConverterProvider {
                   recordSchema.getDoc,
                   recordSchema.getNamespace,
                   recordSchema.isError,
-                  recordSchema.getFields.asScala.map(f => new _root_.org.apache.avro.Schema.Field(f.name(), f.schema())).toList.asJava
+                  recordSchema.getFields.asScala.map(f => new _root_.org.apache.avro.Schema.Field(f.name(), f.schema(), f.doc(), f.defaultVal())).asJava
                 )
               )
             }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/SchemaProvider.scala
@@ -45,7 +45,9 @@ private[types] object SchemaProvider {
           converted.getDoc,
           BeamAvroConverterNamespace,
           converted.isError,
-          converted.getFields.asScala.map(f => new Schema.Field(f.name(), f.schema())).asJava
+          converted.getFields.asScala
+            .map(f => new Schema.Field(f.name(), f.schema(), f.doc(), f.defaultVal()))
+            .asJava
         )
       }
     )


### PR DESCRIPTION
macros compiled using Avro 1.8 w/ latest Scio snapshot fail with:

```
[error] /Users/clairem/spotify-scio-2/elitzur-internal-scio/src/test/scala/com/spotify/elitzur/ElitzurValidationTest.scala:134:4: multiple constructors for Field with alternatives:
[error]   (x$1: String,x$2: org.apache.avro.Schema,x$3: String,x$4: Object,x$5: org.apache.avro.Schema.Field.Order)org.apache.avro.Schema.Field <and>
[error]   (x$1: String,x$2: org.apache.avro.Schema,x$3: String,x$4: Object)org.apache.avro.Schema.Field <and>
[error]   (x$1: String,x$2: org.apache.avro.Schema,x$3: String,x$4: org.codehaus.jackson.JsonNode,x$5: org.apache.avro.Schema.Field.Order)org.apache.avro.Schema.Field <and>
[error]   (x$1: String,x$2: org.apache.avro.Schema,x$3: String,x$4: org.codehaus.jackson.JsonNode)org.apache.avro.Schema.Field
[error]  cannot be invoked with (String, org.apache.avro.Schema)
[error]   @BigQueryType.toTable
[error]    ^
```

solution: use Field constructor that exists across Avro versions