### PR TITLE
(iceberg) Fix scala-to-java List conversion for managed config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1158,8 +1158,9 @@ lazy val `scio-managed` = project
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
       "com.spotify" %% "magnolify-beam" % magnolifyVersion,
       "com.spotify" %% "magnolify-shared" % magnolifyVersion,
-      "com.softwaremill.magnolia1_2" %% "magnolia" % magnoliaVersion
+      "com.softwaremill.magnolia1_2" %% "magnolia" % magnoliaVersion,
       // test
+      "org.yaml" % "snakeyaml" % "2.2" % Test
     ),
     // remove on next release
     tlMimaPreviousVersions := Set.empty

--- a/scio-managed/src/main/scala/com/spotify/scio/managed/ManagedIO.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/managed/ManagedIO.scala
@@ -64,8 +64,8 @@ object ManagedIO {
       a match {
         case m: Map[_, _] =>
           m.asInstanceOf[Map[_, Object]].map { case (k, v) => k -> _convert(v) }.asJava
-        case i: Iterable[_] => i.map(o => _convert(o.asInstanceOf[Object])).asJava
-        case _              => a
+        case i: Seq[_] => i.map(o => _convert(o.asInstanceOf[Object])).asJava
+        case _         => a
       }
     }
     config.map { case (k, v) => k -> _convert(v) }.asJava

--- a/scio-managed/src/test/scala/com/spotify/scio/iceberg/IcebergIOTest.scala
+++ b/scio-managed/src/test/scala/com/spotify/scio/iceberg/IcebergIOTest.scala
@@ -18,6 +18,9 @@ package com.spotify.scio.iceberg
 
 import com.spotify.scio.managed.ManagedIO
 import com.spotify.scio.testing.ScioIOSpec
+import org.apache.beam.sdk.schemas.utils.YamlUtils
+
+import scala.jdk.CollectionConverters._
 
 case class Fake(a: String, b: Int)
 
@@ -84,5 +87,28 @@ class IcebergIOTest extends ScioIOSpec {
 
     // don't throw
     configs.map(ManagedIO.convertConfig)
+  }
+
+  it should "produce Java iterables compatible with Beam ManagedIO's yaml-parsing library" in {
+    val config = ManagedIO.convertConfig(
+      IcebergIO[Fake]("tableName", Some("catalogName")).config(
+        IcebergIO.ReadParam(
+          Map("a" -> "b"),
+          Map("c" -> "d", "e" -> "f")
+        )
+      )
+    )
+
+    assert(
+      config == Map(
+        "config_properties" -> Map("c" -> "d", "e" -> "f").asJava,
+        "catalog_properties" -> Map("a" -> "b").asJava,
+        "table" -> "tableName",
+        "catalog_name" -> "catalogName"
+      ).asJava
+    )
+
+    // invoked by Beam's Managed transform internally; shouldn't throw
+    YamlUtils.yamlStringFromMap(config)
   }
 }


### PR DESCRIPTION
Fix https://github.com/spotify/scio/issues/5940

root cause: the `Iterable#toJava` conversion was producing an `IterableWrapper` not a Java list, which the SnakeYaml library apparently can't handle