### PR TITLE
docs: fix stale master branch link to scio-examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cat wc/part-00000-of-00004.txt
 
 [Getting Started](https://spotify.github.io/scio/Getting-Started.html) is the best place to start with Scio. If you are new to Apache Beam and distributed data processing, check out the [Beam Programming Guide](https://beam.apache.org/documentation/programming-guide/) first for a detailed explanation of the Beam programming model and concepts. If you have experience with other Scala data processing libraries, check out this comparison between [Scio, Scalding and Spark](https://spotify.github.io/scio/Scio,-Scalding-and-Spark.html).
 
-Example Scio pipelines and tests can be found under [scio-examples](https://github.com/spotify/scio/tree/master/scio-examples/src). A lot of them are direct ports from Beam's Java [examples](https://github.com/apache/beam/tree/master/examples). See this [page](http://spotify.github.io/scio/examples/) for some of them with side-by-side explanation. Also see [Big Data Rosetta Code](https://github.com/spotify/big-data-rosetta-code) for common data processing code snippets in Scio, Scalding and Spark.
+Example Scio pipelines and tests can be found under [scio-examples](https://github.com/spotify/scio/tree/main/scio-examples/src). A lot of them are direct ports from Beam's Java [examples](https://github.com/apache/beam/tree/master/examples). See this [page](http://spotify.github.io/scio/examples/) for some of them with side-by-side explanation. Also see [Big Data Rosetta Code](https://github.com/spotify/big-data-rosetta-code) for common data processing code snippets in Scio, Scalding and Spark.
 
 - [Scio Docs](https://spotify.github.io/scio/) - main documentation site
 - [Scio Scaladocs](http://spotify.github.io/scio/api/) - current API documentation


### PR DESCRIPTION
The link to scio-examples in the Documentation section still pointed to the old `master` branch, while the repo's default branch is `main` (other links in the same README already point to `main`).

Updated to `tree/main/scio-examples/src` for consistency. The neighbouring apache/beam link was left as `master`, since that repo's default branch is still `master`.