### PR TITLE
Add wrapper for setRowSchema method

### DIFF
--- a/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/values/SCollection.scala
@@ -147,6 +147,12 @@ sealed trait SCollection[T] extends PCollectionWrapper[T] {
   def setCoder(coder: org.apache.beam.sdk.coders.Coder[T]): SCollection[T] =
     context.wrap(internal.setCoder(coder))
 
+  /** Assign a Schema to an SCollection[Row]. */
+  def setRowSchema(schema: org.apache.beam.sdk.schemas.Schema)(implicit
+    ev: T <:< Row
+  ): SCollection[T] =
+    context.wrap(internal.setRowSchema(schema))
+
   def setSchema(schema: Schema[T])(implicit ct: ClassTag[T]): SCollection[T] =
     if (!internal.hasSchema) {
       val (s, to, from) = SchemaMaterializer.materialize(schema)


### PR DESCRIPTION
a few Beam transforms require a Schema to be set on the SCollection; though the method `SCollection#def setSchema(schema: com.spotify.scio.schemas.Schema[T])` already exists, if you're working with magnolify-beam, calling RowType#schema gives you a `org.apache.beam.sdk.schemas.Schema`, not a  `com.spotify.scio.schemas.Schema`.