### PR TITLE
Update Apache Beam version matrix in documentation

### DIFF
--- a/site/src/main/paradox/releases/Apache-Beam.md
+++ b/site/src/main/paradox/releases/Apache-Beam.md
@@ -33,6 +33,9 @@ Also check out the [SDK Version Support Status](https://cloud.google.com/dataflo
 
 | **Scio Version** | **Beam Version** | **Details**                                           |
 |:----------------:|:----------------:|:------------------------------------------------------|
+|     0.14.18      |      2.66.0      | This version will be deprecated on July 1, 2026.      |
+|     0.14.17      |      2.64.0      | This version will be deprecated on March 31, 2026.    |
+|     0.14.16      |      2.64.0      | This version will be deprecated on March 31, 2026.    |
 |     0.14.15      |      2.64.0      | This version will be deprecated on March 31, 2026.    |
 |     0.14.14      |      2.63.0      | This version will be deprecated on February 18, 2026. |
 |     0.14.13      |      2.63.0      | This version will be deprecated on February 18, 2026. |


### PR DESCRIPTION
https://cloud.google.com/dataflow/docs/support/sdk-version-support-status#apache-beam-sdks-2x