### PR TITLE
Upgrade to Beam 2.74.0, drop bigdataoss v2, rework checkBeamDependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1255,7 +1255,8 @@ lazy val `scio-parquet` = project
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % Runtime excludeAll (Exclude.metricsCore),
       "io.dropwizard.metrics" % "metrics-core" % metricsVersion % Runtime,
       // test
-      "org.slf4j" % "slf4j-simple" % slf4jBom.key.value % Test
+      "org.slf4j" % "slf4j-simple" % slf4jBom.key.value % Test,
+      "com.google.cloud.bigdataoss" % "gcsio" % bigdataossVersion % Test
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1251,7 +1251,6 @@ lazy val `scio-parquet` = project
       // provided
       "org.tensorflow" % "tensorflow-core-native" % tensorFlowVersion % Provided,
       "com.google.cloud.bigdataoss" % "gcs-connector" % bigdataossVersion % Provided,
-      "com.google.cloud.bigdataoss" % "gcsio" % bigdataossVersion % Provided,
       // runtime
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % Runtime excludeAll (Exclude.metricsCore),
       "io.dropwizard.metrics" % "metrics-core" % metricsVersion % Runtime,

--- a/build.sbt
+++ b/build.sbt
@@ -37,8 +37,6 @@ val autoServiceVersion = "1.0.1"
 val autoValueVersion = "1.9"
 val avroVersion = sys.props.getOrElse("avro.version", "1.12.0")
 val bigdataossVersion = "3.1.16"
-// beam pins bigtable behind the GCP BOM version. See https://github.com/apache/beam/pull/38861
-val bigtableVersion = "2.73.1"
 val bigtableClientVersion = "1.28.0"
 val commonsCodecVersion = "1.18.0"
 val commonsCompressVersion = "1.26.2"
@@ -46,8 +44,14 @@ val commonsIoVersion = "2.16.1"
 val commonsLang3Version = "3.18.0"
 val commonsMath3Version = "3.6.1"
 val gcpLibrariesVersion = "26.80.0"
+// in theory, googleApiClientsVersion and googleClientsVersion should be a single value
+// beam declares 2.0.0 but transitively depends on 2.7.2 for only the google-api-client artifact
+// which gets caught in our undeclared filter if we use the declared 2.0.0 version.
+// the googleApiServices* versions should however align with the declared 2.0.0 version
+val googleApiClientsVersion = "2.7.2"
 val googleClientsVersion = "2.0.0"
-val googleOauthClientsVersion = "1.34.1"
+// pinned by beam at 1.34.1 but transitively depends on 1.39.0
+val googleOauthClientsVersion = "1.39.0"
 val guavaVersion = "33.1.0-jre"
 val hamcrestVersion = "2.1"
 val httpClientVersion = "4.5.13"
@@ -699,7 +703,7 @@ lazy val `scio-core` = project
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
       "com.github.luben" % "zstd-jni" % zstdJniVersion,
       "com.google.api" % "gax" % gcpBom.key.value,
-      "com.google.api-client" % "google-api-client" % googleClientsVersion,
+      "com.google.api-client" % "google-api-client" % googleApiClientsVersion,
       "com.google.auto.service" % "auto-service-annotations" % autoServiceVersion,
       "com.google.auto.service" % "auto-service" % autoServiceVersion,
       "com.google.code.findbugs" % "jsr305" % jsr305Version,
@@ -925,7 +929,7 @@ lazy val `scio-google-cloud-platform` = project
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
       "com.google.api" % "gax" % gcpBom.key.value,
       "com.google.api" % "gax-grpc" % gcpBom.key.value,
-      "com.google.api-client" % "google-api-client" % googleClientsVersion,
+      "com.google.api-client" % "google-api-client" % googleApiClientsVersion,
       "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % gcpBom.key.value,
       "com.google.api.grpc" % "proto-google-cloud-bigquerystorage-v1" % gcpBom.key.value,
       "com.google.api.grpc" % "proto-google-cloud-bigtable-admin-v2" % gcpBom.key.value,
