### PR TITLE
Update zstd-jni from 1.5.6-3 to 1.5.6-5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ val jodaTimeVersion = "2.14.0"
 val nettyVersion = "4.1.130.Final"
 val protobufVersion = "4.33.2"
 val slf4jVersion = "2.0.16"
-val zstdJniVersion = "1.5.6-3"
+val zstdJniVersion = "1.5.6-5"
 // dependent versions
 val googleApiServicesBigQueryVersion = s"v2-rev20251012-$googleClientsVersion"
 val googleApiServicesDataflowVersion = s"v1b3-rev20260405-$googleClientsVersion"


### PR DESCRIPTION
Fixes build error when Snowflake deps are included, in conjonction with `SnowflakeIO`.

```
[error] found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error]
[error] 	* com.github.luben:zstd-jni:1.5.6-5 (strict) is selected over {1.5.6-3, 1.5.6-3} for compile
[error] 	    +- net.snowflake:snowflake-ingest-sdk:4.4.2           (depends on 1.5.6-5)
[error] 	    +- com.spotify:scio-core_2.13:0.15.7                  (depends on 1.5.6-3)
```