### PR TITLE
Share sparkey readers with memory-aware heap fallback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,7 @@ val scalaCollectionCompatVersion = "2.14.0"
 val scalaMacrosVersion = "2.1.1"
 val scalatestVersion = "3.2.19"
 val shapelessVersion = "2.3.13"
-val sparkeyVersion = "3.5.1"
+val sparkeyVersion = "3.7.0"
 val tensorFlowVersion = "1.1.0"
 val tensorFlowMetadataVersion = "1.16.1"
 val testContainersVersion = "0.44.1"
@@ -330,6 +330,10 @@ ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ),
   ProblemFilters.exclude[MissingClassProblem](
     "org.apache.beam.sdk.extensions.sorter.BufferedExternalSorter$Options"
+  ),
+  // checkMemory replaced by HostMemoryTracker (private object, no external callers)
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "com.spotify.scio.extra.sparkey.package#SparkeySideInput.checkMemory"
   )
 )
 

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/HostMemoryTracker.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/HostMemoryTracker.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.extra.sparkey
+
+import com.sun.management.OperatingSystemMXBean
+import java.lang.management.ManagementFactory
+import java.util.concurrent.atomic.AtomicLong
+import org.slf4j.LoggerFactory
+
+/**
+ * Tracks memory budgets for sparkey readers on this JVM, covering both off-heap and on-heap memory.
+ * On Dataflow, the JVM heap is hardcoded to ~70% of worker memory, leaving only ~30% for off-heap
+ * use (page cache, OS, kernel, etc.).
+ *
+ * Sparkey readers are opened via mmap (off-heap) by default. When the off-heap budget is exhausted,
+ * readers can fall back to heap-backed mode. This tracker provides atomic budget claiming for both
+ * pools to coordinate across threads.
+ *
+ * Budget is claimed but never released — readers are cached for the JVM lifetime and never closed.
+ * If a reader fails to open partway through (e.g. a sharded sparkey with some shards already
+ * claimed), the budget for those shards is leaked. This is acceptable since a reader failure is
+ * fatal to the pipeline.
+ */
+private[sparkey] class HostMemoryTracker(val offHeapBudget: Long, val heapBudget: Long) {
+
+  private val remainingOffHeap = new AtomicLong(offHeapBudget)
+  private val remainingHeap = new AtomicLong(heapBudget)
+  private val totalUnboundedOffHeap = new AtomicLong(0)
+
+  /**
+   * Atomically try to claim `bytes` from the off-heap budget. Returns true if the claim succeeded
+   * (enough budget remaining), false otherwise.
+   */
+  def tryClaimOffHeap(bytes: Long): Boolean = tryClaim(remainingOffHeap, bytes)
+
+  /**
+   * Atomically try to claim `bytes` from the heap budget. Returns true if the claim succeeded
+   * (enough budget remaining), false otherwise.
+   */
+  def tryClaimHeap(bytes: Long): Boolean = tryClaim(remainingHeap, bytes)
+
+  /** Record `bytes` of unbounded off-heap mmap usage (neither budget had room). */
+  def addUnboundedOffHeap(bytes: Long): Long = totalUnboundedOffHeap.addAndGet(bytes)
+
+  private def tryClaim(budget: AtomicLong, bytes: Long): Boolean = {
+    val prev =
+      budget.getAndAccumulate(bytes, (current, b) => if (current >= b) current - b else current)
+    prev >= bytes
+  }
+}
+
+private[sparkey] object HostMemoryTracker {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  // Reserve 2 GB of off-heap memory for OS, kernel structures, JVM class files, Beam shuffle, etc.
+  private val OffHeapReserveBytes: Long = 2L * 1024 * 1024 * 1024
+
+  // Reserve 10% of max heap (min 4 GB) for GC headroom and non-sparkey allocations.
+  private val HeapReserveBytes: Long = {
+    val maxHeap = Runtime.getRuntime.maxMemory()
+    Math.max(4L * 1024 * 1024 * 1024, (maxHeap * 0.1).toLong)
+  }
+
+  private val offHeapBudget: Long = {
+    val totalPhysical = ManagementFactory.getOperatingSystemMXBean
+      .asInstanceOf[OperatingSystemMXBean]
+      .getTotalPhysicalMemorySize
+    val maxHeap = Runtime.getRuntime.maxMemory()
+    Math.max(0, totalPhysical - maxHeap - OffHeapReserveBytes)
+  }
+
+  private val heapBudget: Long = {
+    val maxHeap = Runtime.getRuntime.maxMemory()
+    Math.max(0, maxHeap - HeapReserveBytes)
+  }
+
+  val instance: HostMemoryTracker = new HostMemoryTracker(offHeapBudget, heapBudget)
+
+  logger.info(
+    "HostMemoryTracker — off-heap budget: {} bytes, heap budget: {} bytes",
+    Array[AnyRef](Long.box(offHeapBudget), Long.box(heapBudget)): _*
+  )
+}

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyUri.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/SparkeyUri.scala
@@ -21,11 +21,11 @@ import java.io.File
 import java.net.URI
 import com.spotify.scio.util.{RemoteFileUtil, ScioUtil}
 import com.spotify.scio.extra.sparkey.instances.ShardedSparkeyReader