@@ -936,7 +940,7 @@ lazy val `scio-google-cloud-platform` = project
       "com.google.auth" % "google-auth-library-credentials" % gcpBom.key.value,
       "com.google.auth" % "google-auth-library-oauth2-http" % gcpBom.key.value,
       "com.google.cloud" % "google-cloud-bigquerystorage" % gcpBom.key.value,
-      "com.google.cloud" % "google-cloud-bigtable" % bigtableVersion,
+      "com.google.cloud" % "google-cloud-bigtable" % gcpBom.key.value,
       "com.google.cloud" % "google-cloud-core" % gcpBom.key.value,
       "com.google.cloud" % "google-cloud-spanner" % gcpBom.key.value,
       "com.google.cloud.bigdataoss" % "util" % bigdataossVersion,
@@ -1405,7 +1409,7 @@ lazy val `scio-examples` = project
       "co.elastic.clients" % "elasticsearch-java" % elasticsearch8Version,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
-      "com.google.api-client" % "google-api-client" % googleClientsVersion,
+      "com.google.api-client" % "google-api-client" % googleApiClientsVersion,
       "com.google.api.grpc" % "proto-google-cloud-bigtable-v2" % gcpBom.key.value,
       "com.google.api.grpc" % "proto-google-cloud-datastore-v1" % gcpBom.key.value,
       "com.google.apis" % "google-api-services-bigquery" % googleApiServicesBigQueryVersion,
