### PR TITLE
Add integration tests for overridden type

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1862,6 +1862,7 @@ lazy val integration = project
       }
       testSkipped.value
     },
+    Test / javaOptions += "-Doverride.type.provider=com.spotify.scio.bigquery.validation.SampleOverrideTypeProvider",
     undeclaredCompileDependenciesTest := undeclaredCompileDependenciesTestSkipped.value,
     unusedCompileDependenciesTest := unusedCompileDependenciesTestSkipped.value,
     libraryDependencies ++= Seq(


### PR DESCRIPTION
Add IT tests for OverrideTypeProvider types. It turns out non-String overridden types do not work with GenericRecord format but do work with TableRow json format (see https://github.com/spotify/scio/issues/5644). 