### PR TITLE
Enable deterministic sampling with SCollection.sample

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/util/random/RandomSampler.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/util/random/RandomSampler.scala
@@ -66,10 +66,14 @@ abstract private[scio] class RandomSampler[T, R] extends DoFn[T, T] {
  *
  * @param fraction
  *   the sampling fraction, aka Bernoulli sampling probability
+ * @param seedOpt
+ *   optional random seed to make sampling deterministic
+ *   default to None, which samples non-deterministically
  * @tparam T
  *   item type
  */
-private[scio] class BernoulliSampler[T](val fraction: Double) extends RandomSampler[T, JRandom] {
+private[scio] class BernoulliSampler[T](val fraction: Double, private val seedOpt: Option[Long])
+  extends RandomSampler[T, JRandom] {
 
   /** Epsilon slop to avoid failure from floating point jitter */
   require(
@@ -80,9 +84,7 @@ private[scio] class BernoulliSampler[T](val fraction: Double) extends RandomSamp
 
   override def init: JRandom = {
     val r = RandomSampler.newDefaultRNG
-    if (seed > 0) {
-      r.setSeed(seed)
-    }
+    seedOpt.foreach(r.setSeed)
     r
   }
 
@@ -96,15 +98,24 @@ private[scio] class BernoulliSampler[T](val fraction: Double) extends RandomSamp
     }
 }
 
+/** Companion object set seed to None by default, which samples non-deterministically */
+object BernoulliSampler {
+  def apply[T](fraction: Double, seed: Option[Long] = None): BernoulliSampler[T] =
+    new BernoulliSampler[T](fraction, seed)
+}
+
 /**
  * A sampler for sampling with replacement, based on values drawn from Poisson distribution.
  *
  * @param fraction
  *   the sampling fraction (with replacement)
+ * @param seedOpt
+ *   optional random seed to make sampling deterministic
+ *   default to None, which samples non-deterministically
  * @tparam T
  *   item type
  */
-private[scio] class PoissonSampler[T](val fraction: Double)
+private[scio] class PoissonSampler[T](val fraction: Double, private val seedOpt: Option[Long])
     extends RandomSampler[T, IntegerDistribution] {
 
   /** Epsilon slop to avoid failure from floating point jitter. */
@@ -117,13 +128,17 @@ private[scio] class PoissonSampler[T](val fraction: Double)
   // If fraction is <= 0, 0 is used below, so we can use any placeholder value.
   override def init: IntegerDistribution = {
     val r = new PoissonDistribution(if (fraction > 0.0) fraction else 1.0)
-    if (seed > 0) {
-      r.reseedRandomGenerator(seed)
-    }
+    seedOpt.foreach(r.reseedRandomGenerator)
     r
   }
 
   override def samples: Int = if (fraction <= 0.0) 0 else rng.sample()
+}
+
+/** Companion object set seed to None by default, which samples non-deterministically */
+object PoissonSampler {
+  def apply[T](fraction: Double, seed: Option[Long] = None): PoissonSampler[T] =
+    new PoissonSampler[T](fraction, seed)
 }
 
 abstract private[scio] class RandomValueSampler[K, V, R](val fractions: Map[K, Double])

--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -938,11 +938,18 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
    *   sampled only once
    * @param fraction
    *   the sampling fraction
+   * @param seedOpt
+   *   if the same seed is set, sampling is done deterministically
+   *   default to None where sampling is done non-deterministically
    * @group transform
    */
   // TODO move to implicit
+  def sample(withReplacement: Boolean, fraction: Double, seedOpt: Option[Long]): SCollection[T] =
+    new SampleSCollectionFunctions(this).sample(withReplacement, fraction, seedOpt)
+
+  // Ensures binary compatibility
   def sample(withReplacement: Boolean, fraction: Double): SCollection[T] =
-    new SampleSCollectionFunctions(this).sample(withReplacement, fraction)
+    new SampleSCollectionFunctions(this).sample(withReplacement, fraction, None)
 
   /**
    * Return an SCollection with the elements from `this` that are not in `other`.

--- a/scio-core/src/main/scala/com/spotify/scio/values/SampleSCollectionFunctions.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SampleSCollectionFunctions.scala
@@ -129,15 +129,21 @@ class SampleSCollectionFunctions[T](self: SCollection[T]) {
    *   sampled only once
    * @param fraction
    *   the sampling fraction
+   * @param seedOpt
+   *   if the same seed is set, sampling is done deterministically
+   *   default to None where sampling is done non-deterministically
    * @group transform
    */
-  def sample(withReplacement: Boolean, fraction: Double): SCollection[T] = {
+  def sample(withReplacement: Boolean, fraction: Double, seedOpt: Option[Long]): SCollection[T] = {
     import self.coder
     if (withReplacement) {
-      self.parDo(new PoissonSampler[T](fraction))
+      self.parDo(new PoissonSampler[T](fraction, seedOpt))
     } else {
-      self.parDo(new BernoulliSampler[T](fraction))
+      self.parDo(new BernoulliSampler[T](fraction, seedOpt))
     }
   }
 
+  // Reintroduce the original method: delegates to new one
+  def sample(withReplacement: Boolean, fraction: Double): SCollection[T] =
+    sample(withReplacement, fraction, None)
 }

--- a/scio-core/src/test/scala/com/spotify/scio/util/random/RandomSamplerTest.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/util/random/RandomSamplerTest.scala
@@ -55,9 +55,9 @@ class RandomSamplerTest extends PipelineSpec {
     val expected = expectedSamples(withReplacement, expectedFraction)
 
     val sampler = if (withReplacement) {
-      new PoissonSampler[Int](actualFraction)
+      PoissonSampler[Int](actualFraction)
     } else {
-      new BernoulliSampler[Int](actualFraction)
+      BernoulliSampler[Int](actualFraction)
     }
     sampler.setSeed(fixedSeed)
 
@@ -78,6 +78,46 @@ class RandomSamplerTest extends PipelineSpec {
     testSampler(false, 0.7, 0.7) should be < D
     testSampler(false, 0.9, 0.9) should be < D
     testSampler(false, 0.4, 0.6) should be >= D
+  }
+
+  "PoissonSampler" should "produce identical output for same seed" in {
+    val sampler1 = new PoissonSampler[Int](0.5, Some(fixedSeed))
+    val sampler2 = new PoissonSampler[Int](0.5, Some(fixedSeed))
+
+    val result1 = test(sampler1, population).toArray
+    val result2 = test(sampler2, population).toArray
+
+    result1 should contain theSameElementsInOrderAs(result2)
+  }
+
+  "PoissonSampler" should "produce different output for different seeds" in {
+    val sampler1 = new PoissonSampler[Int](0.5, Some(fixedSeed))
+    val sampler2 = new PoissonSampler[Int](0.5, Some(otherSeed))
+
+    val result1 = test(sampler1, population).toArray
+    val result2 = test(sampler2, population).toArray
+
+    result1 should not contain theSameElementsInOrderAs(result2)
+  }
+
+  "BernoulliSampler" should "produce identical output for same seed" in {
+    val sampler1 = new BernoulliSampler[Int](0.5, Some(fixedSeed))
+    val sampler2 = new BernoulliSampler[Int](0.5, Some(fixedSeed))
+
+    val result1 = test(sampler1, population).toArray
+    val result2 = test(sampler2, population).toArray
+
+    result1 should contain theSameElementsInOrderAs(result2)
+  }
+
+  "BernoulliSampler" should "produce different output for different seeds" in {
+    val sampler1 = new BernoulliSampler[Int](0.5, Some(fixedSeed))
+    val sampler2 = new BernoulliSampler[Int](0.5, Some(otherSeed))
+
+    val result1 = test(sampler1, population).toArray
+    val result2 = test(sampler2, population).toArray
+
+    result1 should not contain theSameElementsInOrderAs(result2)
   }
 
   def testValueSampler(

--- a/scio-core/src/test/scala/com/spotify/scio/util/random/RandomSamplerUtils.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/util/random/RandomSamplerUtils.scala
@@ -51,6 +51,7 @@ object RandomSamplerUtils extends Serializable {
   val D = 0.0544280747619
 
   val fixedSeed = 235711L
+  val otherSeed = 1244321L
 
   // I'm not a big fan of fixing seeds, but unit testing based on running statistical tests
   // will always fail with some nonzero probability, so I'll fix the seed to prevent these

--- a/scio-core/src/test/scala/com/spotify/scio/values/SampleSCollectionFunctionsTest.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/values/SampleSCollectionFunctionsTest.scala
@@ -62,4 +62,15 @@ class SampleSCollectionFunctionsTest extends PipelineSpec {
     }
   }
 
+  it should "support sample() with different seeds" in {
+    import RandomSamplerUtils._
+
+    val sample1 = runWithData(population)(_.sample(false, 0.2, Some(fixedSeed)))
+    val sample2 = runWithData(population)(_.sample(false, 0.2, Some(fixedSeed)))
+    val sample3 = runWithData(population)(_.sample(false, 0.2, Some(otherSeed)))
+
+    sample1 should contain theSameElementsAs(sample2)
+    sample1 should not contain theSameElementsAs(sample3)
+  }
+
 }


### PR DESCRIPTION
This PR adds an optional seed to SCollection.sample to allow for sampling deterministically.