### PR TITLE
Fix `FileNotFoundException` due to race in `NativeFileSorter`

### DIFF
--- a/scio-extra/src/main/scala/com/spotify/scio/extra/sorter/syntax/SCollectionSyntax.scala
+++ b/scio-extra/src/main/scala/com/spotify/scio/extra/sorter/syntax/SCollectionSyntax.scala
@@ -70,20 +70,13 @@ final class SorterOps[K1, K2: SortingKey, V](self: SCollection[(K1, Iterable[(K2
       .applyTransform(SortValues.create[K1, K2, V](options))(coder)
       .withName("KvToTuple")
       .map { kv =>
-        val iter = new Iterable[(K2, V)] {
-          override def iterator: Iterator[(K2, V)] = new AbstractIterator[(K2, V)] {
-            private[this] val iter = kv.getValue.iterator()
-            override def hasNext: Boolean = iter.hasNext
-
-            override def next(): (K2, V) = {
-              val next = iter.next()
-              (next.getKey, next.getValue)
-            }
-          }
-
-          override def toString: String = "<iterable>"
+        val iter = kv.getValue.iterator()
+        val buf = Vector.newBuilder[(K2, V)]
+        while (iter.hasNext) {
+          val next = iter.next()
+          buf += ((next.getKey, next.getValue))
         }
-        (kv.getKey, iter)
+        (kv.getKey, buf.result(): Iterable[(K2, V)])
       }(Coder.beam(c.internal.getCoder))
   }
 }


### PR DESCRIPTION
Closes https://github.com/spotify/scio/issues/5765

The bug apparently was a race due to the lazy iterator escaping its DoFn's lifecycle.
The flow goes -
1. `SortValues` internally wrote spilled data to temp files
2. Beam's `SortValuesDoFn` deleted those temp files when it finished processing the element (end of `@ProcessElement`)
3. The `KvToTuple` map returns a lazy `Iterable[(K2, V)]` that wrapped the `DecodingIterable`
4. Downstream `List.prependedAll` called `.iterator` on the lazy wrapper after the DoFn has already cleaned up the temp files, causing the `FileNotFoundException`

```
List.prependedAll          <- forces the iterator here (lazy consumer)
  -> anon Iterable.iterator
    -> NativeFileSorter.mergeSortedFiles  <- file already deleted
```


Fix was simply to force full consumption of the `DecodingIterable` while the DoFn is still alive and the temp files still exist.

Now by the time `.map` returns a `(K1, Iterable[(K2, V)])`, the Iterable is a plain Scala Vector with no references to Beam internals or temp files.