### PR TITLE
Add EmptyMatchTreatment support for SMB reads (#5759)

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/AvroSortedBucketIO.java
@@ -38,6 +38,7 @@ import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType;
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.Predicate;
 import org.apache.beam.sdk.extensions.smb.SortedBucketTransform.NewBucketMetadataFn;
 import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.EmptyMatchTreatment;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
@@ -218,6 +219,9 @@ public class AvroSortedBucketIO {
     @Nullable
     abstract Predicate<T> getPredicate();
 
+    @Nullable
+    abstract EmptyMatchTreatment getEmptyMatchTreatment();
+
     abstract Builder<T> toBuilder();
 
     @AutoValue.Builder
@@ -235,6 +239,8 @@ public class AvroSortedBucketIO {
       abstract Builder<T> setDatumFactory(AvroDatumFactory<T> datumFactory);
 
       abstract Builder<T> setPredicate(Predicate<T> predicate);
+
+      abstract Builder<T> setEmptyMatchTreatment(EmptyMatchTreatment emptyMatchTreatment);
 
       abstract Read<T> build();
     }
@@ -264,6 +270,11 @@ public class AvroSortedBucketIO {
       return toBuilder().setPredicate(predicate).build();
     }
 
+    /** Specifies the empty match treatment for handling empty directories. */
+    public Read<T> withEmptyMatchTreatment(EmptyMatchTreatment emptyMatchTreatment) {
+      return toBuilder().setEmptyMatchTreatment(emptyMatchTreatment).build();
+    }
+
     @SuppressWarnings("unchecked")
     FileOperations<T> getFileOperations() {
       return AvroFileOperations.of(getDatumFactory(), getSchema());
@@ -278,7 +289,8 @@ public class AvroSortedBucketIO {
           getInputDirectories(),
           getFilenameSuffix(),
           getFileOperations(),
-          getPredicate());
+          getPredicate(),
+          getEmptyMatchTreatment());
     }
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/JsonSortedBucketIO.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.extensions.smb.SortedBucketSource.Predicate;
 import org.apache.beam.sdk.extensions.smb.SortedBucketTransform.NewBucketMetadataFn;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.EmptyMatchTreatment;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
@@ -118,6 +119,9 @@ public class JsonSortedBucketIO {
     @Nullable
     abstract Predicate<TableRow> getPredicate();
 
+    @Nullable
+    abstract EmptyMatchTreatment getEmptyMatchTreatment();
+
     abstract Builder toBuilder();
 
     @AutoValue.Builder
@@ -133,6 +137,8 @@ public class JsonSortedBucketIO {
       abstract Builder setCompression(Compression compression);
 
       abstract Builder setPredicate(Predicate<TableRow> predicate);
+
+      abstract Builder setEmptyMatchTreatment(EmptyMatchTreatment emptyMatchTreatment);
 
       abstract Read build();
     }
@@ -156,6 +162,19 @@ public class JsonSortedBucketIO {
       return toBuilder().setPredicate(predicate).build();
     }
 
+    /**
+     * Specifies how to handle empty file matches when reading input directories.
+     *
+     * @param emptyMatchTreatment the behavior when file patterns don't match any files. Use
+     *     {@link EmptyMatchTreatment#ALLOW} to proceed with empty inputs, {@link
+     *     EmptyMatchTreatment#DISALLOW} to fail on empty matches, or {@link
+     *     EmptyMatchTreatment#ALLOW_IF_WILDCARD} to allow empty matches only for wildcard patterns.
+     * @return a new {@link Read} instance with the specified empty match treatment
+     */
+    public Read withEmptyMatchTreatment(EmptyMatchTreatment emptyMatchTreatment) {
+      return toBuilder().setEmptyMatchTreatment(emptyMatchTreatment).build();
+    }
+
     FileOperations<TableRow> getFileOperations() {
       return JsonFileOperations.of(getCompression());
     }
@@ -168,7 +187,8 @@ public class JsonSortedBucketIO {
           getInputDirectories(),
           getFilenameSuffix(),
           getFileOperations(),
-          getPredicate());
+          getPredicate(),
+          getEmptyMatchTreatment());
     }
   }
 

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/TensorFlowBucketIO.java
@@ -28,6 +28,7 @@ import org.apache.beam.sdk.extensions.smb.SortedBucketSource.Predicate;
 import org.apache.beam.sdk.extensions.smb.SortedBucketTransform.NewBucketMetadataFn;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.EmptyMatchTreatment;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
