### PR TITLE
bug: reset coder on covary and contravary in SCollection

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -275,13 +275,16 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   // =======================================================================
 
   /** lifts this [[SCollection]] to the specified type */
-  def covary[U >: T]: SCollection[U] = this.asInstanceOf[SCollection[U]]
+  def covary[U >: T: Coder]: SCollection[U] =
+    this.asInstanceOf[SCollection[U]].setCoder(CoderMaterializer.beam(context, Coder[U]))
 
   /** lifts this [[SCollection]] to the specified type */
-  def covary_[U](implicit @unused ev: T <:< U): SCollection[U] = this.asInstanceOf[SCollection[U]]
+  def covary_[U: Coder](implicit @unused ev: T <:< U): SCollection[U] =
+    this.asInstanceOf[SCollection[U]].setCoder(CoderMaterializer.beam(context, Coder[U]))
 
   /** lifts this [[SCollection]] to the specified type */
-  def contravary[U <: T]: SCollection[U] = this.asInstanceOf[SCollection[U]]
+  def contravary[U <: T: Coder]: SCollection[U] =
+    this.asInstanceOf[SCollection[U]].setCoder(CoderMaterializer.beam(context, Coder[U]))
 
   /**
    * Convert this SCollection to an [[SCollectionWithFanout]] that uses an intermediate node to


### PR DESCRIPTION
Fixes #3809

`covary`, `covary_`, and `contravary` previously only cast the underlying `SCollection` via `asInstanceOf`, which caused issues when mixing `SCollection`s of ADTs because the Beam coder didn't match the new type.

This PR adds an implicit `Coder[U]` context bound to each method and resets the coder to the correct type by calling `.setCoder(CoderMaterializer.beam(context, Coder[U]))`.

### Breaking change

This is a source-breaking change: call sites that don't have an implicit `Coder[U]` in scope will need to provide one. This is intentional — the previous behavior silently used the wrong coder, which could cause runtime serialization failures.