### PR TITLE
Expand IcebergIO write API to cover all write options

### DIFF
--- a/integration/src/test/scala/com/spotify/scio/iceberg/IcebergIOIT.scala
+++ b/integration/src/test/scala/com/spotify/scio/iceberg/IcebergIOIT.scala
@@ -17,6 +17,7 @@
 package com.spotify.scio.iceberg
 
 import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import com.spotify.scio.parquet.BeamInputFile
 import com.spotify.scio.testing.PipelineSpec
 import magnolify.beam._
 import org.apache.iceberg.catalog.{Namespace, TableIdentifier}
@@ -28,7 +29,15 @@ import org.apache.iceberg.types.Types.{
   StringType,
   StructType
 }
-import org.apache.iceberg.{CatalogProperties, CatalogUtil, PartitionSpec, Schema}
+import org.apache.iceberg.{
+  CatalogProperties,
+  CatalogUtil,
+  NullOrder,
+  PartitionSpec,
+  Schema,
+  SortDirection
+}
+import org.apache.parquet.hadoop.ParquetFileReader
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
 
 import java.time.Duration
@@ -65,12 +74,15 @@ class IcebergIOIT extends PipelineSpec with ForAllTestContainer {
 
   lazy val uri = s"http://${container.containerIpAddress}:${container.mappedPort(ContainerPort)}"
 
-  override def afterStart(): Unit = {
+  lazy val catalog: RESTCatalog = {
     val cat = new RESTCatalog()
     cat.initialize(CatalogName, Map("uri" -> uri).asJava)
+    cat
+  }
 
-    cat.createNamespace(Namespace.of(NamespaceName))
-    cat.createTable(
+  override def afterStart(): Unit = {
+    catalog.createNamespace(Namespace.of(NamespaceName))
+    catalog.createTable(
       TableIdentifier.parse(TableName),
       new Schema(
         NestedField.required(0, "a", IntegerType.get()),
@@ -102,6 +114,106 @@ class IcebergIOIT extends PipelineSpec with ForAllTestContainer {
         TableName,
         catalogProperties = catalogProperties
       ) should containInAnyOrder(elements)
+    }
+  }
+
+  it should "write with sort order" in {
+    val sortedTableName = s"${NamespaceName}.sorted_records"
+    val catalogProperties = Map(
+      CatalogUtil.ICEBERG_CATALOG_TYPE -> CatalogUtil.ICEBERG_CATALOG_TYPE_REST,
+      CatalogProperties.URI -> uri
+    )
+    val elements = 1.to(10).map(i => IcebergIOITRecord(i, s"$i", Nested(i % 2 == 0)))
+
+    runWithRealContext() { sc =>
+      sc.parallelize(elements)
+        .saveAsIceberg(
+          sortedTableName,
+          catalogProperties = catalogProperties,
+          sortFields = List("a asc nulls first")
+        )
+    }
+
+    val table = catalog.loadTable(TableIdentifier.parse(sortedTableName))
+    val sortOrder = table.sortOrder()
+    sortOrder.isSorted shouldBe true
+    sortOrder.fields().size() shouldBe 1
+    sortOrder.fields().get(0).direction() shouldBe SortDirection.ASC
+    sortOrder.fields().get(0).nullOrder() shouldBe NullOrder.NULLS_FIRST
+  }
+
+  it should "write with partition spec" in {
+    val partitionedTableName = s"${NamespaceName}.partitioned_records"
+    val catalogProperties = Map(
+      CatalogUtil.ICEBERG_CATALOG_TYPE -> CatalogUtil.ICEBERG_CATALOG_TYPE_REST,
+      CatalogProperties.URI -> uri
+    )
+    val elements = 1.to(10).map(i => IcebergIOITRecord(i, s"$i", Nested(i % 2 == 0)))
+
+    runWithRealContext() { sc =>
+      sc.parallelize(elements)
+        .saveAsIceberg(
+          partitionedTableName,
+          catalogProperties = catalogProperties,
+          partitionFields = List("bucket(b, 2)")
+        )
+    }
+
+    val table = catalog.loadTable(TableIdentifier.parse(partitionedTableName))
+    val spec = table.spec()
+    spec.isPartitioned shouldBe true
+    spec.fields().size() shouldBe 1
+    spec.fields().get(0).name() shouldBe "b_bucket"
+  }
+
+  it should "propagate Iceberg writeProperties" in {
+    val bfTableName = s"${NamespaceName}.bloom_filter_records"
+    val catalogProperties = Map(
+      CatalogUtil.ICEBERG_CATALOG_TYPE -> CatalogUtil.ICEBERG_CATALOG_TYPE_REST,
+      CatalogProperties.URI -> uri
+    )
+    val elements = 1.to(100).map(i => IcebergIOITRecord(i, s"value_$i", Nested(i % 2 == 0)))
+
+    runWithRealContext() { sc =>
+      sc.parallelize(elements)
+        .saveAsIceberg(
+          bfTableName,
+          catalogProperties = catalogProperties,
+          writeProperties = Map("write.parquet.bloom-filter-enabled.column.b" -> "true")
+        )
+    }
+
+    val table = catalog.loadTable(TableIdentifier.parse(bfTableName))
+    val tasks = table.newScan().planFiles()
+    try {
+      val dataFiles = tasks.iterator().asScala.map(_.file().path().toString).toSeq
+      dataFiles should not be empty
+
+      dataFiles.foreach { path =>
+        val reader = ParquetFileReader.open(BeamInputFile.of(path))
+        try {
+          reader.getFooter.getBlocks.asScala.foreach { block =>
+            block.getColumns.asScala.foreach { col =>
+              val hasBloom = col.getBloomFilterOffset > 0
+              col.getPath.toDotString match {
+                case "b" =>
+                  // flip assertion once https://github.com/apache/beam/pull/39250/ is release in Beam 2.76
+                  withClue(
+                    "Iceberg writeProperties are not supported in Beam versions <= 2.76. Once Beam is upgraded, flip this assertion to `true`."
+                  ) {
+                    hasBloom shouldBe false
+                  }
+                case _ =>
+                  hasBloom shouldBe false
+              }
+            }
+          }
+        } finally {
+          reader.close()
+        }
+      }
+    } finally {
+      tasks.close()
     }
   }
 }

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/IcebergIO.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/IcebergIO.scala
@@ -41,6 +41,7 @@ private[scio] object ConfigMap {
   implicit val stringToMap: ConfigMapType[String] = _ => Map.empty
   implicit val intToMap: ConfigMapType[Int] = _ => Map.empty
   implicit val mapToMap: ConfigMapType[Map[String, String]] = _ => Map.empty
+  implicit val mapAnyRefToMap: ConfigMapType[Map[String, AnyRef]] = _ => Map.empty
   implicit val listToMap: ConfigMapType[List[String]] = _ => Map.empty
   implicit def optionToMap[T]: ConfigMapType[Option[T]] = _ => Map.empty
 
@@ -86,8 +87,10 @@ final case class IcebergIO[T: RowType: Coder](table: String, catalogName: Option
 
   private[scio] def config(params: WriteP)(implicit
     mapper: ConfigMap.ConfigMapType[WriteP]
-  ): Map[String, AnyRef] =
-    baseConfig(params)
+  ): Map[String, AnyRef] = {
+    val extra = Option(params.extraConfigProperties).getOrElse(Map.empty)
+    baseConfig(params) - "extra_config_properties" ++ extra
+  }
 
   private[scio] def config(
     params: ReadP
@@ -133,15 +136,21 @@ object IcebergIO {
   }
   case class WriteParam private (
     catalogProperties: Map[String, String] = WriteParam.DefaultCatalogProperties,
-    configProperties: Map[String, String] = WriteParam.DefaultHadoopConfigProperties,
+    writeProperties: Map[String, String] = WriteParam.DefaultWriteProperties,
+    sortFields: List[String] = WriteParam.DefaultSortFields,
+    partitionFields: List[String] = WriteParam.DefaultPartitionFields,
     triggeringFrequencySeconds: Option[Int] = None,
-    directWriteByteLimit: Option[Int] = None
+    directWriteByteLimit: Option[Int] = None,
+    extraConfigProperties: Map[String, AnyRef] = WriteParam.DefaultExtraConfigProperties
   )
   object WriteParam {
     val DefaultCatalogProperties: Map[String, String] = null
-    val DefaultHadoopConfigProperties: Map[String, String] = null
+    val DefaultWriteProperties: Map[String, String] = null
+    val DefaultSortFields: List[String] = null
+    val DefaultPartitionFields: List[String] = null
     val DefaultTriggeringFrequencySeconds: Int = -1
     val DefaultDirectWriteByteLimit: Int = -1
+    val DefaultExtraConfigProperties: Map[String, AnyRef] = null
 
     implicit val configMap: ConfigMap.ConfigMapType[WriteParam] = ConfigMap.gen[WriteParam]
   }

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergSCollectionSyntax.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergSCollectionSyntax.scala
@@ -35,7 +35,8 @@ class IcebergSCollectionSyntax[T: RowType: Coder](self: SCollection[T]) {
    *   any additional properties required by the Iceberg catalog; see:
    *   https://iceberg.apache.org/docs/latest/catalog-properties
    * @param writeProperties
-   *   any additional properties to pass to the Iceberg RecordWriter
+   *   any additional properties to pass to the Iceberg RecordWriter; see:
+   *   https://iceberg.apache.org/docs/latest/configuration/#write-properties
    * @param sortFields
    *   list of field names defining the sort order for written files
    * @param partitionFields

--- a/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergSCollectionSyntax.scala
+++ b/scio-managed/src/main/scala/com/spotify/scio/iceberg/syntax/IcebergSCollectionSyntax.scala
@@ -34,12 +34,18 @@ class IcebergSCollectionSyntax[T: RowType: Coder](self: SCollection[T]) {
    * @param catalogProperties
    *   any additional properties required by the Iceberg catalog; see:
    *   https://iceberg.apache.org/docs/latest/catalog-properties
-   * @param hadoopConfigProperties
-   *   any additional Hadoop configuration properties
+   * @param writeProperties
+   *   any additional properties to pass to the Iceberg RecordWriter
+   * @param sortFields
+   *   list of field names defining the sort order for written files
+   * @param partitionFields
+   *   list of field names defining the partition spec for the table
    * @param triggeringFrequencySeconds
    *   (streaming only) frequency at which snapshots are produced
    * @param directWriteByteLimit
    *   (streaming only) limit for lifting bundles into the direct write path.
+   * @param extraConfigProperties
+   *   additional properties to pass to the Managed IO config, i.e. `distribution_mode: hash` or `authosharding: true`
    *
    * For a complete reference, see:
    * https://docs.cloud.google.com/dataflow/docs/guides/managed-io-iceberg
@@ -48,19 +54,24 @@ class IcebergSCollectionSyntax[T: RowType: Coder](self: SCollection[T]) {
     table: String,
     catalogName: String = null,
     catalogProperties: Map[String, String] = IcebergIO.WriteParam.DefaultCatalogProperties,
-    hadoopConfigProperties: Map[String, String] =
-      IcebergIO.WriteParam.DefaultHadoopConfigProperties,
+    writeProperties: Map[String, String] = IcebergIO.WriteParam.DefaultWriteProperties,
+    sortFields: List[String] = IcebergIO.WriteParam.DefaultSortFields,
+    partitionFields: List[String] = IcebergIO.WriteParam.DefaultPartitionFields,
+    extraConfigProperties: Map[String, AnyRef] = IcebergIO.WriteParam.DefaultExtraConfigProperties,
     triggeringFrequencySeconds: Int = IcebergIO.WriteParam.DefaultTriggeringFrequencySeconds,
     directWriteByteLimit: Int = IcebergIO.WriteParam.DefaultDirectWriteByteLimit
   ): ClosedTap[Nothing] = {
 
     val params = IcebergIO.WriteParam(
       catalogProperties,
-      hadoopConfigProperties,
+      writeProperties,
+      sortFields,
+      partitionFields,
       Option(triggeringFrequencySeconds).filter(
         _ != IcebergIO.WriteParam.DefaultTriggeringFrequencySeconds
       ),
-      Option(directWriteByteLimit).filter(_ != IcebergIO.WriteParam.DefaultDirectWriteByteLimit)
+      Option(directWriteByteLimit).filter(_ != IcebergIO.WriteParam.DefaultDirectWriteByteLimit),
+      extraConfigProperties
     )
     self.write(IcebergIO(table, Option(catalogName)))(params)
   }

--- a/scio-managed/src/test/scala/com/spotify/scio/iceberg/IcebergIOTest.scala
+++ b/scio-managed/src/test/scala/com/spotify/scio/iceberg/IcebergIOTest.scala
@@ -48,12 +48,16 @@ class IcebergIOTest extends ScioIOSpec {
       IcebergIO.WriteParam(
         Map.empty,
         Map.empty,
+        Nil,
+        Nil,
         None,
         None
       ),
       IcebergIO.WriteParam(
         Map("catalogProp1" -> "catalogProp1Value"),
         Map("configProp1" -> "configProp1Value", "configProp2" -> "configProp2Value"),
+        List("sortField1"),
+        List("partField1"),
         Some(10),
         Some(100)
       )
@@ -70,6 +74,9 @@ class IcebergIOTest extends ScioIOSpec {
       // reads
       "filter",
       // writes
+      "write_properties",
+      "sort_fields",
+      "partition_fields",
       "triggering_frequency_seconds",
       "direct_write_byte_limit"
     )
@@ -129,14 +136,24 @@ class IcebergIOTest extends ScioIOSpec {
 
     val writeParam = IcebergIO.WriteParam(
       Map("a" -> "b"),
-      Map("c" -> "d", "e" -> "f")
+      Map("c" -> "d", "e" -> "f"),
+      List("col1", "col2"),
+      List("partCol1"),
+      extraConfigProperties = Map(
+        "distribution_mode" -> "hash",
+        "autosharding" -> (true: java.lang.Boolean)
+      )
     )
 
     val managedConfig: Map[String, AnyRef] = io.config(writeParam)
 
     managedConfig should contain only (
-      "config_properties" -> Map("c" -> "d", "e" -> "f"),
+      "write_properties" -> Map("c" -> "d", "e" -> "f"),
+      "sort_fields" -> List("col1", "col2"),
+      "partition_fields" -> List("partCol1"),
       "catalog_properties" -> Map("a" -> "b"),
+      "distribution_mode" -> "hash",
+      "autosharding" -> true,
       "table" -> "tableName",
       "catalog_name" -> "catalogName"
     )


### PR DESCRIPTION
Expands iceberg write API to support

- sort order
- partition spec
- arbitrary other options you want to pass to the ManagedIO config map, ie. `distribution_mode`

+ Renames `configProperties` to `writeProperties` to match Iceberg convention https://iceberg.apache.org/docs/latest/configuration/#write-properties