@@ -135,6 +136,9 @@ public class TensorFlowBucketIO {
     @Nullable
     abstract Predicate<Example> getPredicate();
 
+    @Nullable
+    abstract EmptyMatchTreatment getEmptyMatchTreatment();
+
     abstract Builder toBuilder();
 
     @AutoValue.Builder
@@ -150,6 +154,8 @@ public class TensorFlowBucketIO {
       abstract Builder setCompression(Compression compression);
 
       abstract Builder setPredicate(Predicate<Example> predicate);
+
+      abstract Builder setEmptyMatchTreatment(EmptyMatchTreatment emptyMatchTreatment);
 
       abstract Read build();
     }
@@ -169,6 +175,19 @@ public class TensorFlowBucketIO {
       return toBuilder().setPredicate(predicate).build();
     }
 
+    /**
+     * Specifies how to handle empty file matches when reading input directories.
+     *
+     * @param emptyMatchTreatment the behavior when file patterns don't match any files. Use
+     *     {@link EmptyMatchTreatment#ALLOW} to proceed with empty inputs, {@link
+     *     EmptyMatchTreatment#DISALLOW} to fail on empty matches, or {@link
+     *     EmptyMatchTreatment#ALLOW_IF_WILDCARD} to allow empty matches only for wildcard patterns.
+     * @return a new {@link Read} instance with the specified empty match treatment
+     */
+    public Read withEmptyMatchTreatment(EmptyMatchTreatment emptyMatchTreatment) {
+      return toBuilder().setEmptyMatchTreatment(emptyMatchTreatment).build();
+    }
+
     FileOperations<Example> getFileOperations() {
       return TensorFlowFileOperations.of(getCompression());
     }
@@ -180,7 +199,8 @@ public class TensorFlowBucketIO {
           getInputDirectories(),
           getFilenameSuffix(),
           getFileOperations(),
-          getPredicate());
+          getPredicate(),
+          getEmptyMatchTreatment());
     }
   }
 

--- a/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIO.scala
+++ b/scio-smb/src/main/scala/org/apache/beam/sdk/extensions/smb/ParquetTypeSortedBucketIO.scala
@@ -23,6 +23,7 @@ import org.apache.beam.sdk.extensions.smb.BucketMetadata.HashType
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.Predicate
 import org.apache.beam.sdk.extensions.smb.SortedBucketSource.BucketedInput
 import org.apache.beam.sdk.io.FileSystems
+import org.apache.beam.sdk.io.fs.EmptyMatchTreatment
 import org.apache.beam.sdk.io.fs.ResourceId
 import org.apache.beam.sdk.values.TupleTag
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList
@@ -64,7 +65,8 @@ object ParquetTypeSortedBucketIO {
     filenameSuffix: String = DefaultSuffix,
     filterPredicate: FilterPredicate = null,
     predicate: Predicate[T] = null,
-    configuration: Configuration = new Configuration()
+    configuration: Configuration = new Configuration(),
+    emptyMatchTreatment: EmptyMatchTreatment = null
   ) extends SortedBucketIO.Read[T] {
     def from(inputDirectories: String*): Read[T] =
       this.copy(inputDirectories = inputDirectories)
@@ -81,6 +83,19 @@ object ParquetTypeSortedBucketIO {
     def withConfiguration(configuration: Configuration): Read[T] =
       this.copy(configuration = configuration)
 
+    /**
+     * Specifies how to handle empty file matches when reading input directories.
+     *
+     * @param emptyMatchTreatment the behavior when file patterns don't match any files. Use
+     *                           [[EmptyMatchTreatment.ALLOW]] to proceed with empty inputs,
+     *                           [[EmptyMatchTreatment.DISALLOW]] to fail on empty matches, or
+     *                           [[EmptyMatchTreatment.ALLOW_IF_WILDCARD]] to allow empty matches
+     *                           only for wildcard patterns.
+     * @return a new Read instance with the specified empty match treatment
+     */
+    def withEmptyMatchTreatment(emptyMatchTreatment: EmptyMatchTreatment): Read[T] =
+      this.copy(emptyMatchTreatment = emptyMatchTreatment)
+
     def getInputDirectories: ImmutableList[String] =
       ImmutableList.copyOf(inputDirectories.asJava: java.lang.Iterable[String])
     def getFilenameSuffix: String = filenameSuffix
@@ -96,7 +111,8 @@ object ParquetTypeSortedBucketIO {
         inputDirectories.asJava,
         filenameSuffix,
         getFileOperations,
-        predicate
+        predicate,
+        emptyMatchTreatment
       )
     }
 

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroSortedBucketIOTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroSortedBucketIOTest.java
@@ -22,6 +22,7 @@ import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.extensions.avro.io.AvroGeneratedUser;
+import org.apache.beam.sdk.io.fs.EmptyMatchTreatment;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.util.SerializableUtils;
@@ -111,5 +112,36 @@ public class ParquetAvroSortedBucketIOTest {
 
     Assert.assertEquals(tempDirectory, write.getTempDirectoryOrDefault(pipeline));
     Assert.assertEquals(tempDirectory, transform.getTempDirectoryOrDefault(pipeline));
+  }
+
+  @Test
+  public void testEmptyMatchTreatment() {
+    // Test that EmptyMatchTreatment can be set without throwing exceptions
+    final ParquetAvroSortedBucketIO.Read<GenericRecord> read =
+        ParquetAvroSortedBucketIO.read(new TupleTag<>("input"), AvroGeneratedUser.getClassSchema())
+            .from(folder.toString())
+            .withEmptyMatchTreatment(EmptyMatchTreatment.ALLOW);
+
+    // Verify that the parameter is stored correctly
+    Assert.assertEquals(EmptyMatchTreatment.ALLOW, read.getEmptyMatchTreatment());
+
+    // Test default behavior
+    final ParquetAvroSortedBucketIO.Read<GenericRecord> defaultRead =
+        ParquetAvroSortedBucketIO.read(new TupleTag<>("input"), AvroGeneratedUser.getClassSchema())
+            .from(folder.toString());
+    Assert.assertNull(defaultRead.getEmptyMatchTreatment());
+
+    // Test all EmptyMatchTreatment values
+    final ParquetAvroSortedBucketIO.Read<GenericRecord> disallowRead =
+        ParquetAvroSortedBucketIO.read(new TupleTag<>("input"), AvroGeneratedUser.getClassSchema())
+            .from(folder.toString())
+            .withEmptyMatchTreatment(EmptyMatchTreatment.DISALLOW);
+    Assert.assertEquals(EmptyMatchTreatment.DISALLOW, disallowRead.getEmptyMatchTreatment());
+
+    final ParquetAvroSortedBucketIO.Read<GenericRecord> wildcardRead =
+        ParquetAvroSortedBucketIO.read(new TupleTag<>("input"), AvroGeneratedUser.getClassSchema())
+            .from(folder.toString())
+            .withEmptyMatchTreatment(EmptyMatchTreatment.ALLOW_IF_WILDCARD);
+    Assert.assertEquals(EmptyMatchTreatment.ALLOW_IF_WILDCARD, wildcardRead.getEmptyMatchTreatment());
   }
 }

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransformTest.java
@@ -109,6 +109,7 @@ public class SortedBucketTransformTest {
             Collections.singletonList(inputLhsFolder.getRoot().getAbsolutePath()),
             ".txt",
             new TestFileOperations(),
+            null,
             null),
         BucketedInput.of(
             keying,
@@ -116,7 +117,8 @@ public class SortedBucketTransformTest {
             Collections.singletonList(inputRhsFolder.getRoot().getAbsolutePath()),
             ".txt",
             new TestFileOperations(),
-            predicate));
+            predicate,
+            null));
   }
 
   @BeforeClass
