### PR TITLE
Parameterize BQ write format; set TableRow as default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -495,7 +495,15 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   ProblemFilters.exclude[IncompatibleResultTypeProblem](
     "com.spotify.scio.bigquery.types.package#Json.parse"
-  )
+  ),
+  // Adding BigQuery Format API in 0.14 patch
+  ProblemFilters.exclude[DirectMissingMethodProblem]("com.spotify.scio.bigquery.BigQueryTyped#Table.copy"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("com.spotify.scio.bigquery.BigQueryTyped#Table.this"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("com.spotify.scio.bigquery.Writes#WriteParamDefaults.com$spotify$scio$bigquery$Writes$WriteParamDefaults$_setter_$DefaultFormat_="),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("com.spotify.scio.bigquery.Writes#WriteParamDefaults.DefaultFormat"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("com.spotify.scio.bigquery.syntax.SCollectionTypedOps.saveAsTypedBigQueryTable$extension"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("com.spotify.scio.bigquery.syntax.SCollectionTypedOps.saveAsTypedBigQueryTable"),
+  ProblemFilters.exclude[DirectMissingMethodProblem]("com.spotify.scio.bigquery.syntax.SCollectionTypedOps.saveAsTypedBigQueryTable$extension")
 )
 
 // headers

--- a/build.sbt
+++ b/build.sbt
@@ -497,13 +497,27 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
     "com.spotify.scio.bigquery.types.package#Json.parse"
   ),
   // Adding BigQuery Format API in 0.14 patch
-  ProblemFilters.exclude[DirectMissingMethodProblem]("com.spotify.scio.bigquery.BigQueryTyped#Table.copy"),
-  ProblemFilters.exclude[DirectMissingMethodProblem]("com.spotify.scio.bigquery.BigQueryTyped#Table.this"),
-  ProblemFilters.exclude[ReversedMissingMethodProblem]("com.spotify.scio.bigquery.Writes#WriteParamDefaults.com$spotify$scio$bigquery$Writes$WriteParamDefaults$_setter_$DefaultFormat_="),
-  ProblemFilters.exclude[ReversedMissingMethodProblem]("com.spotify.scio.bigquery.Writes#WriteParamDefaults.DefaultFormat"),
-  ProblemFilters.exclude[DirectMissingMethodProblem]("com.spotify.scio.bigquery.syntax.SCollectionTypedOps.saveAsTypedBigQueryTable$extension"),
-  ProblemFilters.exclude[DirectMissingMethodProblem]("com.spotify.scio.bigquery.syntax.SCollectionTypedOps.saveAsTypedBigQueryTable"),
-  ProblemFilters.exclude[DirectMissingMethodProblem]("com.spotify.scio.bigquery.syntax.SCollectionTypedOps.saveAsTypedBigQueryTable$extension")
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "com.spotify.scio.bigquery.BigQueryTyped#Table.copy"
+  ),
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "com.spotify.scio.bigquery.BigQueryTyped#Table.this"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "com.spotify.scio.bigquery.Writes#WriteParamDefaults.com$spotify$scio$bigquery$Writes$WriteParamDefaults$_setter_$DefaultFormat_="
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "com.spotify.scio.bigquery.Writes#WriteParamDefaults.DefaultFormat"
+  ),
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "com.spotify.scio.bigquery.syntax.SCollectionTypedOps.saveAsTypedBigQueryTable$extension"
+  ),
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "com.spotify.scio.bigquery.syntax.SCollectionTypedOps.saveAsTypedBigQueryTable"
+  ),
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "com.spotify.scio.bigquery.syntax.SCollectionTypedOps.saveAsTypedBigQueryTable$extension"
+  )
 )
 
 // headers

--- a/integration/src/test/scala/com/spotify/scio/bigquery/TypedBigQueryIT.scala
+++ b/integration/src/test/scala/com/spotify/scio/bigquery/TypedBigQueryIT.scala
@@ -279,7 +279,7 @@ class TypedBigQueryIT extends PipelineSpec with BeforeAndAfterAll {
         Format.TableRow,
         WriteMethod.FILE_LOADS
       )(sample(implicitly[Arbitrary[JsonRecord]].arbitrary))
