### PR TITLE
(iceberg) Infer `keep` config from Magnolify RowType schema

### DIFF
--- a/integration/src/test/scala/com/spotify/scio/iceberg/IcebergIOIT.scala
+++ b/integration/src/test/scala/com/spotify/scio/iceberg/IcebergIOIT.scala
@@ -21,7 +21,13 @@ import com.spotify.scio.testing.PipelineSpec
 import magnolify.beam._
 import org.apache.iceberg.catalog.{Namespace, TableIdentifier}
 import org.apache.iceberg.rest.RESTCatalog
-import org.apache.iceberg.types.Types.{IntegerType, NestedField, StringType}
+import org.apache.iceberg.types.Types.{
+  BooleanType,
+  IntegerType,
+  NestedField,
+  StringType,
+  StructType
+}
 import org.apache.iceberg.{CatalogProperties, CatalogUtil, PartitionSpec, Schema}
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
 
@@ -30,7 +36,8 @@ import java.io.File
 import java.nio.file.Files
 import scala.jdk.CollectionConverters._
 
-case class IcebergIOITRecord(a: Int, b: String)
+case class Nested(d: Boolean)
+case class IcebergIOITRecord(a: Int, b: String, c: Nested)
 object IcebergIOITRecord {
   implicit val icebergIOITRecordRowType: RowType[IcebergIOITRecord] = RowType[IcebergIOITRecord]
 }
@@ -67,7 +74,12 @@ class IcebergIOIT extends PipelineSpec with ForAllTestContainer {
       TableIdentifier.parse(TableName),
       new Schema(
         NestedField.required(0, "a", IntegerType.get()),
-        NestedField.required(1, "b", StringType.get())
+        NestedField.required(1, "b", StringType.get()),
+        NestedField.required(
+          2,
+          "c",
+          StructType.of(NestedField.required(3, "d", BooleanType.get()))
+        )
       ),
       PartitionSpec.unpartitioned()
     )
@@ -78,7 +90,7 @@ class IcebergIOIT extends PipelineSpec with ForAllTestContainer {
       CatalogUtil.ICEBERG_CATALOG_TYPE -> CatalogUtil.ICEBERG_CATALOG_TYPE_REST,
       CatalogProperties.URI -> uri
     )
