### PR TITLE
(fix #5665) BigQueryType#toAvro should compile for nested case classes with repeat field names

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/bigquery/types/ConverterProvider.scala
@@ -207,7 +207,7 @@ private[types] object ConverterProvider {
 
         // nested records
         case t if isCaseClass(c)(t) =>
-          val fn = TermName("r" + fieldName)
+          val fn = TermName("r" + s"${fieldName}_${t.typeSymbol.name}")
           q"""{
                 val $fn = $tree
                 ${constructor(fieldName, t, fn)}

--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/types/ConverterProviderTest.scala
@@ -214,6 +214,12 @@ class ConverterProviderTest extends AnyFlatSpec with Matchers {
     bqt.toAvro(cc2) shouldBe avro2
     bqt.fromAvro(avro2) shouldBe cc2
   }
+
+  it should "produce a valid toAvro impl for records with nested repeated field names" in {
+    val record = NestedBase(NestedLevel1(NestedLevel2("foo")))
+    val bqt = BigQueryType[NestedBase]
+    bqt.fromAvro(bqt.toAvro(record)) shouldEqual record
+  }
 }
 
 object ConverterProviderTest {
@@ -271,4 +277,9 @@ object ConverterProviderTest {
     repeatedField: List[Required],
     doubleNestedField: DoubleNested
   )
+
+  @BigQueryType.toTable
+  case class NestedBase(repeatFieldName: NestedLevel1)
+  case class NestedLevel1(repeatFieldName: NestedLevel2)
+  case class NestedLevel2(s: String)
 }


### PR DESCRIPTION
Deduplicate intermediate variable names by type as well as field name to fix regression introduced [here](https://github.com/spotify/scio/pull/5611/files#diff-0443680c91a5b790b7caf73c88e2b05c88704c56c58ea0c6e444e62adbb9f7fcR210). For the following case class:

```scala
  @BigQueryType.toTable
  case class NestedBase(repeatFieldName: NestedLevel1)
  case class NestedLevel1(repeatFieldName: NestedLevel2)
  case class NestedLevel2(s: String)
```

This PR produces the following diff to the generated macro code for `toAvroInternal`:

```diff
{
	val result = {
	  import _root_.scala.jdk.CollectionConverters._;
	  val recordSchema = _root_.com.spotify.scio.bigquery.types.BigQueryType.avroSchemaOf[com.spotify.scio.bigquery.types.ConverterProviderTest.NestedBase];
	  new _root_.org.apache.avro.generic.GenericRecordBuilder(_root_.org.apache.avro.Schema.createRecord("NestedBase", recordSchema.getDoc, recordSchema.getNamespace, recordSchema.isError, recordSchema.getFields.asScala.map(((f) => new _root_.org.apache.avro.Schema.Field(f.name(), f.schema(), f.doc(), f.defaultVal()))).asJava))
	};
	result.set("repeatFieldName", {
-	  val rrepeatFieldName = r.repeatFieldName;
+ 	  val rrepeatFieldName_NestedLevel1 = r.repeatFieldName;
	  {
		val result = {
		  import _root_.scala.jdk.CollectionConverters._;
		  val recordSchema = _root_.com.spotify.scio.bigquery.types.BigQueryType.avroSchemaOf[com.spotify.scio.bigquery.types.ConverterProviderTest.NestedLevel1 @com.spotify.scio.bigquery.types.BigQueryTag];
		  new _root_.org.apache.avro.generic.GenericRecordBuilder(_root_.org.apache.avro.Schema.createRecord("repeatFieldName", recordSchema.getDoc, recordSchema.getNamespace, recordSchema.isError, recordSchema.getFields.asScala.map(((f) => new _root_.org.apache.avro.Schema.Field(f.name(), f.schema(), f.doc(), f.defaultVal()))).asJava))
		};
		result.set("repeatFieldName", {
-		  val rrepeatFieldName = rrepeatFieldName_NestedLevel1.repeatFieldName;
+		  val rrepeatFieldName_NestedLevel2 = rrepeatFieldName_NestedLevel1.repeatFieldName;
		  {
			val result = {
			  import _root_.scala.jdk.CollectionConverters._;
			  val recordSchema = _root_.com.spotify.scio.bigquery.types.BigQueryType.avroSchemaOf[com.spotify.scio.bigquery.types.ConverterProviderTest.NestedLevel2];
			  new _root_.org.apache.avro.generic.GenericRecordBuilder(_root_.org.apache.avro.Schema.createRecord("repeatFieldName", recordSchema.getDoc, recordSchema.getNamespace, recordSchema.isError, recordSchema.getFields.asScala.map(((f) => new _root_.org.apache.avro.Schema.Field(f.name(), f.schema(), f.doc(), f.defaultVal()))).asJava))
			};
			result.set("s", rrepeatFieldName_NestedLevel2.s);
			result.build()
		  }
		});
		result.build()
	  }
	});
	result.build()
	}
})
```