### PR TITLE
Fix mergeStrategy for scio-repl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1733,6 +1733,9 @@ lazy val `scio-repl` = project
             ) =>
           // merge conflicting netty config files
           MergeStrategy.filterDistinctLines
+        case PathList("META-INF", "license", "LICENSE.boringssl.txt") =>
+          // drop conflicting netty-tcnative-boringssl license
+          MergeStrategy.discard
         case s => old(s)
       }
     }


### PR DESCRIPTION
Since the netty bump, `sbt scio-repl/assembly` fails with:

```
[error] 1 error(s) were encountered during the merge:
[error] java.lang.RuntimeException: 
[error] Deduplicate found different file contents in the following:
[error]   Jar name = grpc-netty-shaded-1.71.0.jar, jar org = io.grpc, entry target = META-INF/license/LICENSE.boringssl.txt
[error]   Jar name = netty-tcnative-boringssl-static-2.0.74.Final.jar, jar org = io.netty, entry target = META-INF/license/LICENSE.boringssl.txt
[error]   Jar name = netty-tcnative-boringssl-static-2.0.74.Final.jar, jar org = io.netty, entry target = META-INF/license/LICENSE.boringssl.txt
[error]   Jar name = netty-tcnative-boringssl-static-2.0.74.Final.jar, jar org = io.netty, entry target = META-INF/license/LICENSE.boringssl.txt
[error]   Jar name = netty-tcnative-boringssl-static-2.0.74.Final.jar, jar org = io.netty, entry target = META-INF/license/LICENSE.boringssl.txt
[error]   Jar name = netty-tcnative-boringssl-static-2.0.74.Final.jar, jar org = io.netty, entry target = META-INF/license/LICENSE.boringssl.txt
[error]   Jar name = beam-vendor-grpc-1_69_0-0.1.jar, jar org = org.apache.beam, entry target = META-INF/license/LICENSE.boringssl.txt
[error] 	at sbtassembly.Assembly$.merge(Assembly.scala:604)
```

Discard conflicting license files during assembly.