### PR TITLE
Add test assertion for OverrideTypeProvider field name

### DIFF
--- a/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/validation/BigQueryValidationTest.scala
+++ b/scio-google-cloud-platform/src/test/scala/com/spotify/scio/bigquery/validation/BigQueryValidationTest.scala
@@ -66,6 +66,9 @@ class BigQueryValidationTest extends AnyFlatSpec with Matchers with BeforeAndAft
     CountryOutput.schema.getFields.get(0).getType shouldBe "STRING"
     CountryOutput.schema.getFields.get(1).getType shouldBe "STRING"
     CountryOutput.schema.getFields.get(2).getType shouldBe "STRING"
+
+    // Overridden type should keep its given field name, even if type is overridden
+    CountryOutput.schema.getFields.get(0).getName shouldBe "country"
   }
 
   "ValidationProvider" should "properly validate data" in {


### PR DESCRIPTION
now that we're adding similar functionality to Magnolify, I realized we don't explicitly assert on whether the user-provided field name is kept, or if that's overridden too. 

For reference, given the following setup:

```scala
case class Country(data: String) extends BaseValidationType[String](data)

@BigQueryType.toTable
case class CountryOutput(
  country: Country,
)
```

The result of `BigQueryType[CountryOutput].schema` is:

```
GenericData{
  classInfo=[fields, foreignTypeInfo], {fields=[
    GenericData{
      classInfo=[categories, collation, dataPolicies, defaultValueExpression, description, fields, foreignTypeDefinition, maxLength, mode, name, policyTags, precision, rangeElementType, roundingMode, scale, type],
      {description=COUNTRY, mode=REQUIRED, name=country, type=STRING}
    }
  ]
}
````