### PR TITLE
Fall back to TableRow representation for typed BQ writes containing a LocalDateTime field

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/io/Tap.scala
@@ -171,4 +171,7 @@ final case class ClosedTap[T] private (
    */
   def get(result: ScioResult): Tap[T] = result.tap(this)
   def output[U](sideOutput: SideOutput[U]): SCollection[U] = outputs.get(sideOutput)
+
+  private[scio] def map[U: Coder](fn: T => U): ClosedTap[U] =
+    new ClosedTap[U](underlying.map(fn), outputs)
 }

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryUtil.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryUtil.scala
@@ -42,14 +42,17 @@ object BigQueryUtil {
   private[bigquery] def isStorageApiWrite(method: Method): Boolean =
     method == Method.STORAGE_WRITE_API || method == Method.STORAGE_API_AT_LEAST_ONCE
 
-  private[bigquery] def containsTimeType(schema: TableSchema): Boolean =
-    containsTimeType(schema.getFields.asScala)
+  private[bigquery] def containsType(schema: TableSchema, typeName: String): Boolean =
+    containsType(schema.getFields.asScala, typeName)
 
-  private[bigquery] def containsTimeType(fields: Iterable[TableFieldSchema]): Boolean = {
+  private[bigquery] def containsType(
+    fields: Iterable[TableFieldSchema],
+    typeName: String
+  ): Boolean = {
     fields.exists(field =>
       field.getType match {
-        case "TIME"              => true
-        case "RECORD" | "STRUCT" => containsTimeType(field.getFields.asScala)
+        case t if t == typeName  => true
+        case "RECORD" | "STRUCT" => containsType(field.getFields.asScala, typeName)
         case _                   => false
       }
     )

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -312,16 +312,17 @@ final class SCollectionTypedOps[T <: HasAnnotation](private val self: SCollectio
     // but not FILE_LOADS writes. Fall back by switching to TableRow representation
     if (
       BigQueryUtil.containsType(bqt.schema, "DATETIME") &&
-        !BigQueryUtil.containsType(
-          bqt.schema,
-          "JSON"
-        ) && // TableRow representation doesn't properly support JSON
-        !BigQueryUtil.isStorageApiWrite(method) &&
+      !BigQueryUtil.containsType(
+        bqt.schema,
+        "JSON" // TableRow representation doesn't properly support JSON
+      ) &&
+      !BigQueryUtil.isStorageApiWrite(method)
     ) {
       LoggerFactory
         .getLogger(this.getClass)
         .warn(
-          "DATETIME types are not supported for typed FILE_LOADS writes. Defaulting to STORAGE_API write method."
+          "DATETIME types are not supported for typed FILE_LOADS writes using BigQueryIO's GenericRecord interface." +
+            " Falling back to TableRow interface."
         )
       val tap = self
         .map(bqt.toTableRow)


### PR DESCRIPTION
typed FILE_LOADS writes containing a LocalDateTime field fail with this error:

```json
  "status": {
    "errorResult": {
      "location": "query",
      "message": "Field month has incompatible types. Configured schema: datetime; Avro file: string.",
      "reason": "invalidQuery"
    },
    "errors": [
      {
        "location": "query",
        "message": "Field month has incompatible types. Configured schema: datetime; Avro file: string.",
        "reason": "invalidQuery"
      }
    ],
    "state": "DONE"
  },
```

as it turns out, Beam's TableRow-to-Avro converter writes LocalDateTimes as a _datetime string_, which is supported by the Storage Writes API. Unfortunately, FILE_LOADS expects a _micro timestamp as a Long_. 