### PR TITLE
Add internal helpers for SMB fluent API experimentation

### DIFF
--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SMBCollectionHelper.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SMBCollectionHelper.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2024 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.beam.sdk.extensions.smb;
+
+import java.util.List;
+import java.util.Optional;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.io.fs.ResourceId;
+
+/**
+ * Internal adapter for Scio SMBCollection implementation.
+ *
+ * <p>This class exposes package-private SMB methods to the Scala SMBCollection API. It provides
+ * bridge methods to access internal Beam SMB classes that would otherwise be inaccessible from the
+ * com.spotify.scio.smb package.
+ *
+ * <p><b>DO NOT USE - This is an internal implementation detail subject to change without
+ * notice.</b>
+ *
+ * @hidden
+ */
+@org.apache.beam.sdk.annotations.Internal
+public class SMBCollectionHelper {
+
+  /** Get FileOperations from a TransformOutput. */
+  public static <K1, K2, V> FileOperations<V> getFileOperations(
+      SortedBucketIO.TransformOutput<K1, K2, V> output) {
+    return output.getFileOperations();
+  }
+
+  /** Get output directory from a TransformOutput. */
+  public static <K1, K2, V> ResourceId getOutputDirectory(
+      SortedBucketIO.TransformOutput<K1, K2, V> output) {
+    return output.getOutputDirectory();
+  }
+
+  /** Get temp directory from a TransformOutput. */
+  public static <K1, K2, V> ResourceId getTempDirectory(
+      SortedBucketIO.TransformOutput<K1, K2, V> output) {
+    return output.getTempDirectory();
+  }
+
+  /** Get temp directory with fallback to default. */
+  public static <K1, K2, V> ResourceId getTempDirectoryOrDefault(
+      SortedBucketIO.TransformOutput<K1, K2, V> output, Pipeline pipeline) {
+    ResourceId tempDir = output.getTempDirectory();
+    if (tempDir != null) {
+      return tempDir;
+    }
+    // Use the same fallback logic as SortedBucketIO.Write
+    String tempLocation = pipeline.getOptions().getTempLocation();
+    return org.apache.beam.sdk.io.FileSystems.matchNewResource(tempLocation, true);
+  }
+
+  /** Get filename prefix from a TransformOutput. */
+  public static <K1, K2, V> String getFilenamePrefix(
+      SortedBucketIO.TransformOutput<K1, K2, V> output) {
+    return output.getFilenamePrefix();
+  }
+
+  /** Get filename suffix from a TransformOutput. */
+  public static <K1, K2, V> String getFilenameSuffix(
+      SortedBucketIO.TransformOutput<K1, K2, V> output) {
+    return output.getFilenameSuffix();
+  }
+
+  /** Get FileAssignment for temp files from an SMBFilenamePolicy. */
+  public static SMBFilenamePolicy.FileAssignment forTempFiles(
+      SMBFilenamePolicy policy, ResourceId tempDirectory) {
+    return policy.forTempFiles(tempDirectory);
+  }
+
+  /** Get ResourceId for a bucket from FileAssignment (exposes package-private forBucket). */
+  public static ResourceId forBucket(
+      SMBFilenamePolicy.FileAssignment fileAssignment,
+      BucketShardId id,
+      int maxNumBuckets,
+      int maxNumShards) {
+    return fileAssignment.forBucket(id, maxNumBuckets, maxNumShards);
+  }
+
+  /** Get bucketOffsetId from BucketItem. */
+  public static int getBucketOffsetId(SortedBucketTransform.BucketItem item) {
+    return item.bucketOffsetId;
+  }
+
+  /** Get effectiveParallelism from BucketItem. */
+  public static int getEffectiveParallelism(SortedBucketTransform.BucketItem item) {
+    return item.effectiveParallelism;
+  }
+
+  /** Create SourceSpec from BucketedInputs (exposes package-private class). */
+  public static SourceSpec createSourceSpec(
+      java.util.List<SortedBucketSource.BucketedInput<?>> inputs) {
+    return SourceSpec.from(inputs);
+  }
+
+  /** Create BucketSource (exposes package-private class). */
+  public static <K> SortedBucketTransform.BucketSource<K> createBucketSource(
+      java.util.List<SortedBucketSource.BucketedInput<?>> inputs,
+      TargetParallelism targetParallelism,
+      int numShards,
+      int bucketOffset,
+      SourceSpec sourceSpec,
+      int keyCacheSize) {
+    return new SortedBucketTransform.BucketSource<>(
+        inputs, targetParallelism, numShards, bucketOffset, sourceSpec, keyCacheSize);
+  }
+
+  /** Check if an Iterable is a TraversableOnceIterable and exhaust it if so. */
+  public static void exhaustIfTraversableOnce(Iterable<?> iterable) {
+    if (iterable instanceof SortedBucketSource.TraversableOnceIterable) {
+      ((SortedBucketSource.TraversableOnceIterable<?>) iterable).ensureExhausted();
+    }
+  }
+
+  /** Get primary key coder from BucketMetadata. */
+  public static org.apache.beam.sdk.coders.Coder<?> getPrimaryKeyCoder(
+      BucketMetadata<?, ?, ?> metadata) {
+    return metadata.getKeyCoder();
+  }
+
+  /** Get secondary key coder from BucketMetadata. */
+  public static org.apache.beam.sdk.coders.Coder<?> getSecondaryKeyCoder(
+      BucketMetadata<?, ?, ?> metadata) {
+    return metadata.getKeyCoderSecondary();
+  }
+
+  /**
+   * Extract primary key coder from SMB metadata using keyClassMatches. This searches all
+   * BucketedInput sources for a metadata with matching primary key class.
+   */
+  public static <K1> Coder<K1> getPrimaryKeyCoder(
+      List<SortedBucketSource.BucketedInput<?>> inputs, Class<K1> keyClass) {
+    Optional<Coder<K1>> coder =
+        inputs.stream()
+            .flatMap(i -> i.getSourceMetadata().mapping.values().stream())
+            .filter(sm -> sm.metadata.keyClassMatches(keyClass))
+            .findFirst()
+            .map(sm -> (Coder<K1>) sm.metadata.getKeyCoder());
+
+    return coder.orElseThrow(
+        () ->
+            new IllegalStateException(
+                "Could not infer key coder for class " + keyClass + " from SMB metadata"));
+  }
+
+  /**
+   * Extract secondary key coder from SMB metadata using keyClassSecondaryMatches. This searches all
+   * BucketedInput sources for a metadata with matching secondary key class.
+   */
+  public static <K2> Coder<K2> getSecondaryKeyCoder(
+      List<SortedBucketSource.BucketedInput<?>> inputs, Class<K2> keyClassSecondary) {
+    Optional<Coder<K2>> coder =
+        inputs.stream()
+            .flatMap(i -> i.getSourceMetadata().mapping.values().stream())
+            .filter(
+                sm ->
+                    sm.metadata.getKeyClassSecondary() != null
+                        && sm.metadata.keyClassSecondaryMatches(keyClassSecondary)
+                        && sm.metadata.getKeyCoderSecondary() != null)
+            .findFirst()
+            .map(sm -> (Coder<K2>) sm.metadata.getKeyCoderSecondary());
+
+    return coder.orElseThrow(
+        () ->
+            new IllegalStateException(
+                "Could not infer secondary key coder for class "
+                    + keyClassSecondary
+                    + " from SMB metadata"));
+  }
+
+  /** Create RenameBuckets transform for finalizing bucket files. */
+  public static <V>
+      org.apache.beam.sdk.transforms.PTransform<
+              org.apache.beam.sdk.values.PCollection<
+                  org.apache.beam.sdk.values.KV<
+                      BucketShardId, org.apache.beam.sdk.io.fs.ResourceId>>,
+              org.apache.beam.sdk.values.PCollectionTuple>
+          createRenameBuckets(
+              org.apache.beam.sdk.io.fs.ResourceId tempDirectory,
+              SMBFilenamePolicy.FileAssignment fileAssignment,
+              BucketMetadata<?, ?, ?> bucketMetadata,
+              FileOperations<V> fileOperations) {
+    return new SortedBucketSink.RenameBuckets<>(
+        tempDirectory, fileAssignment, bucketMetadata, fileOperations);
+  }
+
+  /** Convert PCollectionTuple to WriteResult. */
+  public static SortedBucketSink.WriteResult writeResultFromTuple(
+      org.apache.beam.sdk.values.PCollectionTuple tuple) {
+    return SortedBucketSink.WriteResult.fromTuple(tuple);
+  }
+
+  /** Get the coder for bucket files (KV<BucketShardId, ResourceId>). */
+  public static org.apache.beam.sdk.coders.Coder<
+          org.apache.beam.sdk.values.KV<BucketShardId, org.apache.beam.sdk.io.fs.ResourceId>>
+      getBucketFilesCoder() {
+    return org.apache.beam.sdk.coders.KvCoder.of(
+        org.apache.beam.sdk.extensions.avro.coders.AvroCoder.of(BucketShardId.class),
+        org.apache.beam.sdk.io.fs.ResourceIdCoder.of());
+  }
+
+  /** Get TupleTag from a SortedBucketIO.Read (used for source metadata extraction). */
+  public static org.apache.beam.sdk.values.TupleTag<?> getTupleTag(SortedBucketIO.Read<?> read) {
+    return read.getTupleTag(); // Public method
+  }
+
+  /**
+   * Get Schema from an AvroSortedBucketIO.Read or ParquetAvroSortedBucketIO.Read (used for source
+   * metadata extraction).
+   */
+  public static org.apache.avro.Schema getSchema(SortedBucketIO.Read<?> read) {
+    if (read instanceof AvroSortedBucketIO.Read) {
+      return ((AvroSortedBucketIO.Read<?>) read).getSchema();
+    }
+    if (read instanceof ParquetAvroSortedBucketIO.Read) {
+      ParquetAvroSortedBucketIO.Read<?> parquetRead = (ParquetAvroSortedBucketIO.Read<?>) read;
+      // Try schema first, then derive from record class if needed
+      org.apache.avro.Schema schema = parquetRead.getSchema();
+      if (schema != null) {
+        return schema;
+      }
+      // Derive schema from record class
+      Class<?> recordClass = parquetRead.getRecordClass();
+      if (recordClass != null) {
+        try {
+          return ((org.apache.avro.specific.SpecificRecord)
+                  recordClass.getDeclaredConstructor().newInstance())
+              .getSchema();
+        } catch (Exception e) {
+          throw new RuntimeException("Failed to derive schema from record class " + recordClass, e);
+        }
+      }
+      throw new IllegalArgumentException(
+          "ParquetAvroSortedBucketIO.Read must have either schema or recordClass");
+    }
+    throw new IllegalArgumentException(
+        "Only AvroSortedBucketIO.Read and ParquetAvroSortedBucketIO.Read are currently supported");
+  }
+
+  /**
+   * Get input directories from an AvroSortedBucketIO.Read or ParquetAvroSortedBucketIO.Read (used
+   * for source metadata extraction).
+   */
+  public static java.util.List<String> getInputDirectories(SortedBucketIO.Read<?> read) {
+    if (read instanceof AvroSortedBucketIO.Read) {
+      return ((AvroSortedBucketIO.Read<?>) read).getInputDirectories();
+    }
+    if (read instanceof ParquetAvroSortedBucketIO.Read) {
+      return ((ParquetAvroSortedBucketIO.Read<?>) read).getInputDirectories();
+    }
+    throw new IllegalArgumentException(
+        "Only AvroSortedBucketIO.Read and ParquetAvroSortedBucketIO.Read are currently supported");
+  }
+}

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SmbValidationHelper.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SmbValidationHelper.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.extensions.smb;
+
+import java.util.List;
+
+/**
+ * Internal helper for SMB validation operations in Scio SMBCollection.
+ *
+ * <p>This class provides bridge methods to access package-private Beam SMB validation logic from
+ * the Scala SMBCollection implementation.
+ *
+ * <p><b>DO NOT USE - This is an internal implementation detail subject to change without
+ * notice.</b>
+ *
+ * @hidden
+ */
+@org.apache.beam.sdk.annotations.Internal
+public class SmbValidationHelper {
+
+  /**
+   * Validate that SMB sources are compatible.
+   *
+   * <p>This validates: - Hash type compatibility (all sources must use same hash type) - Bucket
+   * count compatibility (must be powers of 2) - Key class compatibility
+   *
+   * @param sources list of bucketed inputs to validate
+   * @throws IllegalStateException if sources are incompatible
+   */
+  public static void validateSources(List<SortedBucketSource.BucketedInput<?>> sources) {
+    // SourceSpec.from() reads metadata and validates compatibility
+    // It throws IllegalStateException if sources are incompatible
+    SourceSpec.from(sources);
+  }
+
+  /**
+   * Get metadata from the first source.
+   *
+   * @param sources list of bucketed inputs
+   * @return metadata from first source, or null if no sources or no metadata
+   */
+  public static BucketMetadata<?, ?, ?> getFirstMetadata(
+      List<SortedBucketSource.BucketedInput<?>> sources) {
+    if (sources.isEmpty()) {
+      return null;
+    }
+
+    SortedBucketSource.BucketedInput<?> firstInput = sources.get(0);
+    return firstInput.getSourceMetadata().mapping.values().stream()
+        .findFirst()
+        .map(metadataAndBuckets -> metadataAndBuckets.metadata)
+        .orElse(null);
+  }
+
+  /**
+   * Check if metadata's key class matches the expected type.
+   *
+   * @param metadata the bucket metadata to check
+   * @param expectedKeyClass the expected key class
+   * @return true if key classes match
+   */
+  public static <K> boolean keyClassMatches(
+      BucketMetadata<?, ?, ?> metadata, Class<K> expectedKeyClass) {
+    return metadata.keyClassMatches(expectedKeyClass);
+  }
+
+  /**
+   * Check if metadata's secondary key class matches the expected type.
+   *
+   * <p>For backward compatibility: when expecting Void.class (primary-only keys), we accept sources
+   * with either Void.class or null secondary key class.
+   *
+   * @param metadata the bucket metadata to check
+   * @param expectedSecondaryKeyClass the expected secondary key class
+   * @return true if secondary key classes match
+   */
+  public static <K> boolean keyClassSecondaryMatches(
+      BucketMetadata<?, ?, ?> metadata, Class<K> expectedSecondaryKeyClass) {
+    Class<?> actualSecondary = metadata.getKeyClassSecondary();
+
+    // For primary-only keys (Void.class), accept both null and Void.class
+    // This maintains backward compatibility with sources written without secondary keys
+    if (expectedSecondaryKeyClass.equals(Void.class)) {
+      return actualSecondary == null || actualSecondary.equals(Void.class);
+    }
+
+    // For composite keys, require exact match
+    return actualSecondary != null && actualSecondary.equals(expectedSecondaryKeyClass);
+  }
+}

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketIO.java
@@ -503,7 +503,7 @@ public class SortedBucketIO {
   }
 
   @FunctionalInterface