-    val elements = 1.to(10).map(i => IcebergIOITRecord(i, s"$i"))
+    val elements = 1.to(10).map(i => IcebergIOITRecord(i, s"$i", Nested(i % 2 == 0)))
 
     runWithRealContext() { sc =>
       sc.parallelize(elements)

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/IcebergIO.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/IcebergIO.scala
@@ -110,26 +110,26 @@ final case class IcebergIO[T: RowType: Coder](table: String, catalogName: Option
 object IcebergIO {
   case class ReadParam private (
     catalogProperties: Map[String, String] = ReadParam.DefaultCatalogProperties,
-    configProperties: Map[String, String] = ReadParam.DefaultConfigProperties,
+    configProperties: Map[String, String] = ReadParam.DefaultHadoopConfigProperties,
     filter: String = ReadParam.DefaultFilter
   )
 
   object ReadParam {
     val DefaultCatalogProperties: Map[String, String] = null
-    val DefaultConfigProperties: Map[String, String] = null
+    val DefaultHadoopConfigProperties: Map[String, String] = null
     val DefaultFilter: String = null
 
     implicit val configMap: ConfigMap.ConfigMapType[ReadParam] = ConfigMap.gen[ReadParam]
   }
   case class WriteParam private (
     catalogProperties: Map[String, String] = WriteParam.DefaultCatalogProperties,
-    configProperties: Map[String, String] = WriteParam.DefaultConfigProperties,
+    configProperties: Map[String, String] = WriteParam.DefaultHadoopConfigProperties,
     triggeringFrequencySeconds: Option[Int] = None,
     directWriteByteLimit: Option[Int] = None
   )
   object WriteParam {
     val DefaultCatalogProperties: Map[String, String] = null
-    val DefaultConfigProperties: Map[String, String] = null
+    val DefaultHadoopConfigProperties: Map[String, String] = null
     val DefaultTriggeringFrequencySeconds: Int = -1
     val DefaultDirectWriteByteLimit: Int = -1
 

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/IcebergIO.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/IcebergIO.scala
@@ -73,9 +73,25 @@ final case class IcebergIO[T: RowType: Coder](table: String, catalogName: Option
 
   override def testId: String = s"IcebergIO(${(Some(table) ++ catalogName).mkString(", ")})"
 
-  private[scio] def config[P](
+  private def baseConfig[P](
     params: P
   )(implicit mapper: ConfigMap.ConfigMapType[P]): Map[String, AnyRef] = {
+    val b = Map.newBuilder[String, AnyRef]
+    b += ("table" -> table)
+    catalogName.foreach(name => b += ("catalog_name" -> name))
+    b ++= mapper.toMap(params)
+
+    b.result()
+  }
+
+  private[scio] def config(params: WriteP)(implicit
+    mapper: ConfigMap.ConfigMapType[WriteP]
+  ): Map[String, AnyRef] =
+    baseConfig(params)
+
+  private[scio] def config(
+    params: ReadP
+  )(implicit mapper: ConfigMap.ConfigMapType[ReadP]): Map[String, AnyRef] = {
     def leafFieldNames(schema: BSchema, prefix: String = ""): List[String] =
       schema.getFields.asScala.toList.flatMap { field =>
         val name = if (prefix.isEmpty) field.getName else s"$prefix.${field.getName}"
@@ -85,13 +101,7 @@ final case class IcebergIO[T: RowType: Coder](table: String, catalogName: Option
           List(name)
       }
 
-    val b = Map.newBuilder[String, AnyRef]
-    b += ("table" -> table)
-    catalogName.foreach(name => b += ("catalog_name" -> name))
-    b += ("keep" -> leafFieldNames(rowType.schema))
-    b ++= mapper.toMap(params)
-
-    b.result()
+    baseConfig(params) + ("keep" -> leafFieldNames(rowType.schema))
   }
 
   override protected def read(sc: ScioContext, params: IcebergIO.ReadParam): SCollection[T] = {

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/IcebergIO.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/IcebergIO.scala
@@ -24,8 +24,10 @@ import magnolify.beam.RowType
 import org.apache.beam.sdk.managed.Managed
 import com.spotify.scio.managed.ManagedIO
 import org.apache.beam.sdk.coders.RowCoder
+import org.apache.beam.sdk.schemas.{Schema => BSchema}
 import org.apache.beam.sdk.values.Row
 import magnolia1._
+import scala.jdk.CollectionConverters._
 
 private[scio] object ConfigMap {
   type Typeclass[T] = ConfigMapType[T]
@@ -74,10 +76,21 @@ final case class IcebergIO[T: RowType: Coder](table: String, catalogName: Option
   private[scio] def config[P](
     params: P
   )(implicit mapper: ConfigMap.ConfigMapType[P]): Map[String, AnyRef] = {
+    def leafFieldNames(schema: BSchema, prefix: String = ""): List[String] =
+      schema.getFields.asScala.toList.flatMap { field =>
+        val name = if (prefix.isEmpty) field.getName else s"$prefix.${field.getName}"
+        if (field.getType.getTypeName == BSchema.TypeName.ROW)
+          leafFieldNames(field.getType.getRowSchema, name)
+        else
+          List(name)
+      }
+
     val b = Map.newBuilder[String, AnyRef]
     b += ("table" -> table)
     catalogName.foreach(name => b += ("catalog_name" -> name))
+    b += ("keep" -> leafFieldNames(rowType.schema))
     b ++= mapper.toMap(params)
+
     b.result()
   }
 
@@ -98,15 +111,12 @@ object IcebergIO {
   case class ReadParam private (
     catalogProperties: Map[String, String] = ReadParam.DefaultCatalogProperties,
     configProperties: Map[String, String] = ReadParam.DefaultConfigProperties,
-    keep: List[String] = ReadParam.DefaultKeep,
-    drop: List[String] = ReadParam.DefaultDrop,
     filter: String = ReadParam.DefaultFilter
   )
+
   object ReadParam {
     val DefaultCatalogProperties: Map[String, String] = null
     val DefaultConfigProperties: Map[String, String] = null
-    val DefaultKeep: List[String] = null
-    val DefaultDrop: List[String] = null
     val DefaultFilter: String = null
 
     implicit val configMap: ConfigMap.ConfigMapType[ReadParam] = ConfigMap.gen[ReadParam]
@@ -115,19 +125,13 @@ object IcebergIO {
     catalogProperties: Map[String, String] = WriteParam.DefaultCatalogProperties,
     configProperties: Map[String, String] = WriteParam.DefaultConfigProperties,
     triggeringFrequencySeconds: Option[Int] = None,
-    directWriteByteLimit: Option[Int] = None,
-    keep: List[String] = WriteParam.DefaultKeep,
-    drop: List[String] = WriteParam.DefaultDrop,
-    only: String = WriteParam.DefaultOnly
+    directWriteByteLimit: Option[Int] = None
   )
   object WriteParam {
     val DefaultCatalogProperties: Map[String, String] = null
     val DefaultConfigProperties: Map[String, String] = null
     val DefaultTriggeringFrequencySeconds: Int = -1
     val DefaultDirectWriteByteLimit: Int = -1
-    val DefaultKeep: List[String] = null
-    val DefaultDrop: List[String] = null
-    val DefaultOnly: String = null
 
     implicit val configMap: ConfigMap.ConfigMapType[WriteParam] = ConfigMap.gen[WriteParam]
   }

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergSCollectionSyntax.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergSCollectionSyntax.scala
@@ -35,10 +35,7 @@ class IcebergSCollectionSyntax[T: RowType: Coder](self: SCollection[T]) {
     catalogProperties: Map[String, String] = IcebergIO.WriteParam.DefaultCatalogProperties,
     configProperties: Map[String, String] = IcebergIO.WriteParam.DefaultConfigProperties,
     triggeringFrequencySeconds: Int = IcebergIO.WriteParam.DefaultTriggeringFrequencySeconds,
-    directWriteByteLimit: Int = IcebergIO.WriteParam.DefaultDirectWriteByteLimit,
-    keep: List[String] = IcebergIO.WriteParam.DefaultKeep,
-    drop: List[String] = IcebergIO.WriteParam.DefaultDrop,
-    only: String = IcebergIO.WriteParam.DefaultOnly
+    directWriteByteLimit: Int = IcebergIO.WriteParam.DefaultDirectWriteByteLimit
   ): ClosedTap[Nothing] = {
 
     val params = IcebergIO.WriteParam(
@@ -47,10 +44,7 @@ class IcebergSCollectionSyntax[T: RowType: Coder](self: SCollection[T]) {
       Option(triggeringFrequencySeconds).filter(
         _ != IcebergIO.WriteParam.DefaultTriggeringFrequencySeconds
       ),
-      Option(directWriteByteLimit).filter(_ != IcebergIO.WriteParam.DefaultDirectWriteByteLimit),
-      keep,
-      drop,
-      only
+      Option(directWriteByteLimit).filter(_ != IcebergIO.WriteParam.DefaultDirectWriteByteLimit)
     )
     self.write(IcebergIO(table, Option(catalogName)))(params)
   }

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergSCollectionSyntax.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergSCollectionSyntax.scala
@@ -25,15 +25,30 @@ import magnolify.beam.RowType
 class IcebergSCollectionSyntax[T: RowType: Coder](self: SCollection[T]) {
 
   /**
-   * @see
-   *   [[org.apache.beam.sdk.io.iceberg.IcebergWriteSchemaTransformProvider IcebergWriteSchemaTransformProvider]]
-   *   https://github.com/apache/beam/blob/v2.68.0/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergWriteSchemaTransformProvider.java#L135-L153
+   * Writes to an Iceberg table using Beam's [[org.apache.beam.sdk.managed.Managed]] IO.
+   *
+   * @param table
+   *   the unique identifier for the Iceberg table, in the format `{table_namespace}.{table_name}`.
+   * @param catalogName
+   *   the name of the Iceberg catalog
+   * @param catalogProperties
+   *   any additional properties required by the Iceberg catalog; see:
+   *   https://iceberg.apache.org/docs/latest/catalog-properties
+   * @param configProperties
+   *   any additional Hadoop configuration properties
+   * @param triggeringFrequencySeconds
+   *   (streaming only) frequency at which snapshots are produced
+   * @param directWriteByteLimit
+   *   (streaming only) limit for lifting bundles into the direct write path.
+   *
+   * For a complete reference, see:
+   * https://docs.cloud.google.com/dataflow/docs/guides/managed-io-iceberg
    */
   def saveAsIceberg(
     table: String,
     catalogName: String = null,
     catalogProperties: Map[String, String] = IcebergIO.WriteParam.DefaultCatalogProperties,
-    configProperties: Map[String, String] = IcebergIO.WriteParam.DefaultConfigProperties,
+    configProperties: Map[String, String] = IcebergIO.WriteParam.DefaultHadoopConfigProperties,
     triggeringFrequencySeconds: Int = IcebergIO.WriteParam.DefaultTriggeringFrequencySeconds,
     directWriteByteLimit: Int = IcebergIO.WriteParam.DefaultDirectWriteByteLimit
   ): ClosedTap[Nothing] = {

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergSCollectionSyntax.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergSCollectionSyntax.scala
@@ -34,7 +34,7 @@ class IcebergSCollectionSyntax[T: RowType: Coder](self: SCollection[T]) {
    * @param catalogProperties
    *   any additional properties required by the Iceberg catalog; see:
    *   https://iceberg.apache.org/docs/latest/catalog-properties
-   * @param configProperties
+   * @param hadoopConfigProperties
    *   any additional Hadoop configuration properties
    * @param triggeringFrequencySeconds
    *   (streaming only) frequency at which snapshots are produced
@@ -48,14 +48,15 @@ class IcebergSCollectionSyntax[T: RowType: Coder](self: SCollection[T]) {
     table: String,
     catalogName: String = null,
     catalogProperties: Map[String, String] = IcebergIO.WriteParam.DefaultCatalogProperties,
-    configProperties: Map[String, String] = IcebergIO.WriteParam.DefaultHadoopConfigProperties,
+    hadoopConfigProperties: Map[String, String] =
+      IcebergIO.WriteParam.DefaultHadoopConfigProperties,
     triggeringFrequencySeconds: Int = IcebergIO.WriteParam.DefaultTriggeringFrequencySeconds,
     directWriteByteLimit: Int = IcebergIO.WriteParam.DefaultDirectWriteByteLimit
   ): ClosedTap[Nothing] = {
 
     val params = IcebergIO.WriteParam(
       catalogProperties,
-      configProperties,
+      hadoopConfigProperties,
       Option(triggeringFrequencySeconds).filter(
         _ != IcebergIO.WriteParam.DefaultTriggeringFrequencySeconds
       ),

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergScioContextSyntax.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergScioContextSyntax.scala
@@ -25,15 +25,29 @@ import magnolify.beam.RowType
 class IcebergScioContextSyntax(self: ScioContext) {
 
   /**
-   * @see
-   *   [[org.apache.beam.sdk.io.iceberg.IcebergReadSchemaTransformProvider IcebergReadSchemaTransformProvider]]
-   *   https://github.com/apache/beam/blob/v2.68.0/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergReadSchemaTransformProvider.java#L107-L139
+   * Reads from an Iceberg table using Beam's [[org.apache.beam.sdk.managed.Managed]] IO.
+   *
+   * @param table
+   *   the unique identifier for the Iceberg table, in the format `{table_namespace}.{table_name}`.
+   * @param catalogName
+   *   the name of the Iceberg catalog
+   * @param catalogProperties
+   *   any additional properties required by the Iceberg catalog; see:
+   *   https://iceberg.apache.org/docs/latest/catalog-properties
+   * @param configProperties
+   *   any additional Hadoop configuration properties
+   * @param filter
+   *   the predicate to apply to the Iceberg read Multiple filters can be combined using AND/OR, for
+   *   example: `__PARTITIONTIME > '2026-01-01' AND age > 25`
+   *
+   * For a complete reference, see:
+   * https://docs.cloud.google.com/dataflow/docs/guides/managed-io-iceberg
    */
   def iceberg[T: Coder](
     table: String,
     catalogName: String = null,
     catalogProperties: Map[String, String] = IcebergIO.ReadParam.DefaultCatalogProperties,
-    configProperties: Map[String, String] = IcebergIO.ReadParam.DefaultConfigProperties,
+    configProperties: Map[String, String] = IcebergIO.ReadParam.DefaultHadoopConfigProperties,
     filter: String = IcebergIO.ReadParam.DefaultFilter
   )(implicit rt: RowType[T]): SCollection[T] = {
     val params = IcebergIO.ReadParam(catalogProperties, configProperties, filter)

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergScioContextSyntax.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergScioContextSyntax.scala
@@ -34,11 +34,9 @@ class IcebergScioContextSyntax(self: ScioContext) {
     catalogName: String = null,
     catalogProperties: Map[String, String] = IcebergIO.ReadParam.DefaultCatalogProperties,
     configProperties: Map[String, String] = IcebergIO.ReadParam.DefaultConfigProperties,
-    keep: List[String] = IcebergIO.ReadParam.DefaultKeep,
-    drop: List[String] = IcebergIO.ReadParam.DefaultDrop,
     filter: String = IcebergIO.ReadParam.DefaultFilter
   )(implicit rt: RowType[T]): SCollection[T] = {
-    val params = IcebergIO.ReadParam(catalogProperties, configProperties, keep, drop, filter)
+    val params = IcebergIO.ReadParam(catalogProperties, configProperties, filter)
     self.read(IcebergIO(table, Option(catalogName)))(params)
   }
 }

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergScioContextSyntax.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergScioContextSyntax.scala
@@ -34,7 +34,7 @@ class IcebergScioContextSyntax(self: ScioContext) {
    * @param catalogProperties
    *   any additional properties required by the Iceberg catalog; see:
    *   https://iceberg.apache.org/docs/latest/catalog-properties
-   * @param configProperties
+   * @param hadoopConfigProperties
    *   any additional Hadoop configuration properties
    * @param filter
    *   the predicate to apply to the Iceberg read Multiple filters can be combined using AND/OR, for
@@ -47,10 +47,10 @@ class IcebergScioContextSyntax(self: ScioContext) {
     table: String,
     catalogName: String = null,
     catalogProperties: Map[String, String] = IcebergIO.ReadParam.DefaultCatalogProperties,
-    configProperties: Map[String, String] = IcebergIO.ReadParam.DefaultHadoopConfigProperties,
+    hadoopConfigProperties: Map[String, String] = IcebergIO.ReadParam.DefaultHadoopConfigProperties,
     filter: String = IcebergIO.ReadParam.DefaultFilter
   )(implicit rt: RowType[T]): SCollection[T] = {
-    val params = IcebergIO.ReadParam(catalogProperties, configProperties, filter)
+    val params = IcebergIO.ReadParam(catalogProperties, hadoopConfigProperties, filter)
     self.read(IcebergIO(table, Option(catalogName)))(params)
   }
 }

--- a/scio-managed/src/test/scala/com/spotify/scio/iceberg/IcebergIOTest.scala
+++ b/scio-managed/src/test/scala/com/spotify/scio/iceberg/IcebergIOTest.scala
@@ -24,6 +24,8 @@ import scala.jdk.CollectionConverters._
 
 case class Fake(a: String, b: Int)
 
+case class FakeNested(a: String, b: Int, c: Fake)
+
 class IcebergIOTest extends ScioIOSpec {
   "IcebergIO" should "produce snake_case config maps" in {
     val io = IcebergIO[Fake]("tableName", Some("catalogName"))
@@ -33,15 +35,11 @@ class IcebergIOTest extends ScioIOSpec {
       IcebergIO.ReadParam(
         Map.empty,
         Map.empty,
-        List.empty,
-        List.empty,
         ""
       ),
       IcebergIO.ReadParam(
         Map("catalogProp1" -> "catalogProp1Value"),
         Map("configProp1" -> "configProp1Value", "configProp2" -> "configProp2Value"),
-        List("keep1", "keep2", "keep3"),
-        List("drop1", "drop2", "drop3"),
         "id > 10"
       )
     )
@@ -51,19 +49,13 @@ class IcebergIOTest extends ScioIOSpec {
         Map.empty,
         Map.empty,
         None,
-        None,
-        List.empty,
-        List.empty,
-        ""
+        None
       ),
       IcebergIO.WriteParam(
         Map("catalogProp1" -> "catalogProp1Value"),
         Map("configProp1" -> "configProp1Value", "configProp2" -> "configProp2Value"),
         Some(10),
-        Some(100),
-        List("keep1", "keep2", "keep3"),
-        List("drop1", "drop2", "drop3"),
-        "only"
+        Some(100)
       )
     )
 
@@ -75,13 +67,11 @@ class IcebergIOTest extends ScioIOSpec {
       "catalog_properties",
       "config_properties",
       "keep",
-      "drop",
       // reads
       "filter",
       // writes
       "triggering_frequency_seconds",
-      "direct_write_byte_limit",
-      "only"
+      "direct_write_byte_limit"
     )
     assert(configs.flatMap(_.keys).toSet.intersect(expectedKeys) == expectedKeys)
 
@@ -110,5 +100,26 @@ class IcebergIOTest extends ScioIOSpec {
 
     // invoked by Beam's Managed transform internally; shouldn't throw
     YamlUtils.yamlStringFromMap(config)
+  }
+
+  it should "infer correct read config for Magnolify RowTypes" in {
+    val io = IcebergIO[FakeNested]("tableName", Some("catalogName"))
+
+    val readParam = IcebergIO.ReadParam(
+      Map("a" -> "b"),
+      Map("c" -> "d", "e" -> "f"),
+      "id > 10"
+    )
+
+    val managedConfig: Map[String, AnyRef] = io.config(readParam)
+
+    managedConfig should contain only (
+      "config_properties" -> Map("c" -> "d", "e" -> "f"),
+      "filter" -> "id > 10",
+      "catalog_properties" -> Map("a" -> "b"),
+      "table" -> "tableName",
+      "keep" -> List("a", "b", "c.a", "c.b"),
+      "catalog_name" -> "catalogName"
+    )
   }
 }

--- a/scio-managed/src/test/scala/com/spotify/scio/iceberg/IcebergIOTest.scala
+++ b/scio-managed/src/test/scala/com/spotify/scio/iceberg/IcebergIOTest.scala
@@ -94,7 +94,8 @@ class IcebergIOTest extends ScioIOSpec {
         "config_properties" -> Map("c" -> "d", "e" -> "f").asJava,
         "catalog_properties" -> Map("a" -> "b").asJava,
         "table" -> "tableName",
-        "catalog_name" -> "catalogName"
+        "catalog_name" -> "catalogName",
+        "keep" -> List("a", "b").asJava
       ).asJava
     )
 
@@ -119,6 +120,24 @@ class IcebergIOTest extends ScioIOSpec {
       "catalog_properties" -> Map("a" -> "b"),
       "table" -> "tableName",
       "keep" -> List("a", "b", "c.a", "c.b"),
+      "catalog_name" -> "catalogName"
+    )
+  }
+
+  it should "infer correct write config for Magnolify RowTypes" in {
+    val io = IcebergIO[FakeNested]("tableName", Some("catalogName"))
+
+    val writeParam = IcebergIO.WriteParam(
+      Map("a" -> "b"),
+      Map("c" -> "d", "e" -> "f")
+    )
+
+    val managedConfig: Map[String, AnyRef] = io.config(writeParam)
+
+    managedConfig should contain only (
+      "config_properties" -> Map("c" -> "d", "e" -> "f"),
+      "catalog_properties" -> Map("a" -> "b"),
+      "table" -> "tableName",
       "catalog_name" -> "catalogName"
     )
   }


### PR DESCRIPTION
Fix #5941 https://github.com/spotify/scio/issues/5939

Infers `keep` based on case class fields, since that presumably represents the desired projection.

It does mean we get rid of `drop`/`only` since they're mutually exclusive with `keep`.

Also updates Scaladoc
