### PR TITLE
Disable parquet vectored reads to fix gcs-connector incompatibility

### DIFF
--- a/scio-parquet/src/main/resources/core-site.xml
+++ b/scio-parquet/src/main/resources/core-site.xml
@@ -30,4 +30,8 @@
     <name>parquet.avro.compatible</name>
     <value>false</value>
   </property>
+  <property>
+    <name>parquet.hadoop.vectored.io.enabled</name>
+    <value>false</value>
+  </property>
 </configuration>


### PR DESCRIPTION
## Summary
- Disables parquet-hadoop vectored reads via `parquet.hadoop.vectored.io.enabled=false` in `core-site.xml`
- gcs-connector 3.1.16 calls `VectoredReadUtils.validateRangeRequest(FileRange)` expecting a `void` return, but hadoop-common 3.4.3 changed the return type to `FileRange`, causing `NoSuchMethodError` at runtime when parquet-hadoop attempts vectored reads through `GoogleHadoopFileSystem`
- This affects the legacy `HadoopFormatIO` read path (used when `UseSplittableDoFn=false`)

## Test plan
- [x] Reproduced via integration test in #5950 (`ParquetReadIT`)
- [ ] Verify integration test passes with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)