@@ -1760,7 +1764,7 @@ lazy val integration = project
     unusedCompileDependenciesTest := unusedCompileDependenciesTestSkipped.value,
     libraryDependencies ++= Seq(
       // compile
-      "com.google.api-client" % "google-api-client" % googleClientsVersion,
+      "com.google.api-client" % "google-api-client" % googleApiClientsVersion,
       "com.google.apis" % "google-api-services-bigquery" % googleApiServicesBigQueryVersion,
       "com.google.guava" % "guava" % guavaVersion,
       "com.google.http-client" % "google-http-client" % gcpBom.key.value,

--- a/build.sbt
+++ b/build.sbt
@@ -1243,6 +1243,7 @@ lazy val `scio-parquet` = project
       // provided
       "org.tensorflow" % "tensorflow-core-native" % tensorFlowVersion % Provided,
       "com.google.cloud.bigdataoss" % "gcs-connector" % bigdataossVersion % Provided,
+      "com.google.cloud.bigdataoss" % "gcsio" % bigdataossVersion % Provided,
       // runtime
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % Runtime excludeAll (Exclude.metricsCore),
       "io.dropwizard.metrics" % "metrics-core" % metricsVersion % Runtime,

--- a/build.sbt
+++ b/build.sbt
@@ -1155,7 +1155,10 @@ lazy val `scio-managed` = project
       // compile
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-managed" % beamVersion,
-      "com.spotify" %% "magnolify-beam" % magnolifyVersion
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+      "com.spotify" %% "magnolify-beam" % magnolifyVersion,
+      "com.spotify" %% "magnolify-shared" % magnolifyVersion,
+      "com.softwaremill.magnolia1_2" %% "magnolia" % magnoliaVersion
       // test
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -29,36 +29,38 @@ import org.typelevel.scalacoptions.JavaMajorVersion.javaMajorVersion
 // To test release candidates, find the beam repo and add it as a resolver
 // ThisBuild / resolvers += "apache-beam-staging" at "https://repository.apache.org/content/repositories/"
 val beamVendorVersion = "0.1"
-val beamVersion = "2.72.0"
+val beamVersion = "2.74.0"
 
 // check version used by beam
-// https://github.com/apache/beam/blob/v2.72.0/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+// https://github.com/apache/beam/blob/v2.74.0/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
 val autoServiceVersion = "1.0.1"
 val autoValueVersion = "1.9"
-val avroVersion = sys.props.getOrElse("avro.version", "1.11.5")
-val bigdataossVersion = "2.2.26"
-val bigdataoss3Version = "3.1.3"
+val avroVersion = sys.props.getOrElse("avro.version", "1.12.0")
+val bigdataossVersion = "3.1.16"
+// beam pins bigtable behind the GCP BOM version. See https://github.com/apache/beam/pull/38861
+val bigtableVersion = "2.73.1"
 val bigtableClientVersion = "1.28.0"
 val commonsCodecVersion = "1.18.0"
 val commonsCompressVersion = "1.26.2"
 val commonsIoVersion = "2.16.1"
 val commonsLang3Version = "3.18.0"
 val commonsMath3Version = "3.6.1"
-val gcpLibrariesVersion = "26.76.0"
+val gcpLibrariesVersion = "26.80.0"
 val googleClientsVersion = "2.0.0"
+val googleOauthClientsVersion = "1.34.1"
 val guavaVersion = "33.1.0-jre"
 val hamcrestVersion = "2.1"
 val httpClientVersion = "4.5.13"
 val httpCoreVersion = "4.4.14"
 val jacksonVersion = "2.15.4"
 val jodaTimeVersion = "2.14.0"
-val nettyVersion = "4.1.128.Final"
+val nettyVersion = "4.1.130.Final"
 val protobufVersion = "4.33.2"
 val slf4jVersion = "2.0.16"
 val zstdJniVersion = "1.5.6-3"
 // dependent versions
 val googleApiServicesBigQueryVersion = s"v2-rev20251012-$googleClientsVersion"
-val googleApiServicesDataflowVersion = s"v1b3-rev20260118-$googleClientsVersion"
+val googleApiServicesDataflowVersion = s"v1b3-rev20260405-$googleClientsVersion"
 val googleApiServicesPubsubVersion = s"v1-rev20220904-$googleClientsVersion"
 // beam tested versions
 val zetasketchVersion = "0.1.0" // sdks/java/extensions/zetasketch/build.gradle
@@ -545,9 +547,9 @@ def vectoredReadSettings: Seq[Setting[_]] = sys.props
   .collect { case true =>
     Seq(
       dependencyOverrides ++= Seq(
-        "com.google.cloud.bigdataoss" % "gcs-connector" % bigdataoss3Version,
-        "com.google.cloud.bigdataoss" % "gcsio" % bigdataoss3Version,
-        "com.google.cloud.bigdataoss" % "util-hadoop" % bigdataoss3Version,
+        "com.google.cloud.bigdataoss" % "gcs-connector" % bigdataossVersion,
+        "com.google.cloud.bigdataoss" % "gcsio" % bigdataossVersion,
+        "com.google.cloud.bigdataoss" % "util-hadoop" % bigdataossVersion,
         "org.apache.hadoop" % "hadoop-common" % "3.3.6",
         "org.apache.hadoop" % "hadoop-auth" % "3.3.6",
         "org.apache.hadoop" % "hadoop-client" % "3.3.6"
@@ -697,7 +699,7 @@ lazy val `scio-core` = project
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
       "com.github.luben" % "zstd-jni" % zstdJniVersion,
       "com.google.api" % "gax" % gcpBom.key.value,
-      "com.google.api-client" % "google-api-client" % gcpBom.key.value,
+      "com.google.api-client" % "google-api-client" % googleClientsVersion,
       "com.google.auto.service" % "auto-service-annotations" % autoServiceVersion,
       "com.google.auto.service" % "auto-service" % autoServiceVersion,
       "com.google.code.findbugs" % "jsr305" % jsr305Version,
@@ -730,9 +732,9 @@ lazy val `scio-core` = project
       "org.apache.beam" % s"beam-runners-spark-$sparkMajorVersion" % beamVersion % Provided,
       "org.apache.beam" % "beam-sdks-java-extensions-google-cloud-platform-core" % beamVersion % Provided,
       "org.apache.hadoop" % "hadoop-common" % hadoopVersion % Provided,
-      "com.google.cloud.bigdataoss" % "gcs-connector" % s"hadoop2-$bigdataossVersion" % Provided,
+      "com.google.cloud.bigdataoss" % "gcs-connector" % bigdataossVersion % Provided,
       "com.google.cloud.bigdataoss" % "gcsio" % bigdataossVersion % Provided,
-      "com.google.cloud.bigdataoss" % "util-hadoop" % s"hadoop2-$bigdataossVersion" % Provided,
+      "com.google.cloud.bigdataoss" % "util-hadoop" % bigdataossVersion % Provided,
       // test
       "com.lihaoyi" %% "fansi" % fansiVersion % Test,
       "com.lihaoyi" %% "pprint" % pprintVersion % Test,
@@ -923,7 +925,7 @@ lazy val `scio-google-cloud-platform` = project
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
       "com.google.api" % "gax" % gcpBom.key.value,
       "com.google.api" % "gax-grpc" % gcpBom.key.value,
-      "com.google.api-client" % "google-api-client" % gcpBom.key.value,
+      "com.google.api-client" % "google-api-client" % googleClientsVersion,
       "com.google.api.grpc" % "grpc-google-cloud-pubsub-v1" % gcpBom.key.value,
       "com.google.api.grpc" % "proto-google-cloud-bigquerystorage-v1" % gcpBom.key.value,
       "com.google.api.grpc" % "proto-google-cloud-bigtable-admin-v2" % gcpBom.key.value,
@@ -934,7 +936,7 @@ lazy val `scio-google-cloud-platform` = project
       "com.google.auth" % "google-auth-library-credentials" % gcpBom.key.value,
       "com.google.auth" % "google-auth-library-oauth2-http" % gcpBom.key.value,
       "com.google.cloud" % "google-cloud-bigquerystorage" % gcpBom.key.value,
-      "com.google.cloud" % "google-cloud-bigtable" % gcpBom.key.value,
+      "com.google.cloud" % "google-cloud-bigtable" % bigtableVersion,
       "com.google.cloud" % "google-cloud-core" % gcpBom.key.value,
       "com.google.cloud" % "google-cloud-spanner" % gcpBom.key.value,
       "com.google.cloud.bigdataoss" % "util" % bigdataossVersion,
@@ -1219,7 +1221,7 @@ lazy val `scio-parquet` = project
       // compile
       "com.softwaremill.magnolia1_2" %% "magnolia" % magnoliaVersion,
       "com.google.auth" % "google-auth-library-oauth2-http" % gcpBom.key.value,
-      "com.google.cloud.bigdataoss" % "util-hadoop" % s"hadoop2-$bigdataossVersion",
+      "com.google.cloud.bigdataoss" % "util-hadoop" % bigdataossVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "com.spotify" %% "magnolify-parquet" % magnolifyVersion,
       "com.twitter" %% "chill" % chillVersion,
@@ -1240,7 +1242,7 @@ lazy val `scio-parquet` = project
       "org.slf4j" % "slf4j-api" % slf4jBom.key.value,
       // provided
       "org.tensorflow" % "tensorflow-core-native" % tensorFlowVersion % Provided,
-      "com.google.cloud.bigdataoss" % "gcs-connector" % s"hadoop2-$bigdataossVersion" % Provided,
+      "com.google.cloud.bigdataoss" % "gcs-connector" % bigdataossVersion % Provided,
       // runtime
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % Runtime excludeAll (Exclude.metricsCore),
       "io.dropwizard.metrics" % "metrics-core" % metricsVersion % Runtime,
@@ -1402,7 +1404,7 @@ lazy val `scio-examples` = project
       "co.elastic.clients" % "elasticsearch-java" % elasticsearch8Version,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
-      "com.google.api-client" % "google-api-client" % gcpBom.key.value,
+      "com.google.api-client" % "google-api-client" % googleClientsVersion,
       "com.google.api.grpc" % "proto-google-cloud-bigtable-v2" % gcpBom.key.value,
       "com.google.api.grpc" % "proto-google-cloud-datastore-v1" % gcpBom.key.value,
       "com.google.apis" % "google-api-services-bigquery" % googleApiServicesBigQueryVersion,
@@ -1413,7 +1415,7 @@ lazy val `scio-examples` = project
       "com.google.code.findbugs" % "jsr305" % jsr305Version,
       "com.google.guava" % "guava" % guavaVersion,
       "com.google.http-client" % "google-http-client" % gcpBom.key.value,
-      "com.google.oauth-client" % "google-oauth-client" % gcpBom.key.value,
+      "com.google.oauth-client" % "google-oauth-client" % googleOauthClientsVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "com.mysql" % "mysql-connector-j" % "9.6.0",
       "com.softwaremill.magnolia1_2" %% "magnolia" % magnoliaVersion,
@@ -1447,7 +1449,7 @@ lazy val `scio-examples` = project
       "org.tensorflow" % "tensorflow-core-native" % tensorFlowVersion,
       "redis.clients" % "jedis" % jedisVersion,
       // runtime
-      "com.google.cloud.bigdataoss" % "gcs-connector" % s"hadoop2-$bigdataossVersion" % Runtime,
+      "com.google.cloud.bigdataoss" % "gcs-connector" % bigdataossVersion % Runtime,
       "com.google.cloud.sql" % "mysql-socket-factory-connector-j-8" % "1.28.2" % Runtime,
       // test
       "org.scalacheck" %% "scalacheck" % scalacheckVersion % Test
@@ -1757,7 +1759,7 @@ lazy val integration = project
     unusedCompileDependenciesTest := unusedCompileDependenciesTestSkipped.value,
     libraryDependencies ++= Seq(
       // compile
-      "com.google.api-client" % "google-api-client" % gcpBom.key.value,
+      "com.google.api-client" % "google-api-client" % googleClientsVersion,
       "com.google.apis" % "google-api-services-bigquery" % googleApiServicesBigQueryVersion,
       "com.google.guava" % "guava" % guavaVersion,
       "com.google.http-client" % "google-http-client" % gcpBom.key.value,

--- a/build.sbt
+++ b/build.sbt
@@ -1160,7 +1160,9 @@ lazy val `scio-managed` = project
       "com.spotify" %% "magnolify-shared" % magnolifyVersion,
       "com.softwaremill.magnolia1_2" %% "magnolia" % magnoliaVersion
       // test
-    )
+    ),
+    // remove on next release
+    tlMimaPreviousVersions := Set.empty
   )
 
 lazy val `scio-jdbc` = project

--- a/project/CheckBeamDependencies.scala
+++ b/project/CheckBeamDependencies.scala
@@ -35,31 +35,50 @@ object CheckBeamDependencies extends AutoPlugin {
 
   private[this] val beamDeps = new ConcurrentHashMap[String, Map[String, Set[String]]]()
 
+  private val AnsiCode = s"\\x1b\\[[0-9;]*m".r
+
+  private def coursierResolveTree(coordinate: String): List[String] =
+    Seq("sh", "-c", s"""coursier resolve --tree "$coordinate" 2>/dev/null""")
+      .lineStream_!
+      .toList
+
+  // Parses direct (first-level) dependencies from beam module POMs via `coursier resolve --tree`.
+  // Only direct deps are meaningful; transitive resolution picks up unrelated version conflicts.
   private def resolveBeamDependencies(deps: Seq[(String, String)]): Map[String, Set[String]] =
     deps
-      .filter(d => d._1.startsWith("org.apache.beam"))
+      .filter(_._1.startsWith("org.apache.beam"))
       .map { case (orgName, rev) =>
         beamDeps.computeIfAbsent(
           orgName,
           new JFunction[String, Map[String, Set[String]]] {
             override def apply(key: String): Map[String, Set[String]] = {
-              val output = s"coursier resolve $key:$rev" lineStream_!
-
-              output
-                .flatMap { dep =>
-                  dep.split(":").toList match {
-                    case org :: name :: rev :: _ => Some((s"$org:$name", rev))
-                    case _                       => None
+              coursierResolveTree(s"$key:$rev")
+                .map(l => AnsiCode.replaceAllIn(l, ""))
+                .filter(l =>
+                  l.length > 3 &&
+                    l.startsWith("   ") &&
+                    (l.charAt(3) == '├' || l.charAt(3) == '└')
+                )
+                .flatMap { line =>
+                  val coord = line.dropWhile(c => !c.isLetterOrDigit)
+                  coord.split(":").toList match {
+                    case org :: name :: rest :: _ if !org.startsWith("org.apache.beam") =>
+                      Some((s"$org:$name", rest.split(" -> ").head.trim))
+                    case _ => None
                   }
                 }
-                .toList
                 .groupBy(_._1)
                 .mapValues(_.map(_._2).toSet)
+                .toMap
             }
           }
         )
       }
-      .foldLeft(Map.empty[String, Set[String]])(_ ++ _)
+      .foldLeft(Map.empty[String, Set[String]]) { case (acc, m) =>
+        m.foldLeft(acc) { case (a, (k, v)) =>
+          a + (k -> (a.getOrElse(k, Set.empty[String]) ++ v))
+        }
+      }
 
   override lazy val projectSettings = Seq(
     checkBeamDependencies := {

--- a/project/CheckBeamDependencies.scala
+++ b/project/CheckBeamDependencies.scala
@@ -38,9 +38,7 @@ object CheckBeamDependencies extends AutoPlugin {
   private val AnsiCode = s"\\x1b\\[[0-9;]*m".r
 
   private def coursierResolveTree(coordinate: String): List[String] =
-    Seq("sh", "-c", s"""coursier resolve --tree "$coordinate" 2>/dev/null""")
-      .lineStream_!
-      .toList
+    Seq("sh", "-c", s"""coursier resolve --tree "$coordinate" 2>/dev/null""").lineStream_!.toList
 
   // Parses direct (first-level) dependencies from beam module POMs via `coursier resolve --tree`.
   // Only direct deps are meaningful; transitive resolution picks up unrelated version conflicts.

--- a/scio-avro/src/main/scala/com/spotify/scio/avro/AvroDatumFactory.scala
+++ b/scio-avro/src/main/scala/com/spotify/scio/avro/AvroDatumFactory.scala
@@ -77,6 +77,12 @@ private[scio] class SpecificRecordDatumFactory[T <: SpecificRecord](recordType: 
 
   // TODO move this to companion object
   private class ScioSpecificDatumReader extends SpecificDatumReader[T](recordType) {
+    // Avro 1.12.0 bug: SpecificDatumReader(Class) chains to SpecificDatumReader(SpecificData)
+    // which doesn't populate trustedPackages with SERIALIZABLE_PACKAGES defaults
+    getTrustedPackages.addAll(
+      java.util.Arrays.asList(SpecificDatumReader.SERIALIZABLE_PACKAGES: _*)
+    )
+
     override def findStringClass(schema: Schema): Class[_] = super.findStringClass(schema) match {
       case cls if cls == classOf[CharSequence] => classOf[String]
       case cls                                 => cls

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -473,12 +473,12 @@ class ScioContext private[scio] (
           .pipe(o =>
             Option(config.get(GfsConfig.GCS_INPUT_STREAM_FAST_FAIL_ON_NOT_FOUND_ENABLE.getKey))
               .map(_.toBoolean)
-              .fold(o)(o.setFastFailOnNotFound)
+              .fold(o)(o.setFastFailOnNotFoundEnabled)
           )
           .pipe(o =>
             Option(config.get(GfsConfig.GCS_INPUT_STREAM_SUPPORT_GZIP_ENCODING_ENABLE.getKey))
               .map(_.toBoolean)
-              .fold(o)(o.setSupportGzipEncoding)
+              .fold(o)(o.setGzipEncodingSupportEnabled)
           )
           .pipe(o =>
             Option(config.get(GfsConfig.GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.getKey))
@@ -492,7 +492,7 @@ class ScioContext private[scio] (
           )
           .pipe(o =>
             Option(config.get(GfsConfig.GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.getKey))
-              .map(_.toInt)
+              .map(_.toLong)
               .fold(o)(o.setMinRangeRequestSize)
           )
           .pipe(o =>
@@ -501,34 +501,19 @@ class ScioContext private[scio] (
               .fold(o)(o.setGrpcChecksumsEnabled)
           )
           .pipe(o =>
-            Option(config.get(GfsConfig.GCS_GRPC_READ_TIMEOUT_MS.getKey))
-              .map(_.toLong)
-              .fold(o)(o.setGrpcReadTimeoutMillis)
+            Option(config.get(GfsConfig.GCS_GRPC_READ_TIMEOUT.getKey))
+              .map(v => java.time.Duration.ofMillis(v.toLong))
+              .fold(o)(o.setGrpcReadTimeout)
           )
           .pipe(o =>
-            Option(config.get(GfsConfig.GCS_GRPC_READ_MESSAGE_TIMEOUT_MS.getKey))
-              .map(_.toLong)
-              .fold(o)(o.setGrpcReadMessageTimeoutMillis)
-          )
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_GRPC_READ_METADATA_TIMEOUT_MS.getKey))
-              .map(_.toLong)
-              .fold(o)(o.setGrpcReadMetadataTimeoutMillis)
+            Option(config.get(GfsConfig.GCS_GRPC_READ_MESSAGE_TIMEOUT.getKey))
+              .map(v => java.time.Duration.ofMillis(v.toLong))
+              .fold(o)(o.setGrpcReadMessageTimeout)
           )
           .pipe(o =>
             Option(config.get(GfsConfig.GCS_GRPC_READ_ZEROCOPY_ENABLE.getKey))
               .map(_.toBoolean)
               .fold(o)(o.setGrpcReadZeroCopyEnabled)
-          )
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_TRACE_LOG_ENABLE.getKey))
-              .map(_.toBoolean)
-              .fold(o)(o.setTraceLogEnabled)
-          )
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_TRACE_LOG_TIME_THRESHOLD_MS.getKey))
-              .map(_.toLong)
-              .fold(o)(o.setTraceLogTimeThreshold)
           )
           .build()
       )

--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/GcsConnectorUtil.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/GcsConnectorUtil.scala
@@ -107,7 +107,7 @@ class ApplicationDefaultTokenProvider() extends AccessTokenProvider {
 
   override def getAccessToken: AccessTokenProvider.AccessToken = {
     val gToken = Option(adc.getAccessToken).getOrElse { adc.refresh(); adc.getAccessToken }
-    new AccessTokenProvider.AccessToken(gToken.getTokenValue, gToken.getExpirationTime.getTime)
+    new AccessTokenProvider.AccessToken(gToken.getTokenValue, gToken.getExpirationTime.toInstant)
   }
   override def refresh(): Unit = adc.refresh()
   override def setConf(c: Configuration): Unit = conf = Some(c)

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/avro/ParquetAvroIOTest.scala
@@ -433,7 +433,7 @@ class ParquetAvroIOTest extends ScioIOSpec with TapSpec with BeforeAndAfterAll {
         |{
         |"type":"record",
         |"name":"TestRecordProjection",
-        |"namespace":"com.spotify.scio.parquet.avro.ParquetAvroIOTest$",
+        |"namespace":"com.spotify.scio.parquet.avro.ParquetAvroIOTest",
         |"fields":[{"name":"int_field","type":["null", "int"]}]}
         |""".stripMargin
     )

--- a/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
+++ b/scio-smb/src/test/java/org/apache/beam/sdk/extensions/smb/ParquetAvroFileOperationsTest.java
@@ -55,7 +55,7 @@ public class ParquetAvroFileOperationsTest {
   private static final Schema USER_SCHEMA =
       SchemaBuilder.record("User")
           // intentionally set this namespace for testGenericRecord
-          .namespace("org.apache.beam.sdk.extensions.smb.ParquetAvroFileOperationsTest$")
+          .namespace("org.apache.beam.sdk.extensions.smb.ParquetAvroFileOperationsTest")
           .fields()
           .name("name")
           .type()

--- a/site/src/main/paradox/releases/Apache-Beam.md
+++ b/site/src/main/paradox/releases/Apache-Beam.md
@@ -36,12 +36,13 @@ Also check out the [SDK Version Support Status](https://cloud.google.com/dataflo
 
 | **Scio Version** | **Beam Version** | **Details**                                            |
 |:----------------:|:----------------:|:-------------------------------------------------------|
-|     0.15.5       |      2.72.0      |                                                        |
-|     0.15.4       |      2.71.0      | This version will be deprecated on January 22, 2027.   |
-|     0.15.3       |      2.71.0      | This version will be deprecated on January 22, 2027.   |
-|     0.15.2       |      2.70.0      | This version will be deprecated on December 16, 2026.  |
-|     0.15.1       |      2.68.0      | This version will be deprecated on September 22, 2026. |
-|     0.15.0       |      2.68.0      | This version will be deprecated on September 22, 2026. |
+|      0.15.6      |      2.74.0      | This version will be deprecated on June 2, 2027.       |
+|      0.15.5      |      2.72.0      | This version will be deprecated on March 30, 2027.     |
+|      0.15.4      |      2.71.0      | This version will be deprecated on January 22, 2027.   |
+|      0.15.3      |      2.71.0      | This version will be deprecated on January 22, 2027.   |
+|      0.15.2      |      2.70.0      | This version will be deprecated on December 16, 2026.  |
+|      0.15.1      |      2.68.0      | This version will be deprecated on September 22, 2026. |
+|      0.15.0      |      2.68.0      | This version will be deprecated on September 22, 2026. |
 |     0.14.20      |      2.68.0      | This version will be deprecated on September 22, 2026. |
 |     0.14.19      |      2.67.0      | This version will be deprecated on August 12, 2026.    |
 |     0.14.18      |      2.66.0      | This version will be deprecated on July 1, 2026.       |
@@ -84,7 +85,7 @@ Also check out the [SDK Version Support Status](https://cloud.google.com/dataflo
 
 Scio's other library dependencies are kept in sync with Beam's to avoid compatibility issues. Scio will typically _not_ bump dependency versions beyond what is supported in Beam due to the large test surface and the potential for data loss.
 
-You can find Beam's dependency list in its [Groovy config](https://github.com/apache/beam/blob/v2.62.0/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy) (substitute the version tag in the URL with the desired Beam version). Additionally, Beam keeps many of its Google dependencies in sync with a [central BOM](https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/24.0.0/artifact_details.html) (substitute the version tag in the URL with the value of `google_cloud_platform_libraries_bom` from Beam). Scio users who suspect incompatibility issues in their pipelines (common issues are GRPC, Netty, or Guava) can run `sbt evicted` and `sbt dependencyTree` to ensure their direct and transitive dependencies don't conflict with Scio or Beam.
+You can find Beam's dependency list in its [Groovy config](https://github.com/apache/beam/blob/v2.74.0/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy) (substitute the version tag in the URL with the desired Beam version). Additionally, Beam keeps many of its Google dependencies in sync with a [central BOM](https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/24.0.0/artifact_details.html) (substitute the version tag in the URL with the value of `google_cloud_platform_libraries_bom` from Beam). Scio users who suspect incompatibility issues in their pipelines (common issues are GRPC, Netty, or Guava) can run `sbt evicted` and `sbt dependencyTree` to ensure their direct and transitive dependencies don't conflict with Scio or Beam.
 
 ## Release cycle and backport procedures
 


### PR DESCRIPTION
Several of the beam deps were not aligned with GCP bom as previous versions of scio expected, so these are now independently managed.