### PR TITLE
ci: declare workflow-level `contents: read` on 1 workflows

### DIFF
--- a/.github/workflows/populate-it-data.yml
+++ b/.github/workflows/populate-it-data.yml
@@ -3,6 +3,9 @@ name: Populate Integration Test Data
 on:
   workflow_dispatch # Manually triggered
 
+permissions:
+  contents: read
+
 jobs:
   populate-integration-test-data:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 1 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `ci.yml`, `clean.yml`, `it.yml`, `scalafix.yaml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.