### PR TITLE
Fix GcsConnectorUtil auth for gcs-connector 3.x

### DIFF
--- a/scio-parquet/src/main/scala/com/spotify/scio/parquet/GcsConnectorUtil.scala
+++ b/scio-parquet/src/main/scala/com/spotify/scio/parquet/GcsConnectorUtil.scala
@@ -48,19 +48,23 @@ private[parquet] object GcsConnectorUtil {
       case _                            => None
     } match {
       case Success(Some(sa)) =>
+        conf.set("fs.gs.auth.type", "SERVICE_ACCOUNT_JSON_KEYFILE")
         conf.set("fs.gs.auth.service.account.json.keyfile", sa)
       case Success(None) =>
+        conf.set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER")
         conf.set(
           "fs.gs.auth.access.token.provider.impl",
           "com.spotify.scio.parquet.ApplicationDefaultTokenProvider"
         )
       case _ =>
+        conf.set("fs.gs.auth.type", "UNAUTHENTICATED")
         conf.setBoolean("fs.gs.auth.service.account.enable", false)
         conf.setBoolean("fs.gs.auth.null.enable", true)
     }
   }
 
   def unsetCredentials(conf: Configuration): Unit = {
+    conf.unset("fs.gs.auth.type")
     conf.unset("fs.gs.auth.service.account.json.keyfile")
     conf.unset("fs.gs.auth.access.token.provider.impl")
     conf.unset("fs.gs.auth.null.enable")

--- a/scio-parquet/src/test/scala/com/spotify/scio/parquet/GcsConnectorUtilTest.scala
+++ b/scio-parquet/src/test/scala/com/spotify/scio/parquet/GcsConnectorUtilTest.scala
@@ -25,6 +25,26 @@ import org.scalatest.matchers.should.Matchers
 
 class GcsConnectorUtilTest extends AnyFlatSpec with Matchers {
 
+  "setCredentials" should "set SERVICE_ACCOUNT_JSON_KEYFILE auth type for service account credentials" in {
+    val conf = ParquetConfiguration.empty()
+    sys.env.get("GOOGLE_APPLICATION_CREDENTIALS").foreach { _ =>
+      GcsConnectorUtil.setCredentials(conf)
+      val authType = conf.get("fs.gs.auth.type")
+      authType should (
+        equal("SERVICE_ACCOUNT_JSON_KEYFILE") or equal("ACCESS_TOKEN_PROVIDER")
+      )
+    }
+  }
+
+  it should "set auth type and clear it on unset" in {
+    val conf = ParquetConfiguration.empty()
+    GcsConnectorUtil.setCredentials(conf)
+    conf.get("fs.gs.auth.type") should not be null
+
+    GcsConnectorUtil.unsetCredentials(conf)
+    conf.get("fs.gs.auth.type") shouldBe null
+  }
+
   private def getInputPaths(sc: ScioContext, path: String): Array[String] = {
     val conf = ParquetConfiguration.empty()
     GcsConnectorUtil.setInputPaths(sc, conf, path)


### PR DESCRIPTION
Scio 0.15.9 upgraded `com.google.cloud.bigdataoss:gcs-connector` from `hadoop2-2.2.26` (2.x) to `3.1.16` (3.x). The 3.x connector [migrated authentication](https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/tag/v3.0.0) from implicit type detection to an explicit `fs.gs.auth.type` enum property, and [removed](https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/tag/v3.0.0) several legacy 2.x properties:

- `fs.gs.auth.null.enable` (removed)
- `fs.gs.auth.service.account.enable` (removed)
- `fs.gs.auth.service.account.email` (removed)
- `fs.gs.auth.service.account.keyfile` (removed, not to be confused with `...json.keyfile` which is still valid)

`GcsConnectorUtil.setCredentials()` was still setting only the old 2.x-style config keys without ever setting `fs.gs.auth.type`. Without it, gcs-connector 3.x [defaults to `COMPUTE_ENGINE`](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/CONFIGURATION.md), which tries to reach the GCE metadata server at `169.254.169.254`. This breaks all local and qstyx pipeline runs that use the legacy HadoopFormatIO parquet read path, because the metadata server doesn't exist outside GCE VMs.

### Why production is unaffected

`setCredentials` only matters for local runners. For non-local runners (Dataflow), `setInputPaths` calls `unsetCredentials` which clears all credential config from the Hadoop Configuration. Dataflow workers are GCE VMs, so gcs-connector's default `COMPUTE_ENGINE` auth works - the metadata server at `169.254.169.254` is available on GCE.

### Fix

Set [`fs.gs.auth.type`](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/CONFIGURATION.md) in each branch of `setCredentials()`, and clear it in `unsetCredentials()`:

| Environment | `getApplicationDefault()` returns | `fs.gs.auth.type` set |
|---|---|---|
| `GOOGLE_APPLICATION_CREDENTIALS` set (qstyx, CI) | `ServiceAccountCredentials` | `SERVICE_ACCOUNT_JSON_KEYFILE` |
| `gcloud auth application-default login` (dev laptop) | `UserCredentials` | `ACCESS_TOKEN_PROVIDER` |
| On a GCE VM with DirectRunner | `ComputeEngineCredentials` | `ACCESS_TOKEN_PROVIDER` |
| No credentials at all (unit tests) | throws | `UNAUTHENTICATED` |

Note that `COMPUTE_ENGINE` is never set explicitly. It doesn't need to be - `setCredentials` always configures a specific auth mechanism. The GCE VM case falls into `ACCESS_TOKEN_PROVIDER` because `ComputeEngineCredentials` is not a `ServiceAccountCredentials`; the `ApplicationDefaultTokenProvider` wraps it and reaches the metadata server through ADC rather than gcs-connector's built-in `COMPUTE_ENGINE` pathway. Same result, different plumbing.

`BeamInputFile.java` already sets `fs.gs.auth.type = APPLICATION_DEFAULT` for the SDF/vectored-read path, and `ParquetReadIT` sets it in integration tests. This fix closes the gap for the legacy `setInputPaths` / `HadoopFormatIO` path.

### References

- [gcs-connector 3.x CONFIGURATION.md](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/CONFIGURATION.md) -- canonical property reference
- [gcs-connector 3.0.0 release notes](https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/tag/v3.0.0) -- lists removed 2.x auth properties