-    } should have message "JSON schemas are supported for typed BigQuery writes using the FILE_LOADS API and TableRow representation. Please either use the STORAGE_WRITE_API method or GenericRecord Format."
+    } should have message "JSON schemas are not supported for typed BigQuery writes using the FILE_LOADS API and TableRow representation. Please either use the STORAGE_WRITE_API method or GenericRecord Format."
   }
 
   it should "support Json types for GenericRecord representation and FILE_LOADS write API" in {

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -739,7 +739,7 @@ object BigQueryTyped {
   /** Get a typed SCollection for a BigQuery table. */
   final case class Table[T <: HasAnnotation: TypeTag: Coder](
     table: STable,
-    format: Format[_] = Format.TableRow
+    format: Format[_]
   ) extends BigQueryIO[T]
       with WriteResultIO[T] {
     override type ReadP = Unit
@@ -802,6 +802,9 @@ object BigQueryTyped {
   }
 
   object Table {
+    def apply[T <: HasAnnotation: TypeTag: Coder](table: STable): Table[T] =
+      Table[T](table, Format.TableRow)
+
     final case class WriteParam[T] private (
       method: WriteMethod,
       writeDisposition: WriteDisposition,

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryIO.scala
@@ -19,6 +19,7 @@ package com.spotify.scio.bigquery
 
 import com.google.api.services.bigquery.model.TableSchema
 import com.spotify.scio.ScioContext
+import com.spotify.scio.bigquery.BigQueryTypedTable.Format
 import com.spotify.scio.bigquery.client.BigQuery
 import com.spotify.scio.bigquery.types.BigQueryType.HasAnnotation
 import com.spotify.scio.coders._
@@ -193,6 +194,7 @@ private[bigquery] object Writes {
     type ConfigOverride[T] = beam.BigQueryIO.Write[T] => beam.BigQueryIO.Write[T]
 
     val DefaultMethod: WriteMethod = WriteMethod.DEFAULT
+    val DefaultFormat: Format[_] = Format.TableRow
     val DefaultSchema: TableSchema = null
     val DefaultWriteDisposition: WriteDisposition = null
     val DefaultCreateDisposition: CreateDisposition = null

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryUtil.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/BigQueryUtil.scala
@@ -22,6 +22,7 @@ import java.util.UUID
 import com.google.api.client.json.JsonObjectParser
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableSchema}
+import com.spotify.scio.bigquery.BigQueryTypedTable.Format
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.Method
 
 import scala.jdk.CollectionConverters._
@@ -38,6 +39,9 @@ object BigQueryUtil {
   /* Generates job ID */
   def generateJobId(projectId: String): String =
     projectId + "-" + UUID.randomUUID().toString
+
+  private[bigquery] def isAvroFormat(format: Format[_]): Boolean =
+    format == Format.GenericRecord || format == Format.GenericRecordWithLogicalTypes
 
   private[bigquery] def isStorageApiWrite(method: Method): Boolean =
     method == Method.STORAGE_WRITE_API || method == Method.STORAGE_API_AT_LEAST_ONCE

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -274,13 +274,13 @@ final class SCollectionTypedOps[T <: HasAnnotation](private val self: SCollectio
     createDisposition: CreateDisposition = TableWriteParam.DefaultCreateDisposition,
     clustering: Clustering = TableWriteParam.DefaultClustering,
     method: Method = TableWriteParam.DefaultMethod,
-    format: Format[_] = TableWriteParam.DefaultFormat,
     triggeringFrequency: Duration = TableWriteParam.DefaultTriggeringFrequency,
     sharding: Sharding = TableWriteParam.DefaultSharding,
     failedInsertRetryPolicy: InsertRetryPolicy = TableWriteParam.DefaultFailedInsertRetryPolicy,
     successfulInsertsPropagation: Boolean = TableWriteParam.DefaultSuccessfulInsertsPropagation,
     extendedErrorInfo: Boolean = TableWriteParam.DefaultExtendedErrorInfo,
-    configOverride: TableWriteParam.ConfigOverride[T] = TableWriteParam.DefaultConfigOverride
+    configOverride: TableWriteParam.ConfigOverride[T] = TableWriteParam.DefaultConfigOverride,
+    format: Format[_] = TableWriteParam.DefaultFormat
   )(implicit tt: TypeTag[T], coder: Coder[T]): ClosedTap[T] = {
     val bqt = BigQueryType[T]
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -302,7 +302,7 @@ final class SCollectionTypedOps[T <: HasAnnotation](private val self: SCollectio
       )
     ) {
       throw new IllegalArgumentException(
-        "JSON schemas are supported for typed BigQuery writes using the FILE_LOADS API and TableRow representation. Please either use the STORAGE_WRITE_API method or GenericRecord Format."
+        "JSON schemas are not supported for typed BigQuery writes using the FILE_LOADS API and TableRow representation. Please either use the STORAGE_WRITE_API method or GenericRecord Format."
       )
     }
 

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/syntax/SCollectionSyntax.scala
@@ -283,20 +283,6 @@ final class SCollectionTypedOps[T <: HasAnnotation](private val self: SCollectio
     extendedErrorInfo: Boolean = TableWriteParam.DefaultExtendedErrorInfo,
     configOverride: TableWriteParam.ConfigOverride[T] = TableWriteParam.DefaultConfigOverride
   )(implicit tt: TypeTag[T], coder: Coder[T]): ClosedTap[T] = {
-    val param = TableWriteParam[T](
-      method,
-      writeDisposition,
-      createDisposition,
-      timePartitioning,
-      clustering,
-      triggeringFrequency,
-      sharding,
-      failedInsertRetryPolicy,
-      successfulInsertsPropagation,
-      extendedErrorInfo,
-      configOverride
-    )
-
     val bqt = BigQueryType[T]
 
     if (
@@ -345,7 +331,21 @@ final class SCollectionTypedOps[T <: HasAnnotation](private val self: SCollectio
 
         tap.map(bqt.fromTableRow)
       case _: Format.AvroFormat =>
-        self.write(BigQueryTyped.Table[T](table))(param)
+        self.write(BigQueryTyped.Table[T](table))(
+          TableWriteParam[T](
+            method,
+            writeDisposition,
+            createDisposition,
+            timePartitioning,
+            clustering,
+            triggeringFrequency,
+            sharding,
+            failedInsertRetryPolicy,
+            successfulInsertsPropagation,
+            extendedErrorInfo,
+            configOverride
+          )
+        )
     }
   }
 }


### PR DESCRIPTION
See #5642. There have been too many regressions with the new GenericRecord format default. On the other hand, certain types have better support with GenericRecord (Json, for example). Let's just make the Format a write parameter and set the user opt-in to Avro if they'd prefer, but keep the prior TableRow behavior the default.