### PR TITLE
feat(sparkey): Deduplicate SparkeyReader across DoFn clones

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sparkey/package.scala
@@ -32,6 +32,7 @@ import org.apache.beam.sdk.util.CoderUtils
 import org.apache.beam.sdk.values.PCollectionView
 import org.slf4j.LoggerFactory
 
+import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
 import scala.util.hashing.MurmurHash3
 
 /**
@@ -545,12 +546,11 @@ package object sparkey extends SparkeyReaderInstances with SparkeyCoders {
     mapFn: SparkeyReader => T
   ) extends SideInput[T] {
     override def updateCacheOnGlobalWindow: Boolean = false
-    override def get[I, O](context: DoFn[I, O]#ProcessContext): T =
-      mapFn(
-        SparkeySideInput.checkMemory(
-          context.sideInput(view).getReader(RemoteFileUtil.create(context.getPipelineOptions))
-        )
-      )
+    override def get[I, O](context: DoFn[I, O]#ProcessContext): T = {
+      val uri = context.sideInput(view)
+      val rfu = RemoteFileUtil.create(context.getPipelineOptions)
+      mapFn(SparkeySideInput.getOrCreateReader(uri, rfu))
+    }
   }
 
   /**
@@ -561,8 +561,10 @@ package object sparkey extends SparkeyReaderInstances with SparkeyCoders {
       extends SideInput[SparkeyMap[K, V]] {
     override def updateCacheOnGlobalWindow: Boolean = false
     override def get[I, O](context: DoFn[I, O]#ProcessContext): SparkeyMap[K, V] = {
+      val uri = context.sideInput(view)
+      val rfu = RemoteFileUtil.create(context.getPipelineOptions)
       new SparkeyMap(
-        context.sideInput(view).getReader(RemoteFileUtil.create(context.getPipelineOptions)),
+        SparkeySideInput.getOrCreateReader(uri, rfu),
         CoderMaterializer.beam(context.getPipelineOptions, Coder[K]),
         CoderMaterializer.beam(context.getPipelineOptions, Coder[V])
       )
@@ -576,15 +578,41 @@ package object sparkey extends SparkeyReaderInstances with SparkeyCoders {
   private class LargeSetSideInput[K: Coder](val view: PCollectionView[SparkeyUri])
       extends SideInput[SparkeySet[K]] {
     override def updateCacheOnGlobalWindow: Boolean = false
-    override def get[I, O](context: DoFn[I, O]#ProcessContext): SparkeySet[K] =
+    override def get[I, O](context: DoFn[I, O]#ProcessContext): SparkeySet[K] = {
+      val uri = context.sideInput(view)
+      val rfu = RemoteFileUtil.create(context.getPipelineOptions)
       new SparkeySet(
-        context.sideInput(view).getReader(RemoteFileUtil.create(context.getPipelineOptions)),
+        SparkeySideInput.getOrCreateReader(uri, rfu),
         CoderMaterializer.beam(context.getPipelineOptions, Coder[K])
       )
+    }
   }
 
+  // Readers are cached for the lifetime of the JVM and never closed. This is intentional:
+  // Beam side inputs have no close/teardown lifecycle, and in batch pipelines the JVM exits
+  // when the pipeline finishes.
+  // Note: the cache is keyed by URI path only. If the same path is rewritten with different
+  // data and a new pipeline is run in the same JVM (e.g. DirectRunner, REPL), stale readers
+  // will be returned. This is acceptable for Dataflow batch (one pipeline per JVM).
   private object SparkeySideInput {
     private val logger = LoggerFactory.getLogger(this.getClass)
+
+    private val readerCache =
+      new ConcurrentHashMap[String, CompletableFuture[SparkeyReader]]()
+
+    def getOrCreateReader(uri: SparkeyUri, rfu: RemoteFileUtil): SparkeyReader =
+      readerCache
+        .computeIfAbsent(
+          uri.path,
+          _ =>
+            CompletableFuture.supplyAsync { () =>
+              val reader = uri.getReader(rfu)
+              checkMemory(reader)
+              reader
+            }
+        )
+        .join()
+
     def checkMemory(reader: SparkeyReader): SparkeyReader = {
       val memoryBytes = java.lang.management.ManagementFactory.getOperatingSystemMXBean
         .asInstanceOf[com.sun.management.OperatingSystemMXBean]


### PR DESCRIPTION
## Summary

Beam creates one DoFn clone per vCPU thread (e.g. 80 on an n4-standard-80 worker). Previously, each clone independently called `uri.getReader()`, which downloads files from GCS and opens new `SparkeyReader` instances — duplicating file I/O, file descriptors, and mmap regions.

This adds a `CompletableFuture`-based reader cache so the first thread loads the reader and all others wait on the same future. The reader is reused for the JVM lifetime, which is safe for Dataflow batch (one pipeline per JVM).

### Changes

- `SparkeySideInput`, `LargeMapSideInput`, and `LargeSetSideInput` now go through `SparkeySideInput.getOrCreateReader()` instead of calling `uri.getReader()` directly
- Reader cache is a `ConcurrentHashMap[String, CompletableFuture[SparkeyReader]]` keyed by URI path
- `checkMemory` is preserved but called once per reader (inside the cache loader) instead of on every `get()` call
- No API changes, no new dependencies, no version bumps

### Why this is safe

- **No behavior change for correct programs**: readers were already expected to be long-lived; this just ensures they're shared
- **Thread safety**: `SparkeyReader` from `Sparkey.open()` returns a `PooledSparkeyReader` which is already thread-safe
- **Cache semantics**: keyed by path, never evicted. Acceptable for Dataflow batch where one pipeline runs per JVM. For DirectRunner/REPL reuse, stale readers could be returned if the same path is rewritten — same limitation as the existing `checkMemory` which also uses a static reference

### What this does NOT include

This is intentionally minimal. The heap-backed reader fallback and memory-aware shard placement from #5903 / #5904 are separate concerns and will be proposed separately (likely as opt-in features).

## Test plan

- [ ] Existing sparkey tests pass (no behavior change for single-reader scenarios)
- [ ] Verified on production Dataflow pipeline (n4-standard-80, 80 DoFn clones) — readers are loaded once instead of 80 times

🤖 Generated with [Claude Code](https://claude.com/claude-code)