### PR TITLE
Fix GCS/hadoop read options

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -48,6 +48,7 @@ import scala.collection.mutable.{Buffer => MBuffer}
 import scala.concurrent.duration.Duration
 import scala.io.Source
 import scala.reflect.ClassTag
+import scala.util.chaining._
 import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success, Try}
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions
@@ -474,26 +475,50 @@ class ScioContext private[scio] (
       val long: Getter[java.lang.Long] = (k, d) => config.getLong(k, d)
       val int: Getter[java.lang.Integer] = (k, d) => config.getInt(k, d)
 
+      type Builder = GoogleCloudStorageReadOptions.Builder
       implicit class PropOps[T](val prop: HadoopConfigurationProperty[T]) {
-        def ifSet(getter: Getter[T])(setter: T => Any): Unit =
-          if (config.get(prop.getKey) != null) setter(prop.get(config, getter))
-        def ifSetDuration(setter: java.time.Duration => Any): Unit =
-          if (config.get(prop.getKey) != null) setter(prop.getTimeDuration(config))
+        def ifSet(getter: Getter[T])(setter: Builder => T => Builder)(b: Builder): Builder =
+          if (config.get(prop.getKey) != null) setter(b)(prop.get(config, getter)) else b
+        def ifSetDuration(setter: Builder => java.time.Duration => Builder)(b: Builder): Builder =
+          if (config.get(prop.getKey) != null) setter(b)(prop.getTimeDuration(config)) else b
       }
 
-      val b = GoogleCloudStorageReadOptions.builder()
-      GCS_INPUT_STREAM_FADVISE.ifSet(fadvise)(b.setFadvise(_))
-      GCS_INPUT_STREAM_FAST_FAIL_ON_NOT_FOUND_ENABLE.ifSet(bool)(b.setFastFailOnNotFoundEnabled(_))
-      GCS_INPUT_STREAM_SUPPORT_GZIP_ENCODING_ENABLE.ifSet(bool)(b.setGzipEncodingSupportEnabled(_))
-      GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.ifSet(longBytes)(b.setInplaceSeekLimit(_))
-      GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.ifSet(longBytes)(b.setMinRangeRequestSize(_))
-      GCS_GRPC_CHECKSUMS_ENABLE.ifSet(bool)(b.setGrpcChecksumsEnabled(_))
-      GCS_GRPC_READ_TIMEOUT.ifSetDuration(b.setGrpcReadTimeout(_))
-      GCS_GRPC_READ_MESSAGE_TIMEOUT.ifSetDuration(b.setGrpcReadMessageTimeout(_))
-      GCS_GRPC_READ_ZEROCOPY_ENABLE.ifSet(bool)(b.setGrpcReadZeroCopyEnabled(_))
-      BLOCK_SIZE.ifSet(long)(b.setBlockSize(_))
-      GCS_FADVISE_REQUEST_TRACK_COUNT.ifSet(int)(b.setFadviseRequestTrackCount(_))
-      o.setGoogleCloudStorageReadOptions(b.build())
+      o.setGoogleCloudStorageReadOptions(
+        GoogleCloudStorageReadOptions
+          .builder()
+          .pipe(GCS_INPUT_STREAM_FADVISE.ifSet(fadvise)(_.setFadvise))
+          .pipe(
+            GCS_INPUT_STREAM_FAST_FAIL_ON_NOT_FOUND_ENABLE.ifSet(bool)(b =>
+              v => b.setFastFailOnNotFoundEnabled(v)
+            )
+          )
+          .pipe(
+            GCS_INPUT_STREAM_SUPPORT_GZIP_ENCODING_ENABLE.ifSet(bool)(b =>
+              v => b.setGzipEncodingSupportEnabled(v)
+            )
+          )
+          .pipe(
+            GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.ifSet(longBytes)(b => v => b.setInplaceSeekLimit(v))
+          )
+          .pipe(
+            GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.ifSet(longBytes)(b =>
+              v => b.setMinRangeRequestSize(v)
+            )
+          )
+          .pipe(GCS_GRPC_CHECKSUMS_ENABLE.ifSet(bool)(b => v => b.setGrpcChecksumsEnabled(v)))
+          .pipe(GCS_GRPC_READ_TIMEOUT.ifSetDuration(b => v => b.setGrpcReadTimeout(v)))
+          .pipe(
+            GCS_GRPC_READ_MESSAGE_TIMEOUT.ifSetDuration(b => v => b.setGrpcReadMessageTimeout(v))
+          )
+          .pipe(
+            GCS_GRPC_READ_ZEROCOPY_ENABLE.ifSet(bool)(b => v => b.setGrpcReadZeroCopyEnabled(v))
+          )
+          .pipe(BLOCK_SIZE.ifSet(long)(b => v => b.setBlockSize(v)))
+          .pipe(
+            GCS_FADVISE_REQUEST_TRACK_COUNT.ifSet(int)(b => v => b.setFadviseRequestTrackCount(v))
+          )
+          .build()
+      )
     } catch {
       // Hadoop and/or gcs-connector is excluded from classpath, do not try to set options
       case _: LinkageError =>

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -461,6 +461,7 @@ class ScioContext private[scio] (
     import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration._
     import com.google.cloud.hadoop.fs.gcs.HadoopConfigurationProperty
     import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions
+    import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.{Builder, Fadvise}
 
     try {
       // If Hadoop is on the classpath, try to parse default gcs-connector options
@@ -469,53 +470,65 @@ class ScioContext private[scio] (
       val o = optionsAs[GcsOptions]
 
       type Getter[T] = java.util.function.BiFunction[String, T, T]
-      val fadvise: Getter[GoogleCloudStorageReadOptions.Fadvise] = (k, d) => config.getEnum(k, d)
+      val fadvise: Getter[Fadvise] = (k, d) => config.getEnum(k, d)
       val bool: Getter[java.lang.Boolean] = (k, d) => config.getBoolean(k, d)
       val longBytes: Getter[java.lang.Long] = (k, d) => config.getLongBytes(k, d)
       val long: Getter[java.lang.Long] = (k, d) => config.getLong(k, d)
       val int: Getter[java.lang.Integer] = (k, d) => config.getInt(k, d)
 
-      type Builder = GoogleCloudStorageReadOptions.Builder
       implicit class PropOps[T](val prop: HadoopConfigurationProperty[T]) {
-        def ifSet(getter: Getter[T])(setter: Builder => T => Builder)(b: Builder): Builder =
-          if (config.get(prop.getKey) != null) setter(b)(prop.get(config, getter)) else b
-        def ifSetDuration(setter: Builder => java.time.Duration => Builder)(b: Builder): Builder =
-          if (config.get(prop.getKey) != null) setter(b)(prop.getTimeDuration(config)) else b
+        def ifSet(getter: Getter[T], setter: (Builder, T) => Builder)(b: Builder): Builder =
+          if (config.get(prop.getKey) != null) setter(b, prop.get(config, getter)) else b
+        def ifSetDuration(setter: (Builder, java.time.Duration) => Builder)(b: Builder): Builder =
+          if (config.get(prop.getKey) != null) setter(b, prop.getTimeDuration(config)) else b
       }
 
       o.setGoogleCloudStorageReadOptions(
         GoogleCloudStorageReadOptions
           .builder()
-          .pipe(GCS_INPUT_STREAM_FADVISE.ifSet(fadvise)(_.setFadvise))
           .pipe(
-            GCS_INPUT_STREAM_FAST_FAIL_ON_NOT_FOUND_ENABLE.ifSet(bool)(b =>
-              v => b.setFastFailOnNotFoundEnabled(v)
-            )
+            GCS_INPUT_STREAM_FADVISE
+              .ifSet(fadvise, (b, v) => b.setFadvise(v))
           )
           .pipe(
-            GCS_INPUT_STREAM_SUPPORT_GZIP_ENCODING_ENABLE.ifSet(bool)(b =>
-              v => b.setGzipEncodingSupportEnabled(v)
-            )
+            GCS_INPUT_STREAM_FAST_FAIL_ON_NOT_FOUND_ENABLE
+              .ifSet(bool, (b, v) => b.setFastFailOnNotFoundEnabled(v))
           )
           .pipe(
-            GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.ifSet(longBytes)(b => v => b.setInplaceSeekLimit(v))
+            GCS_INPUT_STREAM_SUPPORT_GZIP_ENCODING_ENABLE
+              .ifSet(bool, (b, v) => b.setGzipEncodingSupportEnabled(v))
           )
           .pipe(
-            GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.ifSet(longBytes)(b =>
-              v => b.setMinRangeRequestSize(v)
-            )
-          )
-          .pipe(GCS_GRPC_CHECKSUMS_ENABLE.ifSet(bool)(b => v => b.setGrpcChecksumsEnabled(v)))
-          .pipe(GCS_GRPC_READ_TIMEOUT.ifSetDuration(b => v => b.setGrpcReadTimeout(v)))
-          .pipe(
-            GCS_GRPC_READ_MESSAGE_TIMEOUT.ifSetDuration(b => v => b.setGrpcReadMessageTimeout(v))
+            GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT
+              .ifSet(longBytes, (b, v) => b.setInplaceSeekLimit(v))
           )
           .pipe(
-            GCS_GRPC_READ_ZEROCOPY_ENABLE.ifSet(bool)(b => v => b.setGrpcReadZeroCopyEnabled(v))
+            GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE
+              .ifSet(longBytes, (b, v) => b.setMinRangeRequestSize(v))
           )
-          .pipe(BLOCK_SIZE.ifSet(long)(b => v => b.setBlockSize(v)))
           .pipe(
-            GCS_FADVISE_REQUEST_TRACK_COUNT.ifSet(int)(b => v => b.setFadviseRequestTrackCount(v))
+            GCS_GRPC_CHECKSUMS_ENABLE
+              .ifSet(bool, (b, v) => b.setGrpcChecksumsEnabled(v))
+          )
+          .pipe(
+            GCS_GRPC_READ_TIMEOUT
+              .ifSetDuration((b, v) => b.setGrpcReadTimeout(v))
+          )
+          .pipe(
+            GCS_GRPC_READ_MESSAGE_TIMEOUT
+              .ifSetDuration((b, v) => b.setGrpcReadMessageTimeout(v))
+          )
+          .pipe(
+            GCS_GRPC_READ_ZEROCOPY_ENABLE
+              .ifSet(bool, (b, v) => b.setGrpcReadZeroCopyEnabled(v))
+          )
+          .pipe(
+            BLOCK_SIZE
+              .ifSet(long, (b, v) => b.setBlockSize(v))
+          )
+          .pipe(
+            GCS_FADVISE_REQUEST_TRACK_COUNT
+              .ifSet(int, (b, v) => b.setFadviseRequestTrackCount(v))
           )
           .build()
       )

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -48,7 +48,6 @@ import scala.collection.mutable.{Buffer => MBuffer}
 import scala.concurrent.duration.Duration
 import scala.io.Source
 import scala.reflect.ClassTag
-import scala.util.chaining._
 import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success, Try}
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions
@@ -458,65 +457,43 @@ class ScioContext private[scio] (
 
   {
     import org.apache.hadoop.conf.Configuration
-    import com.google.cloud.hadoop.fs.gcs.{GoogleHadoopFileSystemConfiguration => GfsConfig}
+    import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration._
+    import com.google.cloud.hadoop.fs.gcs.HadoopConfigurationProperty
     import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions
 
     try {
       // If Hadoop is on the classpath, try to parse default gcs-connector options
+      // Todo replace with getReadChannelOptions when GoogleCloudDataproc/hadoop-connectors#1294 is released
       val config = new Configuration()
       val o = optionsAs[GcsOptions]
 
-      // Todo replace with built-in parser from gcsio when GoogleCloudDataproc/hadoop-connectors#1294 is merged
-      o.setGoogleCloudStorageReadOptions(
-        GoogleCloudStorageReadOptions
-          .builder()
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_INPUT_STREAM_FAST_FAIL_ON_NOT_FOUND_ENABLE.getKey))
-              .map(_.toBoolean)
-              .fold(o)(o.setFastFailOnNotFoundEnabled)
-          )
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_INPUT_STREAM_SUPPORT_GZIP_ENCODING_ENABLE.getKey))
-              .map(_.toBoolean)
-              .fold(o)(o.setGzipEncodingSupportEnabled)
-          )
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.getKey))
-              .map(_.toLong)
-              .fold(o)(o.setInplaceSeekLimit)
-          )
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_INPUT_STREAM_FADVISE.getKey))
-              .map(GoogleCloudStorageReadOptions.Fadvise.valueOf)
-              .fold(o)(o.setFadvise)
-          )
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.getKey))
-              .map(_.toLong)
-              .fold(o)(o.setMinRangeRequestSize)
-          )
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_GRPC_CHECKSUMS_ENABLE.getKey))
-              .map(_.toBoolean)
-              .fold(o)(o.setGrpcChecksumsEnabled)
-          )
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_GRPC_READ_TIMEOUT.getKey))
-              .map(v => java.time.Duration.ofMillis(v.toLong))
-              .fold(o)(o.setGrpcReadTimeout)
-          )
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_GRPC_READ_MESSAGE_TIMEOUT.getKey))
-              .map(v => java.time.Duration.ofMillis(v.toLong))
-              .fold(o)(o.setGrpcReadMessageTimeout)
-          )
-          .pipe(o =>
-            Option(config.get(GfsConfig.GCS_GRPC_READ_ZEROCOPY_ENABLE.getKey))
-              .map(_.toBoolean)
-              .fold(o)(o.setGrpcReadZeroCopyEnabled)
-          )
-          .build()
-      )
+      type Getter[T] = java.util.function.BiFunction[String, T, T]
+      val fadvise: Getter[GoogleCloudStorageReadOptions.Fadvise] = (k, d) => config.getEnum(k, d)
+      val bool: Getter[java.lang.Boolean] = (k, d) => config.getBoolean(k, d)
+      val longBytes: Getter[java.lang.Long] = (k, d) => config.getLongBytes(k, d)
+      val long: Getter[java.lang.Long] = (k, d) => config.getLong(k, d)
+      val int: Getter[java.lang.Integer] = (k, d) => config.getInt(k, d)
+
+      implicit class PropOps[T](val prop: HadoopConfigurationProperty[T]) {
+        def ifSet(getter: Getter[T])(setter: T => Any): Unit =
+          if (config.get(prop.getKey) != null) setter(prop.get(config, getter))
+        def ifSetDuration(setter: java.time.Duration => Any): Unit =
+          if (config.get(prop.getKey) != null) setter(prop.getTimeDuration(config))
+      }
+
+      val b = GoogleCloudStorageReadOptions.builder()
+      GCS_INPUT_STREAM_FADVISE.ifSet(fadvise)(b.setFadvise(_))
+      GCS_INPUT_STREAM_FAST_FAIL_ON_NOT_FOUND_ENABLE.ifSet(bool)(b.setFastFailOnNotFoundEnabled(_))
+      GCS_INPUT_STREAM_SUPPORT_GZIP_ENCODING_ENABLE.ifSet(bool)(b.setGzipEncodingSupportEnabled(_))
+      GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.ifSet(longBytes)(b.setInplaceSeekLimit(_))
+      GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.ifSet(longBytes)(b.setMinRangeRequestSize(_))
+      GCS_GRPC_CHECKSUMS_ENABLE.ifSet(bool)(b.setGrpcChecksumsEnabled(_))
+      GCS_GRPC_READ_TIMEOUT.ifSetDuration(b.setGrpcReadTimeout(_))
+      GCS_GRPC_READ_MESSAGE_TIMEOUT.ifSetDuration(b.setGrpcReadMessageTimeout(_))
+      GCS_GRPC_READ_ZEROCOPY_ENABLE.ifSet(bool)(b.setGrpcReadZeroCopyEnabled(_))
+      BLOCK_SIZE.ifSet(long)(b.setBlockSize(_))
+      GCS_FADVISE_REQUEST_TRACK_COUNT.ifSet(int)(b.setFadviseRequestTrackCount(_))
+      o.setGoogleCloudStorageReadOptions(b.build())
     } catch {
       // Hadoop and/or gcs-connector is excluded from classpath, do not try to set options
       case _: LinkageError =>

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -473,7 +473,6 @@ class ScioContext private[scio] (
       val fadvise: Getter[Fadvise] = (k, d) => config.getEnum(k, d)
       val bool: Getter[java.lang.Boolean] = (k, d) => config.getBoolean(k, d)
       val longBytes: Getter[java.lang.Long] = (k, d) => config.getLongBytes(k, d)
-      val long: Getter[java.lang.Long] = (k, d) => config.getLong(k, d)
       val int: Getter[java.lang.Integer] = (k, d) => config.getInt(k, d)
 
       implicit class PropOps[T](val prop: HadoopConfigurationProperty[T]) {
@@ -524,7 +523,7 @@ class ScioContext private[scio] (
           )
           .pipe(
             BLOCK_SIZE
-              .ifSet(long, (b, v) => b.setBlockSize(v))
+              .ifSet(longBytes, (b, v) => b.setBlockSize(v))
           )
           .pipe(
             GCS_FADVISE_REQUEST_TRACK_COUNT

--- a/scio-core/src/test/resources/gcs-read-options-test.xml
+++ b/scio-core/src/test/resources/gcs-read-options-test.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>fs.gs.inputstream.fadvise</name>
+    <value>RANDOM</value>
+  </property>
+  <property>
+    <name>fs.gs.inputstream.fast.fail.on.not.found.enable</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>fs.gs.inputstream.support.gzip.encoding.enable</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>fs.gs.inputstream.inplace.seek.limit</name>
+    <value>8m</value>
+  </property>
+  <property>
+    <name>fs.gs.inputstream.min.range.request.size</name>
+    <value>512k</value>
+  </property>
+  <property>
+    <name>fs.gs.grpc.checksums.enable</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>fs.gs.grpc.read.timeout</name>
+    <value>60s</value>
+  </property>
+  <property>
+    <name>fs.gs.grpc.read.message.timeout</name>
+    <value>7s</value>
+  </property>
+  <property>
+    <name>fs.gs.grpc.read.zerocopy.enable</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>fs.gs.block.size</name>
+    <value>64m</value>
+  </property>
+  <property>
+    <name>fs.gs.fadvise.request.track.count</name>
+    <value>3</value>
+  </property>
+</configuration>

--- a/scio-core/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -331,6 +331,28 @@ class ScioContextTest extends PipelineSpec {
     }
   }
 
+  "ScioContext" should "parse GCS read options from Hadoop configuration" in {
+    import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise
+    import org.apache.beam.sdk.extensions.gcp.options.GcsOptions
+
+    org.apache.hadoop.conf.Configuration.addDefaultResource("gcs-read-options-test.xml")
+
+    val sc = ScioContext()
+    val readOpts = sc.optionsAs[GcsOptions].getGoogleCloudStorageReadOptions
+
+    readOpts.getFadvise shouldBe Fadvise.RANDOM
+    readOpts.isFastFailOnNotFoundEnabled shouldBe true
+    readOpts.isGzipEncodingSupportEnabled shouldBe true
+    readOpts.getInplaceSeekLimit shouldBe 8388608L
+    readOpts.getMinRangeRequestSize shouldBe 524288L
+    readOpts.isGrpcChecksumsEnabled shouldBe true
+    readOpts.getGrpcReadTimeout shouldBe java.time.Duration.ofSeconds(60)
+    readOpts.getGrpcReadMessageTimeout shouldBe java.time.Duration.ofSeconds(7)
+    readOpts.isGrpcReadZeroCopyEnabled shouldBe true
+    readOpts.getBlockSize shouldBe 67108864L
+    readOpts.getFadviseRequestTrackCount shouldBe 3
+  }
+
   "RunnerContext" should "include ~/.m2, ~/.ivy2, ~/.cache/coursier, and ~/.sbt/boot/ dirs, but not other env dirs" in {
     val userDir = sys.props("user.home").replace("\\", "/")
     val paths1 = List(


### PR DESCRIPTION
Previous version did not correctly parse allowed config values with units, e.g. `8m` (8 mega[bytes]) etc

For fun, there's a little type dance to get around the java-scala type interface and some meta to make the actual setting somewhat legible