### PR TITLE
Add staging.jars.allowedenvdirs setting

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -141,15 +141,10 @@ private object RunnerContext {
   private[scio] def isAllowedEnvDir(s: String): Boolean = {
     val sanitized = sanitizePath(s)
     val sanitizedUserHome: String = sanitizePath(sys.props("user.home"))
-    val extraDirs = CoreSysProps.StagingJarsAllowedEnvDirs.valueOption
-      .map(_.split(':').filter(_.nonEmpty).map(_.stripPrefix(".")).mkString("|"))
-      .filter(_.nonEmpty)
-    val allowedPattern = extraDirs match {
-      case Some(extra) =>
-        s"${sanitizedUserHome}/\\.(ivy2|m2|cache/coursier|sbt/boot/[^/]*/lib|$extra)/.+"
-      case None =>
-        s"${sanitizedUserHome}/\\.(ivy2|m2|cache/coursier|sbt/boot/[^/]*/lib)/.+"
-    }
+    val defaultDirs = Seq("ivy2", "m2", "cache/coursier", "sbt/boot/[^/]*/lib")
+    val extraDirs = CoreSysProps.StagingJarsAllowedEnvDirs.valueOption.toSeq
+      .flatMap(_.split(':').filter(_.nonEmpty).map(_.stripPrefix(".")))
+    val allowedPattern = s"${sanitizedUserHome}/\\.(${(defaultDirs ++ extraDirs).mkString("|")})/.+"
     !sanitized.matches(s"${sanitizedUserHome}/\\..+/.+") || sanitized.matches(allowedPattern)
   }
 

--- a/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/ScioContext.scala
@@ -138,11 +138,19 @@ private object RunnerContext {
 
   private val sanitizePath: String => String = _.replace("\\", "/")
 
-  private[scio] def isNonRepositoryEnvDir(s: String): Boolean = {
+  private[scio] def isAllowedEnvDir(s: String): Boolean = {
+    val sanitized = sanitizePath(s)
     val sanitizedUserHome: String = sanitizePath(sys.props("user.home"))
-    s.matches(s"${sanitizedUserHome}/\\..+/.+") && !s.matches(
-      s"${sanitizedUserHome}/\\.(ivy2|m2|cache/coursier|sbt/boot/[^/]*/lib)/.+"
-    )
+    val extraDirs = CoreSysProps.StagingJarsAllowedEnvDirs.valueOption
+      .map(_.split(':').filter(_.nonEmpty).map(_.stripPrefix(".")).mkString("|"))
+      .filter(_.nonEmpty)
+    val allowedPattern = extraDirs match {
+      case Some(extra) =>
+        s"${sanitizedUserHome}/\\.(ivy2|m2|cache/coursier|sbt/boot/[^/]*/lib|$extra)/.+"
+      case None =>
+        s"${sanitizedUserHome}/\\.(ivy2|m2|cache/coursier|sbt/boot/[^/]*/lib)/.+"
+    }
+    !sanitized.matches(s"${sanitizedUserHome}/\\..+/.+") || sanitized.matches(allowedPattern)
   }
 
   /** Borrowed from DataflowRunner. */
@@ -153,7 +161,7 @@ private object RunnerContext {
     val classPathJars = PipelineResources
       .detectClassPathResourcesToStage(classLoader, pipelineOptions)
       .asScala
-      .filterNot(sanitizePath.andThen(isNonRepositoryEnvDir))
+      .filter(isAllowedEnvDir)
     logger.debug(s"Classpath jars: ${classPathJars.mkString(":")}")
 
     classPathJars

--- a/scio-core/src/main/scala/com/spotify/scio/SysProps.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/SysProps.scala
@@ -76,4 +76,8 @@ object CoreSysProps {
   val TmpDir: SysProp = SysProp("java.io.tmpdir", "java temporary directory")
   val User: SysProp = SysProp("user.name", "system username")
   val UserDir: SysProp = SysProp("user.dir", "user dir")
+  val StagingJarsAllowedEnvDirs: SysProp = SysProp(
+    "staging.jars.allowedenvdirs",
+    "Colon-separated list of additional dot-directories under user.home to allow for staging (e.g. .gradle:.venv)"
+  )
 }

--- a/scio-core/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -363,8 +363,27 @@ class ScioContextTest extends PipelineSpec {
     )
     val paths2 = paths1 :+ s"$userDir/.env/a/b/c/foo-0.0.1.jar"
 
-    paths1.filterNot(RunnerContext.isNonRepositoryEnvDir) should contain theSameElementsAs paths1
-    paths2.filterNot(RunnerContext.isNonRepositoryEnvDir) should contain theSameElementsAs paths1
+    paths1.filter(RunnerContext.isAllowedEnvDir) should contain theSameElementsAs paths1
+    paths2.filter(RunnerContext.isAllowedEnvDir) should contain theSameElementsAs paths1
+  }
+
+  it should "allow additional env dirs via staging.jars.allowedenvdirs" in {
+    val userDir = sys.props("user.home").replace("\\", "/")
+    val gradlePath = s"$userDir/.gradle/caches/modules-2/files-2.1/foo-0.0.1.jar"
+    val venvPath = s"$userDir/.venv/lib/python3.9/site-packages/foo.jar"
+    val otherPath = s"$userDir/.other/foo.jar"
+
+    RunnerContext.isAllowedEnvDir(gradlePath) shouldBe false
+    RunnerContext.isAllowedEnvDir(venvPath) shouldBe false
+
+    sys.props("staging.jars.allowedenvdirs") = ".gradle:.venv"
+    try {
+      RunnerContext.isAllowedEnvDir(gradlePath) shouldBe true
+      RunnerContext.isAllowedEnvDir(venvPath) shouldBe true
+      RunnerContext.isAllowedEnvDir(otherPath) shouldBe false
+    } finally {
+      sys.props.remove("staging.jars.allowedenvdirs")
+    }
   }
 
 }

--- a/scio-core/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -371,15 +371,17 @@ class ScioContextTest extends PipelineSpec {
     val userDir = sys.props("user.home").replace("\\", "/")
     val gradlePath = s"$userDir/.gradle/caches/modules-2/files-2.1/foo-0.0.1.jar"
     val venvPath = s"$userDir/.venv/lib/python3.9/site-packages/foo.jar"
+    val bazelPath = s"$userDir/.cache/bazel_repo/flib/flob/python3.9/site-packages/foo.jar"
     val otherPath = s"$userDir/.other/foo.jar"
 
     RunnerContext.isAllowedEnvDir(gradlePath) shouldBe false
     RunnerContext.isAllowedEnvDir(venvPath) shouldBe false
 
-    sys.props("staging.jars.allowedenvdirs") = ".gradle:.venv"
+    sys.props("staging.jars.allowedenvdirs") = ".gradle:.venv:.cache/bazel_repo"
     try {
       RunnerContext.isAllowedEnvDir(gradlePath) shouldBe true
       RunnerContext.isAllowedEnvDir(venvPath) shouldBe true
+      RunnerContext.isAllowedEnvDir(bazelPath) shouldBe true
       RunnerContext.isAllowedEnvDir(otherPath) shouldBe false
     } finally {
       sys.props.remove("staging.jars.allowedenvdirs")

--- a/scio-core/src/test/scala/com/spotify/scio/ScioContextTest.scala
+++ b/scio-core/src/test/scala/com/spotify/scio/ScioContextTest.scala
@@ -376,6 +376,7 @@ class ScioContextTest extends PipelineSpec {
 
     RunnerContext.isAllowedEnvDir(gradlePath) shouldBe false
     RunnerContext.isAllowedEnvDir(venvPath) shouldBe false
+    RunnerContext.isAllowedEnvDir(bazelPath) shouldBe false
 
     sys.props("staging.jars.allowedenvdirs") = ".gradle:.venv:.cache/bazel_repo"
     try {

--- a/site/src/main/paradox/FAQ.md
+++ b/site/src/main/paradox/FAQ.md
@@ -598,6 +598,18 @@ sbt -Dbigquery.connect_timeout=30000 -Dbigquery.read_timeout=30000
 
 Scio traverses JVM stack trace to figure out the proper name of each transform, i.e. `flatMap@{UserAnalysis.scala:30}` but may get confused if your jobs are under the `com.spotify.scio` package. Move them to a different package, e.g. `com.spotify.analytics` to fix the issue.
 
+#### How do I allow additional classpath directories for staging?
+
+By default, Scio filters out JARs from hidden dot-directories under your home directory (e.g. `~/.gradle`, `~/.venv`) when staging classpath resources for remote execution, while allowing known dependency caches like `~/.m2`, `~/.ivy2`, `~/.cache/coursier`, and `~/.sbt/boot/*/lib`.
+
+To allow additional dot-directories, set the `staging.jars.allowedenvdirs` system property to a colon-separated list of directory names:
+
+```bash
+sbt -Dstaging.jars.allowedenvdirs=.gradle:.venv
+```
+
+This will allow JARs from `~/.gradle/...` and `~/.venv/...` to be staged alongside the default allowed directories.
+
 #### How do I fix "RESOURCE_EXHAUSTED" error?
 
 You might see errors like `RESOURCE_EXHAUSTED: IO error: No space left on disk` in a job. They usually indicate that you have allocated insufficient local disk space to process your job. If you are running your job with default settings, your job is running on 3 workers, each with 250 GB of local disk space. Consider modifying the default settings to increase the number of workers available to your job (via `--numWorkers`), to increase the default disk size per worker (via `--diskSizeGb`).


### PR DESCRIPTION
Adds `staging.jars.allowedenvdirs` which lets users whitelist specific env dirs for jar-staging purposes, e.g. if a user wants to stage jars from `~/.cache/bazel_dir` 