### PR TITLE
Fix secondary key getter in ParquetBucketMetadata

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetBucketMetadata.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/ParquetBucketMetadata.java
@@ -197,10 +197,10 @@ public class ParquetBucketMetadata<K1, K2, V> extends BucketMetadata<K1, K2, V> 
       final Class<K2> keyClass = getKeyClassSecondary();
       if (IndexedRecord.class.isAssignableFrom(recordClass)) {
         final IndexedRecord record = (IndexedRecord) value;
-        final int[] path = AvroUtils.toKeyPath(keyField, keyClass, record.getSchema());
+        final int[] path = AvroUtils.toKeyPath(keyFieldSecondary, keyClass, record.getSchema());
         getter = (v) -> AvroBucketMetadata.extractKey(keyClass, path, (IndexedRecord) v);
       } else if (scala.Product.class.isAssignableFrom(recordClass)) {
-        final Method[] methods = toKeyGetters(keyField, keyClass, recordClass);
+        final Method[] methods = toKeyGetters(keyFieldSecondary, keyClass, recordClass);
         getter = (v) -> extractKey(methods, v);
       } else {
         throw new IllegalArgumentException(

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/JsonBucketMetadataTest.java
@@ -48,18 +48,19 @@ public class JsonBucketMetadataTest {
                     .set("currentCountry", "US")
                     .set("prevCountries", Arrays.asList("CN", "MX")));
 
-    Assert.assertEquals(
-        (Integer) 10,
+    BucketMetadata<Integer, String, TableRow> metadata =
         new JsonBucketMetadata<>(
-                1,
-                1,
-                Integer.class,
-                "age",
-                null,
-                null,
-                HashType.MURMUR3_32,
-                SortedBucketIO.DEFAULT_FILENAME_PREFIX)
-            .extractKeyPrimary(user));
+            1,
+            1,
+            Integer.class,
+            "age",
+            String.class,
+            "user",
+            HashType.MURMUR3_32,
+            SortedBucketIO.DEFAULT_FILENAME_PREFIX);
+
+    Assert.assertEquals((Integer) 10, metadata.extractKeyPrimary(user));
+    Assert.assertEquals("Alice", metadata.extractKeySecondary(user));
 
     Assert.assertEquals(
         "US",

--- a/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetBucketMetadataTest.scala
+++ b/scio-smb/src/test/scala/org/apache/beam/sdk/extensions/smb/ParquetBucketMetadataTest.scala
@@ -55,31 +55,33 @@ class ParquetBucketMetadataTest extends AnyFlatSpec with Matchers {
       .set("suffix", "Jr")
       .build()
 
-    val idMeta = new ParquetBucketMetadata[Long, Void, GenericRecord](
+    val idMeta = new ParquetBucketMetadata[Long, ByteBuffer, GenericRecord](
       1,
       1,
       classOf[Long],
       "id",
-      null,
-      null,
+      classOf[ByteBuffer],
+      "location.countryId",
       HashType.MURMUR3_32,
       SortedBucketIO.DEFAULT_FILENAME_PREFIX,
       RECORD_SCHEMA
     )
     idMeta.extractKeyPrimary(user) shouldBe 10L
+    idMeta.extractKeySecondary(user) shouldBe countryId
 
-    val countryIdMeta = new ParquetBucketMetadata[ByteBuffer, Void, GenericRecord](
+    val countryIdMeta = new ParquetBucketMetadata[ByteBuffer, Long, GenericRecord](
       1,
       1,
       classOf[ByteBuffer],
       "location.countryId",
-      null,
-      null,
+      classOf[Long],
+      "id",
       HashType.MURMUR3_32,
       SortedBucketIO.DEFAULT_FILENAME_PREFIX,
       RECORD_SCHEMA
     )
     countryIdMeta.extractKeyPrimary(user) shouldBe countryId
+    countryIdMeta.extractKeySecondary(user) shouldBe 10L
 
     val postalCodeMeta = new ParquetBucketMetadata[ByteBuffer, Void, GenericRecord](
       1,


### PR DESCRIPTION
\+ add missing secondary key extraction test for JsonBucketMetadata