-import com.spotify.sparkey.Sparkey
-import com.spotify.sparkey.SparkeyReader
+import com.spotify.sparkey.{Sparkey, SparkeyReader}
 import org.apache.beam.sdk.io.FileSystems
 import org.apache.beam.sdk.io.fs.{EmptyMatchTreatment, MatchResult, ResourceId}
 import org.apache.beam.sdk.options.PipelineOptions
+import org.slf4j.LoggerFactory
 
 import java.nio.file.Path
 import java.util.UUID
@@ -77,10 +77,10 @@ case class SparkeyUri(path: String) {
   }
 
   def getReader(rfu: RemoteFileUtil): SparkeyReader = {
-    if (!isSharded) {
+    val (reader, plans) = if (!isSharded) {
       val path =
         if (isLocal) new File(basePath) else downloadRemoteUris(Seq(basePath), rfu).head.toFile
-      Sparkey.open(path)
+      ShardedSparkeyUri.openWithMemoryTracking(path)
     } else {
       val (basePaths, numShards) =
         ShardedSparkeyUri.basePathsAndCount(EmptyMatchTreatment.DISALLOW, globExpression)
@@ -91,8 +91,11 @@ case class SparkeyUri(path: String) {
             .map(_.toAbsolutePath.toString.replaceAll("\\.sp[il]$", ""))
             .toSet
         }
-      new ShardedSparkeyReader(ShardedSparkeyUri.localReadersByShard(paths), numShards)
+      val (readers, p) = ShardedSparkeyUri.localReadersByShard(paths)
+      (new ShardedSparkeyReader(readers, numShards), p)
     }
+    ShardedSparkeyUri.logSummary(path, plans)
+    reader
   }
 
   def exists(rfu: RemoteFileUtil): Boolean = {
@@ -113,6 +116,83 @@ case class SparkeyUri(path: String) {
 }
 
 private[sparkey] object ShardedSparkeyUri {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  // Conservative fixed overhead per reader for JVM array/object headers (heap) and page cache
+  // metadata (off-heap). The exact overhead is hard to measure; we prefer to overestimate slightly
+  // rather than risk overcommitting memory.
+  private val PerReaderOverheadBytes: Long = 64 * 1024
+
+  private def formatGiB(bytes: Long): String = f"${bytes / (1024.0 * 1024 * 1024)}%.2f GiB"
+
+  private[sparkey] case class ShardPlan(
+    shardIndex: Short,
+    indexFile: File,
+    size: Long,
+    useHeap: Boolean,
+    budgeted: Boolean
+  ) {
+    def openReader(): SparkeyReader =
+      Sparkey.reader().file(indexFile).useHeap(useHeap).open()
+  }
+
+  /**
+   * Claim memory for a shard from the tracker. Tries bounded off-heap first, then heap, then
+   * unbounded mmap. Returns (useHeap, budgeted).
+   */
+  private def claimMemory(
+    tracker: HostMemoryTracker,
+    totalBytes: Long
+  ): (Boolean, Boolean) = {
+    if (tracker.tryClaimOffHeap(totalBytes)) {
+      (false, true)
+    } else if (tracker.tryClaimHeap(totalBytes)) {
+      (true, true)
+    } else {
+      tracker.addUnboundedOffHeap(totalBytes)
+      (false, false)
+    }
+  }
+
+  private[sparkey] def logSummary(path: String, plans: Seq[ShardPlan]): Unit = {
+    if (plans.isEmpty) return
+
+    val offHeapBytes = plans.filter(p => !p.useHeap && p.budgeted).map(_.size).sum
+    val heapBytes = plans.filter(_.useHeap).map(_.size).sum
+    val unboundedBytes = plans.filter(p => !p.useHeap && !p.budgeted).map(_.size).sum
+
+    val parts = new scala.collection.mutable.ArrayBuffer[String]()
+    if (offHeapBytes > 0) parts += s"${formatGiB(offHeapBytes)} off-heap"
+    if (heapBytes > 0) parts += s"${formatGiB(heapBytes)} on heap"
+    if (unboundedBytes > 0) parts += s"${formatGiB(unboundedBytes)} unbounded mmap"
+
+    val msg = s"Loaded ${plans.size} sparkey shard(s) from $path: ${parts.mkString(", ")}"
+    if (unboundedBytes > 0) logger.warn(msg) else logger.info(msg)
+  }
+
+  private def planShard(
+    shardIndex: Short,
+    indexFile: File,
+    tracker: HostMemoryTracker
+  ): ShardPlan = {
+    val logFile = Sparkey.getLogFile(indexFile)
+    val totalBytes = indexFile.length() + logFile.length() + PerReaderOverheadBytes
+    val (useHeap, budgeted) = claimMemory(tracker, totalBytes)
+    ShardPlan(shardIndex, indexFile, totalBytes, useHeap, budgeted)
+  }
+
+  /**
+   * Open a sparkey reader with memory-aware strategy: try off-heap (mmap) first, fall back to
+   * on-heap (byte[]) if off-heap budget is exhausted, or use off-heap if neither budget has room.
+   */
+  private[sparkey] def openWithMemoryTracking(
+    file: File,
+    tracker: HostMemoryTracker = HostMemoryTracker.instance
+  ): (SparkeyReader, Seq[ShardPlan]) = {
+    val plan = planShard(0, Sparkey.getIndexFile(file), tracker)
+    (plan.openReader(), Seq(plan))
+  }
+
   private[sparkey] def shardsFromPath(path: String): (Short, Short) = {
     "part-([0-9]+)-of-([0-9]+)".r
       .findFirstMatchIn(path)
@@ -126,14 +206,29 @@ private[sparkey] object ShardedSparkeyUri {
       }
   }
 
+  /**
+   * Open readers for all shards:
+   *   1. Plan: claim memory per shard atomically (off-heap → heap → unbounded mmap)
+   *   1. Open readers: heap first (temporary page cache I/O), then mmap (pages stay cached)
+   */
   private[sparkey] def localReadersByShard(
-    localBasePaths: Iterable[String]
-  ): Map[Short, SparkeyReader] =
-    localBasePaths.iterator.map { path =>
+    localBasePaths: Iterable[String],
+    tracker: HostMemoryTracker = HostMemoryTracker.instance
+  ): (Map[Short, SparkeyReader], Seq[ShardPlan]) = {
+    // Step 1: plan — claim memory per shard atomically
+    val plans = localBasePaths.iterator.map { path =>
       val (shardIndex, _) = shardsFromPath(path)
-      val reader = Sparkey.open(new File(path + ".spi"))
-      (shardIndex, reader)
+      val indexFile = Sparkey.getIndexFile(new File(path + ".spi"))
+      planShard(shardIndex, indexFile, tracker)
+    }.toSeq
+
+    // Step 2: open heap readers first, then mmap readers
+    val (heapPlans, mmapPlans) = plans.partition(_.useHeap)
+    val readers = (heapPlans ++ mmapPlans).iterator.map { plan =>
+      (plan.shardIndex, plan.openReader())
     }.toMap
+    (readers, plans)
+  }
 
   def basePathsAndCount(
     emptyMatchTreatment: EmptyMatchTreatment,

--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -30,8 +30,9 @@ import com.spotify.sparkey.{CompressionType, SparkeyReader}
 import org.apache.beam.sdk.transforms.{DoFn, View}
 import org.apache.beam.sdk.util.CoderUtils
 import org.apache.beam.sdk.values.PCollectionView
-import org.slf4j.LoggerFactory
 
+import java.util.concurrent.{CompletableFuture, ConcurrentHashMap, Executors}
+import java.util.concurrent.atomic.AtomicInteger
 import scala.util.hashing.MurmurHash3
 
 /**
@@ -545,12 +546,11 @@ package object sparkey extends SparkeyReaderInstances with SparkeyCoders {
     mapFn: SparkeyReader => T
   ) extends SideInput[T] {
     override def updateCacheOnGlobalWindow: Boolean = false
-    override def get[I, O](context: DoFn[I, O]#ProcessContext): T =
-      mapFn(
-        SparkeySideInput.checkMemory(
-          context.sideInput(view).getReader(RemoteFileUtil.create(context.getPipelineOptions))
-        )
-      )
+    override def get[I, O](context: DoFn[I, O]#ProcessContext): T = {
+      val uri = context.sideInput(view)
+      val rfu = RemoteFileUtil.create(context.getPipelineOptions)
+      mapFn(SparkeySideInput.getOrCreateReader(uri, rfu))
+    }
   }
 
   /**
@@ -561,8 +561,10 @@ package object sparkey extends SparkeyReaderInstances with SparkeyCoders {
       extends SideInput[SparkeyMap[K, V]] {
     override def updateCacheOnGlobalWindow: Boolean = false
     override def get[I, O](context: DoFn[I, O]#ProcessContext): SparkeyMap[K, V] = {
+      val uri = context.sideInput(view)
+      val rfu = RemoteFileUtil.create(context.getPipelineOptions)
       new SparkeyMap(
-        context.sideInput(view).getReader(RemoteFileUtil.create(context.getPipelineOptions)),
+        SparkeySideInput.getOrCreateReader(uri, rfu),
         CoderMaterializer.beam(context.getPipelineOptions, Coder[K]),
         CoderMaterializer.beam(context.getPipelineOptions, Coder[V])
       )
@@ -576,29 +578,51 @@ package object sparkey extends SparkeyReaderInstances with SparkeyCoders {
   private class LargeSetSideInput[K: Coder](val view: PCollectionView[SparkeyUri])
       extends SideInput[SparkeySet[K]] {
     override def updateCacheOnGlobalWindow: Boolean = false
-    override def get[I, O](context: DoFn[I, O]#ProcessContext): SparkeySet[K] =
+    override def get[I, O](context: DoFn[I, O]#ProcessContext): SparkeySet[K] = {
+      val uri = context.sideInput(view)
+      val rfu = RemoteFileUtil.create(context.getPipelineOptions)
       new SparkeySet(
-        context.sideInput(view).getReader(RemoteFileUtil.create(context.getPipelineOptions)),
+        SparkeySideInput.getOrCreateReader(uri, rfu),
         CoderMaterializer.beam(context.getPipelineOptions, Coder[K])
       )
+    }
   }
 
+  // Readers are cached for the lifetime of the JVM and never closed. This is intentional:
+  // Beam side inputs have no close/teardown lifecycle, and in batch pipelines the JVM exits
+  // when the pipeline finishes. The HostMemoryTracker budget is similarly never released.
+  // Note: the cache is keyed by URI path only. If the same path is rewritten with different
+  // data and a new pipeline is run in the same JVM (e.g. DirectRunner, REPL), stale readers
+  // will be returned. This is acceptable for Dataflow batch (one pipeline per JVM).
   private object SparkeySideInput {
-    private val logger = LoggerFactory.getLogger(this.getClass)
-    def checkMemory(reader: SparkeyReader): SparkeyReader = {
-      val memoryBytes = java.lang.management.ManagementFactory.getOperatingSystemMXBean
-        .asInstanceOf[com.sun.management.OperatingSystemMXBean]
-        .getTotalPhysicalMemorySize
-      if (reader.getTotalBytes > memoryBytes) {
-        logger.warn(
-          "Sparkey size {} > total memory {}, look up performance will be severely degraded. " +
-            "Increase memory or use faster SSD drives.",
-          reader.getTotalBytes,
-          memoryBytes
-        )
+    // Small dedicated pool for loading readers concurrently. Multiple side inputs can be
+    // opened in parallel (useful when on-heap loading is CPU-bound), without risking
+    // starvation of the common ForkJoinPool.
+    private val threadCount = new AtomicInteger()
+    private val loaderPool = Executors.newFixedThreadPool(
+      4,
+      r => {
+        val t = new Thread(r)
+        t.setDaemon(true)
+        t.setName(s"sparkey-reader-loader-${threadCount.getAndIncrement()}")
+        t
       }
-      reader
-    }
+    )
+
+    private val readerCache =
+      new ConcurrentHashMap[String, CompletableFuture[SparkeyReader]]()
+
+    def getOrCreateReader(uri: SparkeyUri, rfu: RemoteFileUtil): SparkeyReader =
+      readerCache
+        .computeIfAbsent(
+          uri.path,
+          _ =>
+            CompletableFuture.supplyAsync(
+              () => uri.getReader(rfu),
+              loaderPool
+            )
+        )
+        .join()
   }
 
   sealed trait SparkeyWritable[K, V] extends Serializable {

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/HostMemoryTrackerTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/HostMemoryTrackerTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.extra.sparkey
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HostMemoryTrackerTest extends AnyFlatSpec with Matchers {
+
+  "HostMemoryTracker" should "claim off-heap budget when sufficient" in {
+    val tracker = new HostMemoryTracker(offHeapBudget = 100, heapBudget = 50)
+    tracker.tryClaimOffHeap(60) shouldBe true
+    tracker.tryClaimOffHeap(40) shouldBe true
+  }
+
+  it should "reject off-heap claim when insufficient" in {
+    val tracker = new HostMemoryTracker(offHeapBudget = 100, heapBudget = 50)
+    tracker.tryClaimOffHeap(60) shouldBe true
+    tracker.tryClaimOffHeap(50) shouldBe false
+  }
+
+  it should "claim heap budget when sufficient" in {
+    val tracker = new HostMemoryTracker(offHeapBudget = 0, heapBudget = 100)
+    tracker.tryClaimHeap(60) shouldBe true
+    tracker.tryClaimHeap(40) shouldBe true
+  }
+
+  it should "reject heap claim when insufficient" in {
+    val tracker = new HostMemoryTracker(offHeapBudget = 0, heapBudget = 100)
+    tracker.tryClaimHeap(60) shouldBe true
+    tracker.tryClaimHeap(50) shouldBe false
+  }
+
+  it should "handle zero budgets" in {
+    val tracker = new HostMemoryTracker(offHeapBudget = 0, heapBudget = 0)
+    tracker.tryClaimOffHeap(1) shouldBe false
+    tracker.tryClaimHeap(1) shouldBe false
+  }
+
+  it should "handle exact budget claims" in {
+    val tracker = new HostMemoryTracker(offHeapBudget = 100, heapBudget = 50)
+    tracker.tryClaimOffHeap(100) shouldBe true
+    tracker.tryClaimOffHeap(1) shouldBe false
+  }
+
+  it should "track off-heap and heap budgets independently" in {
+    val tracker = new HostMemoryTracker(offHeapBudget = 100, heapBudget = 100)
+    tracker.tryClaimOffHeap(100) shouldBe true
+    tracker.tryClaimOffHeap(1) shouldBe false
+    // heap should still be available
+    tracker.tryClaimHeap(100) shouldBe true
+    tracker.tryClaimHeap(1) shouldBe false
+  }
+
+  "HostMemoryTracker.instance" should "exist as a singleton" in {
+    HostMemoryTracker.instance should not be null
+    HostMemoryTracker.instance shouldBe theSameInstanceAs(HostMemoryTracker.instance)
+  }
+}

--- a/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/OpenWithMemoryTrackingTest.scala
+++ b/scio-extra/src/test/scala/com/spotify/scio/extra/sparkey/OpenWithMemoryTrackingTest.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.extra.sparkey
+
+import com.spotify.sparkey.Sparkey
+import org.apache.commons.io.FileUtils
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.File
+import java.nio.file.Files
+
+class OpenWithMemoryTrackingTest extends AnyFlatSpec with Matchers {
+
+  private def withSparkey[T](test: File => T): T = {
+    val dir = Files.createTempDirectory("sparkey-test").toFile
+    try {
+      val base = new File(dir, "test")
+      val writer = Sparkey.createNew(base)
+      writer.put("key1", "value1")
+      writer.put("key2", "value2")
+      writer.flush()
+      writer.writeHash()
+      writer.close()
+      test(base)
+    } finally {
+      FileUtils.deleteDirectory(dir)
+    }
+  }
+
+  "openWithMemoryTracking" should "open via mmap when off-heap budget is available" in {
+    withSparkey { base =>
+      val tracker = new HostMemoryTracker(offHeapBudget = Long.MaxValue, heapBudget = 0)
+      val (reader, plans) = ShardedSparkeyUri.openWithMemoryTracking(base, tracker)
+      try {
+        reader.getAsString("key1") shouldBe "value1"
+        plans should have size 1
+        plans.head.useHeap shouldBe false
+        plans.head.budgeted shouldBe true
+      } finally {
+        reader.close()
+      }
+    }
+  }
+
+  it should "open on heap when off-heap is exhausted but heap is available" in {
+    withSparkey { base =>
+      val tracker = new HostMemoryTracker(offHeapBudget = 0, heapBudget = Long.MaxValue)
+      val (reader, plans) = ShardedSparkeyUri.openWithMemoryTracking(base, tracker)
+      try {
+        reader.getAsString("key1") shouldBe "value1"
+        plans should have size 1
+        plans.head.useHeap shouldBe true
+        plans.head.budgeted shouldBe true
+      } finally {
+        reader.close()
+      }
+    }
+  }
+
+  it should "fall back to unbounded mmap when neither budget is available" in {
+    withSparkey { base =>
+      val tracker = new HostMemoryTracker(offHeapBudget = 0, heapBudget = 0)
+      val (reader, plans) = ShardedSparkeyUri.openWithMemoryTracking(base, tracker)
+      try {
+        reader.getAsString("key1") shouldBe "value1"
+        plans should have size 1
+        plans.head.useHeap shouldBe false
+        plans.head.budgeted shouldBe false
+      } finally {
+        reader.close()
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Alternative approach to #5903 for shared sparkey readers with memory-aware heap fallback. Both PRs share the same core features (reader cache, HostMemoryTracker, heap fallback). This PR adds a cleaner architecture on top:

- **2-phase shard opening**: plan all shards first (claiming budgets atomically), then open heap readers before mmap readers. This ensures heap readers' temporary page cache I/O (during file read into `byte[]`) doesn't evict pages that mmap readers need.

- **`ShardPlan` case class**: each shard's plan (index, file, size, useHeap, budgeted) is a first-class value. Summary stats derived via `.filter().map().sum`.

- **Single summary log per load**: instead of per-shard log lines, one INFO/WARN line per sparkey load showing GiB breakdown by mode (e.g. `Loaded 256 sparkey shard(s) from gs://bucket/path/*: 150.32 GiB off-heap, 49.68 GiB on heap`).

- **`planShard`/`openReader` helpers**: deduplicates logic between sharded and unsharded paths.

### Comparison with #5903

| | #5903 | #5904 (this) |
|---|---|---|
| Shared reader cache | ✅ | ✅ |
| HostMemoryTracker | ✅ | ✅ |
| Heap fallback | ✅ | ✅ |
| Sparkey bump (3.5.1 → 3.7.0) | ✅ | ✅ |
| 2-phase shard opening (heap first) | ❌ | ✅ |
| ShardPlan case class | ❌ | ✅ |
| Per-shard logging | per-shard INFO/WARN | single summary line |
| Code deduplication | separate paths | `planShard`/`openReader` helpers |

Both are viable — #5903 is simpler, #5904 is more polished with better page cache behavior for mixed heap+mmap workloads.

## Test plan

- [x] Unit tests for `HostMemoryTracker` (budget claiming, independence, edge cases)
- [x] Unit tests for `OpenWithMemoryTracking` (mmap, heap, unbounded fallback modes)
- [x] Existing sparkey tests pass
- [x] MiMa binary compatibility check passes
- [ ] Integration test on Dataflow with large sharded sparkey

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>