### PR TITLE
Unblock usage of gcs-connector 3.x

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -533,7 +533,7 @@ class ScioContext private[scio] (
       )
     } catch {
       // Hadoop and/or gcs-connector is excluded from classpath, do not try to set options
-      case _: NoClassDefFoundError | _: NoSuchMethodException =>
+      case _: LinkageError =>
     }
   }
 

--- a/site/src/main/paradox/io/Parquet.md
+++ b/site/src/main/paradox/io/Parquet.md
@@ -311,7 +311,7 @@ dependencyOverrides ++= Seq(
 )
 ```
 
-Note that due to binary incompatibilities between gcs-connector 2.x and 3.x, Scio will not be able to autamatically load any
+Note that due to binary incompatibilities between gcs-connector 2.x and 3.x, Scio will not be able to automatically load any
 [gcsio configuration options](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/CONFIGURATION.md#io-configuration) you may be passing though `core-site.xml`.
 You'll have to configure them yourself:
 


### PR DESCRIPTION
gcs-connector 3 has some interesting new features, namely vectored read support for Parquet and a new `FAdvise` mode. However, we're blocked from upgrading to it on the 0.14.x branch, since it's compiled against Java 11. Users on Java 11+ were blocked from overriding their project versions as we weren't properly catching a linkage error:

```
Exception in thread "main" java.lang.NoSuchMethodError: 'com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions$Builder com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions$Builder.setFastFailOnNotFound(boolean)'
	at com.spotify.scio.ScioContext$$anonfun$9$$anonfun$apply$8.apply(ScioContext.scala:475)
	at com.spotify.scio.ScioContext$$anonfun$9$$anonfun$apply$8.apply(ScioContext.scala:475)
	at scala.Option.fold(Option.scala:263)
	at com.spotify.scio.ScioContext$$anonfun$9.apply(ScioContext.scala:475)
	at com.spotify.scio.ScioContext$$anonfun$9.apply(ScioContext.scala:472)
	at scala.util.ChainingOps$.pipe$extension(ChainingOps.scala:64)
	at com.spotify.scio.ScioContext.<init>(ScioContext.scala:472)
	at com.spotify.scio.ContextAndArgs$$anonfun$withParser$1.apply(ScioContext.scala:219)
	at com.spotify.scio.ContextAndArgs$$anonfun$withParser$1.apply(ScioContext.scala:209)
	at com.spotify.scio.ContextAndArgs$.apply(ScioContext.scala:224)
	at com.spotify.data.example.ParquetExample$.pipeline(ParquetExample.scala:26)
	at com.spotify.data.example.ParquetExample$.main(ParquetExample.scala:45)
	at com.spotify.data.example.ParquetExample.main(ParquetExample.scala)
[error] nonzero exit code returned from runner: 1
```