### PR TITLE
Sync scio-smb core-site.xml and add parity test

### DIFF
--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/CoreSiteXmlTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/CoreSiteXmlTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.scio.parquet
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.{Files, Paths}
+
+class CoreSiteXmlTest extends AnyFlatSpec with Matchers {
+
+  "core-site.xml" should "be identical in scio-parquet and scio-smb" in {
+    val parquetCoreSite = Paths.get("src/main/resources/core-site.xml")
+    val smbCoreSite = Paths.get("../scio-smb/src/main/resources/core-site.xml")
+
+    Files.exists(parquetCoreSite) shouldBe true
+    Files.exists(smbCoreSite) shouldBe true
+
+    val parquetContent = Files.readString(parquetCoreSite)
+    val smbContent = Files.readString(smbCoreSite)
+
+    parquetContent shouldBe smbContent
+  }
+}

--- a/scio-smb/src/main/resources/core-site.xml
+++ b/scio-smb/src/main/resources/core-site.xml
@@ -30,4 +30,8 @@
     <name>parquet.avro.compatible</name>
     <value>false</value>
   </property>
+  <property>
+    <name>parquet.hadoop.vectored.io.enabled</name>
+    <value>false</value>
+  </property>
 </configuration>


### PR DESCRIPTION
## Summary
- Adds `parquet.hadoop.vectored.io.enabled=false` to scio-smb's `core-site.xml` to match scio-parquet (fixes gcs-connector incompatibility from #5954)
- Adds a test in `scio-parquet` that asserts the two `core-site.xml` files are identical, so they can't drift apart again

## Test plan
- [x] `CoreSiteXmlTest` passes: verifies both files are byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)