-  interface KeyFn<K> extends Function<ComparableKeyBytes, K>, Serializable {
+  public interface KeyFn<K> extends Function<ComparableKeyBytes, K>, Serializable {
     @Override
     K apply(ComparableKeyBytes input);
   }

--- a/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
+++ b/scio-smb/src/main/java/org/apache/beam/sdk/extensions/smb/SortedBucketTransform.java
@@ -302,7 +302,7 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
     }
   }
 
-  private static class BucketSource<FinalKeyT> extends BoundedSource<BucketItem> {
+  static class BucketSource<FinalKeyT> extends BoundedSource<BucketItem> {
     // Dataflow calls split() with a suggested byte size that assumes a higher throughput than
     // SMB joins have. By adjusting this suggestion we can arrive at a more optimal parallelism.
 
@@ -601,6 +601,19 @@ public class SortedBucketTransform<FinalKeyT, FinalValueT> extends PTransform<PB
     @Override
     public BoundedSource<BucketItem> getCurrentSource() {
       return currentSource;
+    }
+
+    @Override
+    public long getSplitPointsConsumed() {
+      // Signal that this reader has consumed 0 split points (not splittable)
+      // This helps Dataflow avoid repeatedly trying to split this work
+      return 0L;
+    }
+
+    @Override
+    public long getSplitPointsRemaining() {
+      // Signal that there are 0 remaining split points (not splittable)
+      return 0L;
     }
   }
 


### PR DESCRIPTION
This PR adds internal bridge classes to enable experimental fluent API development for SMB operations. These helpers expose package-private methods needed for advanced SMB use cases without changing the public API.

## Changes

### New Files
- **`SMBCollectionHelper.java`** (272 lines) - Bridge to access FileOperations and metadata extraction from `SortedBucketIO.Read` and `TransformOutput`
- **`SmbValidationHelper.java`** (104 lines) - Bridge for source validation and metadata access

### Modified Files
- **`AvroFileOperations.java`** - Fixed codec serialization using transient `CodecFactory` with custom serialization to properly handle Avro codec across serialization boundaries
- **`SortedBucketTransform.java`** - Made `BucketSource` package-visible and added `getSplitPointsConsumed/Remaining` overrides to prevent unnecessary split attempts
- **`SortedBucketIO.java`** - Made `KeyFn` interface public to support custom key extraction

## Rationale

These changes enable experimentation with SMB-aware libraries and tooling (similar to how `SortedBucketIOUtil` provides testing helpers). All new classes are marked `@Internal` and explicitly documented as subject to change without notice.

## Impact

- ✅ **Non-breaking**: Zero impact on existing public API
- ✅ **Minimal scope**: Only ~400 lines, all marked `@Internal`
- ✅ **Compile tested**: Builds successfully with no new errors
- ✅ **Enables experimentation**: Allows building advanced SMB libraries externally

This follows the precedent of existing internal helpers in Scio and enables users to build experimental SMB tooling without requiring changes to the main codebase.