### PR TITLE
Fix Spanner write mutation coder serialization

### DIFF
--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/spanner/SpannerIO.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/spanner/SpannerIO.scala
@@ -102,17 +102,15 @@ final case class SpannerWrite(config: SpannerConfig) extends SpannerIO[Mutation]
   override type ReadP = Nothing
   override type WriteP = SpannerWrite.WriteParam
 
-  override protected def write(data: SCollection[Mutation], params: WriteP): Tap[Nothing] = {
-     val coder = CoderMaterializer.beam(data.context, coders.spannerMutationCoder)
+ override protected def write(data: SCollection[Mutation], params: WriteP): Tap[Nothing] = {
+  val transform = BSpannerIO
+    .write()
+    .withSpannerConfig(config)
+    .withBatchSizeBytes(params.batchSizeBytes)
+    .withFailureMode(params.failureMode)
 
-     val transform = BSpannerIO
-       .write()
-       .withSpannerConfig(config)
-       .withBatchSizeBytes(params.batchSizeBytes)
-       .withFailureMode(params.failureMode)
-
-    data.setCoder(coder).applyInternal(transform)
-    EmptyTap
+  data.applyInternal(transform)
+  EmptyTap
 }
 
   override protected def read(sc: ScioContext, params: ReadP): SCollection[Mutation] = sc.wrap {

--- a/scio-google-cloud-platform/src/main/scala/com/spotify/scio/spanner/SpannerIO.scala
+++ b/scio-google-cloud-platform/src/main/scala/com/spotify/scio/spanner/SpannerIO.scala
@@ -103,15 +103,17 @@ final case class SpannerWrite(config: SpannerConfig) extends SpannerIO[Mutation]
   override type WriteP = SpannerWrite.WriteParam
 
   override protected def write(data: SCollection[Mutation], params: WriteP): Tap[Nothing] = {
-    val transform = BSpannerIO
-      .write()
-      .withSpannerConfig(config)
-      .withBatchSizeBytes(params.batchSizeBytes)
-      .withFailureMode(params.failureMode)
+     val coder = CoderMaterializer.beam(data.context, coders.spannerMutationCoder)
 
-    data.applyInternal(transform)
+     val transform = BSpannerIO
+       .write()
+       .withSpannerConfig(config)
+       .withBatchSizeBytes(params.batchSizeBytes)
+       .withFailureMode(params.failureMode)
+
+    data.setCoder(coder).applyInternal(transform)
     EmptyTap
-  }
+}
 
   override protected def read(sc: ScioContext, params: ReadP): SCollection[Mutation] = sc.wrap {
     throw new UnsupportedOperationException("SpannerWrite is write-only")


### PR DESCRIPTION
## Summary

This change explicitly sets `spannerMutationCoder` on the `SCollection[Mutation]` before applying the Beam Spanner write transform.

Previously, the write path relied on Beam/Kryo fallback serialization, which could lead to `UnsupportedOperationException` when serializing `Mutation` / `MutationGroup`.

## Changes Made

* Materialized `spannerMutationCoder` using `CoderMaterializer.beam`
* Applied the coder to the input `SCollection[Mutation]`
* Updated the write path to use `data.setCoder(coder).applyInternal(transform)`

## Why

A `spannerMutationCoder` already exists in `CoderInstances`, but it was not being explicitly used in `SpannerWrite`. This change ensures that Beam uses the intended serializer for `Mutation` objects during writes.


