### PR TITLE
Fix FixBigtableIO scalafix rule mangling named arguments

### DIFF
--- a/scalafix/input-0_15/src/main/scala/fix/v0_15_0/FixBigtableIO.scala
+++ b/scalafix/input-0_15/src/main/scala/fix/v0_15_0/FixBigtableIO.scala
@@ -26,6 +26,21 @@ object FixBigtableIO {
   // 3-arg call - should NOT be fixed
   sc.bigtable("project", "instance", "table")
 
+  // 4-arg call with named rowFilter - should migrate to BTOptions, preserve named arg
+  sc.bigtable("project", "instance", "table", rowFilter = rowFilter)
+
+  // 4-arg call with named keyRanges - should migrate to BTOptions, preserve named arg
+  sc.bigtable("project", "instance", "table", keyRanges = keyRanges)
+
+  // 5-arg call with both named - should migrate to BTOptions, preserve named args
+  sc.bigtable("project", "instance", "table", keyRanges = keyRanges, rowFilter = rowFilter)
+
+  // 5-arg call with named keyRanges, positional rowFilter - should migrate to BTOptions
+  sc.bigtable("project", "instance", "table", keyRanges = keyRanges, rowFilter)
+
+  // 5-arg call with positional keyRanges, named rowFilter - should migrate to BTOptions
+  sc.bigtable("project", "instance", "table", keyRanges, rowFilter = rowFilter)
+
   // 6-arg call already explicit - should NOT be fixed
   sc.bigtable("project", "instance", "table", keyRanges, rowFilter, None)
 }

--- a/scalafix/output-0_15/src/main/scala/fix/v0_15_0/FixBigtableIO.scala
+++ b/scalafix/output-0_15/src/main/scala/fix/v0_15_0/FixBigtableIO.scala
@@ -24,6 +24,21 @@ object FixBigtableIO {
   // 3-arg call - should NOT be fixed
   sc.bigtable("project", "instance", "table")
 
+  // 4-arg call with named rowFilter - should migrate to BTOptions, preserve named arg
+  sc.bigtable(BTOptions("project", "instance"), "table", rowFilter = rowFilter)
+
+  // 4-arg call with named keyRanges - should migrate to BTOptions, preserve named arg
+  sc.bigtable(BTOptions("project", "instance"), "table", keyRanges = keyRanges)
+
+  // 5-arg call with both named - should migrate to BTOptions, preserve named args
+  sc.bigtable(BTOptions("project", "instance"), "table", keyRanges = keyRanges, rowFilter = rowFilter)
+
+  // 5-arg call with named keyRanges, positional rowFilter - should migrate to BTOptions
+  sc.bigtable(BTOptions("project", "instance"), "table", keyRanges = keyRanges, rowFilter = rowFilter)
+
+  // 5-arg call with positional keyRanges, named rowFilter - should migrate to BTOptions
+  sc.bigtable(BTOptions("project", "instance"), "table", keyRanges = keyRanges, rowFilter = rowFilter)
+
   // 6-arg call already explicit - should NOT be fixed
   sc.bigtable("project", "instance", "table", keyRanges, rowFilter, None)
 }

--- a/scalafix/rules/src/main/scala/fix/v0_15_0/FixBigtableIO.scala
+++ b/scalafix/rules/src/main/scala/fix/v0_15_0/FixBigtableIO.scala
@@ -29,9 +29,13 @@ final class FixBigtableIO extends SemanticRule("FixBigtableIO") {
               val tableId = params(2)
               val rest = params.drop(3)
               val namedArgs = rest.zipWithIndex.map { case (arg, i) =>
-                i match {
-                  case 0 => q"keyRanges = $arg"
-                  case 1 => q"rowFilter = $arg"
+                arg match {
+                  case _: Term.Assign => arg
+                  case _ =>
+                    i match {
+                      case 0 => q"keyRanges = $arg"
+                      case 1 => q"rowFilter = $arg"
+                    }
                 }
               }
               val newParams = List(q"BTOptions($projectId, $instanceId)", tableId) ++ namedArgs


### PR DESCRIPTION
## Summary
- The `FixBigtableIO` scalafix rule assumed rest args after `(projectId, instanceId, tableId)` were always positional, blindly wrapping index 0 with `keyRanges =` and index 1 with `rowFilter =`
- When the original code used a named argument like `rowFilter = ...` (skipping `keyRanges`), this produced invalid code: `keyRanges = rowFilter = ...`
- Fix checks if each arg is already a `Term.Assign` (named arg) and passes it through unchanged instead of wrapping it

## Test plan
- [x] Added test cases for all missing named-argument arities (4-arg named `keyRanges`, 4-arg named `rowFilter`, 5-arg both named, 5-arg mixed named/positional)
- [x] All existing tests continue to pass
- [x] `sbt "tests-scio-0_152_12/test"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)