@@ -358,5 +360,25 @@ public class SortedBucketTransformTest {
         Status.NOT_FOUND);
 
     return KV.of((TestBucketMetadata) metadata, bucketsToOutputs);
+  }
+
+  @Test
+  public void testEmptyMatchTreatmentIntegration() throws Exception {
+    // Test that BucketedInput can be created with EmptyMatchTreatment.ALLOW for nonexistent paths
+    final BucketedInput<String> emptyInput =
+        BucketedInput.of(
+            SortedBucketSource.Keying.PRIMARY,
+            new TupleTag<>("emptyInput"),
+            Collections.singletonList("/nonexistent/path"),
+            ".txt",
+            new TestFileOperations(),
+            null,
+            EmptyMatchTreatment.ALLOW);
+
+    // Should not throw exception when constructing with empty inputs that are allowed
+    Assert.assertNotNull(emptyInput);
+
+    // Should return 0 bytes for nonexistent directories with ALLOW treatment
+    Assert.assertEquals(0L, emptyInput.getOrSampleByteSize());
   }
 }


### PR DESCRIPTION
## Summary
  Adds support for Beam's `EmptyMatchTreatment` parameter in SMB read
   operations, allowing pipelines to handle empty directories gracefully
  instead of failing.

  ## Changes
  - Added `withEmptyMatchTreatment()` method to `AvroSortedBucketIO.Read`
  and `ParquetTypeSortedBucketIO.Read`
  - Updated `SortedBucketSource` to pass through the parameter to
  `FileSystems.match()` calls
  - Maintains full backward compatibility (defaults to `DISALLOW` behavior)
  - Added tests

  ## Usage Example
  ```scala
  import org.apache.beam.sdk.io.fs.EmptyMatchTreatment

  val read = AvroSortedBucketIO
    .read[MyRecord](new TupleTag[MyRecord]("input"))
    .from("/path/to/potentially/empty/directory")
    .withEmptyMatchTreatment(EmptyMatchTreatment.ALLOW)
```

  Testing

  - All existing tests pass
  - Added new test cases for the EmptyMatchTreatment functionality
  - Verified backward compatibility with existing code

  Closes #5759